### PR TITLE
fix: guard migration drift and silent write loss on audited writes

### DIFF
--- a/backend/src/db.rs
+++ b/backend/src/db.rs
@@ -100,6 +100,9 @@ where
             if !applied.is_empty() {
                 info!("Applied {} database migration(s)", applied.len());
             }
+            // Same (migration-capable) connection, so the applied-migrations read
+            // has the privileges the runtime pool role lacks.
+            assert_no_migration_drift(conn)?;
             Ok(())
         }
         Err(e) => {
@@ -153,6 +156,65 @@ fn run_migrations(pool: &Pool) -> Result<(), Box<dyn std::error::Error + Send + 
     }
 }
 
+/// Refuse to start if the database has applied migrations this binary does not
+/// embed — i.e. the DB schema is *ahead* of the code. That happens on a rollback
+/// to an older release, or (in a shared dev DB) when another branch's migration
+/// gets applied and then you switch away from it. Serving old code against a
+/// newer schema silently corrupts writes: a stale-column read inside a write
+/// transaction aborts the transaction, and the subsequent `COMMIT` becomes a
+/// `ROLLBACK` that Diesel reports as success — the write is lost with a 200.
+///
+/// Fail-closed by default. `NOSDESK_ALLOW_MIGRATION_DRIFT=1` overrides it (e.g.
+/// an intentional staged rollback where you accept the risk).
+fn assert_no_migration_drift<C>(
+    conn: &mut C,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>>
+where
+    C: MigrationHarness<diesel::pg::Pg>,
+{
+    use diesel::migration::MigrationSource;
+
+    let embedded: std::collections::HashSet<String> =
+        MigrationSource::<diesel::pg::Pg>::migrations(&MIGRATIONS)
+            .map_err(|e| format!("migration-drift check: listing embedded migrations: {e}"))?
+            .iter()
+            .map(|m| m.name().version().to_string())
+            .collect();
+
+    let unknown: Vec<String> = conn
+        .applied_migrations()
+        .map_err(|e| format!("migration-drift check: reading applied migrations: {e}"))?
+        .into_iter()
+        .map(|v| v.to_string())
+        .filter(|v| !embedded.contains(v))
+        .collect();
+
+    if unknown.is_empty() {
+        return Ok(());
+    }
+
+    let allow = env::var("NOSDESK_ALLOW_MIGRATION_DRIFT")
+        .map(|v| matches!(v.trim(), "1" | "true" | "TRUE"))
+        .unwrap_or(false);
+    if allow {
+        warn!(
+            unknown_migrations = ?unknown,
+            "Migration drift: the database has migrations this binary does not embed. \
+             Continuing because NOSDESK_ALLOW_MIGRATION_DRIFT is set."
+        );
+        return Ok(());
+    }
+
+    Err(format!(
+        "Migration drift: the database has {} applied migration(s) this binary does not embed: {unknown:?}. \
+         The DB is AHEAD of this build (a rollback to an older release, or a foreign migration applied to a \
+         shared dev database). Serving this code against a newer schema risks silent write loss, so refusing \
+         to start. Resync the database to this build, or set NOSDESK_ALLOW_MIGRATION_DRIFT=1 to override.",
+        unknown.len()
+    )
+    .into())
+}
+
 /// Initialize the database by running migrations
 /// This function is designed to be called only once
 pub async fn initialize_database(
@@ -187,6 +249,8 @@ pub async fn initialize_database(
     // Run migrations. Uses MIGRATION_DATABASE_URL (a privileged role) when set,
     // since the schema migrations need CREATE ROLE / ALTER OWNER / CREATE
     // EXTENSION / GRANT that the runtime nosdesk_app role intentionally lacks.
+    // Runs pending migrations and asserts the DB isn't ahead of this binary
+    // (the drift guard, on the same privileged connection).
     run_migrations(pool)?;
 
     // Post-migration bookkeeping runs as the runtime role on the pool — the

--- a/backend/src/handlers/assets.rs
+++ b/backend/src/handlers/assets.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::collections::HashMap;
 use std::sync::Arc;
-use tracing::{debug, error};
+use tracing::{debug, error, warn};
 use uuid::Uuid;
 
 use crate::models::{Asset, AssetUpdate, Group, NewAsset, User};
@@ -27,9 +27,11 @@ use crate::services::search::SearchService;
 fn asset_validation_response(err: AssetValidationError) -> HttpResponse {
     match err {
         AssetValidationError::UnknownKind(slug) => {
+            warn!(kind = %slug, "Asset write rejected: unknown asset kind");
             errors::unprocessable_entity(format!("Unknown asset kind: {slug}"))
         }
         AssetValidationError::Attributes(inner) => {
+            warn!(error = %inner, "Asset write rejected: invalid attributes");
             errors::unprocessable_entity(format!("Invalid asset attributes: {inner}"))
         }
         AssetValidationError::Database(e) => {
@@ -968,35 +970,67 @@ pub async fn update_device(
         }
     }
 
-    let result = tc.run(|conn| {
-        let device = repository::update_device(conn, device_id, update_data)?;
+    // The write runs in its OWN transaction, with nothing else inside it. A
+    // failure assembling the response below (e.g. an enrichment read against a
+    // drifted schema) must never be able to abort and silently roll this back:
+    // an aborted transaction turns the implicit COMMIT into a ROLLBACK that
+    // still looks like success, so the client's change would vanish with a 200.
+    let device = match tc.run(|conn| repository::update_device(conn, device_id, update_data)) {
+        Ok(device) => device,
+        Err(e) => {
+            return match e {
+                Error::NotFound => errors::not_found_msg(format!("Asset {device_id} not found")),
+                _ => {
+                    error!(device_id, error = ?e, "Database error updating device");
+                    errors::internal(format!("Failed to update device {device_id}"))
+                }
+            }
+        }
+    };
+
+    // Re-index in search. The update reaches clients through the sync pool (the
+    // repository write emits `asset.updated`); no discrete SSE.
+    indexing_tasks::spawn_index_device(search_service.get_ref().clone(), device.clone());
+
+    // Assemble the response from the committed row in a SEPARATE transaction.
+    // Enrichment reads propagate their errors (no silent `unwrap_or_default`),
+    // but because the write already committed, a failure here only costs the
+    // enrichment, never the write.
+    let response = tc.run(|conn| {
         let user = device
             .primary_user_uuid
             .as_ref()
             .and_then(|uuid| get_user_by_uuid(conn, uuid));
-        let groups = groups_repo::get_groups_for_device(conn, device_id).unwrap_or_default();
-        let device_response =
-            AssetResponse::from_device_and_user(device.clone(), user, groups, conn);
-        Ok((device, device_response))
+        let groups = groups_repo::get_groups_for_device(conn, device_id)?;
+        Ok::<_, Error>(AssetResponse::from_device_and_user(
+            device.clone(),
+            user,
+            groups,
+            conn,
+        ))
     });
 
-    match result {
-        Ok((device, device_response)) => {
-            // Re-index the updated device in search
-            indexing_tasks::spawn_index_device(search_service.get_ref().clone(), device);
-
-            // The update reaches clients through the sync pool (the
-            // repository write emits `asset.updated`); no discrete SSE.
-
-            HttpResponse::Ok().json(device_response)
-        }
-        Err(e) => match e {
-            Error::NotFound => errors::not_found_msg(format!("Asset {device_id} not found")),
-            _ => {
-                error!(device_id, error = ?e, "Database error updating device");
-                errors::internal(format!("Failed to update device {device_id}"))
+    match response {
+        Ok(device_response) => HttpResponse::Ok().json(device_response),
+        Err(e) => {
+            warn!(device_id, error = ?e, "Asset updated, but enriching the response failed; returning a minimal response");
+            // The write is durable. Return the saved row without the enrichment
+            // reads that just failed (no owner, no groups) so the client still
+            // sees its change reflected.
+            match tc.run(|conn| {
+                Ok::<_, Error>(AssetResponse::from_device_and_user(
+                    device.clone(),
+                    None,
+                    Vec::new(),
+                    conn,
+                ))
+            }) {
+                Ok(minimal) => HttpResponse::Ok().json(minimal),
+                Err(_) => errors::internal(format!(
+                    "Asset {device_id} updated, but the response could not be built"
+                )),
             }
-        },
+        }
     }
 }
 
@@ -1081,23 +1115,46 @@ pub async fn unmanage_device(
         ..Default::default()
     };
 
-    let result = tc.run(|conn| {
-        let device = repository::update_device(conn, device_id, update_data)?;
+    // Write in its own transaction (see `update_device`: response-assembly
+    // reads must not be able to abort and silently roll back the write).
+    let device = match tc.run(|conn| repository::update_device(conn, device_id, update_data)) {
+        Ok(device) => device,
+        Err(e) => {
+            error!(device_id, error = ?e, "Database error unmanaging device");
+            return errors::internal(format!("Failed to unmanage device {device_id}"));
+        }
+    };
+
+    let response = tc.run(|conn| {
         let user = device
             .primary_user_uuid
             .as_ref()
             .and_then(|uuid| get_user_by_uuid(conn, uuid));
-        let groups = groups_repo::get_groups_for_device(conn, device_id).unwrap_or_default();
-        Ok(AssetResponse::from_device_and_user(
-            device, user, groups, conn,
+        let groups = groups_repo::get_groups_for_device(conn, device_id)?;
+        Ok::<_, Error>(AssetResponse::from_device_and_user(
+            device.clone(),
+            user,
+            groups,
+            conn,
         ))
     });
-
-    match result {
-        Ok(device_response) => HttpResponse::Ok().json(device_response),
+    match response {
+        Ok(resp) => HttpResponse::Ok().json(resp),
         Err(e) => {
-            error!(device_id, error = ?e, "Database error unmanaging device");
-            errors::internal(format!("Failed to unmanage device {device_id}"))
+            warn!(device_id, error = ?e, "Asset unmanaged, but enriching the response failed; returning a minimal response");
+            match tc.run(|conn| {
+                Ok::<_, Error>(AssetResponse::from_device_and_user(
+                    device.clone(),
+                    None,
+                    Vec::new(),
+                    conn,
+                ))
+            }) {
+                Ok(minimal) => HttpResponse::Ok().json(minimal),
+                Err(_) => errors::internal(format!(
+                    "Asset {device_id} unmanaged, but the response could not be built"
+                )),
+            }
         }
     }
 }
@@ -1369,24 +1426,45 @@ fn apply_asset_update_response(
     update: AssetUpdate,
     search_service: &web::Data<Arc<SearchService>>,
 ) -> HttpResponse {
-    let result = tc.run(|conn| {
-        let device = repository::update_device(conn, asset_id, update)?;
+    // Write in its own transaction (see `update_device`: response-assembly
+    // reads must not be able to abort and silently roll back the write).
+    let device = match tc.run(|conn| repository::update_device(conn, asset_id, update)) {
+        Ok(device) => device,
+        Err(e) => {
+            error!(asset_id, error = ?e, "apply asset update");
+            return errors::internal("Failed to update asset");
+        }
+    };
+    indexing_tasks::spawn_index_device(search_service.get_ref().clone(), device.clone());
+
+    let response = tc.run(|conn| {
         let user = device
             .primary_user_uuid
             .as_ref()
             .and_then(|uuid| get_user_by_uuid(conn, uuid));
-        let groups = groups_repo::get_groups_for_device(conn, asset_id).unwrap_or_default();
-        let response = AssetResponse::from_device_and_user(device.clone(), user, groups, conn);
-        Ok((device, response))
+        let groups = groups_repo::get_groups_for_device(conn, asset_id)?;
+        Ok::<_, Error>(AssetResponse::from_device_and_user(
+            device.clone(),
+            user,
+            groups,
+            conn,
+        ))
     });
-    match result {
-        Ok((device, response)) => {
-            indexing_tasks::spawn_index_device(search_service.get_ref().clone(), device);
-            HttpResponse::Ok().json(response)
-        }
+    match response {
+        Ok(resp) => HttpResponse::Ok().json(resp),
         Err(e) => {
-            error!(asset_id, error = ?e, "apply asset update");
-            errors::internal("Failed to update asset")
+            warn!(asset_id, error = ?e, "Asset updated, but enriching the response failed; returning a minimal response");
+            match tc.run(|conn| {
+                Ok::<_, Error>(AssetResponse::from_device_and_user(
+                    device.clone(),
+                    None,
+                    Vec::new(),
+                    conn,
+                ))
+            }) {
+                Ok(minimal) => HttpResponse::Ok().json(minimal),
+                Err(_) => errors::internal("Asset updated, but the response could not be built"),
+            }
         }
     }
 }

--- a/backend/src/sync/session.rs
+++ b/backend/src/sync/session.rs
@@ -132,7 +132,17 @@ where
 
     conn.transaction(|conn| {
         set_actor(conn, actor)?;
-        f(conn)
+        let value = f(conn)?;
+        // Backstop against silent write loss. If `f` returned Ok but left the
+        // transaction in an aborted state (a query error that was swallowed
+        // rather than propagated — e.g. a stale-schema read behind an
+        // `unwrap_or_default`), the COMMIT that `transaction` is about to issue
+        // gets downgraded to a ROLLBACK by Postgres while still reporting
+        // success: the writes vanish behind a 2xx. Probe with a trivial
+        // statement so an aborted transaction surfaces as a real error here and
+        // rolls back loudly instead of committing nothing.
+        diesel::sql_query("SELECT 1").execute(conn)?;
+        Ok(value)
     })
 }
 


### PR DESCRIPTION
## Why

A user set warranty fields on an asset, refreshed, and the values were gone. Every symptom said the write succeeded: HTTP 200, the response echoed the saved row, no error in the logs. But nothing persisted and no audit row was written.

Root cause: the shared dev DB had a migration from a parallel branch (`feat/asset-groups`, `20260623000000`) that restructured `asset_groups` out from under this branch's code. On every asset write, `update_device` built its response inside the write transaction by calling `get_groups_for_device`, whose query joins `asset_groups.group_id` (no longer a column). That query **aborted the transaction**, `.unwrap_or_default()` **swallowed the error**, and the trailing `COMMIT` was silently downgraded to a `ROLLBACK` that Diesel reports as success. The write vanished behind a 200.

This PR adds two safeguards so that class of failure can't happen silently again, regardless of how a schema/code skew arises (shared dev DB, prod rollback, rolling deploy).

## What

**Migration-drift startup guard** (`db.rs`)
- Refuse to boot when the database has applied migrations this binary does not embed, i.e. the DB is *ahead* of the code. Runs on the privileged migration connection, fail-closed, with `NOSDESK_ALLOW_MIGRATION_DRIFT=1` to override.
- Live-validated: against the contaminated DB it correctly named `20260623000000` and refused to start.

**Silent-rollback hardening on the audited-write path**
- `with_actor_context` probes for an aborted transaction before commit (universal backstop): a swallowed query error now fails loud instead of committing nothing.
- `update_device`, the model stamp/clear helper, and `unmanage_device` run the write in its own transaction and assemble the response (owner, groups) in a separate one, so a response-read failure can no longer roll back the committed write.
- Log asset validation rejections.

## Testing
- `cargo check` (lib + tests) and `cargo clippy` clean on the touched files.
- Guard verified live (blocked the foreign migration, then booted clean after the DB was resynced; the previously-fatal join now resolves).
- DB-backed suite runs in CI.