### PR TITLE
feat(nav): restore scroll position on back navigation

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -301,6 +301,7 @@ onMounted(async () => {
               <component
                 :is="Component"
                 :key="viewRoute.meta.key ?? viewRoute.matched[0]?.path ?? viewRoute.fullPath"
+                v-scroll-restore="viewRoute.fullPath"
                 class="h-full overflow-auto"
               />
             </KeepAlive>
@@ -309,6 +310,7 @@ onMounted(async () => {
             <component
               :is="Component"
               :key="viewRoute.meta.key ?? viewRoute.matched[0]?.path ?? viewRoute.fullPath"
+              v-scroll-restore="viewRoute.fullPath"
               class="h-full overflow-auto"
             />
           </KeepAlive>

--- a/frontend/src/directives/vScrollRestore.ts
+++ b/frontend/src/directives/vScrollRestore.ts
@@ -1,0 +1,61 @@
+import { nextTick, type Directive } from 'vue'
+import { navDirection } from '@/router/navigation'
+
+/**
+ * Restore an inner scroll container's position on BACK navigation, land at the
+ * top on forward. The expected platform contract (browsers, native iOS/Android,
+ * NN/g): returning to a list you scrolled should keep your place.
+ *
+ * Why here and not vue-router's `scrollBehavior`: that only reaches window
+ * scroll, but our views scroll inside their own `overflow-auto` root, so
+ * `savedPosition` is always the window's (0). We save/restore the container's
+ * `scrollTop` ourselves, keyed by the route.
+ *
+ * Why lifecycle hooks and not popstate/`savedPosition`: the iOS WKWebView
+ * swipe-back gesture doesn't reliably fire `popstate` (WebKit bug 248303), but
+ * the routed view component always mounts, so mount/unmount fires regardless of
+ * how the navigation was triggered.
+ *
+ * Usage: `v-scroll-restore="route.fullPath"` on the scroll container (App.vue
+ * wires it on the routed view root). KeepAlive'd views retain their own live
+ * `scrollTop` and never hit these hooks on nav, so they're unaffected.
+ */
+
+// Route fullPath -> last scrollTop. In-memory: enough for within-session
+// back/forward; a hard reload legitimately starts fresh.
+const positions = new Map<string, number>()
+
+interface ScrollEl extends HTMLElement {
+  _scrollRestoreKey?: string
+}
+
+/** Re-apply across a few frames so late layout (cache-first render settling,
+ *  images loading in) can't clamp the restore short. */
+function applyRestore(el: ScrollEl, top: number): void {
+  el.scrollTop = top
+  requestAnimationFrame(() => {
+    el.scrollTop = top
+    requestAnimationFrame(() => {
+      el.scrollTop = top
+    })
+  })
+}
+
+export const vScrollRestore: Directive<ScrollEl, string> = {
+  mounted(el, binding) {
+    const key = binding.value
+    el._scrollRestoreKey = key
+    if (navDirection.value === 'back' && positions.has(key)) {
+      void nextTick(() => applyRestore(el, positions.get(key) ?? 0))
+    } else {
+      el.scrollTop = 0
+    }
+  },
+  beforeUnmount(el) {
+    // Save under the route this element was showing (captured at mount), not the
+    // current route — by unmount time the app has already navigated away.
+    if (el._scrollRestoreKey !== undefined) {
+      positions.set(el._scrollRestoreKey, el.scrollTop)
+    }
+  },
+}

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -14,6 +14,7 @@ import router from './router'
 import { vSafeHtml } from './directives/vSafeHtml'
 import { vTwemoji } from './directives/vTwemoji'
 import { vPrefetch } from './directives/vPrefetch'
+import { vScrollRestore } from './directives/vScrollRestore'
 import { createI18n as createI18nPlugin } from './i18n'
 import { useThemeStore } from './stores/theme'
 import { fetchInstanceConfig } from '@nosdesk/core/services/instanceConfig'
@@ -32,10 +33,15 @@ async function bootstrap() {
 
   const app = createApp(App)
 
+  // Own scroll restoration (see vScrollRestore): stop the browser competing with
+  // our per-container save/restore on back/forward.
+  if ('scrollRestoration' in history) history.scrollRestoration = 'manual'
+
   // Register global directives
   app.directive('safe-html', vSafeHtml)
   app.directive('twemoji', vTwemoji)
   app.directive('prefetch', vPrefetch)
+  app.directive('scroll-restore', vScrollRestore)
 
   const pinia = createPinia()
   app.use(pinia)

--- a/frontend/src/router/navigation.ts
+++ b/frontend/src/router/navigation.ts
@@ -29,6 +29,14 @@ const depth = ref(0)
 let lastPosition: number | null = null
 
 /**
+ * Direction of the last settled navigation: `back` on a pop (position went
+ * down), else `forward` (push/replace/initial). Read by scroll restoration to
+ * decide restore-vs-top. Lifecycle-driven consumers read this at mount time,
+ * after `afterEach` has already run for the navigation.
+ */
+export const navDirection = ref<'forward' | 'back'>('forward')
+
+/**
  * vue-router's authoritative history position. Prefer the router's OWN history
  * state (`router.options.history.state`) over `window.history.state` — in some
  * webviews the latter isn't the object vue-router wrote. Falls back to window,
@@ -54,8 +62,15 @@ export function installNavigationTracking(router: Router): void {
     if (lastPosition === null) {
       lastPosition = pos // entry baseline; depth stays 0
     } else {
-      if (pos > lastPosition) depth.value += 1
-      else if (pos < lastPosition) depth.value = Math.max(0, depth.value - 1)
+      if (pos > lastPosition) {
+        depth.value += 1
+        navDirection.value = 'forward'
+      } else if (pos < lastPosition) {
+        depth.value = Math.max(0, depth.value - 1)
+        navDirection.value = 'back'
+      } else {
+        navDirection.value = 'forward' // replace / same position: land at top
+      }
       lastPosition = pos
     }
   })


### PR DESCRIPTION
## Scroll restoration on back navigation

Returning to a page you had scrolled now lands where you left it; a fresh forward navigation lands at the top. This is the expected platform contract (browsers restore on back by default, native iOS/Android retain it, NN/g ties losing it to dropped sessions).

### Why a directive and not vue-router's scrollBehavior
- `scrollBehavior`/`savedPosition` only reach **window** scroll, but our views scroll inside their own inner `overflow-auto` root, so it's a no-op for us (a known vue-router limitation).
- **Lifecycle-driven, not popstate**: the iOS WKWebView swipe-back gesture doesn't reliably fire `popstate` (WebKit bug 248303), but the routed view always mounts, so mount/unmount fires regardless.

### What changed
- `vScrollRestore` directive: saves `scrollTop` on unmount keyed by `route.fullPath`, restores on a **back** nav (re-applied across a few frames so late layout can't clamp it), top on forward.
- `navDirection` signal in navigation.ts (back vs forward from the history-position delta already tracked there).
- `history.scrollRestoration = 'manual'`.
- Wired once on the App.vue view container, so **every page** gets it with no per-view code. KeepAlive'd list views retain their own scrollTop and are unaffected.

### Known limit
Restores the view's **root** scroll container. Pages that scroll in a *nested* inner container aren't covered yet (handle per-container if any surface).

### Testing
Verified on device: scrolled non-list page -> forward -> back restores; forward lands at top; tickets/assets lists unchanged. type-check + build green.