### PR TITLE
feat(dev): add make seed-demo realistic demo-data seeder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ LDAP_COMPOSE := $(COMPOSE) -f compose.ldap-test.yaml
 .DEFAULT_GOAL := help
 
 .PHONY: help dev dev-bg dev-lan dev-bg-lan watch down clean clean-db restart restart-frontend migrate schema \
-        test test-frontend logs logs-frontend shell psql mailpit token \
+        test test-frontend logs logs-frontend shell psql mailpit token seed-demo \
         ldap-test ldap-test-down install-hooks
 
 help: ## Show this help message
@@ -103,6 +103,15 @@ migrate: ## Run pending diesel migrations
 schema: ## Regenerate backend/src/schema.rs from the live DB
 	$(COMPOSE) exec nosdesk sh -c 'DATABASE_URL="$${MIGRATION_DATABASE_URL:-$$DATABASE_URL}" RUST_LOG=off diesel print-schema 2>/dev/null' > backend/src/schema.rs
 	@echo "Regenerated backend/src/schema.rs"
+
+# Seed a realistic demo dataset (users/projects/tickets/devices) plus a year
+# of backdated history (for the activity graph) into the running dev stack's
+# bootstrap workspace. Requires onboarding to be complete (an admin user must
+# exist). Idempotent: skips if already seeded. Reset with make clean-db, then
+# re-run onboarding and this target. Set SEED_HISTORY=off for a lighter seed
+# without the year of history.
+seed-demo: ## Seed demo helpdesk data into the running dev stack
+	$(COMPOSE) exec nosdesk cargo run --bin seed_demo
 
 # (Re)provision the nosdesk_app LOGIN role on an EXISTING dev DB, for the
 # dev/prod parity flip without a full `make clean`. init-db-dev.sh does this

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -18,6 +18,10 @@ path = "src/bin/import_tickets.rs"
 name = "nosdesk-cli"
 path = "src/bin/nosdesk_cli.rs"
 
+[[bin]]
+name = "seed_demo"
+path = "src/bin/seed_demo.rs"
+
 [dependencies]
 actix-web = "4.9.0"
 diesel = { version = "2.2.0", features = ["postgres", "r2d2", "chrono", "serde_json", "uuid", "network-address", "numeric"] }

--- a/backend/seeds/demo-history.json
+++ b/backend/seeds/demo-history.json
@@ -1,0 +1,2414 @@
+{
+ "tickets": [
+  {
+   "title": "Laptop won't charge",
+   "category": "Support",
+   "priority": "high"
+  },
+  {
+   "title": "Dell XPS 13 screen flickering",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "ThinkPad battery drains too fast",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "Keyboard keys sticking randomly",
+   "category": "Support",
+   "priority": "low"
+  },
+  {
+   "title": "Trackpad not responding - LT-0091",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "Desktop fans making loud noise",
+   "category": "Support",
+   "priority": "low"
+  },
+  {
+   "title": "Monitor won't wake from sleep",
+   "category": "Support",
+   "priority": "low"
+  },
+  {
+   "title": "Laptop overheating during use",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "HP EliteBook blue screen on boot",
+   "category": "Bug",
+   "priority": "urgent"
+  },
+  {
+   "title": "USB-C port loose won't charge",
+   "category": "Support",
+   "priority": "high"
+  },
+  {
+   "title": "Laptop screen black with backlight on",
+   "category": "Support",
+   "priority": "high"
+  },
+  {
+   "title": "Keyboard stopped working mid-day",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "External monitor not detected - DT-0156",
+   "category": "Support",
+   "priority": "low"
+  },
+  {
+   "title": "Laptop freezing with loud fans",
+   "category": "Bug",
+   "priority": "medium"
+  },
+  {
+   "title": "Battery shows unknown status",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "MacBook trackpad unresponsive",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "Desktop won't power on - DT-0203",
+   "category": "Support",
+   "priority": "urgent"
+  },
+  {
+   "title": "Laptop speaker crackling",
+   "category": "Support",
+   "priority": "low"
+  },
+  {
+   "title": "Graphics card fan grinding",
+   "category": "Support",
+   "priority": "high"
+  },
+  {
+   "title": "Won't boot past BIOS screen",
+   "category": "Bug",
+   "priority": "urgent"
+  },
+  {
+   "title": "RAM slot 2 not recognized - DT-0089",
+   "category": "Support",
+   "priority": "high"
+  },
+  {
+   "title": "Laptop display cable damaged",
+   "category": "Support",
+   "priority": "high"
+  },
+  {
+   "title": "Keyboard auto-repeat stuck on",
+   "category": "Support",
+   "priority": "low"
+  },
+  {
+   "title": "Dell monitor has color banding",
+   "category": "Bug",
+   "priority": "low"
+  },
+  {
+   "title": "Laptop hinges cracked",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "Power button stuck - LT-0167",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "Hard drive making clicking sounds",
+   "category": "Support",
+   "priority": "urgent"
+  },
+  {
+   "title": "ThinkPad won't hold charge",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "Desktop PSU fan not spinning",
+   "category": "Support",
+   "priority": "high"
+  },
+  {
+   "title": "Laptop cooling paste dried out",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "Monitor keeps switching inputs",
+   "category": "Support",
+   "priority": "low"
+  },
+  {
+   "title": "USB hub not recognizing devices",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "Laptop won't enter sleep mode",
+   "category": "Bug",
+   "priority": "low"
+  },
+  {
+   "title": "Screen dims randomly - LT-0245",
+   "category": "Support",
+   "priority": "low"
+  },
+  {
+   "title": "Keyboard water damaged",
+   "category": "Support",
+   "priority": "high"
+  },
+  {
+   "title": "Desktop keeps rebooting unexpectedly",
+   "category": "Bug",
+   "priority": "high"
+  },
+  {
+   "title": "Touchscreen not responding",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "HDMI port 3 not working - DT-0167",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "Fan speed not adjustable in BIOS",
+   "category": "Support",
+   "priority": "low"
+  },
+  {
+   "title": "Laptop won't connect to charger",
+   "category": "Support",
+   "priority": "high"
+  },
+  {
+   "title": "No graphics output signal detected",
+   "category": "Support",
+   "priority": "high"
+  },
+  {
+   "title": "System boots to black screen only",
+   "category": "Bug",
+   "priority": "high"
+  },
+  {
+   "title": "Memory test fails on slot 1",
+   "category": "Support",
+   "priority": "urgent"
+  },
+  {
+   "title": "Screen has vertical display lines",
+   "category": "Bug",
+   "priority": "medium"
+  },
+  {
+   "title": "Numpad not working - LT-0198",
+   "category": "Support",
+   "priority": "low"
+  },
+  {
+   "title": "Desktop thermal throttling performance",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "Optical drive won't eject disc",
+   "category": "Support",
+   "priority": "low"
+  },
+  {
+   "title": "Battery calibration issue",
+   "category": "Support",
+   "priority": "low"
+  },
+  {
+   "title": "Hard drive failure imminent warning",
+   "category": "Support",
+   "priority": "urgent"
+  },
+  {
+   "title": "ThinkPad charger port broken",
+   "category": "Support",
+   "priority": "high"
+  },
+  {
+   "title": "Monitor flickering constantly",
+   "category": "Bug",
+   "priority": "medium"
+  },
+  {
+   "title": "CPU fan stopped spinning",
+   "category": "Support",
+   "priority": "urgent"
+  },
+  {
+   "title": "SSD not detected on startup",
+   "category": "Bug",
+   "priority": "high"
+  },
+  {
+   "title": "Trackpad button broken - LT-0267",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "Power supply making clicking noise",
+   "category": "Support",
+   "priority": "high"
+  },
+  {
+   "title": "Screen blacks out under heavy load",
+   "category": "Bug",
+   "priority": "medium"
+  },
+  {
+   "title": "Keyboard backlight very dim",
+   "category": "Support",
+   "priority": "none"
+  },
+  {
+   "title": "Motherboard capacitor bulging visibly",
+   "category": "Support",
+   "priority": "high"
+  },
+  {
+   "title": "Battery won't recalibrate properly",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "Fan bearings worn out",
+   "category": "Support",
+   "priority": "low"
+  },
+  {
+   "title": "Can't install Microsoft Office - license issue",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "Zoom keeps crashing during calls",
+   "category": "Bug",
+   "priority": "high"
+  },
+  {
+   "title": "Teams won't load properly",
+   "category": "Bug",
+   "priority": "high"
+  },
+  {
+   "title": "Adobe Creative Suite installation failed",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "Windows 11 update stuck on installation",
+   "category": "Support",
+   "priority": "high"
+  },
+  {
+   "title": "Need VPN client for remote work",
+   "category": "Support",
+   "priority": "none"
+  },
+  {
+   "title": "Slack app keeps disconnecting",
+   "category": "Bug",
+   "priority": "medium"
+  },
+  {
+   "title": "Excel crashes when opening large files",
+   "category": "Bug",
+   "priority": "high"
+  },
+  {
+   "title": "Chrome browser freezing randomly",
+   "category": "Bug",
+   "priority": "medium"
+  },
+  {
+   "title": "Need to upgrade to Office 365",
+   "category": "Feature request",
+   "priority": "low"
+  },
+  {
+   "title": "Printer driver not working after Windows update",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "Outlook sync issues on Mac",
+   "category": "Bug",
+   "priority": "medium"
+  },
+  {
+   "title": "Adobe Reader won't open PDF files",
+   "category": "Bug",
+   "priority": "medium"
+  },
+  {
+   "title": "Request software license for new hire",
+   "category": "Support",
+   "priority": "none"
+  },
+  {
+   "title": "Windows update causing login issues",
+   "category": "Support",
+   "priority": "high"
+  },
+  {
+   "title": "Zoom license renewal needed",
+   "category": "Feature request",
+   "priority": "low"
+  },
+  {
+   "title": "Teams meeting audio not working",
+   "category": "Bug",
+   "priority": "high"
+  },
+  {
+   "title": "macOS Big Sur installation problems",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "Slack notifications not showing",
+   "category": "Bug",
+   "priority": "low"
+  },
+  {
+   "title": "Firefox slow on startup",
+   "category": "Bug",
+   "priority": "low"
+  },
+  {
+   "title": "Need license for Adobe Photoshop",
+   "category": "Feature request",
+   "priority": "low"
+  },
+  {
+   "title": "Outlook crashing on startup",
+   "category": "Bug",
+   "priority": "high"
+  },
+  {
+   "title": "VPN disconnects every few minutes",
+   "category": "Bug",
+   "priority": "high"
+  },
+  {
+   "title": "Teams screen sharing not working",
+   "category": "Bug",
+   "priority": "high"
+  },
+  {
+   "title": "Zoom recording feature not available",
+   "category": "Support",
+   "priority": "low"
+  },
+  {
+   "title": "Windows Defender blocking software installation",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "Need to downgrade Office version",
+   "category": "Support",
+   "priority": "low"
+  },
+  {
+   "title": "Chrome extensions not loading",
+   "category": "Bug",
+   "priority": "medium"
+  },
+  {
+   "title": "Adobe Acrobat Pro license key needed",
+   "category": "Feature request",
+   "priority": "none"
+  },
+  {
+   "title": "Slack cannot attach files",
+   "category": "Bug",
+   "priority": "medium"
+  },
+  {
+   "title": "Teams chat history not syncing",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "macOS Ventura compatibility issue with app",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "Outlook not connecting to email",
+   "category": "Bug",
+   "priority": "urgent"
+  },
+  {
+   "title": "Zoom webinar registration not working",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "Windows taskbar applications crashing",
+   "category": "Bug",
+   "priority": "high"
+  },
+  {
+   "title": "Need Microsoft Project license",
+   "category": "Feature request",
+   "priority": "low"
+  },
+  {
+   "title": "Teams background blur feature missing",
+   "category": "Support",
+   "priority": "low"
+  },
+  {
+   "title": "VPN client installation issues",
+   "category": "Support",
+   "priority": "high"
+  },
+  {
+   "title": "Adobe InDesign won't launch",
+   "category": "Bug",
+   "priority": "medium"
+  },
+  {
+   "title": "Slack workspace sync problem",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "Teams recording not saving",
+   "category": "Bug",
+   "priority": "high"
+  },
+  {
+   "title": "Windows installation media needed",
+   "category": "Support",
+   "priority": "none"
+  },
+  {
+   "title": "Outlook delegate access not working",
+   "category": "Bug",
+   "priority": "medium"
+  },
+  {
+   "title": "Zoom host settings not saving",
+   "category": "Bug",
+   "priority": "low"
+  },
+  {
+   "title": "Chrome password manager not syncing",
+   "category": "Bug",
+   "priority": "low"
+  },
+  {
+   "title": "Need license for CAD application",
+   "category": "Feature request",
+   "priority": "low"
+  },
+  {
+   "title": "Teams presence status always offline",
+   "category": "Bug",
+   "priority": "medium"
+  },
+  {
+   "title": "Slack integrations failing",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "Windows network drivers need update",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "Adobe Lightroom crashing on export",
+   "category": "Bug",
+   "priority": "medium"
+  },
+  {
+   "title": "Outlook categories disappeared",
+   "category": "Support",
+   "priority": "low"
+  },
+  {
+   "title": "Zoom license conflict with Teams",
+   "category": "Support",
+   "priority": "low"
+  },
+  {
+   "title": "macOS System Preferences crashing",
+   "category": "Bug",
+   "priority": "medium"
+  },
+  {
+   "title": "Teams mobile app not sending messages",
+   "category": "Bug",
+   "priority": "medium"
+  },
+  {
+   "title": "VPN authentication failing intermittently",
+   "category": "Bug",
+   "priority": "high"
+  },
+  {
+   "title": "Outlook PST file too large",
+   "category": "Support",
+   "priority": "low"
+  },
+  {
+   "title": "Zoom virtual background not working",
+   "category": "Bug",
+   "priority": "low"
+  },
+  {
+   "title": "Teams calendar not displaying events",
+   "category": "Bug",
+   "priority": "medium"
+  },
+  {
+   "title": "Windows 10 security update pending",
+   "category": "Support",
+   "priority": "none"
+  },
+  {
+   "title": "Slack search function broken",
+   "category": "Bug",
+   "priority": "low"
+  },
+  {
+   "title": "Can't log in - password reset needed",
+   "category": "Support",
+   "priority": "high"
+  },
+  {
+   "title": "Account locked after failed login attempts",
+   "category": "Support",
+   "priority": "urgent"
+  },
+  {
+   "title": "Forgot password and need immediate access",
+   "category": "Support",
+   "priority": "high"
+  },
+  {
+   "title": "Password reset email not received",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "Can't unlock account myself",
+   "category": "Support",
+   "priority": "urgent"
+  },
+  {
+   "title": "Need help enrolling in MFA",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "Lost access to authenticator app",
+   "category": "Support",
+   "priority": "high"
+  },
+  {
+   "title": "MFA backup codes not working",
+   "category": "Support",
+   "priority": "high"
+  },
+  {
+   "title": "Recovery phone number needs updating",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "Authenticator showing code invalid error",
+   "category": "Support",
+   "priority": "high"
+  },
+  {
+   "title": "Can't scan MFA QR code on phone",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "Need access to Finance shared drive",
+   "category": "Feature request",
+   "priority": "low"
+  },
+  {
+   "title": "Add me to Marketing distribution list",
+   "category": "Feature request",
+   "priority": "low"
+  },
+  {
+   "title": "Request write access to project folder",
+   "category": "Feature request",
+   "priority": "low"
+  },
+  {
+   "title": "Need elevated permissions for new role",
+   "category": "Feature request",
+   "priority": "medium"
+  },
+  {
+   "title": "Add to executive announcements group",
+   "category": "Feature request",
+   "priority": "low"
+  },
+  {
+   "title": "Can't access team shared drive",
+   "category": "Support",
+   "priority": "high"
+  },
+  {
+   "title": "Permission denied on shared folder",
+   "category": "Support",
+   "priority": "high"
+  },
+  {
+   "title": "Shared drive folder disappeared from view",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "SSO login not working",
+   "category": "Support",
+   "priority": "high"
+  },
+  {
+   "title": "Microsoft login button not responding",
+   "category": "Bug",
+   "priority": "high"
+  },
+  {
+   "title": "Single sign-on redirect loop occurring",
+   "category": "Bug",
+   "priority": "high"
+  },
+  {
+   "title": "SSO session expired - need to re-authenticate",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "Company SSO not recognized by system",
+   "category": "Bug",
+   "priority": "medium"
+  },
+  {
+   "title": "OAuth token expired error",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "Can't link SSO account to application",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "SSO authentication timing out consistently",
+   "category": "Bug",
+   "priority": "medium"
+  },
+  {
+   "title": "Need software license assignment",
+   "category": "Feature request",
+   "priority": "medium"
+  },
+  {
+   "title": "License seat limit reached",
+   "category": "Feature request",
+   "priority": "low"
+  },
+  {
+   "title": "Application license has expired",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "Assign Microsoft Office license to account",
+   "category": "Feature request",
+   "priority": "low"
+  },
+  {
+   "title": "Reassign license to new employee",
+   "category": "Feature request",
+   "priority": "low"
+  },
+  {
+   "title": "Need additional license seats",
+   "category": "Feature request",
+   "priority": "low"
+  },
+  {
+   "title": "Account appears to be disabled",
+   "category": "Support",
+   "priority": "urgent"
+  },
+  {
+   "title": "Need to reactivate deactivated account",
+   "category": "Support",
+   "priority": "high"
+  },
+  {
+   "title": "Contractor account should be disabled",
+   "category": "Support",
+   "priority": "high"
+  },
+  {
+   "title": "Former employee account still active",
+   "category": "Support",
+   "priority": "high"
+  },
+  {
+   "title": "Account requires reactivation after closure",
+   "category": "Support",
+   "priority": "high"
+  },
+  {
+   "title": "Create new user account for hire",
+   "category": "Feature request",
+   "priority": "low"
+  },
+  {
+   "title": "Email forwarding not set up",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "Delete my old user account",
+   "category": "Feature request",
+   "priority": "none"
+  },
+  {
+   "title": "Merge duplicate user accounts",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "Export my account data",
+   "category": "Feature request",
+   "priority": "none"
+  },
+  {
+   "title": "Need account security review",
+   "category": "Support",
+   "priority": "low"
+  },
+  {
+   "title": "Suspicious login activity on my account",
+   "category": "Support",
+   "priority": "urgent"
+  },
+  {
+   "title": "Reset login attempt counter",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "Account needs security verification",
+   "category": "Support",
+   "priority": "high"
+  },
+  {
+   "title": "Temporary contractor access request",
+   "category": "Feature request",
+   "priority": "low"
+  },
+  {
+   "title": "Access needed for archived project files",
+   "category": "Feature request",
+   "priority": "low"
+  },
+  {
+   "title": "Can't change authenticator to new device",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "Password reset link has expired",
+   "category": "Support",
+   "priority": "high"
+  },
+  {
+   "title": "Account locked - need immediate help",
+   "category": "Support",
+   "priority": "urgent"
+  },
+  {
+   "title": "Permission denied on HR folder access",
+   "category": "Support",
+   "priority": "high"
+  },
+  {
+   "title": "Need read access to policies folder",
+   "category": "Feature request",
+   "priority": "low"
+  },
+  {
+   "title": "Admin access to department folder needed",
+   "category": "Feature request",
+   "priority": "medium"
+  },
+  {
+   "title": "Restore access after security incident",
+   "category": "Support",
+   "priority": "urgent"
+  },
+  {
+   "title": "SSO timeout during login attempt",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "Can't update recovery credentials",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "Authentication failing for web application",
+   "category": "Support",
+   "priority": "high"
+  },
+  {
+   "title": "Access needed to compliance documentation",
+   "category": "Feature request",
+   "priority": "medium"
+  },
+  {
+   "title": "Password requirements unclear - help needed",
+   "category": "Support",
+   "priority": "low"
+  },
+  {
+   "title": "VPN disconnections during business hours",
+   "category": "Bug",
+   "priority": "high"
+  },
+  {
+   "title": "Building A WiFi drops every 15 minutes",
+   "category": "Bug",
+   "priority": "high"
+  },
+  {
+   "title": "3rd floor WiFi dead zone near auditorium",
+   "category": "Feature request",
+   "priority": "medium"
+  },
+  {
+   "title": "Cannot establish VPN connection",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "Ethernet port on desk not responding",
+   "category": "Support",
+   "priority": "low"
+  },
+  {
+   "title": "Guest WiFi network down",
+   "category": "Bug",
+   "priority": "high"
+  },
+  {
+   "title": "Slow file transfers to shared drive",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "DNS resolution failures occurring intermittently",
+   "category": "Bug",
+   "priority": "high"
+  },
+  {
+   "title": "2nd floor WiFi experiencing constant drops",
+   "category": "Bug",
+   "priority": "high"
+  },
+  {
+   "title": "Home office VPN connection unstable",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "Access point by copy machine offline",
+   "category": "Support",
+   "priority": "low"
+  },
+  {
+   "title": "Network switch in server room overheating",
+   "category": "Bug",
+   "priority": "urgent"
+  },
+  {
+   "title": "Slow network connectivity in sales department",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "Break room WiFi password rejected",
+   "category": "Support",
+   "priority": "low"
+  },
+  {
+   "title": "WiFi disconnects when moving between rooms",
+   "category": "Bug",
+   "priority": "medium"
+  },
+  {
+   "title": "Guest WiFi requiring credential reset",
+   "category": "Support",
+   "priority": "low"
+  },
+  {
+   "title": "Ethernet cable loose under desk",
+   "category": "Support",
+   "priority": "low"
+  },
+  {
+   "title": "Building B entire network outage",
+   "category": "Bug",
+   "priority": "urgent"
+  },
+  {
+   "title": "DNS server response times slow",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "VPN latency causing video call failures",
+   "category": "Bug",
+   "priority": "high"
+  },
+  {
+   "title": "WiFi coverage gap between east and west wings",
+   "category": "Feature request",
+   "priority": "medium"
+  },
+  {
+   "title": "Network drive mapping fails on login",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "Cannot reach file server over wireless",
+   "category": "Bug",
+   "priority": "high"
+  },
+  {
+   "title": "East wing WiFi connection unreliable",
+   "category": "Bug",
+   "priority": "medium"
+  },
+  {
+   "title": "Ethernet LED lights not active",
+   "category": "Support",
+   "priority": "low"
+  },
+  {
+   "title": "Guest WiFi bandwidth insufficient",
+   "category": "Feature request",
+   "priority": "low"
+  },
+  {
+   "title": "Network switch firmware update available",
+   "category": "Support",
+   "priority": "none"
+  },
+  {
+   "title": "WiFi channels congested causing weak signal",
+   "category": "Feature request",
+   "priority": "medium"
+  },
+  {
+   "title": "VPN session idle timeout too short",
+   "category": "Bug",
+   "priority": "medium"
+  },
+  {
+   "title": "Conference room 401 WiFi spotty",
+   "category": "Bug",
+   "priority": "high"
+  },
+  {
+   "title": "DNS internal hostname resolution broken",
+   "category": "Bug",
+   "priority": "high"
+  },
+  {
+   "title": "4th floor network printer unreachable",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "WiFi authentication loop on connect",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "Floor 5 internet completely down",
+   "category": "Bug",
+   "priority": "urgent"
+  },
+  {
+   "title": "Fiber optic cable cut in main conduit",
+   "category": "Bug",
+   "priority": "urgent"
+  },
+  {
+   "title": "Corporate VPN extremely slow tonight",
+   "category": "Support",
+   "priority": "high"
+  },
+  {
+   "title": "Network switch port flapping continuously",
+   "category": "Bug",
+   "priority": "high"
+  },
+  {
+   "title": "WiFi MAC address being blocked",
+   "category": "Support",
+   "priority": "low"
+  },
+  {
+   "title": "Guest network setup needed for Building C",
+   "category": "Feature request",
+   "priority": "none"
+  },
+  {
+   "title": "Network latency impacting database queries",
+   "category": "Support",
+   "priority": "high"
+  },
+  {
+   "title": "WiFi drops only on iPhones and iPads",
+   "category": "Bug",
+   "priority": "medium"
+  },
+  {
+   "title": "Network router needs reboot unresponsive",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "DNS cache issue causing old IPs returned",
+   "category": "Bug",
+   "priority": "high"
+  },
+  {
+   "title": "Main office WiFi network completely offline",
+   "category": "Bug",
+   "priority": "urgent"
+  },
+  {
+   "title": "Gigabit ethernet negotiating at 100Mbps",
+   "category": "Support",
+   "priority": "low"
+  },
+  {
+   "title": "Meeting room 210 WiFi weak in corners",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "Load balancer failover not working",
+   "category": "Bug",
+   "priority": "urgent"
+  },
+  {
+   "title": "VPN gateway timeout on large file uploads",
+   "category": "Bug",
+   "priority": "high"
+  },
+  {
+   "title": "Guest WiFi SSID broadcast disabled",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "Network firewall ACL blocking external access",
+   "category": "Bug",
+   "priority": "high"
+  },
+  {
+   "title": "WiFi interference from nearby microwave oven",
+   "category": "Feature request",
+   "priority": "medium"
+  },
+  {
+   "title": "Shared drives inaccessible via wireless",
+   "category": "Bug",
+   "priority": "high"
+  },
+  {
+   "title": "Ethernet switch needs security patch",
+   "category": "Support",
+   "priority": "low"
+  },
+  {
+   "title": "VPN split tunneling configuration broken",
+   "category": "Bug",
+   "priority": "medium"
+  },
+  {
+   "title": "WiFi extender range does not cover hallway",
+   "category": "Feature request",
+   "priority": "low"
+  },
+  {
+   "title": "Network outage across multiple departments",
+   "category": "Bug",
+   "priority": "urgent"
+  },
+  {
+   "title": "DNS lookups taking over 5 seconds",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "South side 1st floor WiFi no coverage",
+   "category": "Bug",
+   "priority": "high"
+  },
+  {
+   "title": "VPN certificate expiration warning received",
+   "category": "Support",
+   "priority": "none"
+  },
+  {
+   "title": "Ethernet link drops under heavy load",
+   "category": "Bug",
+   "priority": "medium"
+  },
+  {
+   "title": "Outlook won't sync new emails to mobile device",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "Email stuck in outbox not sending",
+   "category": "Support",
+   "priority": "high"
+  },
+  {
+   "title": "Outlook search returning no results",
+   "category": "Bug",
+   "priority": "low"
+  },
+  {
+   "title": "Outlook add-in not loading",
+   "category": "Support",
+   "priority": "high"
+  },
+  {
+   "title": "Outlook performance very slow with large mailbox",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "Outlook certificate error on Mac",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "Outlook cache corrupted",
+   "category": "Bug",
+   "priority": "medium"
+  },
+  {
+   "title": "Outlook password not accepted on startup",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "Outlook calendar not syncing across devices",
+   "category": "Bug",
+   "priority": "medium"
+  },
+  {
+   "title": "Offline Outlook mode not working",
+   "category": "Bug",
+   "priority": "medium"
+  },
+  {
+   "title": "Cannot export mailbox to PST file",
+   "category": "Support",
+   "priority": "low"
+  },
+  {
+   "title": "Outlook notification not showing new mail",
+   "category": "Support",
+   "priority": "low"
+  },
+  {
+   "title": "Shared mailbox permissions not working",
+   "category": "Support",
+   "priority": "high"
+  },
+  {
+   "title": "Unable to access shared mailbox",
+   "category": "Support",
+   "priority": "high"
+  },
+  {
+   "title": "Shared mailbox missing from Outlook",
+   "category": "Support",
+   "priority": "high"
+  },
+  {
+   "title": "Shared mailbox showing wrong member list",
+   "category": "Bug",
+   "priority": "medium"
+  },
+  {
+   "title": "Send as permission denied",
+   "category": "Support",
+   "priority": "high"
+  },
+  {
+   "title": "Cannot add delegate to mailbox",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "Delegate can't see shared folders",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "Duplicate emails appearing in shared mailbox",
+   "category": "Bug",
+   "priority": "low"
+  },
+  {
+   "title": "Shared mailbox not receiving external emails",
+   "category": "Bug",
+   "priority": "high"
+  },
+  {
+   "title": "Access to shared mailbox suddenly revoked",
+   "category": "Support",
+   "priority": "high"
+  },
+  {
+   "title": "Calendar invite not appearing on recipients calendar",
+   "category": "Bug",
+   "priority": "medium"
+  },
+  {
+   "title": "Teams meeting invite missing from Outlook",
+   "category": "Bug",
+   "priority": "medium"
+  },
+  {
+   "title": "Meeting room calendar showing as unavailable",
+   "category": "Bug",
+   "priority": "medium"
+  },
+  {
+   "title": "Cannot open meeting invites in Teams",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "Calendar showing duplicate meetings",
+   "category": "Bug",
+   "priority": "low"
+  },
+  {
+   "title": "Scheduled Teams meeting not in calendar",
+   "category": "Bug",
+   "priority": "medium"
+  },
+  {
+   "title": "Meeting invites going to spam folder",
+   "category": "Bug",
+   "priority": "medium"
+  },
+  {
+   "title": "Meeting reminders not triggering",
+   "category": "Support",
+   "priority": "low"
+  },
+  {
+   "title": "OneDrive sync stuck on Windows 10",
+   "category": "Bug",
+   "priority": "medium"
+  },
+  {
+   "title": "SharePoint document sync failing",
+   "category": "Bug",
+   "priority": "medium"
+  },
+  {
+   "title": "OneDrive showing old version of files",
+   "category": "Bug",
+   "priority": "low"
+  },
+  {
+   "title": "Teams files folder missing from OneDrive",
+   "category": "Bug",
+   "priority": "medium"
+  },
+  {
+   "title": "OneDrive deleted file recovery",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "Cannot access OneDrive on Linux",
+   "category": "Support",
+   "priority": "low"
+  },
+  {
+   "title": "SharePoint sync icon spinning continuously",
+   "category": "Bug",
+   "priority": "medium"
+  },
+  {
+   "title": "Email delivery delayed 30+ minutes",
+   "category": "Bug",
+   "priority": "high"
+  },
+  {
+   "title": "Distribution list not expanding in compose",
+   "category": "Bug",
+   "priority": "medium"
+  },
+  {
+   "title": "Distribution list members not receiving emails",
+   "category": "Bug",
+   "priority": "high"
+  },
+  {
+   "title": "Mail forwarding rules not executing",
+   "category": "Bug",
+   "priority": "medium"
+  },
+  {
+   "title": "Distribution list bounce-back errors",
+   "category": "Bug",
+   "priority": "high"
+  },
+  {
+   "title": "Email forwarding to external domain failing",
+   "category": "Bug",
+   "priority": "high"
+  },
+  {
+   "title": "Mail flow rules affecting all users",
+   "category": "Bug",
+   "priority": "high"
+  },
+  {
+   "title": "Attachment corrupted after upload",
+   "category": "Bug",
+   "priority": "medium"
+  },
+  {
+   "title": "Cannot reply to encrypted emails",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "Mailbox storage full, can't send or receive",
+   "category": "Support",
+   "priority": "urgent"
+  },
+  {
+   "title": "Email signature not applying correctly",
+   "category": "Support",
+   "priority": "low"
+  },
+  {
+   "title": "Teams chat messages not delivering",
+   "category": "Bug",
+   "priority": "high"
+  },
+  {
+   "title": "Teams call audio not working in meetings",
+   "category": "Support",
+   "priority": "high"
+  },
+  {
+   "title": "Teams presence showing offline when online",
+   "category": "Bug",
+   "priority": "low"
+  },
+  {
+   "title": "Teams meeting recording not saving to OneDrive",
+   "category": "Bug",
+   "priority": "medium"
+  },
+  {
+   "title": "Teams chat search not finding messages",
+   "category": "Bug",
+   "priority": "low"
+  },
+  {
+   "title": "Teams background blur not working",
+   "category": "Support",
+   "priority": "low"
+  },
+  {
+   "title": "Cannot share screen in Teams meeting",
+   "category": "Support",
+   "priority": "high"
+  },
+  {
+   "title": "Out of office auto-reply not triggering",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "Cannot change email display name",
+   "category": "Support",
+   "priority": "low"
+  },
+  {
+   "title": "Archive mailbox not accessible",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "Create new distribution list",
+   "category": "Feature request",
+   "priority": "none"
+  },
+  {
+   "title": "Set up resource mailbox for conference room",
+   "category": "Feature request",
+   "priority": "none"
+  },
+  {
+   "title": "New shared mailbox setup request",
+   "category": "Feature request",
+   "priority": "none"
+  },
+  {
+   "title": "Suspicious email asking to reset password",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "Phishing email pretending to be from IT support",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "Received invoice email with suspicious attachment",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "Antivirus flagged a file as trojan on my laptop",
+   "category": "Support",
+   "priority": "high"
+  },
+  {
+   "title": "Login alert from unfamiliar country",
+   "category": "Support",
+   "priority": "urgent"
+  },
+  {
+   "title": "Account locked after multiple failed login attempts",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "Laptop stolen from car overnight",
+   "category": "Support",
+   "priority": "urgent"
+  },
+  {
+   "title": "Lost company phone at airport",
+   "category": "Support",
+   "priority": "urgent"
+  },
+  {
+   "title": "Unknown USB drive found in break room, is it safe to plug in",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "Policy question about using personal USB drives",
+   "category": "Support",
+   "priority": "low"
+  },
+  {
+   "title": "Sudden spike in spam emails to my inbox",
+   "category": "Support",
+   "priority": "low"
+  },
+  {
+   "title": "Coworker received email from my account I didn't send",
+   "category": "Support",
+   "priority": "high"
+  },
+  {
+   "title": "Suspicious pop-up claiming virus detected, asking to call number",
+   "category": "Support",
+   "priority": "high"
+  },
+  {
+   "title": "Ransomware warning message on shared drive",
+   "category": "Support",
+   "priority": "urgent"
+  },
+  {
+   "title": "Email claims my password was found in a data breach",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "Can't tell if this shipping notification email is legitimate",
+   "category": "Support",
+   "priority": "low"
+  },
+  {
+   "title": "Suspicious login attempt from a VPN IP address",
+   "category": "Support",
+   "priority": "high"
+  },
+  {
+   "title": "Antivirus definitions not updating on workstation",
+   "category": "Bug",
+   "priority": "medium"
+  },
+  {
+   "title": "Endpoint protection agent crashes on startup",
+   "category": "Bug",
+   "priority": "medium"
+  },
+  {
+   "title": "Request to enable multi-factor authentication reminder emails",
+   "category": "Feature request",
+   "priority": "low"
+  },
+  {
+   "title": "Suspicious text message requesting company login credentials",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "Malware alert blocked but computer still running slow",
+   "category": "Support",
+   "priority": "high"
+  },
+  {
+   "title": "Found unfamiliar device listed in my account's login history",
+   "category": "Support",
+   "priority": "high"
+  },
+  {
+   "title": "Request to block sender domain after repeated phishing attempts",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "Customer data may have been emailed to wrong recipient",
+   "category": "Support",
+   "priority": "urgent"
+  },
+  {
+   "title": "Shared file link appears publicly accessible",
+   "category": "Support",
+   "priority": "urgent"
+  },
+  {
+   "title": "Suspicious email requesting gift card purchase from CEO",
+   "category": "Support",
+   "priority": "high"
+  },
+  {
+   "title": "Fake login page mimicking company portal",
+   "category": "Support",
+   "priority": "high"
+  },
+  {
+   "title": "Question about acceptable use policy for personal devices",
+   "category": "Support",
+   "priority": "low"
+  },
+  {
+   "title": "Request for guidance on encrypting USB drives",
+   "category": "Support",
+   "priority": "low"
+  },
+  {
+   "title": "Antivirus quarantined a legitimate business file",
+   "category": "Bug",
+   "priority": "medium"
+  },
+  {
+   "title": "Unusual outbound network traffic detected from my machine",
+   "category": "Support",
+   "priority": "high"
+  },
+  {
+   "title": "Browser extension installed itself without permission",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "Email account sending spam to entire contact list",
+   "category": "Support",
+   "priority": "urgent"
+  },
+  {
+   "title": "Suspicious calendar invite with external tracking link",
+   "category": "Support",
+   "priority": "low"
+  },
+  {
+   "title": "Request to review permissions on shared cloud folder",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "Password manager flagged reused password across accounts",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "Phone displaying ads and redirects after app install",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "Suspicious QR code found on office door poster",
+   "category": "Support",
+   "priority": "low"
+  },
+  {
+   "title": "Request for company policy on reporting lost devices",
+   "category": "Support",
+   "priority": "low"
+  },
+  {
+   "title": "Firewall blocking legitimate vendor connection",
+   "category": "Bug",
+   "priority": "medium"
+  },
+  {
+   "title": "Employee clicked phishing link, unsure what to do next",
+   "category": "Support",
+   "priority": "urgent"
+  },
+  {
+   "title": "Old employee account still able to log in after departure",
+   "category": "Support",
+   "priority": "urgent"
+  },
+  {
+   "title": "Request to enable device encryption on all laptops",
+   "category": "Feature request",
+   "priority": "medium"
+  },
+  {
+   "title": "Suspicious charge on corporate card after online purchase",
+   "category": "Support",
+   "priority": "high"
+  },
+  {
+   "title": "Security camera footage shows unknown person entering server room",
+   "category": "Support",
+   "priority": "urgent"
+  },
+  {
+   "title": "Request for annual phishing awareness training",
+   "category": "Feature request",
+   "priority": "low"
+  },
+  {
+   "title": "MFA push notifications appearing without my action",
+   "category": "Support",
+   "priority": "urgent"
+  },
+  {
+   "title": "Spam filter not catching obvious phishing emails",
+   "category": "Bug",
+   "priority": "medium"
+  },
+  {
+   "title": "Request to add banner warning for external senders",
+   "category": "Feature request",
+   "priority": "medium"
+  },
+  {
+   "title": "Tablet left on train, needs remote wipe",
+   "category": "Support",
+   "priority": "urgent"
+  },
+  {
+   "title": "Unrecognized app requesting camera and microphone access",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "Vendor portal asking for credentials over unencrypted page",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "Suspicious login attempt blocked but want confirmation",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "Request to restrict USB port usage on shared workstations",
+   "category": "Feature request",
+   "priority": "medium"
+  },
+  {
+   "title": "Spam emails bypassing junk folder filters",
+   "category": "Support",
+   "priority": "low"
+  },
+  {
+   "title": "Data export request flagged as unusual activity",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "Request for guidance on securely disposing old hard drives",
+   "category": "Support",
+   "priority": "low"
+  },
+  {
+   "title": "Antivirus license expired on several machines",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "Suspicious wire transfer request via email impersonation",
+   "category": "Support",
+   "priority": "urgent"
+  },
+  {
+   "title": "Printer 2F-East paper jam",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "Out of black toner cartridge",
+   "category": "Support",
+   "priority": "low"
+  },
+  {
+   "title": "Conference room printer offline",
+   "category": "Support",
+   "priority": "high"
+  },
+  {
+   "title": "Monitor not detected after reboot",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "Docking station USB-C not charging",
+   "category": "Support",
+   "priority": "high"
+  },
+  {
+   "title": "Webcam showing black screen",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "Headset mic not working in Teams",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "Keyboard keys sticking",
+   "category": "Support",
+   "priority": "low"
+  },
+  {
+   "title": "Scanner not recognized by PC",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "External USB drive not mounting",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "HDMI cable damaged - need replacement",
+   "category": "Support",
+   "priority": "low"
+  },
+  {
+   "title": "Monitor arm won't adjust height",
+   "category": "Support",
+   "priority": "low"
+  },
+  {
+   "title": "Printer driver installation failed",
+   "category": "Bug",
+   "priority": "medium"
+  },
+  {
+   "title": "Duplicate printer 3F appearing in queue",
+   "category": "Bug",
+   "priority": "low"
+  },
+  {
+   "title": "Dell monitor flickering intermittently",
+   "category": "Bug",
+   "priority": "medium"
+  },
+  {
+   "title": "Dock display port not outputting video",
+   "category": "Support",
+   "priority": "high"
+  },
+  {
+   "title": "Wireless mouse battery drained",
+   "category": "Support",
+   "priority": "low"
+  },
+  {
+   "title": "Overhead projector lamp replacement",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "Printer 1F-West not responding",
+   "category": "Support",
+   "priority": "high"
+  },
+  {
+   "title": "Monitor has dead pixels",
+   "category": "Bug",
+   "priority": "low"
+  },
+  {
+   "title": "Second monitor not detected via DP",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "Headphones crackling audio",
+   "category": "Bug",
+   "priority": "low"
+  },
+  {
+   "title": "Webcam focus extremely blurry",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "Color laser printer low on yellow",
+   "category": "Support",
+   "priority": "low"
+  },
+  {
+   "title": "USB hub only recognizing 1 of 3 devices",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "Meeting room 4A monitor brightness stuck",
+   "category": "Support",
+   "priority": "low"
+  },
+  {
+   "title": "Thermal printer not printing dark",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "External SSD keeps disconnecting",
+   "category": "Bug",
+   "priority": "medium"
+  },
+  {
+   "title": "Upgrade to 4K monitor",
+   "category": "Feature request",
+   "priority": "none"
+  },
+  {
+   "title": "Desk speaker no sound output",
+   "category": "Support",
+   "priority": "low"
+  },
+  {
+   "title": "Printer queue stuck with pending jobs",
+   "category": "Support",
+   "priority": "high"
+  },
+  {
+   "title": "Keyboard backlight not turning on",
+   "category": "Support",
+   "priority": "low"
+  },
+  {
+   "title": "Laptop won't dock properly",
+   "category": "Support",
+   "priority": "high"
+  },
+  {
+   "title": "Scanner feeder jam error",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "Need USB-A to USB-C adapter",
+   "category": "Feature request",
+   "priority": "none"
+  },
+  {
+   "title": "Webcam privacy cover stuck closed",
+   "category": "Support",
+   "priority": "low"
+  },
+  {
+   "title": "Multifunctional printer scan to email down",
+   "category": "Support",
+   "priority": "high"
+  },
+  {
+   "title": "Monitor arm VESA mount loose",
+   "category": "Support",
+   "priority": "low"
+  },
+  {
+   "title": "Printer error code 82.02 displayed",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "Second display keeps going to sleep",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "Cordless headset won't charge",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "Mouse scroll wheel not responsive",
+   "category": "Bug",
+   "priority": "low"
+  },
+  {
+   "title": "Docking station fan making noise",
+   "category": "Bug",
+   "priority": "low"
+  },
+  {
+   "title": "3D printer setup for engineering",
+   "category": "Feature request",
+   "priority": "none"
+  },
+  {
+   "title": "Color accuracy on monitor off",
+   "category": "Support",
+   "priority": "low"
+  },
+  {
+   "title": "Printer 5F toner reorder needed",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "USB keyboard unresponsive after update",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "Monitor not waking from standby",
+   "category": "Bug",
+   "priority": "medium"
+  },
+  {
+   "title": "Label maker ribbon empty",
+   "category": "Support",
+   "priority": "low"
+  },
+  {
+   "title": "DP to HDMI adapter not working",
+   "category": "Bug",
+   "priority": "medium"
+  },
+  {
+   "title": "Keyboard trackpad frozen",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "Wireless charging pad for desk",
+   "category": "Feature request",
+   "priority": "none"
+  },
+  {
+   "title": "Portable monitor power cable missing",
+   "category": "Support",
+   "priority": "low"
+  },
+  {
+   "title": "Printer network configuration issue",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "Headset left ear producing no audio",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "Setup dual-monitor display",
+   "category": "Support",
+   "priority": "low"
+  },
+  {
+   "title": "Upgrade to laser printer for office",
+   "category": "Feature request",
+   "priority": "none"
+  },
+  {
+   "title": "Docking station ethernet not working",
+   "category": "Support",
+   "priority": "high"
+  },
+  {
+   "title": "Receipt printer completely offline",
+   "category": "Support",
+   "priority": "urgent"
+  },
+  {
+   "title": "External display cable intermittent connection",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "New starter setup - sales hire starting Monday",
+   "category": "Support",
+   "priority": "high"
+  },
+  {
+   "title": "Offboarding - finance leaver account disable",
+   "category": "Support",
+   "priority": "high"
+  },
+  {
+   "title": "Request second monitor for new desk",
+   "category": "Feature request",
+   "priority": "low"
+  },
+  {
+   "title": "Laptop provisioning for incoming marketing hire",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "Disable email access for departing contractor",
+   "category": "Support",
+   "priority": "high"
+  },
+  {
+   "title": "Request standing desk for ergonomic needs",
+   "category": "Feature request",
+   "priority": "low"
+  },
+  {
+   "title": "Mobile phone setup for new field technician",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "Meeting room AV not connecting for client demo",
+   "category": "Bug",
+   "priority": "urgent"
+  },
+  {
+   "title": "Request loaner laptop while repair in progress",
+   "category": "Feature request",
+   "priority": "medium"
+  },
+  {
+   "title": "Desk move to third floor - engineering team",
+   "category": "Support",
+   "priority": "low"
+  },
+  {
+   "title": "New starter software provisioning - design suite",
+   "category": "Feature request",
+   "priority": "medium"
+  },
+  {
+   "title": "Revoke building access badge for leaver",
+   "category": "Support",
+   "priority": "high"
+  },
+  {
+   "title": "Request wireless headset for open office noise",
+   "category": "Feature request",
+   "priority": "low"
+  },
+  {
+   "title": "Name change update across email and directory",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "Same-day account disable for terminated employee",
+   "category": "Support",
+   "priority": "urgent"
+  },
+  {
+   "title": "Set up VPN access for new remote hire",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "Request docking station for hybrid workspace",
+   "category": "Feature request",
+   "priority": "low"
+  },
+  {
+   "title": "Conference room projector showing no signal",
+   "category": "Bug",
+   "priority": "high"
+  },
+  {
+   "title": "New hire IT orientation checklist not completed",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "Request additional keyboard and mouse for new desk",
+   "category": "Feature request",
+   "priority": "none"
+  },
+  {
+   "title": "Offboarding checklist - equipment return not logged",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "Provision Salesforce license for new account exec",
+   "category": "Feature request",
+   "priority": "medium"
+  },
+  {
+   "title": "Request ergonomic chair for new employee",
+   "category": "Feature request",
+   "priority": "low"
+  },
+  {
+   "title": "Set up shared mailbox access for new team lead",
+   "category": "Support",
+   "priority": "low"
+  },
+  {
+   "title": "Leaver laptop not returned before final day",
+   "category": "Support",
+   "priority": "high"
+  },
+  {
+   "title": "Request extra monitor arm for dual-screen setup",
+   "category": "Feature request",
+   "priority": "none"
+  },
+  {
+   "title": "New starter cannot log into email on first day",
+   "category": "Bug",
+   "priority": "high"
+  },
+  {
+   "title": "Desk move request - relocating to quiet zone",
+   "category": "Support",
+   "priority": "low"
+  },
+  {
+   "title": "Provision company mobile plan for new sales rep",
+   "category": "Feature request",
+   "priority": "medium"
+  },
+  {
+   "title": "Request loaner projector for offsite meeting",
+   "category": "Feature request",
+   "priority": "low"
+  },
+  {
+   "title": "Set up printer access for new starter",
+   "category": "Support",
+   "priority": "none"
+  },
+  {
+   "title": "Meeting room video conferencing camera frozen",
+   "category": "Bug",
+   "priority": "medium"
+  },
+  {
+   "title": "Request noise-cancelling headset for call center role",
+   "category": "Feature request",
+   "priority": "low"
+  },
+  {
+   "title": "Offboard user from all shared drives and folders",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "New hire needs Slack and Teams access configured",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "Request replacement laptop charger",
+   "category": "Feature request",
+   "priority": "low"
+  },
+  {
+   "title": "Set up multi-factor authentication for new employee",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "Request second desk phone for shared workspace",
+   "category": "Feature request",
+   "priority": "none"
+  },
+  {
+   "title": "Leaver's mobile device not wiped remotely",
+   "category": "Bug",
+   "priority": "high"
+  },
+  {
+   "title": "Provision Adobe Creative Cloud for new designer",
+   "category": "Feature request",
+   "priority": "medium"
+  },
+  {
+   "title": "Request temporary loaner tablet for site visit",
+   "category": "Feature request",
+   "priority": "low"
+  },
+  {
+   "title": "New starter equipment not delivered before start date",
+   "category": "Support",
+   "priority": "high"
+  },
+  {
+   "title": "Update directory listing after employee name change",
+   "category": "Support",
+   "priority": "low"
+  },
+  {
+   "title": "Request standing mat for adjustable desk",
+   "category": "Feature request",
+   "priority": "none"
+  },
+  {
+   "title": "Disable SSO access for terminated manager",
+   "category": "Support",
+   "priority": "urgent"
+  },
+  {
+   "title": "Meeting room audio dropping out during calls",
+   "category": "Bug",
+   "priority": "medium"
+  },
+  {
+   "title": "Request second laptop for backup device policy",
+   "category": "Feature request",
+   "priority": "low"
+  },
+  {
+   "title": "Set up new starter with correct security groups",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "Request whiteboard and markers for new team room",
+   "category": "Feature request",
+   "priority": "none"
+  },
+  {
+   "title": "Offboarding - transfer leaver's files to manager",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "Request loaner monitor while replacement ships",
+   "category": "Feature request",
+   "priority": "medium"
+  },
+  {
+   "title": "New contractor needs temporary system access",
+   "category": "Support",
+   "priority": "medium"
+  },
+  {
+   "title": "Request desk fan due to office temperature",
+   "category": "Feature request",
+   "priority": "none"
+  },
+  {
+   "title": "Meeting room screen sharing not working with laptops",
+   "category": "Bug",
+   "priority": "medium"
+  },
+  {
+   "title": "Set up voicemail greeting for new starter extension",
+   "category": "Support",
+   "priority": "low"
+  },
+  {
+   "title": "Request upgraded laptop for video editing workload",
+   "category": "Feature request",
+   "priority": "medium"
+  },
+  {
+   "title": "Leaver's badge still active after departure date",
+   "category": "Bug",
+   "priority": "urgent"
+  },
+  {
+   "title": "Desk move request - team consolidation to open plan",
+   "category": "Support",
+   "priority": "low"
+  },
+  {
+   "title": "Provision new starter with software license bundle",
+   "category": "Feature request",
+   "priority": "medium"
+  },
+  {
+   "title": "Request replacement mouse - left-click not registering",
+   "category": "Bug",
+   "priority": "low"
+  }
+ ]
+}

--- a/backend/seeds/demo.json
+++ b/backend/seeds/demo.json
@@ -1,0 +1,485 @@
+{
+  "_comment": "Demo dataset seeded by `make seed-demo` (backend/src/bin/seed_demo.rs). All users share the password in `password`. Emails end @demo.nosdesk.test so the seeder can detect and skip an already-seeded instance. Timestamps are expressed as *_days_ago / *_hours_after offsets and backdated after insert. Reset with `make clean-db`, re-run onboarding, then re-run the seed.",
+  "password": "Demo1234!",
+
+  "users": [
+    { "key": "priya",  "name": "Priya Sharma",   "email": "priya@demo.nosdesk.test",  "role": "agent",  "title": "IT Support Lead" },
+    { "key": "marcus", "name": "Marcus Webb",     "email": "marcus@demo.nosdesk.test", "role": "agent",  "title": "Support Engineer" },
+    { "key": "elena",  "name": "Elena Kovacs",    "email": "elena@demo.nosdesk.test",  "role": "agent",  "title": "Security Analyst" },
+    { "key": "tom",    "name": "Tom Nakamura",    "email": "tom@demo.nosdesk.test",    "role": "agent",  "title": "Network Engineer" },
+    { "key": "hannah", "name": "Hannah Brooks",   "email": "hannah@demo.nosdesk.test", "role": "member", "title": "Finance Manager" },
+    { "key": "raj",    "name": "Raj Patel",       "email": "raj@demo.nosdesk.test",    "role": "member", "title": "Account Executive" },
+    { "key": "sofia",  "name": "Sofia Rossi",     "email": "sofia@demo.nosdesk.test",  "role": "member", "title": "HR Coordinator" },
+    { "key": "liam",   "name": "Liam O'Connor",   "email": "liam@demo.nosdesk.test",   "role": "member", "title": "Sales Director" },
+    { "key": "grace",  "name": "Grace Kim",       "email": "grace@demo.nosdesk.test",  "role": "member", "title": "Financial Analyst" },
+    { "key": "noah",   "name": "Noah Bennett",    "email": "noah@demo.nosdesk.test",   "role": "member", "title": "Operations Lead" }
+  ],
+
+  "projects": [
+    {
+      "key": "laptop",
+      "name": "Laptop Refresh FY26",
+      "description": "Company-wide replacement of laptops older than three years, staged by department.",
+      "cycles": [
+        { "key": "laptop_w1", "name": "Wave 1 - Finance & HR", "state": "completed", "start_days_ago": 42, "end_days_ago": 14 },
+        { "key": "laptop_w2", "name": "Wave 2 - Sales & Ops",  "state": "active",    "start_days_ago": 10, "end_days_ago": -18 }
+      ]
+    },
+    {
+      "key": "m365",
+      "name": "Microsoft 365 Migration",
+      "description": "Migrate mailboxes, files, and collaboration off the legacy tenant into Microsoft 365.",
+      "cycles": [
+        { "key": "m365_pilot",   "name": "Pilot Group",   "state": "completed", "start_days_ago": 49, "end_days_ago": 21 },
+        { "key": "m365_rollout", "name": "Company Rollout", "state": "active",   "start_days_ago": 7,  "end_days_ago": -21 }
+      ]
+    },
+    {
+      "key": "network",
+      "name": "Network Upgrade, Building B",
+      "description": "Replace ageing switches and access points in Building B and remediate coverage gaps.",
+      "cycles": [
+        { "key": "net_survey",  "name": "Site Survey",  "state": "completed", "start_days_ago": 45, "end_days_ago": 18 },
+        { "key": "net_install", "name": "Install & Cutover", "state": "active", "start_days_ago": 9, "end_days_ago": -19 }
+      ]
+    }
+  ],
+
+  "devices": [
+    { "key": "lt0042", "name": "LT-0042", "manufacturer": "Dell",    "model": "Latitude 7440",   "serial_number": "5CG3421QX7", "asset_tag": "LT-0042", "location": "Floor 3 - Finance", "primary_user": "hannah", "attributes": { "hostname": "FIN-LT-0042", "warranty_status": "active" } },
+    { "key": "lt0043", "name": "LT-0043", "manufacturer": "Dell",    "model": "Latitude 7440",   "serial_number": "5CG3421QX9", "asset_tag": "LT-0043", "location": "Floor 2 - Sales",   "primary_user": "raj",    "attributes": { "hostname": "SAL-LT-0043", "warranty_status": "expiring" } },
+    { "key": "mbp14",  "name": "MBP-14-SR", "manufacturer": "Apple", "model": "MacBook Pro 14 (M3)", "serial_number": "C02XL0ABHV29", "asset_tag": "MBP-0014", "location": "Floor 1 - HR", "primary_user": "sofia", "attributes": { "hostname": "HR-MBP-0014", "warranty_status": "active" } },
+    { "key": "mbp16",  "name": "MBP-16-LO", "manufacturer": "Apple", "model": "MacBook Pro 16 (M3 Pro)", "serial_number": "C02XL0ABHV44", "asset_tag": "MBP-0016", "location": "Floor 2 - Sales", "primary_user": "liam", "attributes": { "hostname": "SAL-MBP-0016", "warranty_status": "active" } },
+    { "key": "lt0051", "name": "LT-0051", "manufacturer": "Lenovo",  "model": "ThinkPad X1 Carbon", "serial_number": "PF3ABX21", "asset_tag": "LT-0051", "location": "Floor 3 - Finance", "primary_user": "grace", "attributes": { "hostname": "FIN-LT-0051", "warranty_status": "active" } },
+    { "key": "lt0052", "name": "LT-0052", "manufacturer": "Dell",    "model": "Latitude 5440",   "serial_number": "5CG3422RT1", "asset_tag": "LT-0052", "location": "Building B - Ops", "primary_user": "noah", "attributes": { "hostname": "OPS-LT-0052", "warranty_status": "active" } },
+    { "key": "prn3fw", "name": "Printer 3F-West", "manufacturer": "HP", "model": "LaserJet Enterprise M528", "serial_number": "CNBRK12345", "asset_tag": "PRN-3FW", "location": "Floor 3 West", "attributes": { "ip_address": "10.20.3.51", "warranty_status": "active" } },
+    { "key": "prn2fe", "name": "Printer 2F-East", "manufacturer": "Canon", "model": "imageRUNNER 2645i", "serial_number": "GNR54021", "asset_tag": "PRN-2FE", "location": "Floor 2 East", "attributes": { "ip_address": "10.20.2.52", "warranty_status": "expiring" } },
+    { "key": "mr_apollo", "name": "Meeting Room Apollo - AV", "manufacturer": "Logitech", "model": "Rally Bar", "serial_number": "2044LZ0091", "asset_tag": "AV-APOLLO", "location": "Floor 1 - Apollo", "attributes": { "warranty_status": "active" } },
+    { "key": "mr_zephyr", "name": "Meeting Room Zephyr - AV", "manufacturer": "Poly", "model": "Studio X50", "serial_number": "8H2K44120", "asset_tag": "AV-ZEPHYR", "location": "Floor 2 - Zephyr", "attributes": { "warranty_status": "active" } },
+    { "key": "sw_b1", "name": "Switch B-1", "manufacturer": "Cisco", "model": "Catalyst 9300", "serial_number": "FOC2412L0AB", "asset_tag": "NET-SWB1", "location": "Building B - Comms Room", "attributes": { "ip_address": "10.30.0.2", "warranty_status": "active" } },
+    { "key": "ap_b2k", "name": "AP Building B - Kitchen", "manufacturer": "Ubiquiti", "model": "U6 Pro", "serial_number": "F492BF9921AA", "asset_tag": "NET-APB2K", "location": "Building B - Kitchen", "attributes": { "ip_address": "10.30.4.21", "warranty_status": "active" } }
+  ],
+
+  "tickets": [
+    {
+      "title": "VPN drops every 30 minutes on home fibre",
+      "body_md": "Since Monday my VPN disconnects roughly every 30 minutes. It reconnects on its own but Teams calls drop and I lose access to the finance drive each time.\n\nHome connection is fibre, no issues with anything else. Happy to run any diagnostics.",
+      "category": "Support", "priority": "high", "state_category": "active",
+      "requester": "hannah", "assignee": "priya", "device": "lt0042", "created_days_ago": 3,
+      "comments": [
+        { "author": "priya", "body": "Thanks Hannah. Can you grab the client logs next time it drops? Settings > VPN > Export diagnostics. I suspect an idle-timeout on the gateway.", "minutes_after": 55 },
+        { "author": "hannah", "body": "Attached the logs from this morning's drop.", "minutes_after": 180 },
+        { "author": "priya", "body": "Confirmed - the gateway is enforcing a 30-min rekey and the client isn't renewing silently. Rolling out an updated profile to the affected group.", "minutes_after": 320, "internal": true }
+      ]
+    },
+    {
+      "title": "Printer 3F-West jamming on duplex jobs",
+      "body_md": "The floor 3 west printer jams on almost every double-sided job. Single-sided is fine. Paper is fresh from a sealed ream.",
+      "category": "Support", "priority": "medium", "state_category": "active",
+      "requester": "grace", "assignee": "marcus", "device": "prn3fw", "created_days_ago": 2,
+      "comments": [
+        { "author": "marcus", "body": "Sounds like the duplex roller. I'll come up and check the fuser and rollers this afternoon.", "minutes_after": 90 }
+      ]
+    },
+    {
+      "title": "Password reset - locked out after holiday",
+      "body_md": "I'm locked out after two weeks off. It says my password expired and the reset link isn't arriving.",
+      "category": "Support", "priority": "urgent", "state_category": "done",
+      "requester": "raj", "assignee": "elena", "created_days_ago": 6, "closed_hours_after": 1,
+      "comments": [
+        { "author": "elena", "body": "Reset done and forced a sync. You should be able to sign in now - you'll be prompted to set a new password.", "minutes_after": 25 },
+        { "author": "raj", "body": "In now, thank you!", "minutes_after": 40 }
+      ]
+    },
+    {
+      "title": "Laptop fan noise and overheating during Teams calls",
+      "body_md": "My MacBook gets very hot and the fans spin up loudly whenever I'm in a Teams call for more than a few minutes. The bottom case is uncomfortable to touch.",
+      "category": "Support", "priority": "medium", "state_category": "in_review",
+      "requester": "sofia", "assignee": "tom", "device": "mbp14", "created_days_ago": 5,
+      "comments": [
+        { "author": "tom", "body": "Teams is pinned at high CPU on the hardware-encode path for some M-series units. Try the browser client as a test while I check for the app update.", "minutes_after": 130 },
+        { "author": "sofia", "body": "Browser client stays cool. So it does look like the app.", "minutes_after": 1500 }
+      ]
+    },
+    {
+      "title": "Request: second monitor for finance desk",
+      "body_md": "Could I get a second monitor? Reconciliation work across spreadsheets on a single screen is slowing me down.",
+      "category": "Feature request", "priority": "low", "state_category": "backlog",
+      "requester": "grace", "created_days_ago": 9
+    },
+    {
+      "title": "Outlook not syncing shared mailbox after migration",
+      "body_md": "The `ops@` shared mailbox stopped syncing in Outlook after we moved to 365. New mail only shows up on the web, not the desktop app. Removing and re-adding the account didn't help.",
+      "category": "Bug", "priority": "high", "state_category": "active",
+      "requester": "noah", "assignee": "priya", "project": "m365", "cycle": "m365_rollout", "device": "lt0052", "created_days_ago": 4,
+      "comments": [
+        { "author": "priya", "body": "Automapping is stale post-migration. I'll remove the auto-mapped entry and re-add the mailbox manually - that usually forces a clean resync.", "minutes_after": 200 }
+      ]
+    },
+    {
+      "title": "Disk almost full warning on LT-0043",
+      "body_md": "Getting 'low disk space' warnings constantly. Only 2 GB free. Not sure what's eating it.",
+      "category": "Support", "priority": "medium", "state_category": "done",
+      "requester": "raj", "assignee": "marcus", "device": "lt0043", "created_days_ago": 12, "closed_hours_after": 20,
+      "comments": [
+        { "author": "marcus", "body": "Teams cache and old Windows update files were 40 GB combined. Cleared them and enabled Storage Sense. You've got 180 GB free now.", "minutes_after": 300 }
+      ]
+    },
+    {
+      "title": "MFA enrolment fails on new phone",
+      "body_md": "Got a new phone and the Authenticator app won't enrol - the QR scan just spins and times out. Old phone is wiped so I can't approve from it.",
+      "category": "Support", "priority": "high", "state_category": "done",
+      "requester": "liam", "assignee": "elena", "created_days_ago": 8, "closed_hours_after": 3,
+      "comments": [
+        { "author": "elena", "body": "I reset your MFA methods so the old device won't block enrolment. Re-scan the QR now and it should take.", "minutes_after": 60 },
+        { "author": "liam", "body": "Enrolled. Thanks Elena.", "minutes_after": 95 }
+      ]
+    },
+    {
+      "title": "New starter onboarding: accounts + laptop (N. Bennett)",
+      "body_md": "New Operations Lead starting Monday. Needs:\n\n- AD account + email\n- Laptop (standard Ops build)\n- Access to the Ops shared drive and Building B systems\n- Building B door badge",
+      "category": "Support", "priority": "high", "state_category": "done",
+      "requester": "sofia", "assignee": "priya", "created_days_ago": 20, "closed_hours_after": 30,
+      "comments": [
+        { "author": "priya", "body": "Account created, laptop LT-0052 imaged and assigned, drive + Building B access granted. Badge request sent to facilities.", "minutes_after": 900 },
+        { "author": "sofia", "body": "Perfect, all set for Monday.", "minutes_after": 1100 }
+      ]
+    },
+    {
+      "title": "Wi-Fi dead zone in Building B kitchen",
+      "body_md": "No usable Wi-Fi in the Building B kitchen and breakout area. Signal drops to nothing about halfway down the corridor. Several people can't take calls there.",
+      "category": "Bug", "priority": "medium", "state_category": "active",
+      "requester": "noah", "assignee": "tom", "device": "ap_b2k", "project": "network", "cycle": "net_install", "created_days_ago": 6,
+      "comments": [
+        { "author": "tom", "body": "Survey confirmed the gap. New AP (NET-APB2K) is on order for the kitchen; cabling run scheduled with the install wave.", "minutes_after": 240, "internal": true }
+      ]
+    },
+    {
+      "title": "Software install request: Adobe Illustrator",
+      "body_md": "I need Illustrator for the new hire welcome packs. A single named license is fine.",
+      "category": "Feature request", "priority": "low", "state_category": "done",
+      "requester": "sofia", "assignee": "marcus", "device": "mbp14", "created_days_ago": 15, "closed_hours_after": 48,
+      "comments": [
+        { "author": "marcus", "body": "License approved and assigned. Illustrator is pushed to your Mac via self-service - open Company Portal and install.", "minutes_after": 2400 }
+      ]
+    },
+    {
+      "title": "Phishing email reported - please verify",
+      "body_md": "Got an email claiming to be from Finance asking me to 'confirm payroll details' via a link. The sender domain looks slightly off. I did not click. Reporting it to be safe.",
+      "category": "Support", "priority": "urgent", "state_category": "done",
+      "requester": "hannah", "assignee": "elena", "created_days_ago": 10, "closed_hours_after": 2,
+      "comments": [
+        { "author": "elena", "body": "Good catch - it's a lookalike domain, not us. I've blocked the sender tenant-wide and purged the message from all mailboxes. No clicks recorded.", "minutes_after": 45 },
+        { "author": "elena", "body": "Flagging for the monthly security summary.", "minutes_after": 50, "internal": true }
+      ]
+    },
+    {
+      "title": "Teams audio cuts out in Meeting Room Apollo",
+      "body_md": "In Apollo the room mic keeps cutting out mid-sentence on Teams calls. Remote attendees say we vanish for a few seconds at a time. Video is fine.",
+      "category": "Bug", "priority": "medium", "state_category": "active",
+      "requester": "liam", "assignee": "tom", "device": "mr_apollo", "created_days_ago": 3,
+      "comments": [
+        { "author": "tom", "body": "Firmware on the Rally Bar is a version behind and there's a known mic-dropout fix. Scheduling the update for after hours so I don't interrupt a meeting.", "minutes_after": 260 }
+      ]
+    },
+    {
+      "title": "Cannot access shared finance drive",
+      "body_md": "I've lost access to the Finance shared drive this morning - it says permission denied. It was working yesterday. Nothing changed on my end.",
+      "category": "Support", "priority": "high", "state_category": "done",
+      "requester": "grace", "assignee": "priya", "created_days_ago": 18, "closed_hours_after": 5,
+      "comments": [
+        { "author": "priya", "body": "A group cleanup overnight dropped you from the Finance security group by mistake. Re-added you and confirmed access. Sorry about that.", "minutes_after": 200 }
+      ]
+    },
+    {
+      "title": "Screen flickering on MacBook Pro",
+      "body_md": "The screen flickers intermittently, mostly on dark backgrounds. Restarting helps for a while then it comes back.",
+      "category": "Bug", "priority": "medium", "state_category": "triage",
+      "requester": "sofia", "device": "mbp14", "created_days_ago": 1
+    },
+    {
+      "title": "Request: standing desk and docking station",
+      "body_md": "Could I get a sit-stand desk and a docking station for my laptop? Occupational health suggested it.",
+      "category": "Feature request", "priority": "low", "state_category": "backlog",
+      "requester": "raj", "created_days_ago": 22
+    },
+    {
+      "title": "Email delivery delayed to external clients",
+      "body_md": "Several clients report our replies arriving hours late. Internal mail is instant. This started during the pilot migration and is hurting deals in flight.",
+      "category": "Bug", "priority": "high", "state_category": "done",
+      "requester": "liam", "assignee": "marcus", "project": "m365", "cycle": "m365_pilot", "created_days_ago": 30, "closed_hours_after": 60,
+      "comments": [
+        { "author": "marcus", "body": "Outbound was routing through the old connector and getting greylisted. Repointed the send connector to 365 and delivery is back to seconds.", "minutes_after": 1800 },
+        { "author": "liam", "body": "Confirmed with two clients - replies are instant again.", "minutes_after": 2600 }
+      ]
+    },
+    {
+      "title": "OneDrive sync errors after migration",
+      "body_md": "OneDrive shows a red X and 'sync pending' on dozens of files since the rollout. Some documents won't open because they're 'still uploading'.",
+      "category": "Bug", "priority": "medium", "state_category": "active",
+      "requester": "grace", "assignee": "priya", "project": "m365", "cycle": "m365_rollout", "device": "lt0051", "created_days_ago": 5,
+      "comments": [
+        { "author": "priya", "body": "A few filenames have characters 365 rejects (colons and trailing spaces). I'll send a list to rename, then reset the sync client.", "minutes_after": 340 }
+      ]
+    },
+    {
+      "title": "Keyboard keys sticking on LT-0051",
+      "body_md": "The E and R keys stick and sometimes double-type. Cleaning didn't help.",
+      "category": "Support", "priority": "low", "state_category": "done",
+      "requester": "grace", "assignee": "marcus", "device": "lt0051", "created_days_ago": 14, "closed_hours_after": 26,
+      "comments": [
+        { "author": "marcus", "body": "Under warranty - logged a depot repair. Loaner is at reception for you in the meantime.", "minutes_after": 500 }
+      ]
+    },
+    {
+      "title": "Zoom to Teams migration - training request",
+      "body_md": "Now that we're standardising on Teams, could the Sales team get a short training session on meetings, channels, and calling?",
+      "category": "Feature request", "priority": "none", "state_category": "backlog",
+      "requester": "sofia", "created_days_ago": 25
+    },
+    {
+      "title": "VPN certificate expired warning",
+      "body_md": "Connecting to VPN now throws a certificate expired warning. I can click through but it feels wrong - wanted to flag it.",
+      "category": "Support", "priority": "high", "state_category": "done",
+      "requester": "noah", "assignee": "elena", "device": "lt0052", "created_days_ago": 11, "closed_hours_after": 4,
+      "comments": [
+        { "author": "elena", "body": "The gateway cert renewed but the client trust bundle was stale. Pushed the updated bundle - reconnect and the warning is gone. Don't click through cert warnings in future, good instinct to report it.", "minutes_after": 150 }
+      ]
+    },
+    {
+      "title": "Meeting Room Zephyr display won't wake",
+      "body_md": "The Zephyr room display stays black. Remote and power cycling the panel does nothing. Room is unusable for presentations.",
+      "category": "Bug", "priority": "medium", "state_category": "done",
+      "requester": "liam", "assignee": "tom", "device": "mr_zephyr", "created_days_ago": 16, "closed_hours_after": 22,
+      "comments": [
+        { "author": "tom", "body": "HDMI handshake between the Studio X50 and the panel was stuck. Swapped the cable and set the panel to always-on. Working now.", "minutes_after": 700 }
+      ]
+    },
+    {
+      "title": "Request new laptop - cracked screen (H. Brooks)",
+      "body_md": "I dropped my laptop and the screen is badly cracked - about a third is unreadable. I can still work on an external monitor but it's not practical for meetings.",
+      "category": "Support", "priority": "high", "state_category": "in_review",
+      "requester": "hannah", "assignee": "priya", "device": "lt0042", "project": "laptop", "cycle": "laptop_w2", "created_days_ago": 4,
+      "comments": [
+        { "author": "priya", "body": "You're due in the refresh anyway, so I'll bring your replacement forward into Wave 2 rather than repair. New unit is being imaged now.", "minutes_after": 180 }
+      ]
+    },
+    {
+      "title": "Slow login on shared reception PC",
+      "body_md": "The reception PC takes 4-5 minutes to get to the desktop after sign-in. It's awkward when visitors are waiting.",
+      "category": "Support", "priority": "medium", "state_category": "backlog",
+      "requester": "sofia", "created_days_ago": 19
+    },
+    {
+      "title": "Spam getting through to sales inbox",
+      "body_md": "The sales@ inbox is getting 20-30 obvious spam messages a day past the filter this week. Some are convincing fake RFQs.",
+      "category": "Bug", "priority": "medium", "state_category": "active",
+      "requester": "raj", "assignee": "elena", "created_days_ago": 7,
+      "comments": [
+        { "author": "elena", "body": "There's a new campaign hitting shared inboxes. I've tightened the policy and added the top offending domains. Forward anything that still slips through and I'll tune it.", "minutes_after": 220 }
+      ]
+    },
+    {
+      "title": "Access request: HR folder for new manager",
+      "body_md": "New HR manager needs read/write to the HR Confidential folder. Approved by the HR Director.",
+      "category": "Support", "priority": "medium", "state_category": "done",
+      "requester": "sofia", "assignee": "priya", "created_days_ago": 21, "closed_hours_after": 8,
+      "comments": [
+        { "author": "priya", "body": "Access granted and verified. Logged the approver for the audit trail.", "minutes_after": 400 }
+      ]
+    },
+    {
+      "title": "Printer 2F-East out of toner, order replacement",
+      "body_md": "The 2F east printer is out of black toner and there's no spare in the cabinet. Please order a replacement cartridge.",
+      "category": "Support", "priority": "low", "state_category": "done",
+      "requester": "noah", "assignee": "marcus", "device": "prn2fe", "created_days_ago": 13, "closed_hours_after": 30,
+      "comments": [
+        { "author": "marcus", "body": "Ordered a cartridge plus one spare for the cabinet. ETA two business days.", "minutes_after": 200 }
+      ]
+    },
+    {
+      "title": "Laptop won't charge - possible bad adapter",
+      "body_md": "My MacBook stopped charging. No light on the connector, tried both USB-C ports. Battery is at 4%.",
+      "category": "Support", "priority": "high", "state_category": "done",
+      "requester": "liam", "assignee": "tom", "device": "mbp16", "created_days_ago": 9, "closed_hours_after": 18,
+      "comments": [
+        { "author": "tom", "body": "The charger is dead - it doesn't power a test unit either. Swapped you a new 96W adapter and cable. Working now. Left the old one for e-waste.", "minutes_after": 620 }
+      ]
+    },
+    {
+      "title": "Request: bulk password policy review",
+      "body_md": "Can we review the password policy? Some of us are prompted to change far more often than others and it's causing confusion.",
+      "category": "Feature request", "priority": "low", "state_category": "backlog",
+      "requester": "hannah", "created_days_ago": 28
+    },
+    {
+      "title": "Switch B-1 port flapping - network drops in Building B",
+      "body_md": "Building B keeps losing network for 10-20 seconds at a time, several times an hour. Affects everyone on that floor. Started yesterday afternoon.",
+      "category": "Bug", "priority": "urgent", "state_category": "active",
+      "requester": "noah", "assignee": "tom", "device": "sw_b1", "project": "network", "cycle": "net_install", "created_days_ago": 2,
+      "comments": [
+        { "author": "tom", "body": "Uplink port on Switch B-1 is flapping - logs show link up/down every few minutes. Moving the uplink to a spare port now and will replace the SFP.", "minutes_after": 40 },
+        { "author": "noah", "body": "Much better since lunchtime, no drops so far.", "minutes_after": 480 },
+        { "author": "tom", "body": "Keeping this open until the replacement switch lands in the install wave - the whole unit is due for swap.", "minutes_after": 520, "internal": true }
+      ]
+    },
+    {
+      "title": "Cannot join Teams meeting - camera not detected",
+      "body_md": "Teams says 'no camera found' but the camera works in Photos. Reinstalling Teams didn't fix it.",
+      "category": "Support", "priority": "medium", "state_category": "done",
+      "requester": "grace", "assignee": "elena", "device": "lt0051", "created_days_ago": 17, "closed_hours_after": 6,
+      "comments": [
+        { "author": "elena", "body": "Camera privacy permission for Teams got reset in the last Windows update. Re-enabled it under Privacy > Camera and it's detected now.", "minutes_after": 260 }
+      ]
+    },
+    {
+      "title": "SharePoint permissions wrong after migration",
+      "body_md": "After the rollout, the whole Sales team can see the Deals Confidential SharePoint library. It should be restricted to directors only. This is sensitive - please fix urgently.",
+      "category": "Bug", "priority": "high", "state_category": "active",
+      "requester": "liam", "assignee": "priya", "project": "m365", "cycle": "m365_rollout", "created_days_ago": 6,
+      "comments": [
+        { "author": "priya", "body": "Confirmed - broken inheritance during migration re-granted the parent group. I've removed the inherited access and restored the directors-only permission. Auditing who accessed it in the window.", "minutes_after": 70 },
+        { "author": "elena", "body": "Access logs show no downloads by non-directors during the exposure window. Documenting for the security record.", "minutes_after": 300, "internal": true }
+      ]
+    },
+    {
+      "title": "Request: additional software license (Photoshop)",
+      "body_md": "Marketing asked me to help with some image edits. Could I get a Photoshop license added to my Creative Cloud?",
+      "category": "Feature request", "priority": "low", "state_category": "done",
+      "requester": "sofia", "assignee": "marcus", "created_days_ago": 24, "closed_hours_after": 72,
+      "comments": [
+        { "author": "marcus", "body": "Approved and assigned. Sign out and back into Creative Cloud to pick up Photoshop.", "minutes_after": 3600 }
+      ]
+    },
+    {
+      "title": "Laptop stuck on Windows update loop",
+      "body_md": "My laptop has been 'restarting to finish updates' for two hours, cycling the same percentage. I can't get to the desktop.",
+      "category": "Support", "priority": "high", "state_category": "done",
+      "requester": "grace", "assignee": "tom", "device": "lt0051", "created_days_ago": 15, "closed_hours_after": 14,
+      "comments": [
+        { "author": "tom", "body": "A cumulative update was failing to apply and rolling back on loop. Booted to recovery, cleared the pending update, and reapplied cleanly. All your files are intact.", "minutes_after": 500 }
+      ]
+    },
+    {
+      "title": "Guest Wi-Fi password rotation request",
+      "body_md": "We've got a client visit next week - can we rotate the guest Wi-Fi password and send me the new one for the welcome sheet?",
+      "category": "Support", "priority": "low", "state_category": "done",
+      "requester": "noah", "assignee": "elena", "created_days_ago": 26, "closed_hours_after": 40,
+      "comments": [
+        { "author": "elena", "body": "Rotated. New password sent to you separately. It'll be live from tomorrow morning.", "minutes_after": 300 }
+      ]
+    },
+    {
+      "title": "Duplicate calendar invites after migration",
+      "body_md": "Since the rollout every meeting shows up two or three times in my calendar. Accepting one doesn't clear the others.",
+      "category": "Bug", "priority": "low", "state_category": "done",
+      "requester": "raj", "assignee": "marcus", "project": "m365", "cycle": "m365_rollout", "created_days_ago": 8, "closed_hours_after": 30,
+      "comments": [
+        { "author": "marcus", "body": "A leftover calendar sync from the old tenant was duplicating events. Removed it and cleaned the duplicates. Let me know if any stragglers remain.", "minutes_after": 900 }
+      ]
+    },
+    {
+      "title": "Request: encrypted USB drives for finance",
+      "body_md": "Finance occasionally needs to hand-carry sensitive files to auditors. Could we get a few hardware-encrypted USB drives that meet policy?",
+      "category": "Feature request", "priority": "medium", "state_category": "backlog",
+      "requester": "hannah", "created_days_ago": 23
+    },
+    {
+      "title": "Account lockout - repeated failed logins from unknown IP",
+      "body_md": "I keep getting locked out and I'm not the one entering the wrong password. Got an alert about sign-in attempts from a country I've never been to.",
+      "category": "Support", "priority": "urgent", "state_category": "done",
+      "requester": "liam", "assignee": "elena", "created_days_ago": 12, "closed_hours_after": 1,
+      "comments": [
+        { "author": "elena", "body": "Confirmed a password-spray against your account from a foreign IP. MFA held and nothing got in. I've reset your password, revoked active sessions, and blocked the source range. You're safe - please set a new unique password now.", "minutes_after": 20 },
+        { "author": "elena", "body": "Opening a follow-up to check whether other accounts were targeted in the same wave.", "minutes_after": 35, "internal": true }
+      ]
+    },
+    {
+      "title": "Old laptop decommission and data wipe (LT-0043)",
+      "body_md": "Raj's old laptop from before the refresh needs a certified wipe and to be removed from asset inventory before it goes to recycling.",
+      "category": "Support", "priority": "low", "state_category": "done",
+      "requester": "raj", "assignee": "priya", "device": "lt0043", "project": "laptop", "cycle": "laptop_w1", "created_days_ago": 40, "closed_hours_after": 96,
+      "comments": [
+        { "author": "priya", "body": "Certified wipe completed, certificate filed, asset marked decommissioned. Ready for the recycler pickup.", "minutes_after": 4000 }
+      ]
+    },
+    {
+      "title": "New monitor arm mount install request",
+      "body_md": "Could someone mount a monitor arm on my desk? I have the arm, just need it fitted to the desk edge.",
+      "category": "Feature request", "priority": "none", "state_category": "cancelled",
+      "requester": "sofia", "created_days_ago": 33, "closed_hours_after": 200,
+      "comments": [
+        { "author": "sofia", "body": "Never mind - facilities sorted it during the desk move. Please close.", "minutes_after": 5000 }
+      ]
+    },
+    {
+      "title": "Cannot print to Building B printers over VPN",
+      "body_md": "When I'm on VPN from home I can't see or print to any Building B printers. In the office it's fine. Several of the Ops team have the same issue.",
+      "category": "Bug", "priority": "medium", "state_category": "active",
+      "requester": "noah", "assignee": "tom", "project": "network", "created_days_ago": 4,
+      "comments": [
+        { "author": "tom", "body": "The print subnet isn't in the split-tunnel routes for the VPN. I'll add the Building B print range to the profile.", "minutes_after": 280 }
+      ]
+    },
+    {
+      "title": "Teams status stuck on Away",
+      "body_md": "My Teams status shows 'Away' even when I'm actively typing. Colleagues think I'm offline. Setting it manually to Available doesn't stick.",
+      "category": "Bug", "priority": "low", "state_category": "done",
+      "requester": "grace", "assignee": "marcus", "created_days_ago": 18, "closed_hours_after": 20,
+      "comments": [
+        { "author": "marcus", "body": "Known presence bug when Teams and Outlook disagree on idle. Cleared the Teams cache and it's tracking correctly now.", "minutes_after": 600 }
+      ]
+    },
+    {
+      "title": "Request: shared mailbox for support team",
+      "body_md": "Can we set up a shared `itsupport@` mailbox so requests don't land in one person's inbox while they're out?",
+      "category": "Feature request", "priority": "low", "state_category": "in_review",
+      "requester": "hannah", "assignee": "priya", "created_days_ago": 11,
+      "comments": [
+        { "author": "priya", "body": "Good idea. Draft mailbox created for review - deciding on membership and whether replies send as the shared address before we go live.", "minutes_after": 300, "internal": true }
+      ]
+    },
+    {
+      "title": "Malware alert on reception PC - please investigate",
+      "body_md": "The antivirus popped a threat alert on the reception PC and quarantined something. The machine feels sluggish. Flagging urgently since it's a shared, semi-public device.",
+      "category": "Support", "priority": "urgent", "state_category": "done",
+      "requester": "sofia", "assignee": "elena", "created_days_ago": 27, "closed_hours_after": 5,
+      "comments": [
+        { "author": "elena", "body": "Quarantine caught a browser-extension adware bundle - not a real compromise. Removed the extension, ran a full scan (clean), and locked down extension installs on that machine. Sluggishness is gone.", "minutes_after": 240 }
+      ]
+    },
+    {
+      "title": "Slow file transfers to Building B server",
+      "body_md": "Copying files to the Building B file server is crawling - a 500 MB folder takes 20+ minutes. From Building A it's fine.",
+      "category": "Bug", "priority": "medium", "state_category": "backlog",
+      "requester": "noah", "project": "network", "created_days_ago": 20
+    },
+    {
+      "title": "Request: onboarding checklist automation",
+      "body_md": "Could we automate the new-starter checklist? Right now it's a manual list we copy each time and things get missed.",
+      "category": "Feature request", "priority": "low", "state_category": "cancelled",
+      "requester": "hannah", "created_days_ago": 44, "closed_hours_after": 240,
+      "comments": [
+        { "author": "priya", "body": "Parking this for now - it overlaps with the HRIS rollout that will own onboarding workflows next quarter. Closing so it doesn't sit stale; we'll revisit as part of that project.", "minutes_after": 6000, "internal": true }
+      ]
+    },
+    {
+      "title": "Docking station not detecting external monitors",
+      "body_md": "My dock stopped driving the two external monitors - laptop screen works but the externals stay black. Reseating cables didn't help.",
+      "category": "Support", "priority": "medium", "state_category": "done",
+      "requester": "liam", "assignee": "tom", "device": "mbp16", "created_days_ago": 10, "closed_hours_after": 16,
+      "comments": [
+        { "author": "tom", "body": "The dock's firmware needed an update and one DisplayPort output had failed. Updated it and swapped the dock - both monitors are back.", "minutes_after": 700 }
+      ]
+    },
+    {
+      "title": "Email signature not applying firmwide",
+      "body_md": "The standardised email signature we agreed for the pilot group isn't appearing on sent mail for some users. It's inconsistent - works for a few, not for others.",
+      "category": "Bug", "priority": "low", "state_category": "done",
+      "requester": "grace", "assignee": "marcus", "project": "m365", "cycle": "m365_pilot", "created_days_ago": 35, "closed_hours_after": 50,
+      "comments": [
+        { "author": "marcus", "body": "The transport rule only applied to external mail and skipped users with a local signature set. Adjusted the rule scope and cleared local overrides for the pilot group - consistent now.", "minutes_after": 1500 }
+      ]
+    }
+  ]
+}

--- a/backend/src/bin/seed_demo.rs
+++ b/backend/src/bin/seed_demo.rs
@@ -1,0 +1,957 @@
+//! `seed_demo` — fill a dev instance's bootstrap workspace with a
+//! realistic IT-helpdesk demo dataset (users, projects/cycles, devices,
+//! tickets with rich-text bodies and comment threads). Invoked by
+//! `make seed-demo`.
+//!
+//! Design notes:
+//! - Reuses the same sync-wired repository paths the app uses, so every
+//!   seeded row emits the same `sync_actions` events real writes do.
+//! - Runs entirely as `nosdesk_app` inside one bootstrap actor context
+//!   (`app.workspace_id = 1`), exactly like `import_tickets`. No
+//!   privileged role is needed.
+//! - Timestamps in the dataset are relative offsets; a backdating pass
+//!   rewrites `created_at`/`closed_at`/comment times (and the handful of
+//!   `cycle_ticket.added` events that drive burnup) directly after
+//!   insert, so dashboards and burnup charts look alive rather than
+//!   spawned all at once. Direct UPDATEs in a binary are exempt from the
+//!   repository sync-emit lint and emit no extra activity.
+//! - The whole run is one transaction: it either seeds everything or
+//!   nothing.
+
+extern crate backend;
+
+use backend::db;
+use backend::db::DbConnection;
+use backend::models::{
+    ContentFormat, Cycle, NewArticleContent, NewAsset, NewComment, NewCycle, NewProject, NewTicket,
+    NewUserEmail, PlatformRole, ProjectStatus, SyncAggregate, SyncOp, TicketPriority,
+    WorkflowStateCategory,
+};
+use backend::repository;
+use backend::schema::{
+    comments, cycle_tickets, cycles, sync_actions, tickets, user_emails, users, workspaces,
+};
+use backend::services::seed::markdown_to_yjs;
+use backend::sync::actor::{ActorContext, BOOTSTRAP_WORKSPACE_ID};
+use backend::sync::emit::{self, SyncEmit};
+use backend::sync::groups;
+use backend::sync::session::with_actor_context;
+use backend::utils::NewUserBuilder;
+
+use chrono::{DateTime, Datelike, Duration, Utc};
+use diesel::prelude::*;
+use diesel::sql_types::{BigInt, Timestamptz};
+use serde::Deserialize;
+use serde_json::json;
+use std::collections::HashMap;
+use std::process::ExitCode;
+use uuid::Uuid;
+
+const DEMO_EMAIL_DOMAIN: &str = "@demo.nosdesk.test";
+
+// ---------------------------------------------------------------------------
+// Dataset shape (backend/seeds/demo.json). Unknown JSON keys (e.g. the
+// leading `_comment`, per-user `title`) are ignored by serde.
+// ---------------------------------------------------------------------------
+
+#[derive(Deserialize)]
+struct DemoData {
+    password: String,
+    users: Vec<DemoUser>,
+    projects: Vec<DemoProject>,
+    devices: Vec<DemoDevice>,
+    tickets: Vec<DemoTicket>,
+}
+
+#[derive(Deserialize)]
+struct DemoUser {
+    key: String,
+    name: String,
+    email: String,
+    /// "agent" or "member" — the workspace membership role.
+    role: String,
+}
+
+#[derive(Deserialize)]
+struct DemoProject {
+    key: String,
+    name: String,
+    description: Option<String>,
+    cycles: Vec<DemoCycle>,
+}
+
+#[derive(Deserialize)]
+struct DemoCycle {
+    key: String,
+    name: String,
+    /// "active" or "completed".
+    state: String,
+    start_days_ago: i64,
+    /// Negative means the cycle ends in the future (an active cycle).
+    end_days_ago: i64,
+}
+
+#[derive(Deserialize)]
+struct DemoDevice {
+    key: String,
+    name: String,
+    manufacturer: Option<String>,
+    model: Option<String>,
+    serial_number: Option<String>,
+    asset_tag: Option<String>,
+    location: Option<String>,
+    #[serde(default)]
+    primary_user: Option<String>,
+    #[serde(default)]
+    attributes: Option<serde_json::Value>,
+}
+
+#[derive(Deserialize)]
+struct DemoTicket {
+    title: String,
+    body_md: String,
+    category: String,
+    priority: String,
+    state_category: String,
+    requester: String,
+    #[serde(default)]
+    assignee: Option<String>,
+    #[serde(default)]
+    project: Option<String>,
+    #[serde(default)]
+    cycle: Option<String>,
+    #[serde(default)]
+    device: Option<String>,
+    created_days_ago: i64,
+    #[serde(default)]
+    closed_hours_after: Option<i64>,
+    #[serde(default)]
+    comments: Vec<DemoComment>,
+}
+
+#[derive(Deserialize)]
+struct DemoComment {
+    author: String,
+    body: String,
+    minutes_after: i64,
+    #[serde(default)]
+    internal: bool,
+}
+
+/// Low-detail ticket templates (backend/seeds/demo-history.json) that the
+/// history phase expands across the last 365 days to populate the activity
+/// heatmap and long-range analytics. No bodies/comments/links.
+#[derive(Deserialize)]
+struct DemoHistory {
+    tickets: Vec<HistoryTemplate>,
+}
+
+#[derive(Deserialize)]
+struct HistoryTemplate {
+    title: String,
+    category: String,
+    priority: String,
+}
+
+// ---------------------------------------------------------------------------
+// Errors: a thin wrapper so `?` on diesel calls composes with our own
+// precondition/validation failures inside the actor transaction.
+// ---------------------------------------------------------------------------
+
+enum SeedError {
+    /// A precondition failed (no workspace, no admin). Fatal, exit 1.
+    Precondition(String),
+    /// Demo data already present. Not an error to the operator; exit 0.
+    AlreadySeeded,
+    /// A reference in the dataset didn't resolve, etc. Fatal, exit 1.
+    Data(String),
+    Db(diesel::result::Error),
+}
+
+impl From<diesel::result::Error> for SeedError {
+    fn from(e: diesel::result::Error) -> Self {
+        SeedError::Db(e)
+    }
+}
+
+#[derive(Default)]
+struct Summary {
+    users: usize,
+    projects: usize,
+    cycles: usize,
+    devices: usize,
+    tickets: usize,
+    comments: usize,
+    bodies_skipped: usize,
+    history: usize,
+}
+
+fn main() -> ExitCode {
+    let raw = include_str!("../../seeds/demo.json");
+    let data: DemoData = match serde_json::from_str(raw) {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("seed_demo: failed to parse embedded demo.json: {e}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    let history: DemoHistory =
+        match serde_json::from_str(include_str!("../../seeds/demo-history.json")) {
+            Ok(h) => h,
+            Err(e) => {
+                eprintln!("seed_demo: failed to parse embedded demo-history.json: {e}");
+                return ExitCode::FAILURE;
+            }
+        };
+
+    // Hash the shared demo password once, outside the DB transaction so
+    // the bcrypt error type never has to compose with diesel's.
+    let password_hash = match bcrypt::hash(&data.password, bcrypt::DEFAULT_COST) {
+        Ok(h) => h,
+        Err(e) => {
+            eprintln!("seed_demo: bcrypt hash failed: {e}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    let pool = db::establish_connection_pool();
+    let mut conn = match pool.get() {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("seed_demo: database connection error: {e}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    let actor = ActorContext::bootstrap("cli:seed_demo");
+    let result: Result<Summary, SeedError> = with_actor_context(&mut conn, &actor, |c| {
+        seed(c, &data, &history, &password_hash)
+    });
+
+    match result {
+        Ok(summary) => {
+            print_summary(&summary, &data);
+            ExitCode::SUCCESS
+        }
+        Err(SeedError::AlreadySeeded) => {
+            println!("Demo data already present (found {DEMO_EMAIL_DOMAIN} users). Nothing to do.");
+            println!(
+                "Reset with `make clean-db`, complete onboarding, then re-run `make seed-demo`."
+            );
+            ExitCode::SUCCESS
+        }
+        Err(SeedError::Precondition(msg)) => {
+            eprintln!("seed_demo: {msg}");
+            ExitCode::FAILURE
+        }
+        Err(SeedError::Data(msg)) => {
+            eprintln!("seed_demo: dataset error: {msg}");
+            ExitCode::FAILURE
+        }
+        Err(SeedError::Db(e)) => {
+            eprintln!("seed_demo: database error (nothing was written): {e}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn seed(
+    conn: &mut DbConnection,
+    data: &DemoData,
+    history: &DemoHistory,
+    password_hash: &str,
+) -> Result<Summary, SeedError> {
+    let now = Utc::now();
+    let mut summary = Summary::default();
+
+    let admin_uuid = preflight(conn)?;
+
+    // Idempotent belt-and-braces: guarantees workflow states / categories
+    // exist even on an unusual instance where onboarding ran a partial path.
+    backend::services::seed::seed_workspace_defaults(conn, Some(admin_uuid))?;
+
+    // --- Users -------------------------------------------------------------
+    // key -> (uuid, is_agent)
+    let mut user_map: HashMap<String, (Uuid, bool)> = HashMap::new();
+    for du in &data.users {
+        let is_agent = du.role == "agent";
+        let membership_role = if is_agent { "agent" } else { "member" };
+
+        let new_user =
+            NewUserBuilder::local_user(du.name.clone(), du.email.clone(), PlatformRole::User)
+                .build();
+        let user = repository::create_user(new_user, conn)?;
+
+        repository::workspaces::add_membership(
+            conn,
+            BOOTSTRAP_WORKSPACE_ID,
+            user.uuid,
+            membership_role,
+        )?;
+
+        diesel::insert_into(user_emails::table)
+            .values(&NewUserEmail {
+                user_uuid: user.uuid,
+                email: du.email.clone(),
+                email_type: "personal".to_string(),
+                is_primary: true,
+                is_verified: true,
+                source: Some("demo-seed".to_string()),
+            })
+            .execute(conn)?;
+
+        insert_local_identity(conn, user.uuid, &du.email, password_hash)?;
+
+        emit::record(
+            conn,
+            SyncEmit {
+                aggregate: SyncAggregate::User,
+                aggregate_id: user.uuid.to_string(),
+                op: SyncOp::Insert,
+                event_type: "user.created",
+                data: json!({
+                    "uuid": user.uuid,
+                    "name": user.name,
+                    "email": du.email,
+                    "platform_role": "user",
+                    "workspace_role": membership_role,
+                    "avatar_url": null,
+                    "avatar_thumb": null,
+                }),
+                groups: groups::workspace(),
+                causation_id: None,
+            },
+        )?;
+
+        user_map.insert(du.key.clone(), (user.uuid, is_agent));
+        summary.users += 1;
+    }
+
+    let resolve_user = |key: &str| -> Result<(Uuid, bool), SeedError> {
+        user_map
+            .get(key)
+            .copied()
+            .ok_or_else(|| SeedError::Data(format!("unknown user key `{key}`")))
+    };
+
+    // --- Projects & cycles -------------------------------------------------
+    let mut project_map: HashMap<String, i32> = HashMap::new();
+    // cycle key -> cycle_id
+    let mut cycle_map: HashMap<String, i32> = HashMap::new();
+    // Cycles to finalise (state "completed") once their tickets are attached,
+    // paired with their target completed-at timestamp.
+    let mut completed_cycles: Vec<(Cycle, DateTime<Utc>)> = Vec::new();
+    for dp in &data.projects {
+        let project = repository::projects::create_project(
+            conn,
+            NewProject {
+                name: dp.name.clone(),
+                description: dp.description.clone(),
+                status: ProjectStatus::Active,
+                start_date: None,
+                end_date: None,
+            },
+            None,
+        )?;
+        project_map.insert(dp.key.clone(), project.id);
+        summary.projects += 1;
+
+        for dc in &dp.cycles {
+            let want_completed = dc.state == "completed";
+            // Park completed cycles in `planned` at creation: it keeps
+            // completed_at NULL (the cycles_completed_snapshot check) and out
+            // of the one-active-per-project unique index while the sibling
+            // active cycle is created. They're finalised via cycles::complete
+            // after their tickets attach, so the snapshot reflects membership.
+            let create_state = if want_completed {
+                "planned"
+            } else {
+                dc.state.as_str()
+            };
+            let end_at = now - Duration::days(dc.end_days_ago);
+            let cycle = repository::cycles::create(
+                conn,
+                NewCycle {
+                    project_id: project.id,
+                    name: dc.name.clone(),
+                    start_at: Some(now - Duration::days(dc.start_days_ago)),
+                    end_at: Some(end_at),
+                    state: create_state.to_string(),
+                    created_by: Some(admin_uuid),
+                },
+            )?;
+            cycle_map.insert(dc.key.clone(), cycle.id);
+            if want_completed {
+                completed_cycles.push((cycle, end_at));
+            }
+            summary.cycles += 1;
+        }
+    }
+
+    // --- Devices -----------------------------------------------------------
+    let mut device_map: HashMap<String, i32> = HashMap::new();
+    for dd in &data.devices {
+        let primary_user_uuid = match &dd.primary_user {
+            Some(k) => Some(resolve_user(k)?.0),
+            None => None,
+        };
+        let asset = repository::assets::create_device(
+            conn,
+            NewAsset {
+                name: dd.name.clone(),
+                serial_number: dd.serial_number.clone(),
+                manufacturer: dd.manufacturer.clone(),
+                model: dd.model.clone(),
+                location: dd.location.clone(),
+                notes: None,
+                primary_user_uuid,
+                purchase_date: None,
+                asset_tag: dd.asset_tag.clone(),
+                kind: "device".to_string(),
+                attributes: dd.attributes.clone().unwrap_or_else(|| json!({})),
+                quantity: None,
+                unit: None,
+                external_sync_source: None,
+                low_stock_threshold: None,
+            },
+        )?;
+        device_map.insert(dd.key.clone(), asset.id);
+        summary.devices += 1;
+    }
+
+    let category_ids: HashMap<String, i32> = repository::categories::get_all_categories(conn)?
+        .into_iter()
+        .map(|c| (c.name, c.id))
+        .collect();
+
+    // --- Tickets -----------------------------------------------------------
+    for dt in &data.tickets {
+        let category = parse_state_category(&dt.state_category);
+        let workflow_state = repository::workflow_states::first_in_category(conn, category)?;
+        let category_id = category_ids.get(&dt.category).copied();
+        let (requester_uuid, _) = resolve_user(&dt.requester)?;
+        let assignee_uuid = match &dt.assignee {
+            Some(k) => Some(resolve_user(k)?.0),
+            None => None,
+        };
+
+        let new_ticket = NewTicket {
+            title: dt.title.clone(),
+            workflow_state_id: workflow_state.id,
+            priority: parse_priority(&dt.priority),
+            requester_uuid: Some(requester_uuid),
+            assignee_uuid,
+            category_id,
+            submitted_via: Some("web".to_string()),
+            guest_lookup_token: None,
+            verification_state: None,
+            origin_channel_id: None,
+            triage_state: None,
+            due_date: None,
+            start_date: None,
+            recurrence_rule: None,
+            recurrence_template_id: None,
+            resolution_notes: None,
+            spam_suspected: false,
+        };
+
+        let project_id = match &dt.project {
+            Some(k) => Some(
+                *project_map
+                    .get(k)
+                    .ok_or_else(|| SeedError::Data(format!("unknown project key `{k}`")))?,
+            ),
+            None => None,
+        };
+
+        let ticket = match project_id {
+            Some(pid) => repository::tickets::create_ticket_in_project(conn, new_ticket, pid)?,
+            None => repository::tickets::create_ticket(conn, new_ticket)?,
+        };
+        summary.tickets += 1;
+
+        // Body: markdown -> Yjs, via the same converter the welcome page uses.
+        match markdown_to_yjs(&dt.body_md) {
+            Some(yjs_document) => {
+                repository::article_content::create_article_content(
+                    conn,
+                    NewArticleContent {
+                        ticket_id: ticket.id,
+                        yjs_state_vector: None,
+                        yjs_document: Some(yjs_document),
+                        yjs_client_id: None,
+                    },
+                )?;
+            }
+            None => summary.bodies_skipped += 1,
+        }
+
+        let created_at = now - Duration::days(dt.created_days_ago);
+        let mut updated_at = created_at;
+        let mut first_response_at: Option<DateTime<Utc>> = None;
+
+        // Comments.
+        for dc in &dt.comments {
+            let (author_uuid, author_is_agent) = resolve_user(&dc.author)?;
+            let comment = repository::comments::create_comment(
+                conn,
+                NewComment {
+                    content: dc.body.clone(),
+                    ticket_id: ticket.id,
+                    user_uuid: author_uuid,
+                    channel_metadata: None,
+                    is_internal: dc.internal,
+                    // Demo bodies are plain prose; declaring them html
+                    // (the ContentFormat default) routed them into the
+                    // frontend's legacy email-iframe fallback.
+                    content_format: ContentFormat::Plaintext,
+                    body_text: None,
+                    body_html: None,
+                    new_content: None,
+                    quoted_content: None,
+                    raw_source_uri: None,
+                    render_kind: None,
+                },
+                None,
+            )?;
+            summary.comments += 1;
+
+            let comment_at = created_at + Duration::minutes(dc.minutes_after);
+            if comment_at > updated_at {
+                updated_at = comment_at;
+            }
+            // First agent reply drives the SLA first-response clock so
+            // backdated open tickets don't all render as breached.
+            if author_is_agent && !dc.internal && first_response_at.is_none() {
+                first_response_at = Some(comment_at);
+            }
+
+            backdate_comment(conn, comment.id, comment_at)?;
+        }
+
+        // Device link.
+        if let Some(k) = &dt.device {
+            let asset_id = *device_map
+                .get(k)
+                .ok_or_else(|| SeedError::Data(format!("unknown device key `{k}`")))?;
+            repository::tickets::add_device_to_ticket(conn, ticket.id, asset_id)?;
+        }
+
+        // Cycle membership + burnup backdating.
+        if let Some(k) = &dt.cycle {
+            let cycle_id = *cycle_map
+                .get(k)
+                .ok_or_else(|| SeedError::Data(format!("unknown cycle key `{k}`")))?;
+            let cycle_actor = assignee_uuid.unwrap_or(admin_uuid);
+            repository::cycles::add_ticket(conn, cycle_id, ticket.id, Some(cycle_actor))?;
+            backdate_cycle_membership(conn, cycle_id, ticket.id, created_at)?;
+        }
+
+        // Closed timestamp for terminal states.
+        let closed_at = match category {
+            WorkflowStateCategory::Done | WorkflowStateCategory::Cancelled => {
+                dt.closed_hours_after.map(|h| {
+                    let c = created_at + Duration::hours(h);
+                    if c > updated_at {
+                        updated_at = c;
+                    }
+                    c
+                })
+            }
+            _ => None,
+        };
+
+        backdate_ticket(
+            conn,
+            ticket.id,
+            created_at,
+            updated_at,
+            closed_at,
+            first_response_at,
+        )?;
+    }
+
+    // Finalise completed cycles now that their tickets are attached, so the
+    // completion snapshot reflects real membership. complete() stamps
+    // completed_at = now(); backdate it to the cycle's end for a realistic past
+    // cycle.
+    for (cycle, end_at) in &completed_cycles {
+        let snapshot = repository::cycles::build_completion_snapshot(conn, cycle)?;
+        repository::cycles::complete(conn, cycle.uuid, snapshot)?;
+        diesel::update(cycles::table.filter(cycles::uuid.eq(cycle.uuid)))
+            .set(cycles::completed_at.eq(Some(*end_at)))
+            .execute(conn)?;
+    }
+
+    // --- Bulk history (last 365 days) --------------------------------------
+    // Populates the activity heatmap + long-range analytics. Skippable via
+    // SEED_HISTORY=off for a lighter seed.
+    if !matches!(
+        std::env::var("SEED_HISTORY").as_deref(),
+        Ok("off") | Ok("0") | Ok("false")
+    ) {
+        // Deterministic, key-sorted agent/requester lists for round-robin.
+        let mut agents: Vec<Uuid> = Vec::new();
+        let mut requesters: Vec<Uuid> = Vec::new();
+        let mut keys: Vec<&String> = user_map.keys().collect();
+        keys.sort();
+        for k in keys {
+            let (uuid, is_agent) = user_map[k];
+            if is_agent {
+                agents.push(uuid);
+            } else {
+                requesters.push(uuid);
+            }
+        }
+        summary.history = seed_history(conn, history, now, &agents, &requesters, &category_ids)?;
+    }
+
+    Ok(summary)
+}
+
+/// Expand the history template pool across the last 365 days: one low-detail
+/// ticket per generated slot, weekday-weighted, mostly closed (older than ~3
+/// weeks always terminal), round-robined across requesters and agents. Drives
+/// the activity heatmap (buckets by closed_at / updated_at) and long-range
+/// analytics. No bodies, comments, projects, or cycles.
+#[allow(clippy::too_many_arguments)]
+fn seed_history(
+    conn: &mut DbConnection,
+    history: &DemoHistory,
+    now: DateTime<Utc>,
+    agents: &[Uuid],
+    requesters: &[Uuid],
+    category_ids: &HashMap<String, i32>,
+) -> Result<usize, SeedError> {
+    if history.tickets.is_empty() || agents.is_empty() || requesters.is_empty() {
+        return Ok(0);
+    }
+
+    // Resolve one workflow state per category once.
+    let done = repository::workflow_states::first_in_category(conn, WorkflowStateCategory::Done)?;
+    let cancelled =
+        repository::workflow_states::first_in_category(conn, WorkflowStateCategory::Cancelled)?;
+    let active =
+        repository::workflow_states::first_in_category(conn, WorkflowStateCategory::Active)?;
+    let in_review =
+        repository::workflow_states::first_in_category(conn, WorkflowStateCategory::InReview)?;
+    let backlog =
+        repository::workflow_states::first_in_category(conn, WorkflowStateCategory::Backlog)?;
+    let triage =
+        repository::workflow_states::first_in_category(conn, WorkflowStateCategory::Triage)?;
+
+    let mut created = 0usize;
+    let mut seq: u64 = 0;
+
+    for d in (0..=364i64).rev() {
+        let day = now - Duration::days(d);
+        let weekday = day.weekday().num_days_from_monday(); // 0=Mon .. 6=Sun
+        let is_weekend = weekday >= 5;
+
+        // Tickets on this day: weekdays 1-4, weekends usually 0 (occasional 1).
+        let hday = hash(d as u64);
+        let count = if is_weekend {
+            if hday % 5 == 0 {
+                1
+            } else {
+                0
+            }
+        } else {
+            1 + (hday % 4)
+        };
+
+        for k in 0..count {
+            let h = hash(d as u64 * 131 + k + 1);
+
+            let tmpl = &history.tickets[(seq as usize) % history.tickets.len()];
+            let requester = requesters[(seq as usize) % requesters.len()];
+            let assignee = agents[(h as usize) % agents.len()];
+
+            // State: older than ~3 weeks is always terminal; recent is a mix.
+            // ~10% of terminal tickets are cancelled.
+            let recent_open = d <= 18 && h % 100 < 45;
+            let (state_id, terminal) = if recent_open {
+                match h % 4 {
+                    0 => (active.id, false),
+                    1 => (in_review.id, false),
+                    2 => (triage.id, false),
+                    _ => (backlog.id, false),
+                }
+            } else if h % 10 == 0 {
+                (cancelled.id, true)
+            } else {
+                (done.id, true)
+            };
+
+            // created_at: spread within the working day, always <= now.
+            let created_at =
+                day - Duration::hours((h % 9) as i64) - Duration::minutes((h % 47) as i64);
+
+            let new_ticket = NewTicket {
+                title: tmpl.title.clone(),
+                workflow_state_id: state_id,
+                priority: parse_priority(&tmpl.priority),
+                requester_uuid: Some(requester),
+                assignee_uuid: Some(assignee),
+                category_id: category_ids.get(&tmpl.category).copied(),
+                submitted_via: Some("web".to_string()),
+                guest_lookup_token: None,
+                verification_state: None,
+                origin_channel_id: None,
+                triage_state: None,
+                due_date: None,
+                start_date: None,
+                recurrence_rule: None,
+                recurrence_template_id: None,
+                resolution_notes: None,
+                spam_suspected: false,
+            };
+            let ticket = repository::tickets::create_ticket(conn, new_ticket)?;
+
+            // first response ~15min-3h after open, so SLA pills stay green.
+            let first_response_at = created_at + Duration::minutes(15 + (h % 165) as i64);
+
+            let (closed_at, updated_at) = if terminal {
+                // Resolve 1h-4d later, clamped before now.
+                let dur = Duration::hours(1 + (h % 96) as i64);
+                let mut c = created_at + dur;
+                let ceiling = now - Duration::minutes(1);
+                if c > ceiling {
+                    c = ceiling;
+                }
+                (Some(c), c)
+            } else {
+                // Open: last touched a bit after open (drives activity-mode).
+                (None, created_at + Duration::hours((h % 6) as i64))
+            };
+
+            backdate_ticket(
+                conn,
+                ticket.id,
+                created_at,
+                updated_at,
+                closed_at,
+                Some(first_response_at.min(updated_at)),
+            )?;
+
+            seq += 1;
+            created += 1;
+        }
+    }
+
+    Ok(created)
+}
+
+/// Cheap deterministic hash (splitmix-ish) for reproducible pseudo-random
+/// spread without a dependency on rand (keeps seeds reproducible).
+fn hash(mut x: u64) -> u64 {
+    x = x.wrapping_add(0x9E3779B97F4A7C15);
+    x = (x ^ (x >> 30)).wrapping_mul(0xBF58476D1CE4E5B9);
+    x = (x ^ (x >> 27)).wrapping_mul(0x94D049BB133111EB);
+    x ^ (x >> 31)
+}
+
+/// Verify the instance is ready to seed. Returns a user uuid to attribute
+/// provisioning writes to (prefers a platform admin).
+fn preflight(conn: &mut DbConnection) -> Result<Uuid, SeedError> {
+    let ws_count: i64 = workspaces::table.count().get_result(conn)?;
+    if ws_count == 0 {
+        return Err(SeedError::Precondition(
+            "no workspace found. Start the stack (`make dev`) and let migrations run first."
+                .to_string(),
+        ));
+    }
+
+    // Guard: seeding users into a virgin instance would trip the
+    // `count_users > 0` short-circuit in create_initial_admin and lock the
+    // operator out of ever creating their admin. Require onboarding first.
+    let user_count = repository::count_users(conn)?;
+    if user_count == 0 {
+        return Err(SeedError::Precondition(
+            "no users yet — complete onboarding first (open the setup URL, or run \
+             `nosdesk-cli admin create`), then re-run `make seed-demo`. Seeding users \
+             now would block admin setup."
+                .to_string(),
+        ));
+    }
+
+    let already: i64 = user_emails::table
+        .filter(user_emails::email.like(format!("%{DEMO_EMAIL_DOMAIN}")))
+        .count()
+        .get_result(conn)?;
+    if already > 0 {
+        return Err(SeedError::AlreadySeeded);
+    }
+
+    let admin_uuid: Uuid = users::table
+        .filter(users::platform_role.eq("platform_admin"))
+        .filter(users::deleted_at.is_null())
+        .order(users::created_at.asc())
+        .select(users::uuid)
+        .first(conn)
+        .optional()?
+        .map(Ok)
+        .unwrap_or_else(|| {
+            // No platform admin (unusual) — attribute to the oldest user.
+            users::table
+                .filter(users::deleted_at.is_null())
+                .order(users::created_at.asc())
+                .select(users::uuid)
+                .first(conn)
+        })?;
+
+    Ok(admin_uuid)
+}
+
+/// Insert a local (password) auth identity, mirroring
+/// `services::admin_setup::create_initial_admin`.
+fn insert_local_identity(
+    conn: &mut DbConnection,
+    user_uuid: Uuid,
+    email: &str,
+    password_hash: &str,
+) -> QueryResult<usize> {
+    #[derive(diesel::Insertable)]
+    #[diesel(table_name = backend::schema::user_auth_identities)]
+    struct NewLocalAuthIdentity<'a> {
+        user_uuid: Uuid,
+        provider_type: &'a str,
+        external_id: &'a str,
+        email: Option<&'a str>,
+        password_hash: Option<&'a str>,
+    }
+    diesel::insert_into(backend::schema::user_auth_identities::table)
+        .values(&NewLocalAuthIdentity {
+            user_uuid,
+            provider_type: "local",
+            external_id: email,
+            email: Some(email),
+            password_hash: Some(password_hash),
+        })
+        .execute(conn)
+}
+
+/// Backdate a ticket. `updated_at` is set explicitly so the
+/// `diesel_set_updated_at` BEFORE-UPDATE trigger keeps our value instead of
+/// stamping `now()`.
+fn backdate_ticket(
+    conn: &mut DbConnection,
+    ticket_id: i32,
+    created_at: DateTime<Utc>,
+    updated_at: DateTime<Utc>,
+    closed_at: Option<DateTime<Utc>>,
+    first_response_at: Option<DateTime<Utc>>,
+) -> QueryResult<usize> {
+    diesel::update(tickets::table.find(ticket_id))
+        .set((
+            tickets::created_at.eq(created_at),
+            tickets::updated_at.eq(updated_at),
+            tickets::closed_at.eq(closed_at),
+            tickets::first_response_at.eq(first_response_at),
+        ))
+        .execute(conn)
+}
+
+fn backdate_comment(
+    conn: &mut DbConnection,
+    comment_id: i32,
+    at: DateTime<Utc>,
+) -> QueryResult<usize> {
+    diesel::update(comments::table.find(comment_id))
+        .set((comments::created_at.eq(at), comments::updated_at.eq(at)))
+        .execute(conn)
+}
+
+/// Backdate a ticket's cycle membership so the burnup chart rises across the
+/// cycle rather than spiking at seed time. Rewrites both `cycle_tickets.added_at`
+/// and the `cycle_ticket.added` sync event that `membership_intervals` replays.
+/// A cross-partition move of the sync row re-fires the webhook-outbox trigger,
+/// which is idempotent (`ON CONFLICT DO NOTHING`), so no cleanup is needed.
+fn backdate_cycle_membership(
+    conn: &mut DbConnection,
+    cycle_id: i32,
+    ticket_id: i32,
+    at: DateTime<Utc>,
+) -> QueryResult<usize> {
+    diesel::update(
+        cycle_tickets::table
+            .filter(cycle_tickets::cycle_id.eq(cycle_id))
+            .filter(cycle_tickets::ticket_id.eq(ticket_id)),
+    )
+    .set(cycle_tickets::added_at.eq(at))
+    .execute(conn)?;
+
+    let sync_ids: Vec<i64> = sync_actions::table
+        .filter(sync_actions::aggregate.eq(SyncAggregate::CycleTicket))
+        .filter(sync_actions::aggregate_id.eq(format!("{cycle_id}:{ticket_id}")))
+        .filter(sync_actions::event_type.eq("cycle_ticket.added"))
+        .select(sync_actions::sync_id)
+        .load(conn)?;
+
+    let mut n = 0;
+    for sid in sync_ids {
+        n += diesel::sql_query("UPDATE sync_actions SET occurred_at = $1 WHERE sync_id = $2")
+            .bind::<Timestamptz, _>(at)
+            .bind::<BigInt, _>(sid)
+            .execute(conn)?;
+    }
+    Ok(n)
+}
+
+fn parse_priority(s: &str) -> TicketPriority {
+    match s {
+        "none" => TicketPriority::None,
+        "low" => TicketPriority::Low,
+        "high" => TicketPriority::High,
+        "urgent" => TicketPriority::Urgent,
+        _ => TicketPriority::Medium,
+    }
+}
+
+fn parse_state_category(s: &str) -> WorkflowStateCategory {
+    match s {
+        "triage" => WorkflowStateCategory::Triage,
+        "active" => WorkflowStateCategory::Active,
+        "in_review" => WorkflowStateCategory::InReview,
+        "done" => WorkflowStateCategory::Done,
+        "cancelled" => WorkflowStateCategory::Cancelled,
+        _ => WorkflowStateCategory::Backlog,
+    }
+}
+
+fn print_summary(s: &Summary, data: &DemoData) {
+    println!();
+    println!("Demo data seeded into the bootstrap workspace:");
+    println!(
+        "  {} users, {} projects, {} cycles, {} devices, {} detailed tickets, {} comments",
+        s.users, s.projects, s.cycles, s.devices, s.tickets, s.comments
+    );
+    println!(
+        "  {} bulk history tickets spread across the last 365 days (for the activity graph)",
+        s.history
+    );
+    if s.bodies_skipped > 0 {
+        println!(
+            "  ({} ticket bodies could not be converted and were left empty)",
+            s.bodies_skipped
+        );
+    }
+    println!();
+    println!("All demo users share the password: {}", data.password);
+    if let Some(member) = data.users.iter().find(|u| u.role == "member") {
+        println!("  requester (logs in directly): {}", member.email);
+    }
+    if let Some(agent) = data.users.iter().find(|u| u.role == "agent") {
+        println!("  agent:                        {}", agent.email);
+    }
+    println!(
+        "Agent/admin accounts are prompted for a one-time MFA setup on first login\n\
+         (app policy). Requesters and your existing admin sign in directly."
+    );
+    println!();
+    println!(
+        "Note: seeded tickets aren't in the running server's search index yet. As an\n\
+         admin, POST /api/search/rebuild (or restart with an empty index) to index them."
+    );
+}

--- a/backend/src/services/seed.rs
+++ b/backend/src/services/seed.rs
@@ -187,7 +187,10 @@ pub fn seed_getting_started(conn: &mut DbConnection, author: Uuid) -> QueryResul
 /// Builds a y-prosemirror compatible XmlFragment("prosemirror") with proper
 /// block structure (paragraph, heading, bullet_list, etc.) and inline marks
 /// (bold, italic, code) stored as text formatting attributes via XmlDeltaPrelim.
-fn markdown_to_yjs(markdown: &str) -> Option<Vec<u8>> {
+///
+/// Public so the `seed_demo` binary can render demo ticket bodies through the
+/// same converter used for the welcome page.
+pub fn markdown_to_yjs(markdown: &str) -> Option<Vec<u8>> {
     let doc = Doc::new();
     let fragment = {
         let mut txn = doc.transact_mut();


### PR DESCRIPTION
Adds a `seed_demo` binary and a `make seed-demo` target that seed a realistic demo helpdesk into the running dev stack's bootstrap workspace: users, projects, cycles, devices, and ticket threads with rich-text bodies and comment threads, plus a year of backdated lightweight history so the activity heatmap and long-range analytics have something to show. Built for screenshots and for exercising data-hungry views (gantt, cycles, dashboard).

- Datasets are data, not code: `backend/seeds/demo.json` (current-window tickets with bodies/comments/links) and `backend/seeds/demo-history.json` (the backdated year, no bodies).
- Idempotent: re-running skips when already seeded; reset with `make clean-db` then re-onboard. `SEED_HISTORY=off` gives the lighter seed.
- `services::seed::markdown_to_yjs` goes `pub` so demo ticket bodies render through the same y-prosemirror converter as the welcome page.
- Comments are declared `ContentFormat::Plaintext`; combined with #74's repository guard, prose can never route into the legacy email-iframe fallback again.

## Testing
`cargo check --bin seed_demo` clean; seeded repeatedly against the dev stack (agents, projects, 48 tickets, cycles, history) and drove the gantt/cycles/dashboard views on the result.