### PR TITLE
fix(config): require a tenant domain when running in hosted mode

### DIFF
--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -178,6 +178,25 @@ impl Config {
             .map(|s| s.trim().to_string())
             .filter(|s| !s.is_empty());
 
+        // Hosted mode needs a tenant domain. Per-tenant subdomains
+        // (`<slug>.<tenant_domain>`) drive both tenant CORS and the managed
+        // default email identity `support@<slug>.<tenant_domain>`. Without it,
+        // a workspace that has no sending domain of its own can never have its
+        // outbound mail addressed, so the queue defers that mail indefinitely
+        // with no error. Surface the misconfiguration at boot instead.
+        let hosted = crate::middleware::DeploymentMode::from_value(
+            get("NOSDESK_DEPLOYMENT_MODE").as_deref(),
+        ) == crate::middleware::DeploymentMode::Hosted;
+        if hosted && tenant_domain.is_none() {
+            error!(
+                "NOSDESK_TENANT_DOMAIN must be set in hosted mode: per-tenant \
+                 subdomains drive tenant CORS and the managed default email \
+                 identity, and without it identity-less workspaces' outbound \
+                 mail defers forever."
+            );
+            return Err(fatal("NOSDESK_TENANT_DOMAIN is required in hosted mode"));
+        }
+
         let shutdown_timeout_secs = get("NOSDESK_SHUTDOWN_TIMEOUT_SECS")
             .and_then(|s| s.parse::<u64>().ok())
             .unwrap_or(25);
@@ -484,6 +503,44 @@ mod tests {
         .unwrap();
         assert_eq!(c.additional_origins, vec!["https://a.com", "https://b.com"]);
         assert_eq!(c.tenant_domain.as_deref(), Some("nosdesk.app"));
+    }
+
+    #[test]
+    fn hosted_mode_requires_tenant_domain() {
+        // Hosted with no tenant domain fails fast rather than silently
+        // stranding identity-less workspaces' outbound mail.
+        let err = build(
+            &[
+                ("JWT_SECRET", GOOD_JWT),
+                ("NOSDESK_DEPLOYMENT_MODE", "hosted"),
+            ],
+            true,
+        )
+        .unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "NOSDESK_TENANT_DOMAIN is required in hosted mode"
+        );
+
+        // With the tenant domain present it builds.
+        let c = build(
+            &[
+                ("JWT_SECRET", GOOD_JWT),
+                ("NOSDESK_DEPLOYMENT_MODE", "Hosted"),
+                ("NOSDESK_TENANT_DOMAIN", "nosdesk.app"),
+            ],
+            true,
+        )
+        .unwrap();
+        assert_eq!(c.tenant_domain.as_deref(), Some("nosdesk.app"));
+    }
+
+    #[test]
+    fn self_hosted_without_tenant_domain_builds() {
+        // The tenant-domain requirement is hosted-only; self-hosted (the
+        // default mode) has no such dependency.
+        let c = build(&[("JWT_SECRET", GOOD_JWT)], true).unwrap();
+        assert!(c.tenant_domain.is_none());
     }
 
     #[test]

--- a/backend/src/middleware/workspace_context.rs
+++ b/backend/src/middleware/workspace_context.rs
@@ -142,13 +142,16 @@ impl DeploymentMode {
     /// to `SelfHosted` to preserve behaviour for existing
     /// installs that don't set the variable.
     pub fn from_env() -> Self {
-        match std::env::var("NOSDESK_DEPLOYMENT_MODE")
-            .ok()
-            .as_deref()
-            .map(str::trim)
-            .map(str::to_lowercase)
-            .as_deref()
-        {
+        Self::from_value(std::env::var("NOSDESK_DEPLOYMENT_MODE").ok().as_deref())
+    }
+
+    /// Pure parse of a `NOSDESK_DEPLOYMENT_MODE` value, split out so config
+    /// validation can resolve the mode through its injectable env getter
+    /// instead of reading process env directly. `hosted` (case/whitespace
+    /// insensitive) is the only value that selects hosted; anything else,
+    /// including absent, is `SelfHosted`.
+    pub fn from_value(raw: Option<&str>) -> Self {
+        match raw.map(str::trim).map(str::to_lowercase).as_deref() {
             Some("hosted") => DeploymentMode::Hosted,
             _ => DeploymentMode::SelfHosted,
         }


### PR DESCRIPTION
## Finding #7 (edition audit)

Hosted deployments derive per-tenant subdomains (`<slug>.<tenant_domain>`) for tenant CORS and the managed default email identity `support@<slug>.<tenant_domain>`. When the domain is unset, a workspace without its own sending identity has no address to send from, so its outbound mail defers indefinitely with no error. Config now validates the tenant domain at boot in hosted mode, alongside the existing JWT_SECRET and REDIS_URL checks.

Self-hosted deployments are unaffected: the tenant domain stays optional there, and workspace mail resolves through the operator's own SMTP identity or a per-workspace verified sending domain.

## Fix
- Added `DeploymentMode::from_value` so config resolves the mode through its injectable env getter rather than reading process env.
- Covered the hosted-requires-domain and self-hosted-exempt paths in tests.

Full backend suite green.