### PR TITLE
feat(mobile): touch-friendly dropdown/select bottom sheets

### DIFF
--- a/frontend/src/components/UserDropdownMenu.vue
+++ b/frontend/src/components/UserDropdownMenu.vue
@@ -8,15 +8,15 @@
  * `MenuList`'s gutter-aligned action-row format.
  *
  * Positioning, dismiss, focus, and the fade-scale transition
- * delegate to `<Popover>` — same primitive every other dropdown
- * in the app uses.
+ * delegate to `<ResponsiveMenu>` (anchored popover on desktop,
+ * bottom sheet on mobile), same as every other dropdown.
  */
 import { computed, ref } from 'vue'
 import { useRouter } from 'vue-router'
 import { useFluent } from 'fluent-vue'
 import { useAuthStore } from '@/stores/auth'
 import UserAvatar from './UserAvatar.vue'
-import Popover from './common/Popover.vue'
+import ResponsiveMenu from './common/ResponsiveMenu.vue'
 import MenuList, { type MenuItem } from './common/MenuList.vue'
 import { ICON_REGISTRY } from './common/icons'
 import BugReportModal from './BugReportModal.vue'
@@ -105,7 +105,7 @@ function handleSelect(id: string) {
 </script>
 
 <template>
-  <Popover
+  <ResponsiveMenu
     :open="showMenu"
     :anchor="anchor"
     placement="bottom-end"
@@ -140,7 +140,7 @@ function handleSelect(id: string) {
     </button>
 
     <MenuList :items="items" @select="handleSelect" />
-  </Popover>
+  </ResponsiveMenu>
 
   <BugReportModal :is-open="bugReportOpen" @close="bugReportOpen = false" />
 </template>

--- a/frontend/src/components/common/AssignmentPicker.vue
+++ b/frontend/src/components/common/AssignmentPicker.vue
@@ -198,7 +198,7 @@ onBeforeUnmount(() => {
               v-for="group in filteredGroups"
               :key="`g-${group.id}`"
               @mousedown.prevent="selectGroup(group)"
-              class="w-full flex items-center gap-3 px-3 py-2.5 text-left hover:bg-surface-hover transition-colors"
+              class="w-full flex items-center gap-3 px-3 py-2.5 min-h-[44px] md:min-h-0 text-left hover:bg-surface-hover transition-colors"
             >
               <Icon name="team" class="text-tertiary flex-shrink-0" />
               <span class="text-sm text-primary truncate">{{ group.name }}</span>
@@ -214,7 +214,7 @@ onBeforeUnmount(() => {
               v-for="user in filteredUsers"
               :key="`u-${user.uuid}`"
               @mousedown.prevent="selectUser(user)"
-              class="w-full flex items-center gap-3 px-3 py-2.5 text-left hover:bg-surface-hover transition-colors"
+              class="w-full flex items-center gap-3 px-3 py-2.5 min-h-[44px] md:min-h-0 text-left hover:bg-surface-hover transition-colors"
             >
               <div class="w-5 h-5 rounded-full bg-accent/20 flex items-center justify-center flex-shrink-0 overflow-hidden">
                 <img

--- a/frontend/src/components/common/Autocomplete.vue
+++ b/frontend/src/components/common/Autocomplete.vue
@@ -244,7 +244,7 @@ watch(highlightedIndex, async (index) => {
             type="button"
             role="option"
             :aria-selected="opt === modelValue"
-            class="w-full text-left text-primary transition-colors truncate"
+            class="w-full text-left text-primary transition-colors truncate flex items-center min-h-[44px] md:min-h-0"
             :class="[
               sizeClasses.option,
               opt === modelValue

--- a/frontend/src/components/common/ContextMenu.vue
+++ b/frontend/src/components/common/ContextMenu.vue
@@ -2,16 +2,13 @@
 /**
  * Right-click / "more actions" menu, anchored to a click point.
  * Public API unchanged from prior implementations; positioning
- * + dismiss + focus delegate to `<Popover>`, item rendering
- * delegates to `<MenuList>`. This component is now a 30-line
- * connector that picks "click-anchored popover wraps menu list".
- *
- * Element-anchored equivalents (e.g. `DocumentActionsMenu`) use
- * the same `<MenuList>` inside a `<Popover>` with an element
- * anchor — same chrome, different anchor mode.
+ * + dismiss + focus delegate to `<ResponsiveMenu>` (anchored
+ * popover on desktop, bottom sheet on mobile), item rendering
+ * delegates to `<MenuList>`. This component is a thin connector
+ * that picks "click-anchored surface wraps menu list".
  */
 import { computed } from 'vue'
-import Popover from './Popover.vue'
+import ResponsiveMenu from './ResponsiveMenu.vue'
 import MenuList, { type MenuItem } from './MenuList.vue'
 
 // Re-export so existing `import type { MenuItem } from '.../ContextMenu.vue'`
@@ -47,7 +44,7 @@ const anchor = computed(() => ({
 </script>
 
 <template>
-  <Popover
+  <ResponsiveMenu
     :open="open"
     :anchor="anchor"
     placement="bottom-start"
@@ -57,5 +54,5 @@ const anchor = computed(() => ({
     @close="emit('close')"
   >
     <MenuList :items="items" @select="handleSelect" />
-  </Popover>
+  </ResponsiveMenu>
 </template>

--- a/frontend/src/components/common/DatePicker.vue
+++ b/frontend/src/components/common/DatePicker.vue
@@ -32,7 +32,7 @@
  */
 import { computed, nextTick, ref, watch, type Ref } from 'vue'
 import { useFluent } from 'fluent-vue'
-import Popover from '@/components/common/Popover.vue'
+import ResponsiveMenu from '@/components/common/ResponsiveMenu.vue'
 import Icon from '@/components/common/Icon.vue'
 
 interface Props {
@@ -442,7 +442,7 @@ async function onOpen(): Promise<void> {
       @keydown.escape="open = false"
     />
 
-    <Popover
+    <ResponsiveMenu
       :open="open"
       :anchor="{ type: 'element', element: () => triggerRef }"
       placement="bottom-start"
@@ -594,7 +594,7 @@ async function onOpen(): Promise<void> {
           </button>
         </div>
       </template>
-    </Popover>
+    </ResponsiveMenu>
   </div>
 </template>
 

--- a/frontend/src/components/common/MenuList.vue
+++ b/frontend/src/components/common/MenuList.vue
@@ -77,7 +77,7 @@ const emit = defineEmits<{ select: [id: string] }>()
     <button
       v-else
       role="menuitem"
-      class="w-full px-3 py-1.5 text-xs text-left flex items-center gap-2 transition-colors"
+      class="w-full px-3 py-2.5 md:py-1.5 text-sm md:text-xs text-left flex items-center gap-2 min-h-[44px] md:min-h-0 transition-colors"
       :class="
         item.danger
           ? 'text-red-500 hover:text-red-600 hover:bg-red-50 dark:hover:bg-red-950/30'

--- a/frontend/src/components/common/ResponsiveMenu.vue
+++ b/frontend/src/components/common/ResponsiveMenu.vue
@@ -111,14 +111,18 @@ const ariaLabel = computed(() => props.ariaLabel ?? props.title)
       />
     </Transition>
     <Transition name="sheet">
-      <div
-        v-if="open && isMobile"
-        class="fixed inset-x-0 bottom-0 z-overlay flex max-h-[80vh] flex-col rounded-t-xl border-t border-default bg-surface shadow-2xl"
-        :class="{ 'transition-transform': !isDragging }"
-        :style="{ transform: `translateY(${dragOffset}px)` }"
-        :role="role"
-        :aria-label="ariaLabel"
-      >
+      <div v-if="open && isMobile" class="fixed inset-x-0 bottom-0 z-overlay">
+        <!-- Inner panel: the Vue transition slides the WRAPPER on enter/leave,
+             this panel carries the drag offset. Two elements so the two transforms
+             compose, instead of the inline drag transform overriding (and killing)
+             the slide-in. -->
+        <div
+          class="flex max-h-[80vh] flex-col rounded-t-xl border-t border-default bg-surface shadow-2xl"
+          :class="{ 'sheet-panel-settle': !isDragging }"
+          :style="{ transform: `translateY(${dragOffset}px)` }"
+          :role="role"
+          :aria-label="ariaLabel"
+        >
         <!-- Drag handle pill. Tappable area extends beyond the
              pill so the user has more thumb room. -->
         <div
@@ -133,8 +137,11 @@ const ariaLabel = computed(() => props.ariaLabel ?? props.title)
         >
           {{ title }}
         </h2>
-        <div class="flex flex-1 flex-col overflow-y-auto pb-2">
+        <!-- Bottom padding clears the iPhone home indicator so the last option
+             isn't in the dead zone; falls back to 0.5rem where there's no inset. -->
+        <div class="flex flex-1 flex-col overflow-y-auto pb-[calc(0.5rem+env(safe-area-inset-bottom))]">
           <slot />
+        </div>
         </div>
       </div>
     </Transition>

--- a/frontend/src/components/common/ResponsivePanel.vue
+++ b/frontend/src/components/common/ResponsivePanel.vue
@@ -95,14 +95,16 @@ const ariaLabel = computed(() => props.ariaLabel ?? props.title)
       />
     </Transition>
     <Transition name="sheet">
-      <div
-        v-if="open && isMobile"
-        class="fixed inset-x-0 bottom-0 z-overlay flex h-[75vh] flex-col rounded-t-xl border-t border-default bg-surface shadow-2xl"
-        :class="{ 'transition-transform': !isDragging }"
-        :style="{ transform: `translateY(${dragOffset}px)` }"
-        role="dialog"
-        :aria-label="ariaLabel"
-      >
+      <div v-if="open && isMobile" class="fixed inset-x-0 bottom-0 z-overlay">
+        <!-- Inner panel carries the drag offset; the Vue transition slides the
+             wrapper on enter/leave. Two elements so the transforms compose. -->
+        <div
+          class="flex h-[75vh] flex-col rounded-t-xl border-t border-default bg-surface shadow-2xl"
+          :class="{ 'sheet-panel-settle': !isDragging }"
+          :style="{ transform: `translateY(${dragOffset}px)` }"
+          role="dialog"
+          :aria-label="ariaLabel"
+        >
         <!-- Drag handle. Big touch target, but visually a small
              pill so the chrome stays restrained. -->
         <div
@@ -122,8 +124,10 @@ const ariaLabel = computed(() => props.ariaLabel ?? props.title)
             <Icon name="close" size="sm" />
           </button>
         </header>
-        <div class="flex flex-1 flex-col overflow-y-auto">
+        <!-- Bottom padding clears the iPhone home indicator (dead zone). -->
+        <div class="flex flex-1 flex-col overflow-y-auto pb-[calc(0.5rem+env(safe-area-inset-bottom))]">
           <slot />
+        </div>
         </div>
       </div>
     </Transition>
@@ -131,21 +135,34 @@ const ariaLabel = computed(() => props.ariaLabel ?? props.title)
 </template>
 
 <style>
-/* Sheet enter/leave: 200ms upward slide for sheet, paired
-   backdrop fade. Global rather than scoped because the sheet is
-   teleported out of the component's scoped-style context. */
-.sheet-enter-active,
+/* Sheet present/dismiss slide, shared by <ResponsiveMenu> and <ResponsivePanel>.
+   Global (not scoped) because the sheet teleports out of scoped-style context.
+   Present decelerates into place on the iOS present curve over a longer beat so
+   it reads as rising, not popping; dismiss is a touch quicker. The slide lives on
+   the WRAPPER; the drag offset lives on the inner panel (.sheet-panel-settle), so
+   the two transforms never fight. */
+.sheet-enter-active {
+  transition: transform 360ms cubic-bezier(0.32, 0.72, 0, 1);
+}
 .sheet-leave-active {
-  transition: transform 200ms cubic-bezier(0.16, 1, 0.3, 1);
+  transition: transform 280ms cubic-bezier(0.32, 0.72, 0, 1);
 }
 .sheet-enter-from,
 .sheet-leave-to {
   transform: translateY(100%);
 }
 
-.sheet-backdrop-enter-active,
+/* Drag spring-back on release (no dismiss). Same curve as the present, a hair
+   shorter. Absent mid-drag so the panel tracks the finger 1:1. */
+.sheet-panel-settle {
+  transition: transform 320ms cubic-bezier(0.32, 0.72, 0, 1);
+}
+
+.sheet-backdrop-enter-active {
+  transition: opacity 360ms ease-out;
+}
 .sheet-backdrop-leave-active {
-  transition: opacity 200ms ease-out;
+  transition: opacity 280ms ease-in;
 }
 .sheet-backdrop-enter-from,
 .sheet-backdrop-leave-to {

--- a/frontend/src/components/common/SearchableDropdown.vue
+++ b/frontend/src/components/common/SearchableDropdown.vue
@@ -304,7 +304,7 @@ watch(highlightedIndex, async (index) => {
           :aria-selected="isSelected(option.value)"
           @click="selectOption(option)"
           @mouseenter="highlightedIndex = index"
-          class="w-full text-left text-primary transition-colors flex items-center gap-3"
+          class="w-full text-left text-primary transition-colors flex items-center gap-3 min-h-[44px] md:min-h-0"
           :class="[
             sizeClasses.option,
             isSelected(option.value)

--- a/frontend/src/components/common/TimePicker.vue
+++ b/frontend/src/components/common/TimePicker.vue
@@ -21,7 +21,7 @@
  */
 import { computed, nextTick, ref, watch, type Ref } from 'vue'
 import { useFluent } from 'fluent-vue'
-import Popover from '@/components/common/Popover.vue'
+import ResponsiveMenu from '@/components/common/ResponsiveMenu.vue'
 
 interface Props {
   modelValue: string
@@ -185,7 +185,7 @@ defineExpose({ focus: focusInput })
       @keydown.escape="open = false"
     />
 
-    <Popover
+    <ResponsiveMenu
       :open="open"
       :anchor="{ type: 'element', element: () => triggerRef }"
       placement="bottom-start"
@@ -223,7 +223,7 @@ defineExpose({ focus: focusInput })
           </li>
         </ul>
       </div>
-    </Popover>
+    </ResponsiveMenu>
   </div>
 </template>
 

--- a/frontend/src/components/ticketComponents/CannedResponsePicker.vue
+++ b/frontend/src/components/ticketComponents/CannedResponsePicker.vue
@@ -38,13 +38,12 @@ the panel; Enter inserts the active item.
     </button>
 
     <!--
-      Dropdown panel via the shared <Popover>: teleports to <body> (escaping
-      the SectionCard's `overflow: hidden`), stays anchored to the trigger on
-      scroll/resize, clamps to the viewport so it never trails off an edge, and
-      dismisses on outside-click. The inner div keeps the listbox semantics,
-      scroll, and keyboard navigation.
+      Dropdown panel via the shared <ResponsiveMenu>: an anchored popover on
+      desktop (teleports to <body>, stays anchored on scroll/resize, clamps to
+      the viewport, dismisses on outside-click) and a bottom sheet on mobile. The
+      inner div keeps the listbox semantics, scroll, and keyboard navigation.
     -->
-    <Popover
+    <ResponsiveMenu
       :open="isOpen"
       :anchor="anchor"
       placement="top-start"
@@ -143,7 +142,7 @@ the panel; Enter inserts the active item.
           </div>
         </template>
       </div>
-    </Popover>
+    </ResponsiveMenu>
   </div>
 </template>
 
@@ -159,7 +158,7 @@ import {
   type TemplateVars,
 } from '@nosdesk/core/services/cannedResponsesService';
 import { highlightTerms } from '@nosdesk/core/utils/highlight';
-import Popover from '@/components/common/Popover.vue';
+import ResponsiveMenu from '@/components/common/ResponsiveMenu.vue';
 import type { PopoverAnchor } from '@/composables/usePopover';
 
 const { $t } = useFluent();

--- a/frontend/src/components/ticketComponents/TicketWatchersField.vue
+++ b/frontend/src/components/ticketComponents/TicketWatchersField.vue
@@ -35,7 +35,7 @@ import { useAuthStore } from '@/stores/auth'
 import { watcherService } from '@nosdesk/core/services/watcherService'
 import UserAvatar from '@/components/UserAvatar.vue'
 import Icon from '@/components/common/Icon.vue'
-import Popover from '@/components/common/Popover.vue'
+import ResponsiveMenu from '@/components/common/ResponsiveMenu.vue'
 
 const fluent = useFluent()
 const t = (key: string, args?: Record<string, string | number>) => fluent.$t(key, args)
@@ -230,11 +230,12 @@ watch(isWatching, (watching) => {
     <!-- Preferences popover. Anchored to the chevron button next
          to the bell. Per-watch only; the user's global notification
          settings still own digest mode, mute-everything, etc. -->
-    <Popover
+    <ResponsiveMenu
       :open="prefsOpen"
       :anchor="prefsAnchor"
       placement="bottom-end"
       role="dialog"
+      :title="t('ticket-field-watchers-prefs-title')"
       :aria-label="t('ticket-field-watchers-prefs-title')"
       popover-class="bg-surface border border-default rounded-lg overflow-hidden min-w-[220px]"
       @close="prefsOpen = false"
@@ -270,6 +271,6 @@ watch(isWatching, (watching) => {
           {{ prefError }}
         </p>
       </div>
-    </Popover>
+    </ResponsiveMenu>
   </div>
 </template>


### PR DESCRIPTION
## Mobile dropdown/select UX

Makes dropdowns and selection components comfortable on mobile, closing gaps against Apple HIG (44pt) / Material (48dp).

### What changed
- **44px touch targets** on mobile for `MenuList` rows and the selection option rows (`SearchableDropdown`, `Autocomplete`, `AssignmentPicker`); desktop stays compact via `md:` (matches `CustomDropdown`'s existing `min-h-[44px]` precedent).
- **Safe area**: `env(safe-area-inset-bottom)` padding on the `ResponsiveMenu` / `ResponsivePanel` bottom sheets, so the last option clears the iPhone home indicator.
- **Migrated direct-`Popover` components** (`ContextMenu`, `UserDropdownMenu`, `TicketWatchersField`, `CannedResponsePicker`, `DatePicker`, `TimePicker`) to `ResponsiveMenu` — bottom sheets on mobile instead of tiny anchored popovers.
- **Sheet animation**: the sheet wasn't actually sliding (the inline drag transform overrode the transition's `translateY(100%)`, so it popped). Split into a wrapper (owns the enter/leave slide) + inner panel (owns the drag), and tuned to the iOS present curve `cubic-bezier(0.32,0.72,0,1)` at 360ms present / 280ms dismiss.

### Testing
- Verified on device across status/assignee dropdowns, canned responses, user menu, context menus, and date/time pickers.
- `npm run type-check` + `npm run build` green.