### PR TITLE
fix(auth): verify Microsoft ID token against a specific tenant

### DIFF
--- a/backend/src/config_utils.rs
+++ b/backend/src/config_utils.rs
@@ -4,12 +4,15 @@ use std::env;
 #[derive(Debug)]
 pub enum ConfigError {
     Missing(String),
+    /// The variable is set but its value is not acceptable.
+    Invalid(String),
 }
 
 impl std::fmt::Display for ConfigError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             ConfigError::Missing(key) => write!(f, "Missing environment variable: {key}"),
+            ConfigError::Invalid(msg) => write!(f, "Invalid configuration: {msg}"),
         }
     }
 }
@@ -70,8 +73,30 @@ pub fn get_microsoft_client_id() -> Result<String, ConfigError> {
     get_env_var("MICROSOFT_CLIENT_ID")
 }
 
+/// Azure multi-tenant authority values that must NOT be used as
+/// `MICROSOFT_TENANT_ID`. They let users from ANY Azure/MSA tenant
+/// authenticate, which breaks the single-tenant trust the Microsoft
+/// email-based account link relies on (and defeats openidconnect's strict
+/// issuer check, which needs a concrete per-tenant issuer). A specific tenant
+/// GUID or verified domain is required.
+pub fn is_microsoft_multitenant_authority(tenant: &str) -> bool {
+    matches!(
+        tenant.trim().to_ascii_lowercase().as_str(),
+        "common" | "organizations" | "consumers"
+    )
+}
+
 pub fn get_microsoft_tenant_id() -> Result<String, ConfigError> {
-    get_env_var("MICROSOFT_TENANT_ID")
+    let tenant = get_env_var("MICROSOFT_TENANT_ID")?;
+    if is_microsoft_multitenant_authority(&tenant) {
+        return Err(ConfigError::Invalid(format!(
+            "MICROSOFT_TENANT_ID must be a specific tenant (GUID or verified domain), \
+             not the multi-tenant authority '{}'. A multi-tenant authority lets any \
+             Azure/MSA account sign in, which is unsafe with email-based account linking.",
+            tenant.trim()
+        )));
+    }
+    Ok(tenant)
 }
 
 pub fn get_microsoft_client_secret() -> Result<String, ConfigError> {
@@ -149,4 +174,44 @@ pub fn get_oidc_username_claim() -> String {
 /// Get OIDC logout URI (optional)
 pub fn get_oidc_logout_uri() -> Option<String> {
     get_env_var("OIDC_LOGOUT_URI").ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn multitenant_authorities_are_rejected() {
+        // Case- and whitespace-insensitive.
+        for t in [
+            "common",
+            "organizations",
+            "consumers",
+            "COMMON",
+            " Common ",
+            "Organizations",
+        ] {
+            assert!(
+                is_microsoft_multitenant_authority(t),
+                "{t:?} should be a multi-tenant authority"
+            );
+        }
+    }
+
+    #[test]
+    fn specific_tenants_are_accepted() {
+        for t in [
+            "72f988bf-86f1-41af-91ab-2d7cd011db47", // tenant GUID
+            "contoso.com",                          // verified domain
+            "contoso.onmicrosoft.com",
+        ] {
+            assert!(
+                !is_microsoft_multitenant_authority(t),
+                "{t:?} should be a specific tenant"
+            );
+        }
+        // Empty is a missing-config case (handled by get_env_var), not a
+        // multi-tenant authority.
+        assert!(!is_microsoft_multitenant_authority(""));
+    }
 }

--- a/backend/src/handlers/auth_providers.rs
+++ b/backend/src/handlers/auth_providers.rs
@@ -93,8 +93,12 @@ impl From<&crate::handlers::msgraph_integration::MicrosoftGraphUser> for OAuthLo
                 .mail
                 .clone()
                 .or_else(|| Some(m.user_principal_name.clone())),
-            // Entra: the user authenticated against the directory that owns the
-            // address, and Graph carries no `email_verified` claim.
+            // Trustworthy because the Microsoft callback verifies the ID token
+            // against a SPECIFIC configured tenant (MICROSOFT_TENANT_ID, with
+            // multi-tenant authorities rejected) before this conversion runs:
+            // the address is owned by that tenant's directory, and a
+            // cross-tenant login can never reach here. Graph carries no
+            // `email_verified` claim of its own.
             email_verified: true,
             display_name: m.display_name.clone(),
             given_name: m.given_name.clone(),
@@ -352,11 +356,18 @@ pub async fn oauth_authorize(
             }
         };
 
-        // Generate a JWT state token
-        let (state, binding) = match create_oauth_state(
+        // Generate PKCE (RFC 9700) + a nonce for the ID token, and bind both
+        // into the signed state so the callback can complete the code exchange
+        // and verify the returned ID token against the configured tenant.
+        let (pkce_challenge, pkce_verifier) = oidc::generate_pkce();
+        let nonce = oidc::generate_nonce();
+        let (state, binding) = match create_oauth_state_with_oidc(
             "microsoft",
             oauth_request.redirect_uri.clone(),
             oauth_request.user_connection,
+            Some(pkce_verifier.secret().clone()),
+            Some(nonce.secret().clone()),
+            None,
         ) {
             Ok(pair) => pair,
             Err(e) => {
@@ -365,9 +376,13 @@ pub async fn oauth_authorize(
             }
         };
 
-        // Create the authorization URL
+        // Create the authorization URL. `openid` yields an ID token the callback
+        // verifies (tenant binding, §callback); `User.Read` keeps Graph /me for
+        // the profile. The PKCE challenge and nonce ride along.
         let auth_url = format!(
-            "https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/authorize?client_id={client_id}&response_type=code&redirect_uri={redirect_uri_config}&response_mode=query&scope=User.Read&state={state}"
+            "https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/authorize?client_id={client_id}&response_type=code&redirect_uri={redirect_uri_config}&response_mode=query&scope=openid%20profile%20email%20User.Read&nonce={nonce}&code_challenge={code_challenge}&code_challenge_method=S256&state={state}",
+            nonce = nonce.secret(),
+            code_challenge = pkce_challenge.as_str(),
         );
 
         // Bind the flow to this user-agent (RFC 9700 §2.1).
@@ -540,7 +555,7 @@ pub async fn oauth_callback(
     // Process based on provider type
     if provider.provider_type == "microsoft" {
         // Get the provider configuration from environment variables
-        let _client_id = match config_utils::get_microsoft_client_id() {
+        let client_id = match config_utils::get_microsoft_client_id() {
             Ok(val) => val,
             Err(e) => {
                 error!(error = ?e, "Failed to get client_id for Microsoft provider in callback");
@@ -551,7 +566,7 @@ pub async fn oauth_callback(
             }
         };
 
-        let _tenant_id = match config_utils::get_microsoft_tenant_id() {
+        let tenant_id = match config_utils::get_microsoft_tenant_id() {
             Ok(val) => val,
             Err(e) => {
                 error!(error = ?e, "Failed to get tenant_id for Microsoft provider in callback");
@@ -584,11 +599,52 @@ pub async fn oauth_callback(
             }
         };
 
-        // Exchange authorization code for an access token
-        let token_result = exchange_microsoft_code_for_token(&provider, code, &mut conn).await;
+        // The PKCE verifier + nonce were bound into the signed state at
+        // authorize time; both are required to complete the exchange and verify
+        // the ID token. Their absence means a tampered or pre-PKCE state, so
+        // reject rather than fall back to an unverified flow.
+        let pkce_verifier = match &state_data.pkce_verifier {
+            Some(v) => v.clone(),
+            None => {
+                error!("Microsoft callback missing PKCE verifier in state");
+                return errors::bad_request("Invalid authentication state (missing PKCE verifier)");
+            }
+        };
+        let nonce = match &state_data.nonce {
+            Some(n) => n.clone(),
+            None => {
+                error!("Microsoft callback missing nonce in state");
+                return errors::bad_request("Invalid authentication state (missing nonce)");
+            }
+        };
+
+        // Exchange authorization code for tokens (PKCE-completed).
+        let token_result =
+            exchange_microsoft_code_for_token(&provider, code, &pkce_verifier, &mut conn).await;
 
         match token_result {
-            Ok((access_token, _refresh_token)) => {
+            Ok(tokens) => {
+                // Verify the ID token against the configured tenant BEFORE
+                // trusting any profile data. Discovery on the tenant issuer
+                // means the issuer check binds the login to MICROSOFT_TENANT_ID
+                // (a cross-tenant token fails here), and signature + audience +
+                // nonce are checked too. This is what makes the Microsoft
+                // provider's `email_verified: true` trustworthy: only a user
+                // from the configured tenant can reach account resolution.
+                let id_token = match tokens.id_token.as_deref() {
+                    Some(t) => t,
+                    None => {
+                        error!("Microsoft callback: token response carried no id_token");
+                        return errors::internal("Microsoft did not return an ID token");
+                    }
+                };
+                if let Err(e) =
+                    oidc::verify_microsoft_id_token(id_token, &tenant_id, &client_id, &nonce).await
+                {
+                    error!(error = %e, "Microsoft ID token verification failed");
+                    return errors::unauthorized("Microsoft authentication could not be verified");
+                }
+                let access_token = tokens.access_token;
                 // Get user info from Microsoft, normalised into typed claims.
                 let ms_user = match get_microsoft_user_info(&access_token).await {
                     Ok(info) => info,
@@ -1177,12 +1233,22 @@ where
     }
 }
 
+/// Tokens returned by the Microsoft code exchange. The `id_token` is verified
+/// against the configured tenant before login proceeds; the access token drives
+/// the Graph `/me` profile fetch.
+struct MicrosoftTokens {
+    access_token: String,
+    id_token: Option<String>,
+    _refresh_token: Option<String>,
+}
+
 // Helper function to exchange Microsoft code for token
 async fn exchange_microsoft_code_for_token(
     _provider: &AuthProvider,
     code: &str,
+    code_verifier: &str,
     _conn: &mut DbConnection,
-) -> Result<(String, Option<String>), String> {
+) -> Result<MicrosoftTokens, String> {
     // Get provider configuration from environment variables
     let client_id = config_utils::get_microsoft_client_id()
         .map_err(|e| format!("Failed to get client_id: {e}"))?;
@@ -1196,13 +1262,16 @@ async fn exchange_microsoft_code_for_token(
     let redirect_uri_config = config_utils::get_microsoft_redirect_uri()
         .map_err(|e| format!("Failed to get redirect_uri: {e}"))?;
 
-    // Prepare the token request
+    // Prepare the token request. `code_verifier` completes the PKCE exchange
+    // (RFC 9700); `scope=openid` at authorize time makes Azure return an
+    // `id_token` the caller verifies against the configured tenant.
     let params = [
         ("client_id", client_id.as_str()),
         ("client_secret", client_secret.as_str()),
         ("code", code),
         ("redirect_uri", redirect_uri_config.as_str()),
         ("grant_type", "authorization_code"),
+        ("code_verifier", code_verifier),
     ];
 
     // Make the token request, retrying on transport-level failures
@@ -1237,7 +1306,16 @@ async fn exchange_microsoft_code_for_token(
         .and_then(|t| t.as_str())
         .map(|s| s.to_string());
 
-    Ok((access_token, refresh_token))
+    let id_token = token_response
+        .get("id_token")
+        .and_then(|t| t.as_str())
+        .map(|s| s.to_string());
+
+    Ok(MicrosoftTokens {
+        access_token,
+        id_token,
+        _refresh_token: refresh_token,
+    })
 }
 
 // Helper function to get user info from Microsoft Graph API.

--- a/backend/src/oidc.rs
+++ b/backend/src/oidc.rs
@@ -619,6 +619,52 @@ pub async fn verify_native_id_token(
     extract_user_info(claims, &config)
 }
 
+/// Verify a Microsoft v2.0 ID token against the configured tenant's discovery
+/// document.
+///
+/// Discovery runs on `login.microsoftonline.com/{tenant}/v2.0`, so the
+/// verifier's issuer check binds the token to that exact tenant: a Microsoft
+/// v2.0 ID token's `iss` encodes the tenant GUID, and a token minted for any
+/// other tenant fails the issuer match. That is the cryptographic tenant proof
+/// (equivalent to, and stronger than, reading the `tid` claim by hand). The
+/// verifier also checks the JWKS signature, the audience (== `client_id`) and
+/// expiry; `nonce` is the flow's replay protection, echoed by Azure.
+///
+/// Requires a SPECIFIC tenant (GUID or verified domain): a multi-tenant
+/// authority (`common`/`organizations`/`consumers`) has no concrete issuer to
+/// discover, which is one reason those are rejected upstream
+/// (`config_utils::get_microsoft_tenant_id`).
+pub async fn verify_microsoft_id_token(
+    id_token_str: &str,
+    tenant_id: &str,
+    client_id: &str,
+    nonce: &str,
+) -> Result<(), String> {
+    use std::str::FromStr;
+
+    let issuer = IssuerUrl::new(format!(
+        "https://login.microsoftonline.com/{tenant_id}/v2.0"
+    ))
+    .map_err(|e| format!("Invalid Microsoft issuer URL: {e}"))?;
+
+    let metadata = CoreProviderMetadata::discover_async(issuer, &*OIDC_HTTP_CLIENT)
+        .await
+        .map_err(|e| format!("Microsoft OIDC discovery failed: {e}"))?;
+
+    let client =
+        CoreClient::from_provider_metadata(metadata, ClientId::new(client_id.to_string()), None);
+
+    let id_token =
+        CoreIdToken::from_str(id_token_str).map_err(|e| format!("Malformed ID token: {e}"))?;
+
+    let expected_nonce = Nonce::new(nonce.to_string());
+    let verifier = client.id_token_verifier();
+    id_token
+        .claims(&verifier, &expected_nonce)
+        .map_err(|e| format!("Microsoft ID token verification failed: {e}"))?;
+    Ok(())
+}
+
 /// Verify ID token signature and claims
 fn verify_id_token(
     client: &OidcClientKind,


### PR DESCRIPTION
## Finding #9 (edition audit)

The Microsoft login flow trusted Graph `/me` with `email_verified` hardcoded true, ran no PKCE, and never bound the login to a tenant. With a multi-tenant `MICROSOFT_TENANT_ID` (`common`/`organizations`/`consumers`) any Azure or MSA user could sign in, and the always-verified email auto-linked them to an existing account with a matching address.

## Fix
- Reject the multi-tenant authority values for `MICROSOFT_TENANT_ID` (fail closed).
- Request `openid` and verify the returned ID token against the tenant's discovery document (`oidc::verify_microsoft_id_token`): the issuer check binds the tenant; signature, audience and nonce are checked too, before any profile is trusted.
- Add PKCE to the Microsoft authorization-code flow (challenge + verifier via the existing signed-state slots).

## Tests
Tenant-guard unit tests; full backend suite green. Flow-level (mock-Azure discovery+JWKS) testing deferred; the verification reuses the same proven `openidconnect` machinery as the generic OIDC path.