### PR TITLE
fix(auth): single source of truth for the connection-token TTL

### DIFF
--- a/backend/src/handlers/collaboration.rs
+++ b/backend/src/handlers/collaboration.rs
@@ -2537,7 +2537,7 @@ pub async fn get_collab_token(req: HttpRequest) -> impl Responder {
     ) {
         Ok(token) => HttpResponse::Ok().json(json!({
             "token": token,
-            "expires_in": 3600,
+            "expires_in": crate::utils::jwt::CONNECTION_TOKEN_TTL_SECS,
         })),
         Err(_) => errors::internal("Failed to create collab token"),
     }

--- a/backend/src/handlers/sse.rs
+++ b/backend/src/handlers/sse.rs
@@ -912,7 +912,7 @@ pub async fn get_sse_token(
 
     HttpResponse::Ok().json(json!({
         "sse_token": sse_token,
-        "expires_in": 3600,
+        "expires_in": crate::utils::jwt::CONNECTION_TOKEN_TTL_SECS,
         "user_id": user_info.sub
     }))
 }

--- a/backend/src/utils/jwt.rs
+++ b/backend/src/utils/jwt.rs
@@ -17,6 +17,12 @@ lazy_static::lazy_static! {
         std::env::var("JWT_SECRET").expect("JWT_SECRET environment variable must be set");
 }
 
+/// Lifetime of a sessionless connection token (SSE + collab WebSocket). Single
+/// source of truth: it sets both the JWT `exp` (in `create_connection_token`)
+/// and the `expires_in` the mint endpoints report to the client, so the client's
+/// refresh-before-expiry cache can never disagree with the real expiry.
+pub const CONNECTION_TOKEN_TTL_SECS: usize = 3600;
+
 /// JWT token creation and validation utilities
 pub struct JwtUtils;
 
@@ -88,7 +94,7 @@ impl JwtUtils {
             scope: scope.to_string(),
             sid: None,
             workspace_uuid,
-            exp: now + 3600,
+            exp: now + CONNECTION_TOKEN_TTL_SECS,
             iat: now,
         };
 


### PR DESCRIPTION
Surfaced while soak-testing the collab token refresh: the token lifetime was hardcoded in **three** places (the JWT `exp` in `create_connection_token`, and `expires_in` in both `get_sse_token` and `get_collab_token`). They matched by coincidence; nothing enforced it. A drift desyncs the client's refresh-before-expiry cache from the real expiry, so the client can believe a short token is good for an hour and never refetch, stranding a reconnect on an expired token.

One `CONNECTION_TOKEN_TTL_SECS` constant now feeds all three. No behavior change (still 3600).

Verified on local: with a matched short TTL, an expired-then-dropped collab session refetched a fresh token on reconnect and recovered (the 401 loop stopped). The refresh-on-reconnect logic itself is confirmed sound.