### PR TITLE
fix(collab): token through prewarm + mobile undefined-param serialization

### DIFF
--- a/frontend/src/components/CollaborativeEditor.vue
+++ b/frontend/src/components/CollaborativeEditor.vue
@@ -17,7 +17,6 @@ import { WebsocketProvider } from "y-websocket";
 import { useCollabSessionStore, type ConnectionStatus } from "@/stores/collabSession";
 import { SafePermanentUserData } from "@nosdesk/core/utils/safePermanentUserData";
 import { apiBaseUrl, collabWsBaseUrl } from "@nosdesk/core/transport";
-import { getCollabToken } from "@/services/collabToken";
 import { EditorView } from "prosemirror-view";
 import { EditorState, Selection, type Command } from "prosemirror-state";
 import { schema } from "@/components/editor/schema";
@@ -605,12 +604,8 @@ const initEditor = async () => {
         // awareness setLocalStateField, editor view) re-runs on
         // every mount, the previous editor instance's listeners
         // were torn off in `cleanup()`.
-        // The collab WebSocket authenticates with a query-param connection
-        // token (it can't send an Authorization header or a cross-origin
-        // cookie). Cached + workspace-bound; y-websocket appends `params` to the
-        // socket URL.
-        const collabToken = await getCollabToken();
-
+        // The collab session store owns WS auth (it fetches the connection
+        // token and sets it on the provider), so the editor just acquires.
         const session = collab.acquire(props.docId, {
             baseWsUrl,
             providerParams: {
@@ -618,7 +613,6 @@ const initEditor = async () => {
                 // Same-tab BC isn't needed in this SPA and removes
                 // a class of duplicate-message edge cases.
                 disableBc: true,
-                params: { token: collabToken },
             },
         });
         ydoc = session.ydoc;

--- a/frontend/src/stores/collabSession.ts
+++ b/frontend/src/stores/collabSession.ts
@@ -37,6 +37,7 @@ import { ref } from 'vue'
 import { logger } from '@nosdesk/core/utils/logger'
 import { SafePermanentUserData } from '@nosdesk/core/utils/safePermanentUserData'
 import { collabWsBaseUrl } from '@nosdesk/core/transport'
+import { getCollabToken } from '@/services/collabToken'
 
 /**
  * How long after refcount hits 0 we keep the websocket open
@@ -486,15 +487,35 @@ export const useCollabSessionStore = defineStore('collabSession', () => {
    */
   function warm(docId: string, options?: CollabSessionAcquireOptions): void {
     if (sessions.has(docId)) return
-    const opts: CollabSessionAcquireOptions = options ?? {
-      baseWsUrl: collabWsBaseUrl(),
-      providerParams: { resyncInterval: 20000, disableBc: true },
+
+    // Same path as `acquire` but we drop the refcount immediately and start the
+    // grace timer, so the session disconnects on its own if the user never
+    // actually navigates here.
+    const warmWith = (opts: CollabSessionAcquireOptions) => {
+      if (sessions.has(docId)) return // editor (or a prior warm) already acquired
+      acquire(docId, opts)
+      release(docId)
     }
-    // Same path as `acquire` but we drop the refcount immediately
-    // and start the grace timer, so the session disconnects on
-    // its own if the user never actually navigates here.
-    acquire(docId, opts)
-    release(docId)
+
+    if (options) {
+      warmWith(options)
+      return
+    }
+
+    // The WS authenticates with the collab connection token, so the prewarm must
+    // carry it too — otherwise it opens a tokenless socket that the editor's
+    // later acquire just reuses (and never re-auths). Async because the token is
+    // fetched; if the user navigates in first, the editor's acquire wins.
+    void getCollabToken()
+      .then((token) =>
+        warmWith({
+          baseWsUrl: collabWsBaseUrl(),
+          providerParams: { resyncInterval: 20000, disableBc: true, params: { token } },
+        }),
+      )
+      .catch(() => {
+        // Prewarm is best-effort; the editor fetches the token + connects on mount.
+      })
   }
 
   /**

--- a/frontend/src/stores/collabSession.ts
+++ b/frontend/src/stores/collabSession.ts
@@ -111,6 +111,30 @@ function deriveConnectionStatus(provider: WebsocketProvider): ConnectionStatus {
   return 'disconnected'
 }
 
+/**
+ * Fetch the collab connection token, set it on the provider's `params`, and
+ * connect. `params` is a plain object the y-websocket URL getter re-reads on
+ * every (re)connect, so refreshing it on `connection-close` means a session that
+ * outlives the ~1h token reconnects with a fresh one. Owned here so callers
+ * (editor, prewarm) never deal with the token.
+ */
+async function attachCollabToken(provider: WebsocketProvider): Promise<void> {
+  const setToken = async () => {
+    try {
+      provider.params = { token: await getCollabToken() }
+    } catch (err) {
+      logger.warn('Collab session: token fetch failed; socket will retry', { err })
+    }
+  }
+  await setToken()
+  provider.connect()
+  // Refresh before the auto-reconnect reads the URL again (cached within the
+  // hour, so this only re-fetches once the token has actually expired).
+  provider.on('connection-close', () => {
+    void setToken()
+  })
+}
+
 interface SessionEntry {
   docId: string
   ydoc: Y.Doc
@@ -417,12 +441,14 @@ export const useCollabSessionStore = defineStore('collabSession', () => {
       }
     }
 
-    const provider = new WebsocketProvider(
-      options.baseWsUrl,
-      docId,
-      ydoc,
-      options.providerParams,
-    )
+    // Create disconnected: the collab WS authenticates with a connection token
+    // in the URL query (a browser WebSocket can't send a header or cross-origin
+    // cookie). The store owns fetching it (callers don't), then connects.
+    const provider = new WebsocketProvider(options.baseWsUrl, docId, ydoc, {
+      ...options.providerParams,
+      connect: false,
+    })
+    void attachCollabToken(provider)
     const permanentUserData = new SafePermanentUserData(ydoc)
     // One subscription per provider. Derives status from live socket
     // flags on every transition; seeded synchronously so a provider
@@ -487,35 +513,15 @@ export const useCollabSessionStore = defineStore('collabSession', () => {
    */
   function warm(docId: string, options?: CollabSessionAcquireOptions): void {
     if (sessions.has(docId)) return
-
-    // Same path as `acquire` but we drop the refcount immediately and start the
-    // grace timer, so the session disconnects on its own if the user never
-    // actually navigates here.
-    const warmWith = (opts: CollabSessionAcquireOptions) => {
-      if (sessions.has(docId)) return // editor (or a prior warm) already acquired
-      acquire(docId, opts)
-      release(docId)
+    const opts: CollabSessionAcquireOptions = options ?? {
+      baseWsUrl: collabWsBaseUrl(),
+      providerParams: { resyncInterval: 20000, disableBc: true },
     }
-
-    if (options) {
-      warmWith(options)
-      return
-    }
-
-    // The WS authenticates with the collab connection token, so the prewarm must
-    // carry it too — otherwise it opens a tokenless socket that the editor's
-    // later acquire just reuses (and never re-auths). Async because the token is
-    // fetched; if the user navigates in first, the editor's acquire wins.
-    void getCollabToken()
-      .then((token) =>
-        warmWith({
-          baseWsUrl: collabWsBaseUrl(),
-          providerParams: { resyncInterval: 20000, disableBc: true, params: { token } },
-        }),
-      )
-      .catch(() => {
-        // Prewarm is best-effort; the editor fetches the token + connects on mount.
-      })
+    // Same path as `acquire` (which fetches the token + connects); we drop the
+    // refcount immediately and start the grace timer, so the session disconnects
+    // on its own if the user never actually navigates here.
+    acquire(docId, opts)
+    release(docId)
   }
 
   /**

--- a/mobile/src/tauriHttpAdapter.ts
+++ b/mobile/src/tauriHttpAdapter.ts
@@ -25,7 +25,12 @@ function buildUrl(config: InternalAxiosRequestConfig): string {
     ? path
     : `${base.replace(/\/$/, '')}/${path.replace(/^\//, '')}`
   if (config.params) {
-    const qs = new URLSearchParams(config.params as Record<string, string>).toString()
+    // Drop null/undefined params (don't serialise them as the string
+    // "undefined"); axios's default serializer omits them, so match it.
+    const entries = Object.entries(config.params as Record<string, unknown>)
+      .filter(([, v]) => v != null)
+      .map(([k, v]) => [k, String(v)] as [string, string])
+    const qs = new URLSearchParams(entries).toString()
     if (qs) url += (url.includes('?') ? '&' : '?') + qs
   }
   return url


### PR DESCRIPTION
Two on-device bugs found verifying #58/#60:

1. **Collab WS still 401 (web + mobile):** the ticket-row prewarm (`collabSession.warm`, hover/tap) opened the socket with **no token**, and the editor's later `acquire` reused that tokenless session. `warm()` now fetches + passes the collab token like the editor.
2. **Activity log 400 on mobile:** the Tauri HTTP adapter serialized `undefined` params as `"undefined"` (`before=undefined`). Now omits nullish params like axios.

Verifying on-device before merge.