### PR TITLE
fix(mobile): make the Model-C carrier actually attach on native (REST + sync)

### DIFF
--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1510,7 +1510,14 @@ async fn main() -> std::io::Result<()> {
                 "Accept",
                 "Origin",
                 "X-Requested-With",
-                "X-CSRF-Token"
+                "X-CSRF-Token",
+                // Bearer mode + Model-C workspace selection: the native app's
+                // sync engine uses cross-origin (tauri://localhost) raw fetch,
+                // which preflights these. The REST path goes through the native
+                // HTTP plugin and bypasses CORS, but the streaming sync fetch
+                // does not, so the preflight must allow them.
+                "X-Auth-Mode",
+                "X-Nosdesk-Workspace",
             ])
             .expose_headers(vec!["content-disposition"])
             .supports_credentials()

--- a/frontend/src/services/activeWorkspace.ts
+++ b/frontend/src/services/activeWorkspace.ts
@@ -10,6 +10,7 @@
  * resolves the workspace from the Host, as today.
  */
 import { readonly, ref, type Ref } from 'vue';
+import { setSelectionHeaders } from '@nosdesk/core/transport';
 
 const LAST_WORKSPACE_KEY = 'nosdesk:last-workspace';
 
@@ -45,6 +46,14 @@ export const activeWorkspaceSlugRef: Readonly<Ref<string | null>> = readonly(slu
 export function workspaceHeaders(): Record<string, string> {
   return slug.value ? { 'X-Nosdesk-Workspace': slug.value } : {};
 }
+
+// Publish the selection header through the core transport seam so the mobile
+// apiClient (whose bootstrap clears the web apiConfig interceptor that would
+// otherwise attach it) sends it too. The web apiConfig calls workspaceHeaders()
+// directly; this exposes the same source to any seam consumer. Module-load
+// registration: this module is imported by the router's workspace guard before
+// any request fires.
+setSelectionHeaders(workspaceHeaders);
 
 /** The last workspace slug this device was on, for the post-login landing. */
 export function lastWorkspaceSlug(): string | null {

--- a/mobile/src/apiClient.ts
+++ b/mobile/src/apiClient.ts
@@ -9,7 +9,7 @@
  * concerns layered on later, not part of the bootstrap.
  */
 import apiClient from '@nosdesk/core/apiClient'
-import { apiBaseUrl, transport } from '@nosdesk/core/transport'
+import { apiBaseUrl, selectionHeaders, transport } from '@nosdesk/core/transport'
 import type { AxiosError, InternalAxiosRequestConfig } from 'axios'
 import { tauriHttpAdapter } from './tauriHttpAdapter'
 
@@ -41,6 +41,12 @@ export function setupApiClient(): void {
     // canonical store that the native adapter serialises via toJSON.
     const authHeaders = transport().auth.authHeaders()
     for (const [key, value] of Object.entries(authHeaders)) {
+      config.headers.set(key, value)
+    }
+    // Selection headers (Model-C workspace) from the seam: the web apiConfig
+    // attaches these, but this bootstrap cleared it, so apply them here.
+    const selection = selectionHeaders()
+    for (const [key, value] of Object.entries(selection)) {
       config.headers.set(key, value)
     }
     return config

--- a/packages/core/src/transport.ts
+++ b/packages/core/src/transport.ts
@@ -52,9 +52,29 @@ export interface TransportConfig {
 
 let config: TransportConfig | null = null
 
+// Host-supplied per-request headers beyond auth, currently the Model-C
+// workspace-selection header (`X-Nosdesk-Workspace`). The web `apiConfig`
+// interceptor reads the same source directly; the mobile interceptor reads it
+// through this seam because its bootstrap clears the web interceptor. Defaults
+// to none, so a host that never registers a provider is unaffected.
+let selectionHeadersProvider: () => Record<string, string> = () => ({})
+
 /** Wire the active transport. Called once at host bootstrap, before any request. */
 export function configureTransport(c: TransportConfig): void {
   config = c
+}
+
+/**
+ * Register the host's selection-header provider (which workspace this client is
+ * acting in). Called once at bootstrap; read per-request via `selectionHeaders()`.
+ */
+export function setSelectionHeaders(provider: () => Record<string, string>): void {
+  selectionHeadersProvider = provider
+}
+
+/** The host's current selection headers (workspace-selection, etc.) for a request. */
+export function selectionHeaders(): Record<string, string> {
+  return selectionHeadersProvider()
 }
 
 function active(): TransportConfig {


### PR DESCRIPTION
Follow-up to #56, discovered during on-device verification. The app lands on `/mercury` correctly (Phase 2 ✓), but two mobile-specific carrier gaps meant the workspace was never communicated to the backend:

1. **REST (native plugin):** `mobile/setupApiClient` clears the web `apiConfig` interceptor (which attaches `X-Nosdesk-Workspace`) and registers an auth-only one. Now the selection header is exposed through the core transport seam (`setSelectionHeaders`/`selectionHeaders`), registered from `activeWorkspace`, and applied by the mobile interceptor. Web unchanged.
2. **Sync (cross-origin webview fetch):** the streaming sync engine preflights `X-Auth-Mode` + `X-Nosdesk-Workspace`, which CORS didn't allow, so the sync-fed dashboard data never loaded. Added both to `allowed_headers`.

Verified: backend `cargo check`, frontend + mobile type-check. On-device verification to follow on deploy.