### PR TITLE
fix(auth): close hosted local-credential write gaps; fail-closed SSE gate

### DIFF
--- a/backend/src/handlers/invitation.rs
+++ b/backend/src/handlers/invitation.rs
@@ -131,6 +131,13 @@ pub async fn accept_invitation(
         Err(e) => return e,
     };
 
+    // Password-based invitation acceptance writes a local credential, which
+    // hosted deployments disable in favour of SSO onboarding. Refuse before
+    // consuming the token so it stays valid for the SSO path.
+    if crate::handlers::auth::hosted_local_auth_disabled() {
+        return errors::bad_request("Password-based sign-up is not available for this deployment");
+    }
+
     // Validate password
     if request_data.password.len() < 8 {
         return errors::bad_request("Password must be at least 8 characters long");

--- a/backend/src/handlers/password_reset.rs
+++ b/backend/src/handlers/password_reset.rs
@@ -34,6 +34,18 @@ pub async fn request_password_reset(
         return errors::bad_request("Invalid email address");
     }
 
+    // Local passwords are disabled in hosted mode (login refuses them), so a
+    // reset would mint a useless token and email a confusing "reset your
+    // password" link to an SSO account. Return the same generic response with
+    // no work, preserving the enumeration-safe constant latency (the real path
+    // just spawns a detached task, which is likewise instant).
+    if crate::handlers::auth::hosted_local_auth_disabled() {
+        return HttpResponse::Ok().json(PasswordResetResponse {
+            message: "If an account with that email exists, a password reset link has been sent."
+                .to_string(),
+        });
+    }
+
     let ip_address =
         crate::utils::client_ip::from_http_request(&http_request).map(|ip| ip.to_string());
     let user_agent = http_request
@@ -231,6 +243,14 @@ pub async fn reset_password_with_token(
         Ok(c) => c,
         Err(e) => return e,
     };
+
+    // Hosted deployments disable local password auth, so refuse to write a local
+    // credential even if a (pre-switch or forged) token is presented. Requesting
+    // a reset is already a no-op in hosted mode, so a valid token should not
+    // exist here.
+    if crate::handlers::auth::hosted_local_auth_disabled() {
+        return errors::bad_request("Password authentication is not available for this account");
+    }
 
     // Validate new password
     if request_data.new_password.len() < 8 {

--- a/backend/src/handlers/sse.rs
+++ b/backend/src/handlers/sse.rs
@@ -724,6 +724,14 @@ pub async fn sse_events_stream(
             workspace_id,
             user.uuid,
         )?;
+    } else if crate::middleware::workspace_context::selection_resolution_enabled() {
+        // Under Model C selection a stream MUST resolve (and be gated on) a
+        // workspace; an unresolved one is a misrouted or forged connection, not
+        // a legitimate apex stream, so fail closed rather than serve the
+        // topic-contained user+global fallback below. (Self-hosted always
+        // resolves the bootstrap workspace, so this branch is a hosted apex
+        // stream only.)
+        return Ok(errors::forbidden("Not a member of this workspace"));
     }
 
     // Resolve subscription set. The client may declare interest via


### PR DESCRIPTION
## Edition-audit LOW review

Hosted deployments disable local password auth (`login` refuses it), but two credential-write paths and one connection gate hadn't caught up:

- `request_password_reset` / `reset_password_with_token` and `accept_invitation` still wrote **local credentials** in hosted mode.
- The SSE membership gate was **skipped when no workspace resolved** (the pin + `require_workspace_membership` sat inside `if let Some(workspace_id)`).

Exploitability is low (planted local creds are inert because `login` is hard-disabled in hosted, and the SSE no-workspace branch is topic-contained), but both are real defense-in-depth gaps and the SSE one is a structural fail-open where the sibling collab path is fail-closed.

## Fix
- `request_password_reset`: no-op in hosted mode (same enumeration-safe response, no token minted / email sent).
- `reset_password_with_token` / `accept_invitation`: refuse to write a local credential in hosted mode.
- SSE: under Model C selection, **fail closed** when no workspace resolves (a stream must resolve and be gated on one). Self-hosted always resolves the bootstrap workspace, so the legitimate apex/global fallback is preserved.

The deeper structural work (funnel connection-auth through one helper; move the local-credential-write gate into the `user_auth_identities` repository) is recorded in the private roadmap for a follow-up.

Full backend suite green.