### PR TITLE
fix(ci): allowlist user_auth_identities in the tenant-RLS lint

### DIFF
--- a/backend/tests/tenant_table_rls_lint.rs
+++ b/backend/tests/tenant_table_rls_lint.rs
@@ -32,7 +32,16 @@ use common::TestDb;
 /// Tables that have a `workspace_id` column but intentionally do not carry
 /// the workspace-isolation RLS policy. Add an entry only with a
 /// justification, e.g. `"some_global_table", // platform-scoped, not tenant`.
-const RLS_EXEMPT_ALLOWLIST: &[&str] = &[];
+const RLS_EXEMPT_ALLOWLIST: &[&str] = &[
+    // Holds BOTH instance-global login identities (workspace_id NULL: local /
+    // microsoft / oidc, shared across the instance and resolved at login before
+    // a workspace is pinned) AND workspace-scoped directory identities (ldap /
+    // scim). Standard workspace RLS would hide the NULL-workspace global rows
+    // from a pinned session and break login; the scoped rows are isolated by the
+    // explicit workspace_id filters in repository::user_auth_identities
+    // (find_user_by_identity filters workspace_id IS NULL, find_user_by_scoped_identity filters = ws).
+    "user_auth_identities",
+];
 
 #[derive(QueryableByName, Debug)]
 struct TableRls {


### PR DESCRIPTION
Greens `main` after #38. The workspace-scoping migration gave `user_auth_identities` a `workspace_id`, which `tenant_table_rls_lint` requires to be RLS-isolated.

This table deliberately isn't workspace-RLS'd: it holds instance-global login identities (`workspace_id` NULL, resolved at login before a workspace is pinned) alongside workspace-scoped directory identities. Standard workspace RLS would hide the global rows and break login; scoped rows are isolated by explicit `workspace_id` filters in the repo. Added to the lint's allowlist with that justification.

Follow-up worth weighing: a custom `workspace_id IS NULL OR = pin` policy would give the scoped rows real RLS defense-in-depth without breaking login.