### PR TITLE
feat(transport): carry diagnostics headers through the seam (web + mobile)

### DIFF
--- a/frontend/src/services/activeWorkspace.ts
+++ b/frontend/src/services/activeWorkspace.ts
@@ -10,7 +10,7 @@
  * resolves the workspace from the Host, as today.
  */
 import { readonly, ref, type Ref } from 'vue';
-import { setSelectionHeaders } from '@nosdesk/core/transport';
+import { addRequestHeaderProvider } from '@nosdesk/core/transport';
 
 const LAST_WORKSPACE_KEY = 'nosdesk:last-workspace';
 
@@ -47,13 +47,12 @@ export function workspaceHeaders(): Record<string, string> {
   return slug.value ? { 'X-Nosdesk-Workspace': slug.value } : {};
 }
 
-// Publish the selection header through the core transport seam so the mobile
-// apiClient (whose bootstrap clears the web apiConfig interceptor that would
-// otherwise attach it) sends it too. The web apiConfig calls workspaceHeaders()
-// directly; this exposes the same source to any seam consumer. Module-load
-// registration: this module is imported by the router's workspace guard before
-// any request fires.
-setSelectionHeaders(workspaceHeaders);
+// Publish the selection header through the core transport seam so every consumer
+// (the web apiConfig interceptor and the mobile interceptor, whose bootstrap
+// clears apiConfig) attaches it. Registered at module load: the router's
+// workspace guard imports this module before any request fires, so the workspace
+// header is available early — ahead of the diagnostics provider apiConfig adds.
+addRequestHeaderProvider(workspaceHeaders);
 
 /** The last workspace slug this device was on, for the post-login landing. */
 export function lastWorkspaceSlug(): string | null {

--- a/frontend/src/services/apiConfig.ts
+++ b/frontend/src/services/apiConfig.ts
@@ -4,14 +4,13 @@ import { logger } from '@nosdesk/core/utils/logger';
 import { createErrorFromResponse } from '@/utils/errors';
 import { ErrorTracker } from '@/utils/errorTracking';
 import { getSSEClientId } from '@/services/sseService';
-import { workspaceHeaders } from '@/services/activeWorkspace';
 import { getSessionId as getDiagnosticsSessionId } from '@/services/diagnostics/session';
 import { pushApi as pushApiBreadcrumb } from '@/services/diagnostics/breadcrumbs';
 // Transport seam: base URL, credential mode, and auth headers are resolved at
 // request time so the same axios client serves both the web (cookie + CSRF)
 // and mobile (bearer) surfaces. The host wires the active strategy at
 // bootstrap (web: services/transport.ts).
-import { apiBaseUrl, transport } from '@nosdesk/core/transport';
+import { addRequestHeaderProvider, apiBaseUrl, requestHeaders, transport } from '@nosdesk/core/transport';
 
 // API Configuration with Structured Logging and Error Handling
 //
@@ -31,6 +30,33 @@ export function setCorrelationId(id: string) {
   currentCorrelationId = id;
   logger.setCorrelationId(id);
 }
+
+// Per-request diagnostics headers: request-tracing (correlation + per-tab trace
+// id), SSE echo suppression (the client id so the backend doesn't echo a client
+// its own writes), and the auth provider. Registered with the transport seam so
+// the mobile interceptor (which clears the interceptor below) attaches them too;
+// workspace selection is registered separately by activeWorkspace.
+function diagnosticsHeaders(): Record<string, string> {
+  if (!currentCorrelationId) {
+    currentCorrelationId = generateCorrelationId();
+  }
+  const headers: Record<string, string> = {
+    'X-Correlation-ID': currentCorrelationId,
+    // Backend tracing spans pick this up so `grep <session_id>` ties a bug
+    // report's session to every request from the same tab.
+    'X-Nosdesk-Trace-Id': getDiagnosticsSessionId(),
+  };
+  const authProvider = localStorage.getItem('authProvider');
+  if (authProvider) {
+    headers['X-Auth-Provider'] = authProvider;
+  }
+  const sseClientId = getSSEClientId();
+  if (sseClientId) {
+    headers['X-SSE-Client-Id'] = sseClientId;
+  }
+  return headers;
+}
+addRequestHeaderProvider(diagnosticsHeaders);
 
 // The axios instance lives in @nosdesk/core (headless, so core services can
 // import it). This module owns its behaviour: it registers the interceptors
@@ -102,36 +128,15 @@ apiClient.interceptors.request.use(
     config.baseURL = apiBaseUrl();
     config.withCredentials = transport().auth.useCredentials;
 
-    // Generate correlation ID for request tracing
-    if (!currentCorrelationId) {
-      currentCorrelationId = generateCorrelationId();
-    }
-    config.headers['X-Correlation-ID'] = currentCorrelationId;
-
-    // Per-tab diagnostics session id. Backend tracing spans pick it
-    // up so `grep <session_id>` correlates a bug report's session to
-    // every backend request from the same tab.
-    config.headers['X-Nosdesk-Trace-Id'] = getDiagnosticsSessionId();
-
     // Auth headers from the active strategy (web: CSRF; mobile: bearer).
     Object.assign(config.headers, transport().auth.authHeaders());
 
-    // Auth provider header (if available in localStorage)
-    const authProvider = localStorage.getItem('authProvider');
-    if (authProvider) {
-      config.headers['X-Auth-Provider'] = authProvider;
-    }
-
-    // SSE client ID for echo suppression (Pusher-style pattern)
-    const sseClientId = getSSEClientId();
-    if (sseClientId) {
-      config.headers['X-SSE-Client-Id'] = sseClientId;
-    }
-
-    // Selected workspace (Model C single-origin / path mode). The router keeps
-    // this in sync with the URL slug; it's empty in host mode, where the backend
-    // resolves the workspace from the Host instead and ignores this header.
-    Object.assign(config.headers, workspaceHeaders());
+    // App per-request headers — workspace selection + diagnostics (correlation
+    // id, trace id, SSE client id, auth provider) — composed via the transport
+    // seam so the mobile interceptor (which clears this one) sends the identical
+    // set. The diagnostics provider registered below sets currentCorrelationId,
+    // which the logging just below reads.
+    Object.assign(config.headers, requestHeaders());
 
     // Verbose logging (development only)
     if (import.meta.env.DEV && localStorage.getItem('api-verbose-logging') === 'true') {

--- a/mobile/src/apiClient.ts
+++ b/mobile/src/apiClient.ts
@@ -9,7 +9,7 @@
  * concerns layered on later, not part of the bootstrap.
  */
 import apiClient from '@nosdesk/core/apiClient'
-import { apiBaseUrl, selectionHeaders, transport } from '@nosdesk/core/transport'
+import { apiBaseUrl, requestHeaders, transport } from '@nosdesk/core/transport'
 import type { AxiosError, InternalAxiosRequestConfig } from 'axios'
 import { tauriHttpAdapter } from './tauriHttpAdapter'
 
@@ -43,10 +43,10 @@ export function setupApiClient(): void {
     for (const [key, value] of Object.entries(authHeaders)) {
       config.headers.set(key, value)
     }
-    // Selection headers (Model-C workspace) from the seam: the web apiConfig
-    // attaches these, but this bootstrap cleared it, so apply them here.
-    const selection = selectionHeaders()
-    for (const [key, value] of Object.entries(selection)) {
+    // Host per-request headers (workspace selection + diagnostics) from the
+    // seam: the web apiConfig attaches these, but this bootstrap cleared it, so
+    // apply the composed union here.
+    for (const [key, value] of Object.entries(requestHeaders())) {
       config.headers.set(key, value)
     }
     return config

--- a/packages/core/src/transport.ts
+++ b/packages/core/src/transport.ts
@@ -52,12 +52,13 @@ export interface TransportConfig {
 
 let config: TransportConfig | null = null
 
-// Host-supplied per-request headers beyond auth, currently the Model-C
-// workspace-selection header (`X-Nosdesk-Workspace`). The web `apiConfig`
-// interceptor reads the same source directly; the mobile interceptor reads it
-// through this seam because its bootstrap clears the web interceptor. Defaults
-// to none, so a host that never registers a provider is unaffected.
-let selectionHeadersProvider: () => Record<string, string> = () => ({})
+// Host-supplied per-request headers beyond auth: the Model-C workspace-selection
+// header (`X-Nosdesk-Workspace`) and request-tracing/diagnostics headers
+// (correlation id, trace id, SSE client id, auth provider). Each host concern
+// registers its own provider and they compose, so both the web `apiConfig`
+// interceptor and the mobile interceptor (whose bootstrap clears apiConfig) can
+// apply the same union. Empty until a host registers, so a bare config sends none.
+const requestHeaderProviders: Array<() => Record<string, string>> = []
 
 /** Wire the active transport. Called once at host bootstrap, before any request. */
 export function configureTransport(c: TransportConfig): void {
@@ -65,16 +66,20 @@ export function configureTransport(c: TransportConfig): void {
 }
 
 /**
- * Register the host's selection-header provider (which workspace this client is
- * acting in). Called once at bootstrap; read per-request via `selectionHeaders()`.
+ * Register a provider of extra per-request headers (workspace selection,
+ * diagnostics, …). Providers compose in registration order; read per-request via
+ * `requestHeaders()`. Each owner registers near its source so the timing matches
+ * when its value becomes available.
  */
-export function setSelectionHeaders(provider: () => Record<string, string>): void {
-  selectionHeadersProvider = provider
+export function addRequestHeaderProvider(provider: () => Record<string, string>): void {
+  requestHeaderProviders.push(provider)
 }
 
-/** The host's current selection headers (workspace-selection, etc.) for a request. */
-export function selectionHeaders(): Record<string, string> {
-  return selectionHeadersProvider()
+/** The union of every registered host per-request header, for one request. */
+export function requestHeaders(): Record<string, string> {
+  const out: Record<string, string> = {}
+  for (const provider of requestHeaderProviders) Object.assign(out, provider())
+  return out
 }
 
 function active(): TransportConfig {


### PR DESCRIPTION
Follow-up to the workspace-header seam work. The mobile bootstrap clears the web `apiConfig` interceptor, so mobile requests lacked the request-tracing headers (`X-Correlation-ID`, `X-Nosdesk-Trace-Id`), the SSE echo-suppression id (`X-SSE-Client-Id`), and `X-Auth-Provider`.

Generalized the single `selectionHeaders` seam into a **composing provider list** (`addRequestHeaderProvider` / `requestHeaders`): `activeWorkspace` registers the workspace header (early, via the router guard); `apiConfig` registers the diagnostics bundle; both the web interceptor and the mobile interceptor apply the union. The web interceptor's inline header building is replaced by the same `requestHeaders()`, so web and mobile send an identical set.

Most useful gain on mobile: `X-SSE-Client-Id` (read by `handlers/tickets.rs`) means a client's own writes are no longer echoed back to it over SSE.

Verified: frontend + mobile type-check, no stale refs. (On-device header inspection isn't practical, native-plugin requests don't surface in the webview Network tab.)