### PR TITLE
fix(license): derive the workspace cap from the edition in all modes

### DIFF
--- a/backend/src/handlers/admin_workspaces.rs
+++ b/backend/src/handlers/admin_workspaces.rs
@@ -175,8 +175,9 @@ pub async fn get_edition(req: HttpRequest, mut pc: PlatformConn) -> impl Respond
         == crate::middleware::DeploymentMode::SelfHosted;
     let active = pc.run(workspaces::count_active_workspaces).unwrap_or(0);
     let max = edition.max_workspaces();
-    // Hosted deployments are provisioned by the control plane, not gated here.
-    let can_create = !self_hosted || (active as u64) < u64::from(max);
+    // Gated on the edition's workspace cap, not the deployment mode (see
+    // license::workspace_creation_allowed).
+    let can_create = crate::license::workspace_creation_allowed(edition, active as u64);
     HttpResponse::Ok().json(serde_json::json!({
         "edition": edition.name(),
         "self_hosted": self_hosted,
@@ -223,39 +224,44 @@ pub async fn create_workspace(
         }
     };
 
-    // License gate. Self-hosted deployments are capped at the edition's
-    // workspace limit (Community = 1); creating beyond it requires an
-    // Enterprise license. Hosted deployments are provisioned by the control
-    // plane via the /api/internal surface and are not gated here.
-    if crate::middleware::DeploymentMode::current() == crate::middleware::DeploymentMode::SelfHosted
-    {
-        let edition = crate::license::current();
-        let max = edition.max_workspaces();
-        let active = match workspaces::count_active_workspaces(&mut conn) {
-            Ok(n) => n,
-            Err(e) => {
-                error!(error = ?e, "admin/workspaces license-gate count failed");
-                return errors::internal("Failed to create workspace");
-            }
-        };
-        if active as u64 >= u64::from(max) {
-            warn!(
-                active,
-                max,
-                edition = edition.name(),
-                "admin/workspaces blocked by license cap"
-            );
-            return HttpResponse::PaymentRequired().json(serde_json::json!({
-                "error": "license_required",
-                "message": format!(
-                    "This self-hosted deployment is limited to {max} active workspace(s). \
-                     An Enterprise license is required to create more."
-                ),
-                "edition": edition.name(),
-                "max_workspaces": max,
-                "active_workspaces": active,
-            }));
+    // License gate. Capped at the edition's workspace limit (Community = 1;
+    // Enterprise = the licensed count). Gated on the edition, NOT on
+    // NOSDESK_DEPLOYMENT_MODE: keying it on the mode let a self-hoster flip to
+    // `hosted` and skip the cap with no license. Hosted deployments provision
+    // through the control-plane /api/internal surface (uncapped, authoritative
+    // for its own billing), never this self-serve route, so the cap applies
+    // here in every mode. See license::workspace_creation_allowed.
+    let edition = crate::license::current();
+    let max = edition.max_workspaces();
+    let active = match workspaces::count_active_workspaces(&mut conn) {
+        Ok(n) => n,
+        Err(e) => {
+            error!(error = ?e, "admin/workspaces license-gate count failed");
+            return errors::internal("Failed to create workspace");
         }
+    };
+    if !crate::license::workspace_creation_allowed(edition, active as u64) {
+        warn!(
+            active,
+            max,
+            edition = edition.name(),
+            "admin/workspaces blocked by license cap"
+        );
+        let message = if edition.is_enterprise() {
+            format!("Your Enterprise license permits {max} active workspace(s); archive one before creating another.")
+        } else {
+            format!(
+                "The Community edition is limited to {max} active workspace(s). \
+                 An Enterprise license is required to create more."
+            )
+        };
+        return HttpResponse::PaymentRequired().json(serde_json::json!({
+            "error": "license_required",
+            "message": message,
+            "edition": edition.name(),
+            "max_workspaces": max,
+            "active_workspaces": active,
+        }));
     }
 
     let record = NewWorkspace {

--- a/backend/src/license.rs
+++ b/backend/src/license.rs
@@ -157,6 +157,20 @@ pub fn current() -> &'static Edition {
     EDITION.get_or_init(load_from_env)
 }
 
+/// Whether a self-serve admin workspace create is within the edition's cap.
+///
+/// Gated purely on the resolved edition (Community = 1 active workspace;
+/// Enterprise = the licensed count), NOT on `NOSDESK_DEPLOYMENT_MODE`. The cap
+/// used to be skipped whenever the mode was `hosted`, but the mode is an env
+/// var, so a self-hoster could flip it and create unlimited workspaces with no
+/// license. Hosted deployments provision through the control-plane
+/// `/api/internal` surface (which is 404'd off self-hosted and is authoritative
+/// for its own billing), not this self-serve path, so applying the cap here in
+/// every mode is safe and closes the bypass.
+pub fn workspace_creation_allowed(edition: &Edition, active_workspaces: u64) -> bool {
+    active_workspaces < u64::from(edition.max_workspaces())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -238,5 +252,27 @@ mod tests {
     fn community_cap_is_one() {
         assert_eq!(Edition::Community.max_workspaces(), 1);
         assert!(!Edition::Community.is_enterprise());
+    }
+
+    fn enterprise(max: u32) -> Edition {
+        Edition::Enterprise(LicenseInfo {
+            licensee: "Acme Corp".into(),
+            license_id: "lic_test_1".into(),
+            max_workspaces: max,
+            expires_at: 0,
+        })
+    }
+
+    #[test]
+    fn creation_allowed_respects_edition_count_cap() {
+        // Community: one active workspace, then capped.
+        assert!(workspace_creation_allowed(&Edition::Community, 0));
+        assert!(!workspace_creation_allowed(&Edition::Community, 1));
+        assert!(!workspace_creation_allowed(&Edition::Community, 2));
+
+        // Enterprise: up to the licensed count.
+        let ent = enterprise(3);
+        assert!(workspace_creation_allowed(&ent, 2));
+        assert!(!workspace_creation_allowed(&ent, 3));
     }
 }

--- a/backend/tests/admin_workspaces.rs
+++ b/backend/tests/admin_workspaces.rs
@@ -59,15 +59,22 @@ fn mint_user(conn: &mut diesel::pg::PgConnection, name: &str, role: &str) -> Use
 
 #[actix_web::test]
 async fn admin_workspaces_lifecycle_contract() {
-    // This exercises the workspace CRUD handlers, not the self-hosted
-    // single-workspace license gate (covered by workspace_license_gate.rs).
-    // Run in hosted mode so the gate (self-hosted only) doesn't block the
-    // second-workspace create this contract makes. Set before any
-    // DeploymentMode::current() call, which caches process-wide.
-    std::env::set_var("NOSDESK_DEPLOYMENT_MODE", "hosted");
+    // This exercises the workspace CRUD handlers, not the license gate
+    // (covered by workspace_license_gate.rs). The cap is on active workspaces
+    // (Community = 1), so rather than lean on a deployment-mode bypass we
+    // archive the seeded `default` workspace first, freeing the single slot for
+    // the workspace this contract creates and manipulates.
+    std::env::remove_var("NOSDESK_DEPLOYMENT_MODE");
+    std::env::remove_var("NOSDESK_LICENSE_KEY");
     common::ensure_test_keyring();
     let test_db = common::TestDb::new();
     let pool = test_db.pool_with_size(4);
+
+    // Archive the seeded workspace (id 1) so the Community cap of one active
+    // workspace has room for `acme-co` below.
+    diesel::sql_query("UPDATE workspaces SET archived_at = now() WHERE id = 1")
+        .execute(&mut pool.get().expect("conn"))
+        .expect("archive seed workspace");
 
     let admin = mint_user(&mut pool.get().expect("conn"), "PlatformAdmin", "admin");
     let admin_token =

--- a/backend/tests/workspace_cap_hosted.rs
+++ b/backend/tests/workspace_cap_hosted.rs
@@ -1,0 +1,112 @@
+//! Regression: the workspace cap is gated on the license, not the deployment
+//! mode. `NOSDESK_DEPLOYMENT_MODE` is an env var, so keying the self-serve
+//! admin create gate on it let a self-hoster flip to `hosted` and create
+//! unlimited workspaces with no Enterprise license. This proves that even in
+//! hosted mode (no license -> Community edition), the self-serve
+//! `/api/admin/workspaces` create is capped at one active workspace.
+//!
+//! Hosted deployments provision through the control-plane `/api/internal`
+//! surface instead, which is a separate route this test does not touch.
+
+#![allow(clippy::expect_used)]
+
+use actix_web::{web, App};
+use serde_json::json;
+
+use backend::handlers::admin_workspaces;
+use backend::middleware::dual_auth_middleware;
+use backend::models::{NewUser, User};
+
+mod common;
+
+fn mint_platform_admin(conn: &mut diesel::pg::PgConnection, name: &str) -> User {
+    use backend::schema::users;
+    use diesel::prelude::*;
+    let new_user = NewUser {
+        uuid: uuid::Uuid::new_v4(),
+        name: name.to_string(),
+        pronouns: None,
+        avatar_url: None,
+        banner_url: None,
+        avatar_thumb: None,
+        microsoft_uuid: None,
+        mfa_secret: None,
+        mfa_secret_kek_id: None,
+        mfa_enabled: false,
+        platform_role: Some("platform_admin".to_string()),
+    };
+    diesel::insert_into(users::table)
+        .values(&new_user)
+        .get_result(conn)
+        .expect("insert platform admin")
+}
+
+#[actix_web::test]
+async fn hosted_mode_does_not_bypass_the_workspace_cap() {
+    // Hosted mode, no license -> Community edition (cap = 1). Set before any
+    // DeploymentMode::current() call, which caches process-wide.
+    std::env::set_var("NOSDESK_DEPLOYMENT_MODE", "hosted");
+    std::env::remove_var("NOSDESK_LICENSE_KEY");
+    common::ensure_test_keyring();
+
+    let test_db = common::TestDb::new();
+    let pool = test_db.pool_with_size(4);
+
+    let admin = mint_platform_admin(&mut pool.get().expect("conn"), "PlatformAdmin");
+    let admin_token =
+        common::mint_api_token(&mut pool.get().expect("conn"), &admin, "admin-session");
+
+    let pool_for_app = pool.clone();
+    let srv = actix_test::start(move || {
+        App::new()
+            .app_data(web::Data::new(pool_for_app.clone()))
+            .service(
+                web::scope("/api/admin")
+                    .wrap(actix_web::middleware::from_fn(dual_auth_middleware))
+                    .route("/edition", web::get().to(admin_workspaces::get_edition))
+                    .route(
+                        "/workspaces",
+                        web::post().to(admin_workspaces::create_workspace),
+                    ),
+            )
+    });
+
+    let client = awc::Client::new();
+    let auth = || ("Authorization", format!("Bearer {admin_token}"));
+
+    // The seeded `default` workspace already fills the Community slot, so even
+    // in hosted mode the edition summary must report the cap reached.
+    let mut resp = client
+        .get(srv.url("/api/admin/edition"))
+        .insert_header(auth())
+        .send()
+        .await
+        .expect("send edition");
+    assert_eq!(resp.status(), 200);
+    let edition: serde_json::Value =
+        serde_json::from_slice(&resp.body().await.expect("body")).expect("json");
+    assert_eq!(edition["edition"], "community");
+    assert_eq!(
+        edition["can_create_workspace"], false,
+        "hosted mode must not report an uncapped self-serve create"
+    );
+
+    // The actual create must be blocked (402), not silently allowed as it was
+    // when the gate keyed on the deployment mode.
+    let resp = client
+        .post(srv.url("/api/admin/workspaces"))
+        .insert_header(auth())
+        .insert_header(("Content-Type", "application/json"))
+        .send_json(&json!({"slug": "bypass-attempt", "name": "Bypass"}))
+        .await
+        .expect("send create");
+    assert_eq!(
+        resp.status(),
+        402,
+        "hosted mode must not bypass the Community workspace cap"
+    );
+    let mut resp = resp;
+    let body: serde_json::Value =
+        serde_json::from_slice(&resp.body().await.expect("body")).expect("json");
+    assert_eq!(body["error"], "license_required");
+}


### PR DESCRIPTION
## Finding #6 (edition audit)

The self-serve `/api/admin/workspaces` create gate (and its `get_edition` summary) applied the workspace cap only in self-hosted mode. Because the deployment mode is environment-configured, the cap now derives from the resolved edition (Community or Enterprise) consistently, independent of `NOSDESK_DEPLOYMENT_MODE`. Hosted deployments continue to provision through the control-plane `/api/internal` surface, which is unaffected.

## Fix
- Added `license::workspace_creation_allowed` as the single source of truth for both the create gate and the edition summary.
- Reworked the workspace CRUD test to create under the Community cap by archiving the seed workspace instead of switching deployment mode.
- Added a `workspace_cap_hosted` regression test.

Full backend suite green.