### PR TITLE
test: fix integration tests broken by the fail-closed ENVIRONMENT change

### DIFF
--- a/backend/tests/boot_server.rs
+++ b/backend/tests/boot_server.rs
@@ -50,6 +50,11 @@ async fn real_server_boots_and_serves() {
 
     let config = Config::from_source(
         &|k| match k {
+            // Explicit dev label: the mock getter bypasses process env, so the
+            // `.cargo/config.toml` ENVIRONMENT=development doesn't reach here, and
+            // an unset ENVIRONMENT now assumes production (which would demand
+            // FRONTEND_URL etc.). This boots a real server for a smoke test.
+            "ENVIRONMENT" => Some("development".to_string()),
             "JWT_SECRET" => Some("0123456789abcdef0123456789abcdef01".to_string()),
             "REDIS_URL" => Some(redis.clone()),
             _ => None,

--- a/backend/tests/boot_smoke.rs
+++ b/backend/tests/boot_smoke.rs
@@ -52,9 +52,12 @@ async fn boot_wires_state_and_routes() {
     std::env::set_var("REDIS_URL", &redis);
 
     // A development config pointed at the test Redis. Reuses the injectable
-    // `from_source` so this doesn't touch process env.
+    // `from_source` so this doesn't touch process env — which means the explicit
+    // ENVIRONMENT=development is required here, since an unset value now assumes
+    // production (fail-closed) and would demand FRONTEND_URL etc.
     let config = Config::from_source(
         &|k| match k {
+            "ENVIRONMENT" => Some("development".to_string()),
             "JWT_SECRET" => Some("0123456789abcdef0123456789abcdef01".to_string()),
             "REDIS_URL" => Some(redis.clone()),
             _ => None,

--- a/backend/tests/collaboration_ws.rs
+++ b/backend/tests/collaboration_ws.rs
@@ -52,9 +52,10 @@ fn install_fast_heartbeat() {
         if std::env::var("JWT_SECRET").is_err() {
             std::env::set_var("JWT_SECRET", "test-jwt-secret-32-characters-min-for-tests");
         }
-        // Tests are not "production" — relaxes the Origin requirement
-        // in ws_handler.
-        std::env::set_var("ENVIRONMENT", "test");
+        // Relax the ws_handler Origin requirement. `assume_production` is
+        // fail-closed: only "development"/"dev" count as non-production, so a
+        // label like "test" would read as production and reject the WS.
+        std::env::set_var("ENVIRONMENT", "development");
     });
 }
 


### PR DESCRIPTION
Follow-up to #84 — the fail-closed `ENVIRONMENT` change (unset/non-canonical now assumes production) broke three integration tests that relied on the old fail-open default, turning `main` red at the `cargo test` step.

- **boot_server / boot_smoke** build a `Config` via the injectable `from_source` with a mock getter that bypasses process env, so `.cargo/config.toml`'s `ENVIRONMENT=development` never reached them → unset → production → `FRONTEND_URL required` → boot failed. Added `ENVIRONMENT=development` to the getter.
- **collaboration_ws** set `ENVIRONMENT=test` meaning "not production", but `assume_production` (correctly) treats only `development`/`dev` as non-production, so `test` read as production and the `ws_handler` origin check rejected the WS (403). Changed to `development`.

Verified locally with the **full** `cargo test` (0 failures across all binaries) + clippy + fmt — the miss on #84 was running only `--lib`.