### PR TITLE
feat(collab): connection governance for SSE + collab (cap, bounded queue, cheap change-detection)

### DIFF
--- a/backend/src/handlers/collaboration.rs
+++ b/backend/src/handlers/collaboration.rs
@@ -2905,6 +2905,19 @@ pub async fn ws_handler(
         }
     };
 
+    // Reserve a slot in the shared connection cap (per user+workspace) BEFORE
+    // upgrading, so a capped principal is refused with 429 (a post-upgrade WS
+    // close code buys nothing: stock y-websocket ignores it) and no task/socket
+    // is spawned. The guard moves into session_task and frees the slot when the
+    // task ends (close, error, timeout, eviction, panic).
+    let Some(conn_guard) =
+        crate::services::connection_registry::global().try_acquire((user_uuid, workspace_id))
+    else {
+        return Ok(HttpResponse::TooManyRequests()
+            .append_header(("Retry-After", "5"))
+            .finish());
+    };
+
     // Hand off to actix-ws: returns (HttpResponse, Session, MessageStream).
     // The response is returned to the framework synchronously so the
     // 101 Upgrade lands; the session_task runs detached and owns the
@@ -2934,6 +2947,7 @@ pub async fn ws_handler(
         doc_type,
         session,
         msg_stream,
+        conn_guard,
     ));
 
     Ok(response)
@@ -2951,6 +2965,9 @@ async fn session_task(
     doc_type: DocumentType,
     mut session: actix_ws::Session,
     mut msg_stream: actix_ws::AggregatedMessageStream,
+    // Holds this connection's slot in the shared cap; released when this task
+    // returns (all disconnect paths funnel here).
+    _conn_guard: crate::services::connection_registry::ConnGuard,
 ) {
     let started_at = Instant::now();
     let mut last_hb = started_at;

--- a/backend/src/handlers/collaboration.rs
+++ b/backend/src/handlers/collaboration.rs
@@ -349,6 +349,17 @@ static CLIENT_TIMEOUT: once_cell::sync::Lazy<Duration> = once_cell::sync::Lazy::
         .map(Duration::from_millis)
         .unwrap_or(Duration::from_secs(60))
 });
+// Per-session outbound backlog ceiling. A client that stops draining accrues
+// the room's broadcast fan-out in memory; past this it is evicted and its
+// `y-websocket` reconnects + CRDT-resyncs. A byte budget, not a frame count:
+// one sync frame can be up to the 1 MiB frame cap, so a depth-only cap would
+// bound memory far too loosely. Default 8 MiB.
+static OUTBOUND_BYTE_BUDGET: once_cell::sync::Lazy<usize> = once_cell::sync::Lazy::new(|| {
+    std::env::var("NOSDESK_WS_OUTBOUND_BUDGET_BYTES")
+        .ok()
+        .and_then(|s| s.parse::<usize>().ok())
+        .unwrap_or(8 * 1024 * 1024)
+});
 // Minimum time between saves for the same document
 const MIN_SAVE_INTERVAL: Duration = Duration::from_secs(5);
 // Maximum time a document can have pending changes before forcing a save
@@ -969,6 +980,59 @@ type DocumentId = String;
 type SessionId = String;
 
 /// Per-session bookkeeping kept on the collaboration side. The
+/// The write side of a session's outbound channel, tracking the queued byte
+/// backlog so a non-draining client can be evicted before its backlog grows
+/// without bound. Sends stay non-blocking (unbounded channel): back-pressuring
+/// the sender would stall the whole room's broadcast fan-out, which is worse
+/// than evicting one slow consumer. Cloning is cheap (both fields are `Arc`s).
+#[derive(Clone)]
+struct OutboundTx {
+    inner: mpsc::UnboundedSender<Bytes>,
+    queued_bytes: std::sync::Arc<std::sync::atomic::AtomicUsize>,
+}
+
+impl OutboundTx {
+    fn new() -> (Self, mpsc::UnboundedReceiver<Bytes>) {
+        let (inner, rx) = mpsc::unbounded_channel::<Bytes>();
+        (
+            Self {
+                inner,
+                queued_bytes: std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+            },
+            rx,
+        )
+    }
+
+    /// Always-deliver send, for point-to-point frames the client asked for
+    /// (initial sync, per-inbound-frame responses). Accounts the bytes so the
+    /// budget check stays consistent with the drain-side decrement.
+    fn send(&self, bytes: Bytes) {
+        self.queued_bytes
+            .fetch_add(bytes.len(), std::sync::atomic::Ordering::Relaxed);
+        let _ = self.inner.send(bytes);
+    }
+
+    /// Budgeted send, for broadcast fan-out. Returns `false` (dropping the
+    /// frame) when the recipient's backlog would exceed the budget, so the
+    /// caller can evict it; the CRDT resync on reconnect reconciles the gap.
+    fn send_within_budget(&self, bytes: Bytes) -> bool {
+        use std::sync::atomic::Ordering::Relaxed;
+        let len = bytes.len();
+        if self.queued_bytes.fetch_add(len, Relaxed) + len > *OUTBOUND_BYTE_BUDGET {
+            self.queued_bytes.fetch_sub(len, Relaxed);
+            return false;
+        }
+        let _ = self.inner.send(bytes);
+        true
+    }
+
+    /// Decrement after a frame is drained to the wire.
+    fn on_drained(&self, len: usize) {
+        self.queued_bytes
+            .fetch_sub(len, std::sync::atomic::Ordering::Relaxed);
+    }
+}
+
 /// user identity + ticket presence live in
 /// `services::presence::PresenceRegistry`; this map only carries
 /// what the transport needs (the outbound channel and the last
@@ -979,7 +1043,7 @@ type SessionId = String;
 /// Sender is cheap; `broadcast` collects clones under the read
 /// lock and pushes after release.
 struct SessionInfo {
-    tx: mpsc::UnboundedSender<Bytes>,
+    tx: OutboundTx,
     last_active: Instant,
     /// User who owns this session. Forwarded to the presence
     /// registry on add / remove so the registry can deduplicate
@@ -1786,7 +1850,7 @@ impl YjsAppState {
         &self,
         doc_id: &str,
         session_id: &str,
-        tx: mpsc::UnboundedSender<Bytes>,
+        tx: OutboundTx,
         user_uuid: Uuid,
         cancel: Arc<Notify>,
         doc_type: DocumentType,
@@ -2217,26 +2281,30 @@ impl YjsAppState {
         // mpsc::UnboundedSender is cheap to clone (Arc internally).
         // Cloning under the lock lets us release it before doing the
         // (non-blocking) per-recipient send.
-        let recipients: Vec<mpsc::UnboundedSender<Bytes>> = {
+        let recipients: Vec<(OutboundTx, Arc<Notify>)> = {
             let sessions = self.sessions.read().await;
 
             if let Some(room) = sessions.get(doc_id) {
                 room.iter()
                     .filter(|(id, _)| *id != sender_id)
-                    .map(|(_, info)| info.tx.clone())
+                    .map(|(_, info)| (info.tx.clone(), info.cancel.clone()))
                     .collect()
             } else {
                 Vec::new()
             }
         };
 
-        // `send` on an unbounded mpsc only fails if the receiver was
-        // dropped (the session task exited). That can race with our
-        // snapshot above; ignore the error and let the next
-        // cleanup_stale_sessions sweep evict the dead row.
+        // Non-blocking, byte-budgeted per recipient. A slow client whose
+        // backlog would exceed the budget has its frame dropped and is signalled
+        // to evict (its reconnect + CRDT resync reconciles the gap) rather than
+        // back-pressuring the fan-out or growing its queue without bound. A dead
+        // receiver (session task exited) is ignored; the next
+        // cleanup_stale_sessions sweep evicts the row.
         let msg_bytes = Bytes::copy_from_slice(msg);
-        for tx in recipients {
-            let _ = tx.send(msg_bytes.clone());
+        for (tx, cancel) in recipients {
+            if !tx.send_within_budget(msg_bytes.clone()) {
+                cancel.notify_one();
+            }
         }
     }
 
@@ -2905,7 +2973,7 @@ async fn session_task(
     // (b) sender-side backpressure would block other sessions'
     // broadcasts, which is worse than letting one slow consumer's
     // backlog grow.
-    let (tx, mut rx) = mpsc::unbounded_channel::<Bytes>();
+    let (tx, mut rx) = OutboundTx::new();
     // Eviction signal: the owning machine notifies this when it drops the
     // document (lost ownership lease, Phase 2 affinity), so this task
     // tears down and the client reconnects to the new owner.
@@ -2934,12 +3002,12 @@ async fn session_task(
 
         let sv = awareness.doc().transact().state_vector();
         let sync_msg = Message::Sync(SyncMessage::SyncStep1(sv));
-        let _ = tx.send(Bytes::from(sync_msg.encode_v1()));
+        tx.send(Bytes::from(sync_msg.encode_v1()));
 
         match awareness.update() {
             Ok(awareness_update) => {
                 let awareness_msg = Message::Awareness(awareness_update);
-                let _ = tx.send(Bytes::from(awareness_msg.encode_v1()));
+                tx.send(Bytes::from(awareness_msg.encode_v1()));
                 debug!(doc_id = %doc_id, "Sent initial SyncStep1 + awareness to new client");
             }
             Err(e) => {
@@ -2975,7 +3043,10 @@ async fn session_task(
             // which only happens during cleanup. Send failures (peer hung
             // up mid-flight) collapse the loop.
             Some(out) = rx.recv() => {
-                if session.binary(out).await.is_err() {
+                let len = out.len();
+                let send_result = session.binary(out).await;
+                tx.on_drained(len);
+                if send_result.is_err() {
                     debug!(session_id = %session_id, "session.binary failed; client gone");
                     break None;
                 }
@@ -3171,7 +3242,7 @@ async fn process_inbound_binary(
     doc_id: String,
     session_id: String,
     user_uuid: Uuid,
-    tx: mpsc::UnboundedSender<Bytes>,
+    tx: OutboundTx,
 ) {
     if bin.is_empty() {
         return;
@@ -3191,17 +3262,15 @@ async fn process_inbound_binary(
         return;
     };
 
-    // Diagnostic: check fragment text BEFORE protocol.handle so we can
-    // detect "content actually changed" precisely (some sync messages
-    // are no-ops).
-    let content_before = {
-        let txn = awareness.doc().transact();
-        if let Some(fragment) = txn.get_xml_fragment("prosemirror") {
-            fragment.get_string(&txn)
-        } else {
-            String::from("(no fragment)")
-        }
-    };
+    // Snapshot the document state vector BEFORE protocol.handle so we can detect
+    // "the doc actually changed" cheaply: O(clients), not the O(document)
+    // full-text materialization this replaces (which ran on every frame,
+    // regardless of the frame's own size). Any applied op advances some client's
+    // clock; a no-op update (already applied, or a bare state-vector request)
+    // leaves the vector unchanged. This is also more precise than the old text
+    // compare, which only saw the `prosemirror` fragment and missed
+    // formatting-only edits.
+    let sv_before = awareness.doc().transact().state_vector();
 
     let protocol = DefaultProtocol;
     let msg_type = bin.first().copied().unwrap_or(255);
@@ -3224,20 +3293,9 @@ async fn process_inbound_binary(
                 "protocol.handle() succeeded"
             );
 
-            let content_after = {
-                let txn = awareness.doc().transact();
-                if let Some(fragment) = txn.get_xml_fragment("prosemirror") {
-                    fragment.get_string(&txn)
-                } else {
-                    String::from("(no fragment)")
-                }
-            };
-
-            let content_changed = content_before != content_after;
+            let content_changed = sv_before != awareness.doc().transact().state_vector();
             if content_changed {
-                debug!(before = %crate::utils::utf8_trunc::char_prefix(&content_before, 50),
-                    after = %crate::utils::utf8_trunc::char_prefix(&content_after, 50),
-                    "Content changed");
+                debug!(doc_id = %doc_id, "Document content changed");
             } else if msg_type == 0 && bin.len() > 1 && bin[1] == 2 {
                 // SYNC_UPDATE didn't apply — request the client's full
                 // state. Happens when state vectors are misaligned
@@ -3246,12 +3304,12 @@ async fn process_inbound_binary(
                 use yrs::sync::Message;
                 let sync_message =
                     Message::Sync(yrs::sync::SyncMessage::SyncStep1(StateVector::default()));
-                let _ = tx.send(Bytes::from(sync_message.encode_v1()));
+                tx.send(Bytes::from(sync_message.encode_v1()));
             }
 
             for message in messages {
                 let encoded = message.encode_v1();
-                let _ = tx.send(Bytes::from(encoded));
+                tx.send(Bytes::from(encoded));
             }
 
             // Decide which inbound frames to rebroadcast to other

--- a/backend/src/handlers/sse.rs
+++ b/backend/src/handlers/sse.rs
@@ -367,6 +367,10 @@ pub struct SseStream {
     /// visibility filtering. Held across polls because the visibility
     /// check is a blocking DB call run off-thread via `web::block`.
     pending: Option<Pin<Box<dyn Future<Output = String> + Send>>>,
+    /// Holds this connection's slot in the shared connection cap. Dropped with
+    /// the stream (alongside `remove_client`), releasing the slot on every
+    /// stream-end path.
+    _conn_guard: crate::services::connection_registry::ConnGuard,
 }
 
 impl SseStream {
@@ -378,6 +382,7 @@ impl SseStream {
         state: web::Data<SseState>,
         pool: web::Data<crate::db::Pool>,
         viewer: crate::sync::visibility::SyncViewer,
+        conn_guard: crate::services::connection_registry::ConnGuard,
     ) -> Self {
         // 15-second heartbeat. EventSource auto-reconnects when the
         // read side dies, so this is mostly a NAT/proxy keepalive
@@ -400,6 +405,7 @@ impl SseStream {
             pool,
             viewer,
             pending: None,
+            _conn_guard: conn_guard,
         }
     }
 }
@@ -769,6 +775,18 @@ pub async fn sse_events_stream(
     // topic auth); cached for the connection's lifetime.
     let viewer = crate::sync::visibility::SyncViewer::resolve(&mut conn, &user);
 
+    // Reserve a slot in the shared connection cap (per user+workspace). A
+    // capped principal is refused pre-stream with 429 + Retry-After so the
+    // browser's EventSource backs off. The guard lives in SseStream and frees
+    // the slot when the stream ends.
+    let Some(conn_guard) = crate::services::connection_registry::global()
+        .try_acquire((user.uuid, workspace_id.unwrap_or(0)))
+    else {
+        return Ok(HttpResponse::TooManyRequests()
+            .append_header(("Retry-After", "5"))
+            .finish());
+    };
+
     // Generate client ID and create stream
     let client_id = Uuid::now_v7().to_string();
     state.add_client(client_id.clone(), user_info.sub.clone());
@@ -779,6 +797,7 @@ pub async fn sse_events_stream(
         state.clone(),
         pool.clone(),
         viewer,
+        conn_guard,
     );
 
     // Build initial "connected" event so the client knows its own ID

--- a/backend/src/services/connection_registry.rs
+++ b/backend/src/services/connection_registry.rs
@@ -1,0 +1,186 @@
+//! Concurrent long-lived connection cap, shared by the SSE and collaboration
+//! WebSocket surfaces.
+//!
+//! Both surfaces spawn a task + hold a socket + per-session buffers for the life
+//! of a connection, and neither is covered by the `/api` rate limiter (which
+//! deliberately excludes long-lived endpoints). Without a cap, one authenticated
+//! principal can open unbounded streams. This registry bounds the count per
+//! `(user, workspace)` and process-wide; acquisition returns a [`ConnGuard`]
+//! whose `Drop` releases the slot, so every disconnect path (normal close,
+//! error, timeout, panic) decrements exactly once with no bookkeeping in the
+//! handlers.
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use dashmap::DashMap;
+use uuid::Uuid;
+
+/// `(user_uuid, workspace_id)`. Connections are already workspace-bound, so this
+/// is the natural unit; on single-workspace self-hosted it collapses to
+/// per-user.
+pub type ConnKey = (Uuid, i32);
+
+pub struct ConnectionRegistry {
+    per_key: DashMap<ConnKey, usize>,
+    global: AtomicUsize,
+    max_per_key: usize,
+    max_global: usize,
+}
+
+impl ConnectionRegistry {
+    /// Build from env: `NOSDESK_MAX_CONN_PER_USER` (per user+workspace, default
+    /// 50 — generous over a heavy multi-tab/multi-doc user, small enough to cap
+    /// a runaway reconnect loop) and `NOSDESK_MAX_CONN_GLOBAL` (process memory
+    /// backstop, default 10_000).
+    pub fn from_env() -> Self {
+        let max_per_key = std::env::var("NOSDESK_MAX_CONN_PER_USER")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(50);
+        let max_global = std::env::var("NOSDESK_MAX_CONN_GLOBAL")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(10_000);
+        Self::with_limits(max_per_key, max_global)
+    }
+
+    pub fn with_limits(max_per_key: usize, max_global: usize) -> Self {
+        Self {
+            per_key: DashMap::new(),
+            global: AtomicUsize::new(0),
+            max_per_key,
+            max_global,
+        }
+    }
+
+    /// Reserve a connection slot for `key`, or `None` when at the per-key or
+    /// global cap. On success hold the returned guard for the connection's life;
+    /// dropping it frees the slot.
+    pub fn try_acquire(self: &Arc<Self>, key: ConnKey) -> Option<ConnGuard> {
+        // Global ceiling first (CAS loop), so a per-key rejection below can roll
+        // it back cleanly.
+        let mut cur = self.global.load(Ordering::Relaxed);
+        loop {
+            if cur >= self.max_global {
+                return None;
+            }
+            match self.global.compare_exchange_weak(
+                cur,
+                cur + 1,
+                Ordering::AcqRel,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => break,
+                Err(actual) => cur = actual,
+            }
+        }
+
+        // Per-key under the shard entry lock.
+        {
+            let mut entry = self.per_key.entry(key).or_insert(0);
+            if *entry >= self.max_per_key {
+                drop(entry);
+                self.global.fetch_sub(1, Ordering::AcqRel);
+                return None;
+            }
+            *entry += 1;
+        }
+
+        Some(ConnGuard {
+            registry: self.clone(),
+            key,
+        })
+    }
+
+    fn release(&self, key: &ConnKey) {
+        let mut hit_zero = false;
+        if let Some(mut entry) = self.per_key.get_mut(key) {
+            *entry = entry.saturating_sub(1);
+            hit_zero = *entry == 0;
+        }
+        // Keep the map bounded: drop the entry at zero, re-checking under the
+        // shard lock so a concurrent acquire that just bumped it isn't lost.
+        if hit_zero {
+            self.per_key.remove_if(key, |_, v| *v == 0);
+        }
+        self.global.fetch_sub(1, Ordering::AcqRel);
+    }
+
+    #[cfg(test)]
+    fn live(&self) -> usize {
+        self.global.load(Ordering::Relaxed)
+    }
+}
+
+/// Process-wide registry, limits read from env once. Both connection surfaces
+/// acquire against this (no per-request wiring, matching `cors_allowlist`).
+static REGISTRY: once_cell::sync::Lazy<Arc<ConnectionRegistry>> =
+    once_cell::sync::Lazy::new(|| Arc::new(ConnectionRegistry::from_env()));
+
+/// The shared connection registry.
+pub fn global() -> &'static Arc<ConnectionRegistry> {
+    &REGISTRY
+}
+
+/// Releases its connection slot on `Drop` — the reliable decrement across every
+/// disconnect path. Held by `SseStream` and moved into the collab session task.
+pub struct ConnGuard {
+    registry: Arc<ConnectionRegistry>,
+    key: ConnKey,
+}
+
+impl Drop for ConnGuard {
+    fn drop(&mut self) {
+        self.registry.release(&self.key);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn key(n: u128) -> ConnKey {
+        (Uuid::from_u128(n), 1)
+    }
+
+    #[test]
+    fn per_key_cap_and_release() {
+        let reg = Arc::new(ConnectionRegistry::with_limits(2, 100));
+        let k = key(1);
+        let g1 = reg.try_acquire(k).expect("1");
+        let _g2 = reg.try_acquire(k).expect("2");
+        assert!(reg.try_acquire(k).is_none(), "3rd over per-key cap");
+        drop(g1);
+        let _g3 = reg.try_acquire(k).expect("freed slot reusable");
+        assert_eq!(reg.live(), 2);
+    }
+
+    #[test]
+    fn entry_removed_at_zero() {
+        let reg = Arc::new(ConnectionRegistry::with_limits(4, 100));
+        let g = reg.try_acquire(key(7)).expect("acquire");
+        assert_eq!(reg.per_key.len(), 1);
+        drop(g);
+        assert_eq!(reg.per_key.len(), 0, "zeroed key is dropped from the map");
+        assert_eq!(reg.live(), 0);
+    }
+
+    #[test]
+    fn global_ceiling_and_rollback() {
+        let reg = Arc::new(ConnectionRegistry::with_limits(10, 2));
+        let _a = reg.try_acquire(key(1)).expect("a");
+        let _b = reg.try_acquire(key(2)).expect("b");
+        assert!(reg.try_acquire(key(3)).is_none(), "global ceiling");
+
+        // A per-key rejection must not consume a global slot.
+        let reg2 = Arc::new(ConnectionRegistry::with_limits(1, 5));
+        let _x = reg2.try_acquire(key(9)).expect("x");
+        assert!(reg2.try_acquire(key(9)).is_none(), "per-key reject");
+        assert_eq!(
+            reg2.live(),
+            1,
+            "rejected per-key did not leak a global slot"
+        );
+    }
+}

--- a/backend/src/services/mod.rs
+++ b/backend/src/services/mod.rs
@@ -5,6 +5,7 @@ pub mod avatar_thumbnails;
 pub mod backup;
 pub mod channels;
 pub mod collab_ownership;
+pub mod connection_registry;
 pub mod custom_fields;
 pub mod dkim_verification;
 pub mod dns_diagnostics;


### PR DESCRIPTION
## Architectural hardening (LOW/PERF review → connection governance)

The SSE and collaboration WebSocket surfaces had essentially no resource governance and are excluded from the `/api` rate limiter — one authenticated principal could open unbounded connections, drive an unbounded per-session queue, and amplify each frame into O(document) work. Three phased steps (each a commit):

**A — cheap change-detection** (`process_inbound_binary`): replace the two O(document) full-text `get_string`s (before + after every frame) with an O(clients) state-vector compare. Cheaper *and* more precise (the text compare missed formatting-only edits).

**B — bounded outbound queue**: the per-session channel stays unbounded/non-blocking (back-pressure would stall the whole room's fan-out), but now tracks its queued byte backlog; a client past `NOSDESK_WS_OUTBOUND_BUDGET_BYTES` (8 MiB) has the frame dropped and is evicted, its reconnect + CRDT resync reconciling the gap.

**C — connection cap**: a shared `ConnectionRegistry` keyed `(user, workspace)` + global ceiling, with an RAII `ConnGuard` that releases on every disconnect path. Reject pre-upgrade with HTTP 429 + `Retry-After` (a post-upgrade WS close code is ignored by stock `y-websocket`). Limits via `NOSDESK_MAX_CONN_PER_USER` (50) / `NOSDESK_MAX_CONN_GLOBAL` (10k).

## Tests
Registry unit tests (per-key cap, release, entry-removed-at-zero, global ceiling + rollback). Full backend suite green (65 binaries).