### PR TITLE
feat(collab): authenticate the collab WebSocket with a connection token

### DIFF
--- a/backend/src/handlers/collaboration.rs
+++ b/backend/src/handlers/collaboration.rs
@@ -2512,6 +2512,44 @@ impl YjsAppState {
 // Stream/Handler/run_interval triplet.
 // =================================================================
 
+/// Mint a short-lived collab connection token for the WebSocket, which can't
+/// send an `Authorization` header or a cross-origin cookie. Mirrors the SSE
+/// token endpoint (`/api/events/token`): the auth middleware has already
+/// authenticated the user and resolved + membership-gated the workspace, so we
+/// bind that workspace into the token (Model C) and the WS authorizes against it.
+pub async fn get_collab_token(req: HttpRequest) -> impl Responder {
+    use actix_web::HttpMessage;
+
+    let user_info = match req.extensions().get::<crate::models::Claims>() {
+        Some(claims) => claims.clone(),
+        None => return errors::unauthorized("Authentication required"),
+    };
+
+    let workspace_uuid = req
+        .extensions()
+        .get::<crate::extractors::WorkspaceContext>()
+        .map(|w| w.workspace_uuid);
+
+    match crate::utils::jwt::JwtUtils::create_collab_token(
+        &user_info.sub,
+        &user_info.platform_role,
+        workspace_uuid,
+    ) {
+        Ok(token) => HttpResponse::Ok().json(json!({
+            "token": token,
+            "expires_in": 3600,
+        })),
+        Err(_) => errors::internal("Failed to create collab token"),
+    }
+}
+
+/// Query string of the collab WebSocket URL. The token rides here because a
+/// browser WebSocket can't set an `Authorization` header or a cross-origin cookie.
+#[derive(serde::Deserialize)]
+pub struct CollabWsQuery {
+    token: Option<String>,
+}
+
 /// WebSocket connection handler — entry point for WebSocket requests.
 pub async fn ws_handler(
     req: HttpRequest,
@@ -2519,6 +2557,7 @@ pub async fn ws_handler(
     app_state: web::Data<YjsAppState>,
     ws: Option<crate::extractors::WorkspaceContext>,
     path: web::Path<String>,
+    query: web::Query<CollabWsQuery>,
 ) -> Result<HttpResponse, Error> {
     let doc_id = path.into_inner();
     debug!(doc_id = %doc_id, "WebSocket connection request");
@@ -2576,10 +2615,15 @@ pub async fn ws_handler(
         }
     }
 
-    // Extract and validate JWT token from httpOnly cookie
-    let token = req
-        .cookie(crate::utils::cookies::ACCESS_TOKEN_COOKIE)
-        .ok_or_else(|| actix_web::error::ErrorUnauthorized("No authentication cookie"))?;
+    // The collab connection token (POST /api/collaboration/token) rides in the
+    // query string: a browser WebSocket can't set an Authorization header or a
+    // cross-origin cookie. Token-everywhere — web and mobile both use it, like
+    // the SSE token. Per-doc authorization (membership + visibility) is below.
+    let token = query
+        .token
+        .as_deref()
+        .filter(|t| !t.is_empty())
+        .ok_or_else(|| actix_web::error::ErrorUnauthorized("Missing connection token"))?;
 
     // Parse the workspace-namespaced doc_id up front; its embedded
     // workspace_uuid is the tenancy anchor. Rejects legacy bare ids
@@ -2662,8 +2706,25 @@ pub async fn ws_handler(
         crate::handlers::helpers::pin_workspace(&mut conn, workspace_id);
 
         use crate::utils::jwt::JwtUtils;
-        match JwtUtils::validate_token_with_user_check(token.value(), &mut conn).await {
+        match JwtUtils::validate_token_with_user_check(token, &mut conn).await {
             Ok((claims, user)) => {
+                // Only a write-capable collab token opens the editing socket; a
+                // read-only SSE token (or any other) is refused, preserving the
+                // read/write split the separate scopes exist for.
+                if claims.scope != "collab" {
+                    return Err(actix_web::error::ErrorForbidden(
+                        "Token not valid for collaboration",
+                    ));
+                }
+                // The token is workspace-bound (Model C): it must match the doc's
+                // workspace, so a token minted for workspace A can't open a B doc.
+                if let Some(token_ws) = claims.workspace_uuid {
+                    if token_ws != parsed.workspace_uuid {
+                        return Err(actix_web::error::ErrorForbidden(
+                            "Token workspace does not match the document",
+                        ));
+                    }
+                }
                 let accessor = DocAccessor::from_claims(&claims, &mut conn)
                     .ok_or_else(|| actix_web::error::ErrorUnauthorized("Invalid token subject"))?;
                 // Membership gate: the collab WS bypasses the auth

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -2206,6 +2206,11 @@ async fn main() -> std::io::Result<()> {
                     // ===== SERVER-SENT EVENTS (SSE) =====
                     .route("/events/token", web::post().to(handlers::sse::get_sse_token))
 
+                    // ===== COLLAB WEBSOCKET CONNECTION TOKEN =====
+                    // Same auth as the SSE token: mints a short-lived, workspace-
+                    // bound token the browser WebSocket carries in its query string.
+                    .route("/collaboration/token", web::post().to(handlers::collaboration::get_collab_token))
+
                     // ===== SEARCH =====
                     .route("/search", web::get().to(handlers::search::search))
                     .route("/search/rebuild", web::post().to(handlers::search::rebuild_index))

--- a/backend/src/utils/jwt.rs
+++ b/backend/src/utils/jwt.rs
@@ -60,15 +60,20 @@ impl JwtUtils {
         .map_err(JwtError::EncodingError)
     }
 
-    /// Create a short-lived SSE token (1 hour expiry)
-    /// These tokens are specifically for Server-Sent Events and have reduced scope.
-    /// `workspace_uuid` binds the selected workspace into the token (Model C) so
-    /// the stream — which can't receive the selection header over EventSource —
-    /// authorizes against it; `None` for Host-derived / self-hosted callers.
-    pub fn create_sse_token(
+    /// Mint a short-lived (1h), sessionless "connection token" for a URL-only
+    /// channel that can't send an `Authorization` header (EventSource SSE,
+    /// WebSocket collab), so the token rides in the query string instead.
+    /// `workspace_uuid` binds the selected workspace (Model C) so the channel
+    /// authorizes against it without the selection header; `None` for
+    /// Host-derived / self-hosted callers. `scope` distinguishes what a channel
+    /// accepts (read-only `sse` vs write-capable `collab`); the per-channel
+    /// handler enforces the scope it requires.
+    fn create_connection_token(
         user_id: &str,
         platform_role: &str,
         workspace_uuid: Option<uuid::Uuid>,
+        scope: &str,
+        name: &str,
     ) -> Result<String, JwtError> {
         let now = SystemTime::now()
             .duration_since(UNIX_EPOCH)
@@ -77,10 +82,10 @@ impl JwtUtils {
 
         let claims = Claims {
             sub: user_id.to_string(),
-            name: "SSE_TOKEN".to_string(),
+            name: name.to_string(),
             email: String::new(),
             platform_role: platform_role.to_string(),
-            scope: "sse".to_string(),
+            scope: scope.to_string(),
             sid: None,
             workspace_uuid,
             exp: now + 3600,
@@ -93,6 +98,32 @@ impl JwtUtils {
             &EncodingKey::from_secret(JWT_SECRET.as_bytes()),
         )
         .map_err(JwtError::EncodingError)
+    }
+
+    /// Read-only connection token for Server-Sent Events.
+    pub fn create_sse_token(
+        user_id: &str,
+        platform_role: &str,
+        workspace_uuid: Option<uuid::Uuid>,
+    ) -> Result<String, JwtError> {
+        Self::create_connection_token(user_id, platform_role, workspace_uuid, "sse", "SSE_TOKEN")
+    }
+
+    /// Write-capable connection token for the collaborative-editing WebSocket.
+    /// Authorization is still per-document (workspace membership + visibility,
+    /// enforced in the WS handler); this token only attests who + which workspace.
+    pub fn create_collab_token(
+        user_id: &str,
+        platform_role: &str,
+        workspace_uuid: Option<uuid::Uuid>,
+    ) -> Result<String, JwtError> {
+        Self::create_connection_token(
+            user_id,
+            platform_role,
+            workspace_uuid,
+            "collab",
+            "COLLAB_TOKEN",
+        )
     }
 
     /// Create a customer-portal session access token (15 minutes).
@@ -184,10 +215,12 @@ impl JwtUtils {
             });
         }
 
-        // Skip session validation for SSE tokens (short-lived, not stored in active_sessions)
-        let is_sse_token = claims.name == "SSE_TOKEN";
+        // Connection tokens (sse / collab streams) are short-lived and
+        // sessionless (never written to active_sessions), so skip the session
+        // lookup. The per-channel handler enforces the scope it accepts.
+        let is_connection_token = matches!(claims.scope.as_str(), "sse" | "collab");
 
-        if !is_sse_token {
+        if !is_connection_token {
             // Use sid claim to look up session by stable UUID
             let sid_str = claims.sid.as_deref().ok_or(JwtError::SessionRevoked)?;
 
@@ -216,7 +249,11 @@ impl JwtUtils {
                 }
             }
         } else {
-            tracing::debug!("Validating SSE token for user {}", user_uuid);
+            tracing::debug!(
+                scope = %claims.scope,
+                "Validating sessionless connection token for user {}",
+                user_uuid
+            );
         }
 
         Ok((claims, user))

--- a/frontend/src/components/CollaborativeEditor.vue
+++ b/frontend/src/components/CollaborativeEditor.vue
@@ -17,6 +17,7 @@ import { WebsocketProvider } from "y-websocket";
 import { useCollabSessionStore, type ConnectionStatus } from "@/stores/collabSession";
 import { SafePermanentUserData } from "@nosdesk/core/utils/safePermanentUserData";
 import { apiBaseUrl, collabWsBaseUrl } from "@nosdesk/core/transport";
+import { getCollabToken } from "@/services/collabToken";
 import { EditorView } from "prosemirror-view";
 import { EditorState, Selection, type Command } from "prosemirror-state";
 import { schema } from "@/components/editor/schema";
@@ -604,6 +605,12 @@ const initEditor = async () => {
         // awareness setLocalStateField, editor view) re-runs on
         // every mount, the previous editor instance's listeners
         // were torn off in `cleanup()`.
+        // The collab WebSocket authenticates with a query-param connection
+        // token (it can't send an Authorization header or a cross-origin
+        // cookie). Cached + workspace-bound; y-websocket appends `params` to the
+        // socket URL.
+        const collabToken = await getCollabToken();
+
         const session = collab.acquire(props.docId, {
             baseWsUrl,
             providerParams: {
@@ -611,6 +618,7 @@ const initEditor = async () => {
                 // Same-tab BC isn't needed in this SPA and removes
                 // a class of duplicate-message edge cases.
                 disableBc: true,
+                params: { token: collabToken },
             },
         });
         ydoc = session.ydoc;

--- a/frontend/src/services/collabToken.ts
+++ b/frontend/src/services/collabToken.ts
@@ -1,0 +1,40 @@
+/**
+ * Short-lived connection token for the collaborative-editing WebSocket.
+ *
+ * A browser WebSocket can't set an `Authorization` header or send a
+ * cross-origin cookie, so the collab socket authenticates with a query-param
+ * token (mirroring the SSE token). The token is workspace-bound (Model C), so it
+ * is reset on workspace switch / logout via `resetCollabToken()`.
+ */
+import apiClient from '@nosdesk/core/apiClient';
+
+interface CollabTokenResponse {
+  token: string;
+  expires_in: number;
+}
+
+let cached: { token: string; expiresAt: number } | null = null;
+
+// Refetch a little before expiry so a long editing session never connects with
+// an about-to-expire token.
+const REFRESH_BUFFER_MS = 5 * 60 * 1000;
+
+/**
+ * Get a collab connection token, cached until near its expiry. Bound to the
+ * request's active workspace, so callers must `resetCollabToken()` on a
+ * workspace switch (the WS rejects a token whose workspace doesn't match the doc).
+ */
+export async function getCollabToken(): Promise<string> {
+  const now = Date.now();
+  if (cached && now < cached.expiresAt - REFRESH_BUFFER_MS) {
+    return cached.token;
+  }
+  const { data } = await apiClient.post<CollabTokenResponse>('/collaboration/token');
+  cached = { token: data.token, expiresAt: now + data.expires_in * 1000 };
+  return cached.token;
+}
+
+/** Drop the cached token (workspace switch / logout). */
+export function resetCollabToken(): void {
+  cached = null;
+}

--- a/frontend/src/stores/workspaceReset.ts
+++ b/frontend/src/stores/workspaceReset.ts
@@ -62,6 +62,15 @@ export async function resetWorkspaceScopedState(): Promise<void> {
     logger.error('Failed to clear the active workspace slug', e);
   }
 
+  // Drop the cached collab WS token: it's workspace-bound, so a token minted for
+  // the old workspace would be refused when opening a doc in the new one.
+  try {
+    const { resetCollabToken } = await import('@/services/collabToken');
+    resetCollabToken();
+  } catch (e) {
+    logger.error('Failed to clear the collab token', e);
+  }
+
   // Sync runtime, SSE bridge, and collab IndexedDB. The sync pool's IDB is keyed
   // by (user, schema) with no workspace today, so a full teardown is the only
   // way to keep one workspace's rows from bleeding into the next; re-hydration


### PR DESCRIPTION
The collab WebSocket was the last channel still authenticating by **cookie only**, so it 401'd on mobile (bearer, no cross-origin cookie, and browser WebSockets can't set an `Authorization` header). This unifies it with the **already-proven SSE token pattern**.

Designed with @kylephillips: the four channels split into header-capable (REST, sync → bearer header) and URL-only (SSE, collab WS → query-param token). SSE already had the URL-only answer; the collab WS adopts it.

**Backend**
- Generalize SSE's mint into a shared sessionless, workspace-bound **connection token** (`create_connection_token`), with read-only `sse` and write-capable `collab` scopes. `validate_token_with_user_check` skips the session lookup for both (scope-based, replacing the `name == "SSE_TOKEN"` marker).
- `POST /api/collaboration/token` (same auth as `/events/token`).
- WS handler reads the token from the query string (**token-everywhere**, cookie path dropped), requires scope `collab`, and verifies the token's workspace matches the doc's. Per-doc membership + visibility authz unchanged.

**Frontend**
- `services/collabToken.ts` (cached, workspace-bound); the editor passes it as y-websocket `params`; cache reset on workspace switch.

Decisions: separate `sse`/`collab` scopes (preserve read/write split) + token-everywhere on web (consistent with how web already does SSE).

Verified: backend `cargo check` + `cargo test --lib jwt` (SSE token intact), frontend type-check. On-device + web-regression verification on deploy.