### PR TITLE
fix(auth): gate local-credential writes in the repository

### DIFF
--- a/backend/src/handlers/auth.rs
+++ b/backend/src/handlers/auth.rs
@@ -477,7 +477,7 @@ const LOCKOUT_DURATION_SECONDS: u64 = 900; // 15 minutes
 /// origin. Login, recovery, and passkey-login handlers short-circuit on
 /// this so the local paths can't be driven directly.
 pub(crate) fn hosted_local_auth_disabled() -> bool {
-    crate::middleware::DeploymentMode::current() == crate::middleware::DeploymentMode::Hosted
+    !crate::middleware::workspace_context::local_credentials_permitted()
 }
 
 // Authentication handlers
@@ -1251,6 +1251,14 @@ pub async fn setup_initial_admin(
     search_service: web::Data<std::sync::Arc<crate::services::search::SearchService>>,
     admin_data: web::Json<crate::models::AdminSetupRequest>,
 ) -> impl Responder {
+    // Bootstrap writes a local admin credential via a raw insert that bypasses
+    // the repository gate, so refuse here in hosted mode. This is defensive:
+    // hosted mints no bootstrap token (bootstrap_token::reconcile), so the
+    // token gate below already blocks it.
+    if hosted_local_auth_disabled() {
+        return errors::forbidden("Initial admin setup is not available in hosted mode");
+    }
+
     // AUD-005: bootstrap-token gate. Network attackers reaching
     // the listener on first boot cannot proceed without the token
     // written to disk at startup. Accept the token via either

--- a/backend/src/handlers/invitation.rs
+++ b/backend/src/handlers/invitation.rs
@@ -221,7 +221,8 @@ pub async fn accept_invitation(
             workspace_id: None,
         };
 
-        if let Err(e) = repository::user_auth_identities::create_identity(auth_identity, &mut conn)
+        if let Err(e) =
+            repository::user_auth_identities::create_local_identity(auth_identity, &mut conn)
         {
             error!("Failed to create auth identity for invitation: {:?}", e);
             return errors::internal("Error setting password");

--- a/backend/src/handlers/users.rs
+++ b/backend/src/handlers/users.rs
@@ -1057,7 +1057,7 @@ pub async fn create_user(
                 workspace_id: None,
             };
 
-            match repository::user_auth_identities::create_identity(new_identity, &mut conn) {
+            match repository::user_auth_identities::create_local_identity(new_identity, &mut conn) {
                 Ok(_) => {
                     if invitation_sent {
                         info!(user_name = %user.name, "New user created (invitation email sent)");
@@ -2072,6 +2072,13 @@ pub async fn update_user_by_uuid(
         use crate::models::NewUserAuthIdentity;
         use bcrypt::hash;
 
+        // Setting a local password is refused in hosted mode (identity is
+        // SSO-only). Guard before the transaction so the repo gate below is
+        // never the one to trip.
+        if crate::handlers::auth::hosted_local_auth_disabled() {
+            return errors::forbidden("Local password authentication is disabled");
+        }
+
         let password_hash = match hash(password, DEFAULT_COST) {
             Ok(hash) => hash,
             Err(_) => return errors::internal("Error hashing password"),
@@ -2115,7 +2122,8 @@ pub async fn update_user_by_uuid(
                     workspace_id: None,
                 },
             };
-            repository::user_auth_identities::create_identity(new_auth_identity, conn)?;
+            repository::user_auth_identities::create_local_identity(new_auth_identity, conn)
+                .map_err(|e| e.into_diesel())?;
             Ok(())
         });
 

--- a/backend/src/middleware/workspace_context.rs
+++ b/backend/src/middleware/workspace_context.rs
@@ -115,6 +115,18 @@ pub fn selection_resolution_enabled() -> bool {
         )
 }
 
+/// Whether local (username/password) credentials may be written and used.
+/// False in hosted mode, where identity is SSO-only and `login` refuses local
+/// passwords. This is the single predicate the `user_auth_identities` write
+/// repository gates local-credential writes on, so no handler can bypass it.
+///
+/// Reads `from_env()` (fresh), not `current()` (cached), so it is
+/// operationally toggleable and unit tests can flip `NOSDESK_DEPLOYMENT_MODE`
+/// within one process, matching `selection_resolution_enabled` above.
+pub fn local_credentials_permitted() -> bool {
+    DeploymentMode::from_env() != DeploymentMode::Hosted
+}
+
 /// Resolve a selection-header workspace slug to a [`WorkspaceContext`].
 /// `Ok(None)` for an unknown / soft-archived workspace; the caller maps
 /// that to the same 403 a non-member gets so workspace existence does
@@ -502,6 +514,30 @@ mod tests {
         let prev = std::env::var("NOSDESK_DEPLOYMENT_MODE").ok();
         std::env::set_var("NOSDESK_DEPLOYMENT_MODE", "hosted");
         assert_eq!(DeploymentMode::from_env(), DeploymentMode::Hosted);
+        if let Some(v) = prev {
+            std::env::set_var("NOSDESK_DEPLOYMENT_MODE", v);
+        } else {
+            std::env::remove_var("NOSDESK_DEPLOYMENT_MODE");
+        }
+    }
+
+    #[test]
+    fn local_credentials_permitted_only_off_hosted() {
+        let _env = lock_env();
+        let prev = std::env::var("NOSDESK_DEPLOYMENT_MODE").ok();
+
+        std::env::set_var("NOSDESK_DEPLOYMENT_MODE", "hosted");
+        assert!(
+            !local_credentials_permitted(),
+            "hosted disables local creds"
+        );
+
+        std::env::remove_var("NOSDESK_DEPLOYMENT_MODE");
+        assert!(
+            local_credentials_permitted(),
+            "self-hosted (default) permits local creds"
+        );
+
         if let Some(v) = prev {
             std::env::set_var("NOSDESK_DEPLOYMENT_MODE", v);
         } else {

--- a/backend/src/repository/user_auth_identities.rs
+++ b/backend/src/repository/user_auth_identities.rs
@@ -6,17 +6,93 @@ use crate::db::DbConnection;
 use crate::models::{NewUserAuthIdentity, UserAuthIdentity, UserAuthIdentityDisplay};
 use crate::schema::user_auth_identities;
 
+/// The `provider_type` value for a local (username/password) credential.
+pub const LOCAL_PROVIDER: &str = "local";
+
+/// Error from a local-credential write. Distinct from a plain DB error so a
+/// caller can tell "local auth is disabled here" apart from a query failure.
+#[derive(Debug)]
+pub enum LocalCredentialError {
+    /// A local credential write was refused because local auth is disabled
+    /// (hosted mode). See `workspace_context::local_credentials_permitted`.
+    LocalAuthDisabled,
+    Db(Error),
+}
+
+impl std::fmt::Display for LocalCredentialError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::LocalAuthDisabled => {
+                write!(f, "local password authentication is disabled")
+            }
+            Self::Db(e) => write!(f, "{e}"),
+        }
+    }
+}
+
+impl std::error::Error for LocalCredentialError {}
+
+impl From<Error> for LocalCredentialError {
+    fn from(e: Error) -> Self {
+        Self::Db(e)
+    }
+}
+
+impl LocalCredentialError {
+    /// Collapse into a `diesel::Error` for callers inside a transaction closure
+    /// whose error type is fixed to `diesel::Error`. Only correct when the
+    /// caller has already checked `local_credentials_permitted()` before
+    /// entering the transaction, so `LocalAuthDisabled` is unreachable; it maps
+    /// to `RollbackTransaction` as a fail-safe.
+    pub fn into_diesel(self) -> Error {
+        match self {
+            Self::Db(e) => e,
+            Self::LocalAuthDisabled => Error::RollbackTransaction,
+        }
+    }
+}
+
 // Create a user auth identity. `NewUserAuthIdentity.workspace_id` is NULL for a
 // global login identity (local/microsoft/oidc) or set for a workspace-scoped
 // directory identity (ldap/scim).
+//
+// LOCAL credentials must go through [`create_local_identity`], which enforces
+// the hosted local-auth gate; a `local` identity here is a programming error
+// (asserted in debug) so a new caller can't quietly bypass the gate.
 // sync-pending-wire: needs sync aggregate wiring
 pub fn create_identity(
     new_identity: NewUserAuthIdentity,
     conn: &mut DbConnection,
 ) -> Result<UserAuthIdentity, Error> {
+    debug_assert!(
+        new_identity.provider_type != LOCAL_PROVIDER,
+        "local credentials must be written via create_local_identity (gated)"
+    );
     diesel::insert_into(user_auth_identities::table)
         .values(new_identity)
         .get_result::<UserAuthIdentity>(conn)
+}
+
+// Create a LOCAL (username/password) auth identity, refusing the write when
+// local auth is disabled (hosted mode). The single gated entry for
+// local-credential creation; handlers must not insert a `local` identity any
+// other way.
+// sync-pending-wire: needs sync aggregate wiring
+pub fn create_local_identity(
+    new_identity: NewUserAuthIdentity,
+    conn: &mut DbConnection,
+) -> Result<UserAuthIdentity, LocalCredentialError> {
+    debug_assert_eq!(
+        new_identity.provider_type, LOCAL_PROVIDER,
+        "create_local_identity is only for local credentials"
+    );
+    if !crate::middleware::workspace_context::local_credentials_permitted() {
+        return Err(LocalCredentialError::LocalAuthDisabled);
+    }
+    diesel::insert_into(user_auth_identities::table)
+        .values(new_identity)
+        .get_result::<UserAuthIdentity>(conn)
+        .map_err(LocalCredentialError::Db)
 }
 
 // Get all auth identities for a user by UUID
@@ -153,14 +229,18 @@ pub fn update_local_password_hash(
     conn: &mut DbConnection,
     user_uuid: &Uuid,
     new_hash: &str,
-) -> Result<usize, Error> {
+) -> Result<usize, LocalCredentialError> {
+    if !crate::middleware::workspace_context::local_credentials_permitted() {
+        return Err(LocalCredentialError::LocalAuthDisabled);
+    }
     diesel::update(
         user_auth_identities::table
             .filter(user_auth_identities::user_uuid.eq(user_uuid))
-            .filter(user_auth_identities::provider_type.eq("local")),
+            .filter(user_auth_identities::provider_type.eq(LOCAL_PROVIDER)),
     )
     .set(user_auth_identities::password_hash.eq(new_hash))
     .execute(conn)
+    .map_err(LocalCredentialError::Db)
 }
 
 /// Get the local-auth password hash for a user, if they have a local
@@ -362,6 +442,42 @@ mod tests {
 
         let found = find_user_by_identity("github", "gh_123", &mut conn).unwrap();
         assert_eq!(found, Some(user.uuid));
+    }
+
+    #[test]
+    fn local_credential_writes_refused_in_hosted() {
+        // The repo gate is the structural backstop: a caller that reaches the
+        // local-credential write directly (e.g. a handler that forgot its
+        // guard) is still refused in hosted mode, before any DB write.
+        static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+        let _env = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let prev = std::env::var("NOSDESK_DEPLOYMENT_MODE").ok();
+
+        let mut conn = setup_test_connection();
+        let user = TestFixtures::create_user(&mut conn, "gateuser", "user");
+        let ext = user.uuid.to_string();
+
+        std::env::set_var("NOSDESK_DEPLOYMENT_MODE", "hosted");
+        assert!(matches!(
+            create_local_identity(make_identity(user.uuid, LOCAL_PROVIDER, &ext), &mut conn),
+            Err(LocalCredentialError::LocalAuthDisabled)
+        ));
+        assert!(matches!(
+            update_local_password_hash(&mut conn, &user.uuid, "hash"),
+            Err(LocalCredentialError::LocalAuthDisabled)
+        ));
+
+        // Self-hosted: the same create succeeds.
+        std::env::remove_var("NOSDESK_DEPLOYMENT_MODE");
+        assert!(
+            create_local_identity(make_identity(user.uuid, LOCAL_PROVIDER, &ext), &mut conn)
+                .is_ok()
+        );
+
+        match prev {
+            Some(v) => std::env::set_var("NOSDESK_DEPLOYMENT_MODE", v),
+            None => std::env::remove_var("NOSDESK_DEPLOYMENT_MODE"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Architectural hardening (auth-boundary review, Part 2)

Makes "no local credentials in hosted mode" a **structural invariant** rather than a predicate each handler must remember. The gate now lives in the `user_auth_identities` write repository, so a handler that forgets its own check cannot write a local credential in hosted mode.

The design-review pass surfaced that the shipped handler guards (#94) missed the **admin user-management writes** entirely — `create_user`, admin password rotation, and `admin_reset_user_password` had no hosted check at all. This closes them.

## Change
- Relocate the predicate to `workspace_context::local_credentials_permitted` (uses `from_env`, so it's testable); `hosted_local_auth_disabled` delegates to it.
- Add `LocalCredentialError` + `create_local_identity` (the single gated local-create) + gate `update_local_password_hash`. A debug-assert ensures `create_identity` is never handed a `local` identity, so a new caller can't bypass the gate.
- Route the three local creators through the gated path; refuse initial-admin setup in hosted (belt-and-suspenders; hosted already mints no bootstrap token).
- Keep the handler guards (they deliver enumeration-safe responses + don't-consume-token UX the repo layer can't); the repo gate is the structural backstop.

## Tests
The predicate, plus a repo-level proof that a **direct** local write is refused in hosted — the "a forgetful surface can't write" guarantee.

Full backend suite green (65 binaries).