### PR TITLE
fix(collab): token route 404 (scope shadowing)

### DIFF
--- a/backend/src/handlers/collaboration.rs
+++ b/backend/src/handlers/collaboration.rs
@@ -3615,7 +3615,12 @@ pub async fn handshake(
 /// Keeping them in one configurer means `config` applies that auth in a
 /// single place, so a new endpoint can't accidentally land outside it.
 fn rest_routes(cfg: &mut web::ServiceConfig) {
-    cfg.route("/handshake/{doc_id}", web::get().to(handshake))
+    // Mint the collab connection token. Must live INSIDE this scope (not the
+    // `/api` scope): the `/api/collaboration` scope is registered first and would
+    // shadow `/api/collaboration/token` registered elsewhere. dual_auth (wrapping
+    // this scope) supplies the Claims + WorkspaceContext the handler reads.
+    cfg.route("/token", web::post().to(get_collab_token))
+        .route("/handshake/{doc_id}", web::get().to(handshake))
         .route("/article/{doc_id}", web::get().to(get_article_content))
         .route(
             "/tickets/{ticket_id}/revisions",

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -2205,11 +2205,11 @@ async fn main() -> std::io::Result<()> {
 
                     // ===== SERVER-SENT EVENTS (SSE) =====
                     .route("/events/token", web::post().to(handlers::sse::get_sse_token))
-
-                    // ===== COLLAB WEBSOCKET CONNECTION TOKEN =====
-                    // Same auth as the SSE token: mints a short-lived, workspace-
-                    // bound token the browser WebSocket carries in its query string.
-                    .route("/collaboration/token", web::post().to(handlers::collaboration::get_collab_token))
+                    // The collab connection token lives inside the
+                    // /api/collaboration scope (handlers::collaboration::config):
+                    // that scope is matched before this /api scope, so a
+                    // /api/collaboration/token registered here would be shadowed
+                    // and 404. See config()/rest_routes().
 
                     // ===== SEARCH =====
                     .route("/search", web::get().to(handlers::search::search))


### PR DESCRIPTION
Fix-forward for #58: `POST /api/collaboration/token` 404'd because it was registered in the `/api` scope, but the earlier `/api/collaboration` scope (auth-less WS) matches `/api/collaboration/*` first and shadowed it. Moved into `collaboration::config`'s dual_auth-wrapped `rest_routes`. Verified end-to-end on deploy (route returns 401 on bad token, not 404; web + mobile collab connect).