### PR TITLE
fix(webhooks): record durable deliveries atomically with the outbox drain

### DIFF
--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -5625,6 +5625,13 @@ pub struct NewWebhookDelivery {
     pub payload: serde_json::Value,
     pub request_headers: Option<serde_json::Value>,
     pub attempt_number: i32,
+    /// When the retry worker may (re)deliver this row. The immediate-send path
+    /// (worker first attempt) leaves this `None` and delivers off the in-memory
+    /// queue. The transactional-outbox drain sets a short grace window so that
+    /// if the process dies before the queued delivery runs, the retry worker
+    /// still picks the row up: the durable record, not the queue, is the source
+    /// of truth. See `services::webhooks::service::dispatch_outbox_batch`.
+    pub next_retry_at: Option<NaiveDateTime>,
 }
 
 /// Webhook delivery update

--- a/backend/src/services/webhooks/delivery.rs
+++ b/backend/src/services/webhooks/delivery.rs
@@ -157,6 +157,9 @@ impl WebhookDeliveryWorker {
                                 "X-Nosdesk-Delivery": task.payload.id.to_string(),
                             })),
                             attempt_number: task.attempt,
+                            // Immediate send off the queue; no retry scheduled
+                            // until this attempt records an outcome.
+                            next_retry_at: None,
                         },
                     )
                 })

--- a/backend/src/services/webhooks/service.rs
+++ b/backend/src/services/webhooks/service.rs
@@ -82,116 +82,28 @@ impl WebhookService {
         }
     }
 
-    /// Claim a batch of outbox rows, queue the matching webhook
-    /// deliveries, and delete the claimed rows — all in one transaction
-    /// so a row is removed only once its deliveries are committed-queued.
-    /// Non-webhook events are deleted too (a no-op delivery-wise) so the
-    /// outbox drains. Returns whether the batch was full (more remain).
+    /// Claim a batch of outbox rows, record a durable delivery row per
+    /// subscriber, delete the claimed rows, then queue the deliveries for
+    /// immediate send. Returns whether the batch was full (more remain).
+    ///
+    /// Durability: the `webhook_deliveries` rows are written in the SAME
+    /// transaction as the outbox delete (see [`Self::drain_batch_txn`]), so the
+    /// fan-out is at-least-once. If the process dies after the transaction
+    /// commits but before the queued in-memory delivery runs, the retry worker
+    /// recovers the pending rows; the durable record, not the queue, is the
+    /// source of truth. The enqueue happens after the transaction so the row
+    /// locks release promptly.
     async fn dispatch_outbox_batch(
         pool: &Pool,
         delivery_tx: &mpsc::Sender<DeliveryTask>,
     ) -> Result<bool, String> {
-        use crate::schema::{sync_actions, webhook_outbox};
-        use diesel::prelude::*;
-
-        const OUTBOX_BATCH: i64 = 500;
-
         let (tasks, more): (Vec<DeliveryTask>, bool) = crate::sync::session::background_run(
             pool,
             "background:webhook_outbox_dispatch",
-            |conn| {
-                conn.transaction::<_, diesel::result::Error, _>(|conn| {
-                    // Claim the oldest outbox rows, skipping any another
-                    // instance is already processing.
-                    let claimed: Vec<i64> = webhook_outbox::table
-                        .select(webhook_outbox::sync_id)
-                        .order(webhook_outbox::sync_id.asc())
-                        .limit(OUTBOX_BATCH)
-                        .for_update()
-                        .skip_locked()
-                        .load(conn)?;
-                    if claimed.is_empty() {
-                        return Ok((Vec::new(), false));
-                    }
-                    let full = claimed.len() as i64 == OUTBOX_BATCH;
-
-                    // Resolve the source rows for workspace_id + event_type + data.
-                    // workspace_id is load-bearing: this drain runs BYPASSRLS, so
-                    // subscribers must be scoped to the event's own workspace by
-                    // hand (RLS gives no cover here).
-                    let rows: Vec<(i64, i32, String, serde_json::Value)> = sync_actions::table
-                        .filter(sync_actions::sync_id.eq_any(&claimed))
-                        .select((
-                            sync_actions::sync_id,
-                            sync_actions::workspace_id,
-                            sync_actions::event_type,
-                            sync_actions::data,
-                        ))
-                        .load(conn)?;
-
-                    // Cache the subscriber lookup per (workspace, event type) so a
-                    // batch of N same-type rows in a workspace is one query, not N.
-                    let mut subscriber_cache: std::collections::HashMap<
-                        (i32, &'static str),
-                        Vec<crate::models::Webhook>,
-                    > = std::collections::HashMap::new();
-                    let mut tasks: Vec<DeliveryTask> = Vec::new();
-
-                    for (_sync_id, workspace_id, event_type, data) in &rows {
-                        let Some(webhook_type) = WebhookEventType::from_sync_action(event_type)
-                        else {
-                            continue;
-                        };
-                        let event_type_str = webhook_type.as_str();
-                        let cache_key = (*workspace_id, event_type_str);
-                        if !subscriber_cache.contains_key(&cache_key) {
-                            let subs = webhook_repo::get_webhooks_for_event(
-                                conn,
-                                *workspace_id,
-                                event_type_str,
-                            )?;
-                            subscriber_cache.insert(cache_key, subs);
-                        }
-                        let subscribers = &subscriber_cache[&cache_key];
-                        if subscribers.is_empty() {
-                            continue;
-                        }
-                        let payload = WebhookPayload {
-                            id: Uuid::now_v7(),
-                            event_type: event_type_str.to_string(),
-                            timestamp: Utc::now(),
-                            data: data.clone(),
-                        };
-                        for webhook in subscribers {
-                            tasks.push(DeliveryTask {
-                                webhook_id: webhook.id,
-                                webhook_url: webhook.url.clone(),
-                                webhook_secret: webhook.secret.clone(),
-                                webhook_headers: webhook.headers.clone(),
-                                payload: payload.clone(),
-                                attempt: 1,
-                                delivery_id: None,
-                            });
-                        }
-                    }
-
-                    // Delete every claimed row (webhook or not) so the
-                    // outbox drains. They're locked by this transaction,
-                    // so no other instance can re-claim them.
-                    diesel::delete(
-                        webhook_outbox::table.filter(webhook_outbox::sync_id.eq_any(&claimed)),
-                    )
-                    .execute(conn)?;
-
-                    Ok((tasks, full))
-                })
-            },
+            Self::drain_batch_txn,
         )
         .map_err(|e| format!("DB error: {e}"))?;
 
-        // Enqueue outside the claim transaction so the row locks release
-        // promptly; HTTP delivery + retry durability is handled by the
-        // delivery worker exactly as for the SSE gap path.
         for task in tasks {
             if let Err(e) = delivery_tx.send(task).await {
                 tracing::error!(error = %e, "Failed to queue webhook delivery from outbox");
@@ -199,6 +111,154 @@ impl WebhookService {
         }
 
         Ok(more)
+    }
+
+    /// Transactional core of the outbox drain, split out so it can be driven
+    /// directly in tests. Assumes it runs inside a bypass context
+    /// ([`crate::sync::session::with_actor_bypass_context`] supplies the outer
+    /// transaction and the `nosdesk_admin` role), which `background_run` above
+    /// provides.
+    ///
+    /// Claims the oldest outbox rows, fans each out to its subscribers, records
+    /// a durable `webhook_deliveries` row per subscriber, then deletes the
+    /// claimed outbox rows — atomically. The delivery rows carry a short
+    /// `next_retry_at` grace so a row whose in-memory send never runs (a crash)
+    /// is picked up by the retry worker instead of being lost.
+    pub fn drain_batch_txn(
+        conn: &mut crate::db::DbConnection,
+    ) -> diesel::result::QueryResult<(Vec<DeliveryTask>, bool)> {
+        use crate::schema::{sync_actions, webhook_outbox};
+        use diesel::prelude::*;
+
+        const OUTBOX_BATCH: i64 = 500;
+        // Grace before a recorded-but-unsent row becomes retry-eligible.
+        // Comfortably longer than a healthy instance's queue latency, so the
+        // retry worker only ever touches rows the in-memory send genuinely
+        // missed (a crash), not ones merely in flight.
+        const RECOVERY_GRACE_SECS: i64 = 300;
+
+        conn.transaction::<_, diesel::result::Error, _>(|conn| {
+            // Claim the oldest outbox rows, skipping any another instance is
+            // already processing.
+            let claimed: Vec<i64> = webhook_outbox::table
+                .select(webhook_outbox::sync_id)
+                .order(webhook_outbox::sync_id.asc())
+                .limit(OUTBOX_BATCH)
+                .for_update()
+                .skip_locked()
+                .load(conn)?;
+            if claimed.is_empty() {
+                return Ok((Vec::new(), false));
+            }
+            let full = claimed.len() as i64 == OUTBOX_BATCH;
+
+            // Resolve the source rows for workspace_id + event_type + data.
+            // workspace_id is load-bearing: this drain runs BYPASSRLS, so
+            // subscribers must be scoped to the event's own workspace by hand
+            // (RLS gives no cover here).
+            let rows: Vec<(i64, i32, String, serde_json::Value)> = sync_actions::table
+                .filter(sync_actions::sync_id.eq_any(&claimed))
+                .select((
+                    sync_actions::sync_id,
+                    sync_actions::workspace_id,
+                    sync_actions::event_type,
+                    sync_actions::data,
+                ))
+                .load(conn)?;
+
+            // Cache the subscriber lookup per (workspace, event type) so a batch
+            // of N same-type rows in a workspace is one query, not N. Build
+            // (workspace_id, task) pairs; the workspace pins each durable insert.
+            let mut subscriber_cache: std::collections::HashMap<
+                (i32, &'static str),
+                Vec<crate::models::Webhook>,
+            > = std::collections::HashMap::new();
+            let mut pending: Vec<(i32, DeliveryTask)> = Vec::new();
+
+            for (_sync_id, workspace_id, event_type, data) in &rows {
+                let Some(webhook_type) = WebhookEventType::from_sync_action(event_type) else {
+                    continue;
+                };
+                let event_type_str = webhook_type.as_str();
+                let cache_key = (*workspace_id, event_type_str);
+                let subscribers = match subscriber_cache.entry(cache_key) {
+                    std::collections::hash_map::Entry::Occupied(e) => e.into_mut(),
+                    std::collections::hash_map::Entry::Vacant(e) => {
+                        let subs = webhook_repo::get_webhooks_for_event(
+                            conn,
+                            *workspace_id,
+                            event_type_str,
+                        )?;
+                        e.insert(subs)
+                    }
+                };
+                if subscribers.is_empty() {
+                    continue;
+                }
+                let payload = WebhookPayload {
+                    id: Uuid::now_v7(),
+                    event_type: event_type_str.to_string(),
+                    timestamp: Utc::now(),
+                    data: data.clone(),
+                };
+                for webhook in subscribers {
+                    pending.push((
+                        *workspace_id,
+                        DeliveryTask {
+                            webhook_id: webhook.id,
+                            webhook_url: webhook.url.clone(),
+                            webhook_secret: webhook.secret.clone(),
+                            webhook_headers: webhook.headers.clone(),
+                            payload: payload.clone(),
+                            attempt: 1,
+                            delivery_id: None,
+                        },
+                    ));
+                }
+            }
+
+            // Record a durable delivery row per task, grouped by workspace so
+            // the audit trigger + the workspace_id column default resolve to
+            // each row's own workspace. Sorted so we re-pin once per workspace,
+            // not once per row. Pinning sets only app.workspace_id and leaves
+            // the bypass role intact (unlike a full actor-context switch).
+            pending.sort_by_key(|(ws, _)| *ws);
+            let recover_at =
+                Utc::now().naive_utc() + chrono::Duration::seconds(RECOVERY_GRACE_SECS);
+            let mut tasks: Vec<DeliveryTask> = Vec::with_capacity(pending.len());
+            let mut pinned: Option<i32> = None;
+            for (workspace_id, mut task) in pending {
+                if pinned != Some(workspace_id) {
+                    crate::sync::session::pin_workspace(conn, workspace_id)?;
+                    pinned = Some(workspace_id);
+                }
+                let delivery = webhook_repo::create_delivery(
+                    conn,
+                    crate::models::NewWebhookDelivery {
+                        webhook_id: task.webhook_id,
+                        event_type: task.payload.event_type.clone(),
+                        payload: serde_json::to_value(&task.payload).unwrap_or_default(),
+                        request_headers: Some(serde_json::json!({
+                            "X-Nosdesk-Signature": "sha256=***",
+                            "X-Nosdesk-Event": &task.payload.event_type,
+                            "X-Nosdesk-Delivery": task.payload.id.to_string(),
+                        })),
+                        attempt_number: task.attempt,
+                        next_retry_at: Some(recover_at),
+                    },
+                )?;
+                task.delivery_id = Some(delivery.id);
+                tasks.push(task);
+            }
+
+            // Delete every claimed row (webhook or not) so the outbox drains.
+            // They remain locked by this transaction, so no other instance can
+            // re-claim them.
+            diesel::delete(webhook_outbox::table.filter(webhook_outbox::sync_id.eq_any(&claimed)))
+                .execute(conn)?;
+
+            Ok((tasks, full))
+        })
     }
 
     /// Background worker that retries failed deliveries

--- a/backend/src/sync/session.rs
+++ b/backend/src/sync/session.rs
@@ -121,6 +121,21 @@ pub fn current_workspace_id(conn: &mut DbConnection) -> QueryResult<Option<i32>>
     Ok(row.current_setting.and_then(|s| s.parse().ok()))
 }
 
+/// Re-pin `app.workspace_id` for the current transaction WITHOUT touching the
+/// role or the actor GUCs.
+///
+/// For a bypass batch ([`with_actor_bypass_context`]) that writes to an
+/// audited, per-workspace table across several workspaces in one transaction:
+/// the audit trigger reads `app.workspace_id`, and the tenant `workspace_id`
+/// column defaults from it, so it must be re-pinned to each row's workspace
+/// before that row is written. Unlike [`set_actor`], this does not reset the
+/// role, so the surrounding bypass elevation (`SET LOCAL ROLE nosdesk_admin`)
+/// is preserved. Transaction-local (`set_config(_, _, true)`), so it clears on
+/// commit alongside the rest of the actor context.
+pub fn pin_workspace(conn: &mut DbConnection, workspace_id: i32) -> QueryResult<()> {
+    set_config(conn, "app.workspace_id", &workspace_id.to_string())
+}
+
 /// Run a closure inside a transaction with the actor GUCs primed, so
 /// any `audit_log` triggers fired by the contained writes attribute
 /// the change to `actor`. The GUCs are scoped to the transaction

--- a/backend/tests/webhook_outbox_durability.rs
+++ b/backend/tests/webhook_outbox_durability.rs
@@ -1,0 +1,123 @@
+//! Webhook outbox drain is at-least-once.
+//!
+//! The drain used to delete the claimed `webhook_outbox` rows and only queue
+//! the deliveries in memory; the durable `webhook_deliveries` row was written
+//! later by the delivery worker. A crash between the commit and that write
+//! dropped the fan-out. The drain now records a durable delivery row per
+//! subscriber in the SAME transaction as the outbox delete, with a
+//! `next_retry_at` grace so a lost in-memory send is recovered by the retry
+//! worker. This drives the transactional core directly and asserts the durable
+//! record exists (retry-eligible) exactly when the outbox row is gone.
+
+#![allow(clippy::expect_used)]
+
+mod common;
+
+use diesel::prelude::*;
+
+use backend::models::{SyncAggregate, SyncOp};
+use backend::schema::{webhook_deliveries, webhook_outbox};
+use backend::services::webhooks::WebhookService;
+use backend::sync::session::with_actor_bypass_context;
+use backend::sync::ActorContext;
+
+#[test]
+fn outbox_drain_records_durable_delivery_atomically() {
+    common::ensure_test_keyring();
+    let db = common::TestDb::new();
+    let pool = db.pool();
+    let mut conn = pool.get().expect("conn");
+
+    // A subscriber in the bootstrap workspace (id=1, pinned by the pool
+    // customizer) for the ticket.created event.
+    let webhook = backend::repository::webhooks::create_webhook(
+        &mut conn,
+        "durability-probe".into(),
+        "https://example.invalid/hook".into(),
+        "secret".into(),
+        vec!["ticket.created".into()],
+        None,
+        None,
+    )
+    .expect("create webhook");
+
+    // Emit a matching sync action. The AFTER INSERT trigger
+    // (tr_sync_actions_webhook_outbox) enqueues its webhook_outbox row.
+    let sync_id = backend::sync::emit::record(
+        &mut conn,
+        backend::sync::emit::SyncEmit {
+            aggregate: SyncAggregate::Ticket,
+            aggregate_id: "1".into(),
+            op: SyncOp::Insert,
+            event_type: "ticket.created",
+            data: serde_json::json!({ "id": 1 }),
+            groups: vec!["workspace".into()],
+            causation_id: None,
+        },
+    )
+    .expect("emit sync action");
+
+    // Precondition: outbox row present, no delivery recorded yet.
+    let outbox_before: i64 = webhook_outbox::table
+        .filter(webhook_outbox::sync_id.eq(sync_id))
+        .count()
+        .get_result(&mut conn)
+        .expect("count outbox before");
+    assert_eq!(
+        outbox_before, 1,
+        "the emit should have enqueued the outbox row"
+    );
+    let deliveries_before: i64 = webhook_deliveries::table
+        .filter(webhook_deliveries::webhook_id.eq(webhook.id))
+        .count()
+        .get_result(&mut conn)
+        .expect("count deliveries before");
+    assert_eq!(deliveries_before, 0);
+
+    // Drain the batch through the real transactional core (bypass context, as
+    // background_run supplies in production). No delivery worker runs, so this
+    // isolates the durability boundary from the in-memory send.
+    let (tasks, _more) = with_actor_bypass_context(
+        &mut conn,
+        &ActorContext::system("test:webhook_outbox_drain"),
+        WebhookService::drain_batch_txn,
+    )
+    .expect("drain batch");
+
+    // One task, carrying the id of a row that was persisted inside the drain
+    // transaction (not left for the worker to insert).
+    assert_eq!(tasks.len(), 1, "one subscriber => one delivery task");
+    assert!(
+        tasks[0].delivery_id.is_some(),
+        "the delivery row is created in-transaction, so the task carries its id"
+    );
+
+    // Postcondition: the outbox row is gone AND a durable, retry-eligible
+    // delivery row exists. If the process died right now, the retry worker
+    // would still deliver it (delivered_at NULL, next_retry_at set).
+    let outbox_after: i64 = webhook_outbox::table
+        .filter(webhook_outbox::sync_id.eq(sync_id))
+        .count()
+        .get_result(&mut conn)
+        .expect("count outbox after");
+    assert_eq!(outbox_after, 0, "the claimed outbox row is deleted");
+
+    let recorded: Vec<(Option<chrono::NaiveDateTime>, Option<chrono::NaiveDateTime>)> =
+        webhook_deliveries::table
+            .filter(webhook_deliveries::webhook_id.eq(webhook.id))
+            .select((
+                webhook_deliveries::delivered_at,
+                webhook_deliveries::next_retry_at,
+            ))
+            .load(&mut conn)
+            .expect("load deliveries after");
+    assert_eq!(recorded.len(), 1, "the fan-out is durably recorded");
+    assert!(
+        recorded[0].0.is_none(),
+        "not yet delivered (the worker never ran)"
+    );
+    assert!(
+        recorded[0].1.is_some(),
+        "next_retry_at is set so the retry worker recovers a lost in-memory send"
+    );
+}


### PR DESCRIPTION
## Finding #8 (edition audit)

The outbox drain deleted the claimed rows and queued their deliveries only in memory; the durable `webhook_deliveries` row was written later by the delivery worker. A crash between the commit and that write dropped the fan-out (at-most-once). The drain now writes the delivery rows in the same transaction as the outbox delete, so delivery is at-least-once: a send lost before the worker runs is recovered from the durable record.

## Fix
- Record `webhook_deliveries` in-transaction, grouped by workspace, with a `next_retry_at` grace so the retry worker recovers an unsent row.
- Added `session::pin_workspace` to set `app.workspace_id` for the audit trigger without leaving the bypass role.
- Split the drain's transactional core into `drain_batch_txn`.

## Tests
New `webhook_outbox_durability` test drives the real drain core and asserts the durable, retry-eligible row exists exactly when the outbox row is deleted.

Full backend suite green.