### PR TITLE
fix(dashboard): size chart widgets responsively with aspect-ratio

### DIFF
--- a/frontend/src/views/dashboard/DashboardGrid.vue
+++ b/frontend/src/views/dashboard/DashboardGrid.vue
@@ -326,6 +326,7 @@ onBeforeUnmount(endResize)
       :widget-props="widgetById(entry.id)!.props"
       :frame-wraps="widgetById(entry.id)?.frameWraps ?? false"
       :frame-title-key="widgetById(entry.id)?.titleKey"
+      :body-aspect="widgetById(entry.id)?.bodyAspect"
       :class="[
         spanClass(colSpanOf(entry)),
         rowSpanClass(rowSpanOf(entry), store.editMode),

--- a/frontend/src/views/dashboard/DashboardWidgetShell.vue
+++ b/frontend/src/views/dashboard/DashboardWidgetShell.vue
@@ -120,6 +120,17 @@ const props = withDefaults(
      */
     minBodyHeight?: string
     /**
+     * CSS `aspect-ratio` (e.g. `'2 / 1'`) for a PLOTTED chart body (LineChart,
+     * heatmap) that has no intrinsic height. On the stacked mobile layout the
+     * grid row is `auto` (indefinite), so a `height:100%` plot chain collapses
+     * to 0 — worst on iOS WebKit. aspect-ratio manufactures a height from the
+     * always-known width instead, so the plot never collapses and needs no pixel
+     * height. On the xl lattice the row is definite: the body fills it and
+     * aspect-ratio self-disables (it only applies when a dimension is `auto`).
+     * Leave undefined for list/text/KPI widgets — they size to their content.
+     */
+    bodyAspect?: string
+    /**
      * Body padding tier. Maps to the design-language density scale:
      *
      *   `compact`  → p-3   (44-52px hairline rows, list/queue widgets)
@@ -142,6 +153,14 @@ const props = withDefaults(
     density: 'regular',
   },
 )
+
+// Custom properties consumed by the body's aspect-ratio / min-height utilities.
+const bodyStyle = computed(() => {
+  const s: Record<string, string> = {}
+  if (props.minBodyHeight) s['--dash-min-body'] = props.minBodyHeight
+  if (props.bodyAspect) s['--dash-aspect'] = props.bodyAspect
+  return Object.keys(s).length ? s : undefined
+})
 
 const densityPadding = computed(() => {
   if (props.flushBody) return ''
@@ -387,7 +406,16 @@ function sizeKeyToSpan(key: string): WidgetSpan | null {
          the row-cascade shift on initial load. -->
     <div
       :class="[
-        'flex-1 min-h-0 flex flex-col overflow-y-auto',
+        'min-h-0 flex flex-col',
+        // Chart bodies (bodyAspect) derive height from width via aspect-ratio so
+        // a fill-height plot never collapses on the indefinite-height mobile grid
+        // (iOS WebKit), and fill the definite row on the xl lattice (where
+        // aspect-ratio self-disables). Capped at the widget's own rowSpan height
+        // so a wide 1-col card can't produce a giant plot. Non-chart bodies keep
+        // flex-1 + scroll and size to their content.
+        bodyAspect
+          ? 'aspect-[var(--dash-aspect)] max-h-[var(--dash-max-h)] overflow-hidden xl:aspect-auto xl:max-h-none xl:flex-1'
+          : 'flex-1 overflow-y-auto',
         // minBodyHeight is a desktop load-shift guard (keeps skeleton + sparse
         // states the same height on the fixed grid). It's xl-only so the 1-col
         // mobile layout collapses empty/sparse widgets to their content instead.
@@ -395,7 +423,7 @@ function sizeKeyToSpan(key: string): WidgetSpan | null {
         densityPadding,
         dragging ? 'opacity-40 pointer-events-none' : '',
       ]"
-      :style="minBodyHeight ? { '--dash-min-body': minBodyHeight } : undefined"
+      :style="bodyStyle"
     >
       <!--
         State machine for the body: skeleton → (error | empty | data).

--- a/frontend/src/views/dashboard/WidgetFrame.vue
+++ b/frontend/src/views/dashboard/WidgetFrame.vue
@@ -57,6 +57,9 @@ const props = defineProps<{
   /** Fluent key for the title rendered in the frame-supplied shell.
    *  Required when `frameWraps` is `true`. */
   frameTitleKey?: string
+  /** CSS `aspect-ratio` for a plotted-chart body, forwarded to the
+   *  frame-supplied shell. See `DashboardWidgetShell.bodyAspect`. */
+  bodyAspect?: string
 }>()
 
 const emit = defineEmits<{
@@ -90,6 +93,7 @@ provide(DASHBOARD_WIDGET_CONTEXT, context)
     <DashboardWidgetShell
       v-if="frameWraps && frameTitleKey"
       :title="fluent.$t(frameTitleKey)"
+      :body-aspect="bodyAspect"
     >
       <component :is="component" v-bind="widgetProps ?? {}" />
     </DashboardWidgetShell>

--- a/frontend/src/views/dashboard/charts/VolumeKpiRail.vue
+++ b/frontend/src/views/dashboard/charts/VolumeKpiRail.vue
@@ -67,7 +67,10 @@ defineProps<{
         </span>
       </div>
 
-      <div class="flex-1 min-h-0 flex flex-col justify-end py-0.5">
+      <!-- Sparkline: a bounded strip on the stacked layout (gives the rail an
+           intrinsic height so it sizes to content and never collapses), but
+           grows to fill the card on the xl lattice. -->
+      <div class="h-10 xl:h-auto xl:flex-1 min-h-0 flex flex-col justify-end py-0.5">
         <SparklineChart
           v-if="stat.sparkline?.length"
           fluid

--- a/frontend/src/views/dashboard/widgets.ts
+++ b/frontend/src/views/dashboard/widgets.ts
@@ -129,6 +129,14 @@ export interface WidgetDef {
    * working unchanged.
    */
   frameWraps?: boolean
+  /**
+   * CSS `aspect-ratio` (e.g. `'2 / 1'`) for a PLOTTED-chart widget whose body
+   * has no intrinsic height (LineChart, heatmap). Passed to the shell so the
+   * plot derives its height from width on the stacked mobile layout instead of
+   * collapsing, and fills its row on the xl lattice. Omit for KPI tiles / lists
+   * (they size to their content). See `DashboardWidgetShell.bodyAspect`.
+   */
+  bodyAspect?: string
 }
 
 /** Page-chrome elements that widgets may depend on. */
@@ -209,6 +217,7 @@ export const WIDGET_REGISTRY: WidgetDef[] = [
     roles: ['technician', 'admin'],
     chromeDependencies: ['time-range', 'compare'],
     frameWraps: true,
+    bodyAspect: '2 / 1',
   },
   {
     id: 'volume-by-category',


### PR DESCRIPTION
## Responsive chart sizing on the dashboard

Fixes plotted-chart widgets (the "Tickets over time" LineChart) drawing nothing on the stacked mobile/1-column layout, and the whack-a-mole sizing that followed.

### Root cause
A plotted chart has no intrinsic height — it fills its container and measures it via ResizeObserver. On the stacked layout the grid row is `auto` (indefinite), so the chart's `height:100%` chain resolves to 0 (hard collapse on iOS WebKit; inconsistent/oversized on Blink). Forcing a pixel height onto the card fixed the collapse but fought the grid — charts overflowed or came out the wrong size across breakpoints, and different widgets needed different pixels.

### Fix — `aspect-ratio`, the idiomatic responsive-chart pattern
Give chart bodies a CSS `aspect-ratio` (declared per chart *type*, not per-widget pixels):
- **Mobile (auto-rows, indefinite height):** aspect-ratio derives the plot height from the always-known column width → never collapses, no pixel hack.
- **xl lattice (definite row height):** the body fills the row (`flex-1`) and aspect-ratio *self-disables* — it only applies when a dimension is `auto` (per MDN). Capped at the widget's own rowSpan height so a wide 1-column card can't produce a giant plot.

This is what Chart.js (`maintainAspectRatio`), Recharts (`ResponsiveContainer aspect`) and Grafana do, and it sidesteps the WebKit percent-height collapse because it manufactures a height from width instead of inheriting one. Verified in both Chrome and Safari/WebKit before implementing.

Wiring: new `bodyAspect` prop on `DashboardWidgetShell`, declared in the widget registry (`bodyAspect: '2 / 1'` on the LineChart), threaded through `DashboardGrid` → `WidgetFrame`.

### KPI rail handled differently
The ticket-volume KPI rail has real intrinsic content (the numbers), so it sizes to content — no aspect box, no forced height. Its sparkline is a bounded strip on the stacked layout (giving the rail an intrinsic height so it never collapses) that grows to fill on the lattice.

### Testing
On device (iOS) + desktop 1-col + desktop 3-col: chart renders at ~2:1 on mobile, fills its cell on the lattice, no overflow, KPI rail compact with visible sparklines. type-check + build green.