### PR TITLE
fix(auth): enforce API-token scopes on file-serving routes

### DIFF
--- a/backend/src/middleware/token_scope.rs
+++ b/backend/src/middleware/token_scope.rs
@@ -574,4 +574,36 @@ mod enforcement_tests {
             StatusCode::FORBIDDEN
         );
     }
+
+    #[actix_web::test]
+    async fn file_serving_requires_full_scope() {
+        // Tenant file downloads map to Full: even a token that can read the
+        // ticket the file belongs to cannot fetch the file itself with a
+        // narrowed scope. Guards the /api/files scope wiring (the routes used
+        // to sit outside any scope-enforced tree).
+        assert_eq!(
+            status_for(
+                Some("tickets:read"),
+                Method::GET,
+                "/api/files/tickets/5/x.png"
+            )
+            .await,
+            StatusCode::FORBIDDEN
+        );
+        assert_eq!(
+            status_for(
+                Some("*:read"),
+                Method::GET,
+                "/api/files/assets/1/media/y.webp"
+            )
+            .await,
+            StatusCode::FORBIDDEN
+        );
+        // A full credential (cookie session / un-narrowed token) still reaches
+        // the file handler.
+        assert_eq!(
+            status_for(Some("full"), Method::GET, "/api/files/tickets/5/x.png").await,
+            StatusCode::OK
+        );
+    }
 }

--- a/backend/src/startup.rs
+++ b/backend/src/startup.rs
@@ -670,16 +670,29 @@ pub fn configure_app(
                     .route(web::post().to(crate::handlers::csp_reports::report_violation))
             )
 
-            // Public file serving with token-based auth for attachments
-            // Authenticated, workspace-scoped tenant file serving. Each route
-            // is wrapped with dual_auth_middleware (cookie or Bearer, and a
-            // workspace-membership gate); the handlers add a per-ticket
-            // visibility check via TenantConn so a caller can only read files
-            // for tickets they can see in their own workspace.
-            .route("/api/files/tickets/{ticket_id}/notes/{filename:.*}", web::get().to(crate::handlers::serve_ticket_note_image).wrap(actix_web::middleware::from_fn(crate::middleware::dual_auth_middleware)))
-            .route("/api/files/tickets/{filename:.*}", web::get().to(crate::handlers::serve_ticket_file).wrap(actix_web::middleware::from_fn(crate::middleware::dual_auth_middleware)))
-            .route("/api/files/assets/{asset_id}/media/{filename:.*}", web::get().to(crate::handlers::asset_media::serve_asset_media_file).wrap(actix_web::middleware::from_fn(crate::middleware::dual_auth_middleware)))
-            .route("/api/files/temp/{filename:.*}", web::get().to(crate::handlers::serve_temp_file).wrap(actix_web::middleware::from_fn(crate::middleware::dual_auth_middleware)))
+            // Authenticated, workspace-scoped tenant file serving. Its own
+            // scope so the wrap stack matches the main /api scope: dual_auth
+            // (cookie or Bearer + workspace-membership gate) registered last so
+            // it runs first and puts Claims in extensions, then token_scope
+            // enforces API-token scopes. These routes map to `Full`, so a
+            // narrowed token 403s here instead of slipping past scope
+            // enforcement (they used to sit outside any scope-wrapped tree).
+            // The handlers add a per-ticket/asset visibility check via
+            // TenantConn so a caller only reads files it can see in its own
+            // workspace. Registered before the main /api scope so /api/files/*
+            // resolves here; the notes route precedes the generic ticket route
+            // so the `{filename:.*}` tail can't swallow it.
+            .service(
+                web::scope("/api/files")
+                    .wrap(actix_web::middleware::from_fn(
+                        crate::middleware::token_scope::token_scope_middleware,
+                    ))
+                    .wrap(actix_web::middleware::from_fn(crate::middleware::dual_auth_middleware))
+                    .route("/tickets/{ticket_id}/notes/{filename:.*}", web::get().to(crate::handlers::serve_ticket_note_image))
+                    .route("/tickets/{filename:.*}", web::get().to(crate::handlers::serve_ticket_file))
+                    .route("/assets/{asset_id}/media/{filename:.*}", web::get().to(crate::handlers::asset_media::serve_asset_media_file))
+                    .route("/temp/{filename:.*}", web::get().to(crate::handlers::serve_temp_file))
+            )
 
             // SSE endpoints (with custom token-based auth)
             // Main event stream for all real-time updates (tickets, documentation, devices, etc.)

--- a/backend/tests/boot_smoke.rs
+++ b/backend/tests/boot_smoke.rs
@@ -132,4 +132,34 @@ async fn boot_wires_state_and_routes() {
         StatusCode::UNAUTHORIZED,
         "GET /api/users => {status}"
     );
+
+    // Tenant file serving must sit inside the scope-enforced tree: a
+    // deliberately-narrowed API token maps to `Full` on /api/files/* and must
+    // be denied (403) by token_scope, not slip through to the file handler.
+    // This drives the real route tree, so it guards the /api/files scope wiring
+    // itself — the bug was these routes living outside any scope-wrapped scope.
+    let user = common::insert_user(&mut pool.get().expect("conn"), "Files Scope Probe");
+    let narrowed = common::mint_scoped_api_token(
+        &mut pool.get().expect("conn"),
+        &user,
+        "probe",
+        &["tickets:read"],
+    );
+    let resp = test::try_call_service(
+        &app,
+        test::TestRequest::get()
+            .uri("/api/files/tickets/does-not-exist.png")
+            .insert_header(("Authorization", format!("Bearer {narrowed}")))
+            .to_request(),
+    )
+    .await;
+    let status = match resp {
+        Ok(r) => r.status(),
+        Err(e) => e.as_response_error().status_code(),
+    };
+    assert_eq!(
+        status,
+        StatusCode::FORBIDDEN,
+        "narrowed token on /api/files/* must be scope-denied => {status}"
+    );
 }

--- a/backend/tests/common/mod.rs
+++ b/backend/tests/common/mod.rs
@@ -304,9 +304,20 @@ pub fn insert_user(conn: &mut PgConnection, name: &str) -> backend::models::User
         .expect("insert user")
 }
 
-/// Mint a user-bound `api_tokens` row directly. Returns the raw token
-/// string for use in the Authorization header.
+/// Mint a full-scope user-bound `api_tokens` row directly. Returns the raw
+/// token string for use in the Authorization header.
 pub fn mint_api_token(conn: &mut PgConnection, user: &backend::models::User, name: &str) -> String {
+    mint_scoped_api_token(conn, user, name, &["full"])
+}
+
+/// Mint a user-bound `api_tokens` row with an explicit scope set (e.g.
+/// `["tickets:read"]`). Returns the raw token string.
+pub fn mint_scoped_api_token(
+    conn: &mut PgConnection,
+    user: &backend::models::User,
+    name: &str,
+    scopes: &[&str],
+) -> String {
     use backend::models::NewApiToken;
     use backend::repository::api_tokens::{get_token_prefix, hash_token};
     use backend::schema::api_tokens;
@@ -316,7 +327,7 @@ pub fn mint_api_token(conn: &mut PgConnection, user: &backend::models::User, nam
         token_prefix: get_token_prefix(&raw),
         user_uuid: user.uuid,
         name: name.to_string(),
-        scopes: Some(vec![Some("full".to_string())]),
+        scopes: Some(scopes.iter().map(|s| Some((*s).to_string())).collect()),
         created_by: user.uuid,
         expires_at: None,
     };


### PR DESCRIPTION
## Finding #5 (edition audit)

The `/api/files/*` download routes were registered outside the scope-enforced `/api` tree, so `token_scope_middleware` never ran. A deliberately-narrowed API token (e.g. `tickets:read`) authenticated via `dual_auth` and reached tenant file downloads with no scope check. The `required_scope` policy already mapped these routes to `Full`; only the wiring was missing.

## Fix
- Moved the four file routes into a `web::scope("/api/files")` wrapped with `dual_auth` + `token_scope` in the same order as the main `/api` scope (dual_auth outer/first, token_scope inner).
- Collapses four duplicated per-route wraps into one and auto-covers future file routes.

## Tests
- `boot_smoke` real-router regression: a narrowed token on `/api/files/*` → 403 (guards the wiring itself).
- `token_scope` enforcement unit test for `/api/files/*`.
- New `mint_scoped_api_token` test helper.

Full backend suite green.