### PR TITLE
feat(workspace): complete the Model-C selection carrier (web + mobile)

### DIFF
--- a/backend/src/extractors/tenant_conn.rs
+++ b/backend/src/extractors/tenant_conn.rs
@@ -118,6 +118,11 @@ pub enum TenantConnError {
     /// Couldn't get a connection from the pool. Usually means the
     /// DB is unreachable or the pool is exhausted.
     PoolError(String),
+    /// Selection mode is active but the request resolved no workspace to pin.
+    /// A `TenantConn` route is always workspace-scoped, so an unpinned actor
+    /// would read every tenant query as empty (RLS) — fail closed with a clear
+    /// 400 rather than degrade into empty results or a downstream panic.
+    NoWorkspaceSelected,
 }
 
 impl std::fmt::Display for TenantConnError {
@@ -125,6 +130,7 @@ impl std::fmt::Display for TenantConnError {
         match self {
             Self::MissingRequestContext => write!(f, "Authentication required"),
             Self::PoolError(e) => write!(f, "Database error: {e}"),
+            Self::NoWorkspaceSelected => write!(f, "No workspace selected"),
         }
     }
 }
@@ -137,6 +143,8 @@ impl actix_web::ResponseError for TenantConnError {
                 .json(serde_json::json!({"error": "Authentication required"})),
             Self::PoolError(_) => HttpResponse::InternalServerError()
                 .json(serde_json::json!({"error": "Internal server error"})),
+            Self::NoWorkspaceSelected => HttpResponse::BadRequest()
+                .json(serde_json::json!({"error": "No workspace selected"})),
         }
     }
 }
@@ -181,6 +189,19 @@ impl FromRequest for TenantConn {
                 return ready(Err(TenantConnError::MissingRequestContext));
             }
         };
+
+        // Under selection mode (hosted single-origin agent app), the workspace
+        // is carried per-request via the `X-Nosdesk-Workspace` header. A
+        // `TenantConn` route with no resolved workspace means the header was
+        // absent or didn't resolve: fail closed with 400 here, before any
+        // RLS-empty read reaches a handler. Host mode (self-hosted / subdomain)
+        // always has a Host-derived workspace, so this branch is unreachable
+        // there and self-hosted is unaffected.
+        if actor.workspace_id.is_none()
+            && crate::middleware::workspace_context::selection_resolution_enabled()
+        {
+            return ready(Err(TenantConnError::NoWorkspaceSelected));
+        }
 
         let pool = match req.app_data::<web::Data<Pool>>() {
             Some(p) => p.clone(),

--- a/backend/src/repository/workflow_states.rs
+++ b/backend/src/repository/workflow_states.rs
@@ -106,8 +106,12 @@ pub fn default_state(conn: &mut DbConnection) -> QueryResult<WorkflowState> {
                     .cloned()
             })
             .or_else(|| map.values().next().cloned())
-            .expect("workflow_states must have at least one row after migration")
-    })
+    })?
+    // Empty means the workspace-scoped read returned no rows: either an
+    // unseeded workspace or (the common case under selection mode) a request
+    // that reached here with no workspace pinned. Fail closed with NotFound so
+    // callers return a clean error instead of panicking the worker.
+    .ok_or(diesel::result::Error::NotFound)
 }
 
 /// Lowest-position non-archived state in the given category. Used by the

--- a/frontend/src/components/documentationComponents/DocumentationNav.vue
+++ b/frontend/src/components/documentationComponents/DocumentationNav.vue
@@ -23,7 +23,7 @@ import { updateCollection, deleteCollection } from '@nosdesk/core/services/colle
 import type { CollectionWithDetails } from '@nosdesk/core/services/collectionService'
 import { findInTree } from '@/utils/treeUtils'
 import { docUrl } from '@nosdesk/core/utils/docUrl'
-import { subscribe } from '@/sync/lifecycle'
+import { useWorkspaceGroupSubscription } from '@/sync/useWorkspaceGroup'
 import { useDelayedFlag } from '@/composables/useDelayedFlag'
 import { useClipboard } from '@/composables/useClipboard'
 import { docsEmitter } from '@nosdesk/core/services/docsEmitter'
@@ -738,7 +738,11 @@ const pageParentMap = ref<Record<string, string | null>>({})
 // docs"), so we hold off on the empty state. The pool is cache-first
 // (IndexedDB), so on a warm refresh the rows are already here and this
 // flips true without the user ever seeing a loading state.
-const docsReady = ref(false)
+// Subscribe to the active workspace's sync group (which streams the docs
+// collections + pages into the pool) and gate the loading state on it.
+// Re-subscribes on a workspace switch; `ready` releases even on a bootstrap
+// error so the nav never stays stuck blank.
+const { ready: docsReady } = useWorkspaceGroupSubscription()
 
 // Show the skeleton only when a cold bootstrap is genuinely slow
 // (>300ms with nothing cached yet). Warm refreshes hydrate from the
@@ -1181,14 +1185,6 @@ onMounted(async () => {
 
   docNavStore.updateSidebarForScreenSize()
   window.addEventListener('resize', handleResize)
-
-  // Mark docs ready once the workspace bootstrap (which streams the
-  // documentation collections + pages into the pool) settles. Idempotent
-  // and cache-first: resolves immediately on a warm refresh, so the empty
-  // state only ever appears when there genuinely are no collections.
-  // `.finally` so a bootstrap error still releases the loading gate
-  // rather than leaving the nav stuck blank.
-  subscribe('workspace:1').finally(() => { docsReady.value = true });
 })
 
 onUnmounted(() => {

--- a/frontend/src/composables/useActiveCycleSummaries.ts
+++ b/frontend/src/composables/useActiveCycleSummaries.ts
@@ -3,8 +3,8 @@
  *
  * One workspace-wide fetch of active cycles (at most one per project)
  * for their name / end date, with ticket + completed counts derived
- * from the sync pool, the list subscribes to `workspace:1`, which
- * carries every ticket, and each ticket denormalises its `cycle_id`.
+ * from the sync pool, the list subscribes to the active workspace's
+ * group, which carries every ticket, and each ticket denormalises its `cycle_id`.
  * So the whole glance costs a single request; the counts come for free
  * from the same pool the rest of the card reads.
  *

--- a/frontend/src/composables/useProjectRollups.ts
+++ b/frontend/src/composables/useProjectRollups.ts
@@ -1,7 +1,7 @@
 /**
  * Per-project ticket rollup for the projects list, derived entirely
- * from the sync pool (the list subscribes to `workspace:1`, which
- * carries every ticket). One pass over the `project_ticket` aggregate
+ * from the sync pool (the list subscribes to the active workspace's
+ * group, which carries every ticket). One pass over the `project_ticket` aggregate
  * joined against the ticket pool yields, per project: the total, the
  * coarse status breakdown (open / in-progress / closed buckets), and
  * the distinct assignees, so a card/row can show how far along a

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -1046,13 +1046,19 @@ async function checkAuthentication(to: RouteLocationNormalized, _from: RouteLoca
   if (requiresAuth && !authStore.isAuthenticated && !authStore.loading && to.name !== 'login') {
     try {
       await authStore.fetchUserData();
-      if (authStore.user) {
-        return; // Session restored via refresh token
-      }
     } catch {
       // Refresh token expired or invalid — session cannot be restored
     }
-    return { name: 'login', query: { redirect: to.fullPath } };
+    if (!authStore.user) {
+      return { name: 'login', query: { redirect: to.fullPath } };
+    }
+    // Session restored. Deliberately do NOT return here: fall through to the
+    // post-login landing branch below. A Tauri relaunch always restores its
+    // session at the bare `tauri://localhost/` route (no slug in the URL), so
+    // without falling through the workspace-selection header would never engage
+    // and every tenant request would 404. On web the URL already carries the
+    // slug, so this only affects the bare-route case. (fetchUserData set
+    // user.value, so isAuthenticated is now true and the checks below pass.)
   }
 
   // Redirect unauthenticated users from protected routes

--- a/frontend/src/sync/useWorkspaceGroup.ts
+++ b/frontend/src/sync/useWorkspaceGroup.ts
@@ -1,0 +1,40 @@
+import { ref, watch, type Ref } from 'vue'
+import { storeToRefs } from 'pinia'
+import { useMyWorkspacesStore } from '@/stores/myWorkspaces'
+import { subscribe } from '@/sync/lifecycle'
+
+/**
+ * Subscribe the sync pool to the ACTIVE workspace's group, re-subscribing when
+ * the active workspace changes. A workspace switch may reuse the same component
+ * instance (the route slug changes but the view stays mounted), so this watches
+ * the id rather than firing once in `onMounted`. Replaces the hardcoded
+ * `subscribe('workspace:1')` the list views used to call.
+ *
+ * Returns a `ready` ref that releases once the subscribe for the current
+ * workspace settles, resolved OR errored (via `finally`), so a loading gate
+ * never sticks on a bootstrap failure. `afterSubscribe` runs per workspace,
+ * after its bootstrap, for workspace-scoped follow-up loads (e.g. saved views).
+ */
+export function useWorkspaceGroupSubscription(
+  afterSubscribe?: (workspaceId: number) => unknown,
+): { ready: Ref<boolean> } {
+  const { activeWorkspaceId } = storeToRefs(useMyWorkspacesStore())
+  const ready = ref(false)
+
+  watch(
+    activeWorkspaceId,
+    async (id) => {
+      if (id == null) return
+      ready.value = false
+      try {
+        await subscribe(`workspace:${id}`)
+        if (afterSubscribe) await afterSubscribe(id)
+      } finally {
+        ready.value = true
+      }
+    },
+    { immediate: true },
+  )
+
+  return { ready }
+}

--- a/frontend/src/sync/views/TicketsListView.vue
+++ b/frontend/src/sync/views/TicketsListView.vue
@@ -27,7 +27,7 @@ import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useFluent } from 'fluent-vue'
 import { useCreateTicketAction } from '@/composables/useCreateTicketAction'
-import { subscribe } from '@/sync/lifecycle'
+import { useWorkspaceGroupSubscription } from '@/sync/useWorkspaceGroup'
 import { useSyncTicketsStore } from '@/sync/stores/tickets'
 import { useAuthStore } from '@/stores/auth'
 import { useSavedViewsStore } from '@/stores/savedViews'
@@ -87,13 +87,11 @@ const ticketsStore = useSyncTicketsStore()
 const authStore = useAuthStore()
 const savedViewsStore = useSavedViewsStore()
 
-const bootstrapped = ref(false)
-
-onMounted(async () => {
-  await subscribe('workspace:1')
-  await savedViewsStore.ensureLoaded(null)
-  bootstrapped.value = true
-})
+// Subscribe to the active workspace's sync group (re-subscribes on switch) and
+// load that workspace's saved views once its bootstrap settles.
+const { ready: bootstrapped } = useWorkspaceGroupSubscription(() =>
+  savedViewsStore.ensureLoaded(null),
+)
 
 const { activeView, tabItems, overflowItems, allViewItems, selectViewById } = useTicketsViewResolution()
 const { sortField, sortDir, toggleSort, applySort } = useTicketsSort(activeView)

--- a/frontend/src/views/ProjectsView.vue
+++ b/frontend/src/views/ProjectsView.vue
@@ -10,11 +10,11 @@
  * with persisted layout for free; mobile keeps the enriched cards.
  * Rename/status/delete side effects are owned here.
  */
-import { onMounted, computed, ref, type ComponentPublicInstance } from 'vue'
+import { computed, ref, type ComponentPublicInstance } from 'vue'
 import { useRouter } from 'vue-router'
 import { storeToRefs } from 'pinia'
 import { useFluent } from 'fluent-vue'
-import { subscribe } from '@/sync/lifecycle'
+import { useWorkspaceGroupSubscription } from '@/sync/useWorkspaceGroup'
 import { useSyncProjectsStore, type SyncProject } from '@/sync/stores/projects'
 import { useProjectRollups } from '@/composables/useProjectRollups'
 import { useActiveCycleSummaries } from '@/composables/useActiveCycleSummaries'
@@ -47,13 +47,10 @@ const t = (key: string) => fluent.$t(key)
 const projectsStore = useSyncProjectsStore()
 const { sortedByName } = storeToRefs(projectsStore)
 
-const bootstrapped = ref(false)
 const createOpen = ref(false)
 
-onMounted(async () => {
-  await subscribe('workspace:1')
-  bootstrapped.value = true
-})
+// Subscribe to the active workspace's sync group (re-subscribes on switch).
+const { ready: bootstrapped } = useWorkspaceGroupSubscription()
 
 usePageCreateAction(() => {
   createOpen.value = true


### PR DESCRIPTION
Completes the Model-C workspace-selection carrier so the single-origin agent app (web `app.nosdesk.dev` + Tauri iOS) reliably tells the backend which workspace each request operates in via `X-Nosdesk-Workspace`. Plan: `~/.claude/plans/async-jumping-backus.md`.

The carrier was ~90% built (router `/:workspace?` guard, axios + sync headers, IDB scoping, `/api/me/workspaces`, the switcher). Three gaps closed:

**Phase 1 — backend, fail closed (ships independently).** A workspace-scoped request with no workspace pinned read every RLS query empty, and `workflow_states::default_state` `.expect`-panicked the actix worker into a 502 (destabilizing the instance for everyone). `default_state` now returns `NotFound`; `TenantConn` returns a clean `400 No workspace selected` when unpinned under `selection_resolution_enabled()`. Host mode / self-hosted is always Host-pinned, so unaffected.

**Phase 2 — mobile carrier.** The session-restoration branch in `checkAuthentication` early-returned, bypassing the post-login landing. The Tauri app always restores its keychain session at bare `tauri://localhost/`, so it never published a slug and every tenant request went out header-less. Restored sessions now fall through to the landing → redirect to `/<slug>`. Web (URL already slugged) unaffected.

**Phase 3 — sync groups.** `subscribe('workspace:1')` was hardcoded in the tickets/projects/docs views. New `useWorkspaceGroupSubscription()` watches `activeWorkspaceId` and re-subscribes on switch. Also a fix in host mode (id from subdomain, not constant 1).

Verified: backend `cargo check`, frontend + mobile type-check. On-device + web `/mercury` verification to follow on the staging deploy.