### PR TITLE
refactor(auth): funnel connection membership-gating through one entry

### DIFF
--- a/backend/src/handlers/collaboration.rs
+++ b/backend/src/handlers/collaboration.rs
@@ -2713,22 +2713,19 @@ pub async fn ws_handler(
 
     // Validate the token, resolve the connection's workspace, and build the
     // visibility context used to gate per-document access below.
-    let (user_uuid, accessor, workspace_id) = if let Some(pool) =
-        req.app_data::<web::Data<crate::db::Pool>>()
-    {
-        let mut conn = pool.get().map_err(|_| {
-            actix_web::error::ErrorInternalServerError("Database connection failed")
-        })?;
+    let (user_uuid, accessor, workspace_id) =
+        if let Some(pool) = req.app_data::<web::Data<crate::db::Pool>>() {
+            let mut conn = pool.get().map_err(|_| {
+                actix_web::error::ErrorInternalServerError("Database connection failed")
+            })?;
 
-        // Resolve the workspace. A Host-derived context (per-tenant-origin
-        // surface) wins, and the docId must match it — the cross-tenant
-        // guard against a tab cached on workspace A constructing a B docId.
-        // With no Host context (single-origin agent app), the docId's
-        // workspace_uuid IS the selection: the WS can't send the selection
-        // header, so the docId is the carrier (like the SSE token). The
-        // membership gate below is the authorization in both cases.
-        let workspace_id = match &ws {
-            Some(ws) => {
+            // docId-vs-Host integrity: on a per-tenant origin the docId must name
+            // the same workspace as the Host — the cross-tenant guard against a tab
+            // cached on workspace A constructing a B docId. With no Host context
+            // (single-origin agent app) the docId's workspace_uuid IS the selection
+            // (the WS can't send the selection header). The membership gate below
+            // authorizes either way. Integrity only; not a membership check.
+            if let Some(ws) = &ws {
                 if parsed.workspace_uuid != ws.workspace_uuid {
                     warn!(
                         doc_id = %doc_id,
@@ -2740,86 +2737,76 @@ pub async fn ws_handler(
                         "doc_id workspace does not match the request workspace",
                     ));
                 }
-                ws.workspace_id
             }
-            None => {
-                match crate::repository::workspaces::find_by_uuid(&mut conn, parsed.workspace_uuid)
-                {
-                    Ok(Some(w)) => w.id,
-                    // Unknown workspace collapses into the same denial a
-                    // non-member gets, so workspace existence does not leak.
-                    Ok(None) => {
-                        return Err(actix_web::error::ErrorForbidden(
-                            "Not a member of this workspace",
+
+            // Validate the token first (reads only the global `users` row, so it is
+            // pin-independent), then enforce the collab-specific checks, then funnel
+            // through resolve + pin + gate. Ordering this way lets the shared funnel
+            // own pin-before-gate; the caller's own workspace_role read (from_claims)
+            // runs after, under the funnel's pin and only for confirmed members.
+            use crate::utils::jwt::JwtUtils;
+            let (claims, user) =
+                match JwtUtils::validate_token_with_user_check(token, &mut conn).await {
+                    Ok(pair) => pair,
+                    Err(_) => {
+                        return Err(actix_web::error::ErrorUnauthorized(
+                            "Invalid or expired token",
                         ))
                     }
-                    Err(e) => {
-                        error!(error = ?e, "WebSocket docId workspace resolution failed");
-                        return Err(actix_web::error::ErrorInternalServerError(
-                            "Workspace resolution failed",
-                        ));
-                    }
-                }
+                };
+            // Only a write-capable collab token opens the editing socket; a
+            // read-only SSE token (or any other) is refused, preserving the
+            // read/write split the separate scopes exist for.
+            if claims.scope != "collab" {
+                return Err(actix_web::error::ErrorForbidden(
+                    "Token not valid for collaboration",
+                ));
             }
-        };
-
-        // Pin so the accessor's role + visibility resolve under RLS (the
-        // pool clears app.workspace_id on checkout); without it an admin is
-        // downgraded to member document visibility.
-        //
-        // Safety invariant: the pin precedes the membership gate below, but
-        // everything read under it before the gate touches only the CALLER'S
-        // OWN data (their user row in validate_token_with_user_check, their
-        // own workspace_role in from_claims). No other tenant's content is
-        // read until after the gate denies non-members, so pinning a
-        // client-selected workspace here cannot leak. Keep any tenant-content
-        // read (the per-document resolve + visibility check) below the gate.
-        crate::handlers::helpers::pin_workspace(&mut conn, workspace_id);
-
-        use crate::utils::jwt::JwtUtils;
-        match JwtUtils::validate_token_with_user_check(token, &mut conn).await {
-            Ok((claims, user)) => {
-                // Only a write-capable collab token opens the editing socket; a
-                // read-only SSE token (or any other) is refused, preserving the
-                // read/write split the separate scopes exist for.
-                if claims.scope != "collab" {
+            // The token is workspace-bound (Model C): it must match the doc's
+            // workspace, so a token minted for workspace A can't open a B doc.
+            if let Some(token_ws) = claims.workspace_uuid {
+                if token_ws != parsed.workspace_uuid {
                     return Err(actix_web::error::ErrorForbidden(
-                        "Token not valid for collaboration",
+                        "Token workspace does not match the document",
                     ));
                 }
-                // The token is workspace-bound (Model C): it must match the doc's
-                // workspace, so a token minted for workspace A can't open a B doc.
-                if let Some(token_ws) = claims.workspace_uuid {
-                    if token_ws != parsed.workspace_uuid {
-                        return Err(actix_web::error::ErrorForbidden(
-                            "Token workspace does not match the document",
-                        ));
-                    }
+            }
+
+            // Resolve + pin + membership-gate via the shared connection-auth
+            // funnel. A Host-derived context (per-tenant origin) is authoritative
+            // when present — it was cross-checked against the docId above, so
+            // don't re-resolve the docId uuid; with no Host context the docId's
+            // workspace uuid IS the carrier (single-origin agent app). Deny an
+            // unresolved one: a collab connection always names a workspace.
+            use crate::middleware::cookie_auth::{GateOutcome, UnresolvedPolicy, WorkspaceCarrier};
+            let carrier = WorkspaceCarrier::ConnectionToken {
+                token_workspace: ws.is_none().then_some(parsed.workspace_uuid),
+                req: &req,
+            };
+            let workspace_id = match crate::middleware::cookie_auth::resolve_pin_and_gate(
+                &mut conn,
+                &claims,
+                carrier,
+                UnresolvedPolicy::Deny,
+            )? {
+                GateOutcome::Scoped(ctx) => ctx.workspace_id,
+                GateOutcome::Unscoped => {
+                    return Err(actix_web::error::ErrorForbidden(
+                        "Not a member of this workspace",
+                    ))
                 }
-                let accessor = DocAccessor::from_claims(&claims, &mut conn)
-                    .ok_or_else(|| actix_web::error::ErrorUnauthorized("Invalid token subject"))?;
-                // Membership gate: the collab WS bypasses the auth
-                // middleware, so the gate it runs for REST is invoked
-                // explicitly here. Load-bearing under Model C, where the
-                // workspace is client-selected (docId / Host).
-                crate::middleware::cookie_auth::require_workspace_membership(
-                    &mut conn,
-                    workspace_id,
-                    user.uuid,
-                )?;
-                (user.uuid, accessor, workspace_id)
-            }
-            Err(_) => {
-                return Err(actix_web::error::ErrorUnauthorized(
-                    "Invalid or expired token",
-                ))
-            }
-        }
-    } else {
-        return Err(actix_web::error::ErrorInternalServerError(
-            "Database pool not available",
-        ));
-    };
+            };
+
+            // Confirmed member, pinned: resolve the caller's OWN doc-access role.
+            let accessor = DocAccessor::from_claims(&claims, &mut conn)
+                .ok_or_else(|| actix_web::error::ErrorUnauthorized("Invalid token subject"))?;
+
+            (user.uuid, accessor, workspace_id)
+        } else {
+            return Err(actix_web::error::ErrorInternalServerError(
+                "Database pool not available",
+            ));
+        };
 
     debug!(
         doc_id = %doc_id,

--- a/backend/src/handlers/sse.rs
+++ b/backend/src/handlers/sse.rs
@@ -693,52 +693,32 @@ pub async fn sse_events_stream(
         return Ok(errors::forbidden("Token not valid for the event stream"));
     }
 
-    // Resolve the stream's workspace: the token's bound selection (Model C)
-    // wins, else the Host-derived context the middleware put on this request.
-    use actix_web::HttpMessage as _;
-    let workspace_id = match user_info.workspace_uuid {
-        Some(ws_uuid) => match crate::repository::workspaces::find_by_uuid(&mut conn, ws_uuid) {
-            Ok(Some(ws)) => Some(ws.id),
-            // Unknown workspace collapses into the same denial a non-member
-            // gets below, so workspace existence does not leak.
-            Ok(None) => return Ok(errors::forbidden("Not a member of this workspace")),
-            Err(e) => {
-                tracing::error!(error = ?e, "SSE token workspace resolution failed");
-                return Ok(errors::internal("Workspace resolution failed"));
-            }
-        },
-        None => req
-            .extensions()
-            .get::<crate::extractors::WorkspaceContext>()
-            .map(|w| w.workspace_id),
+    // Resolve + pin + membership-gate the stream's workspace through the shared
+    // connection-auth funnel: the token's bound selection (Model C) wins, else
+    // the Host-derived context on the request. SSE bypasses the cookie/dual-auth
+    // middleware, so this is the explicit call the funnel exists to standardise.
+    // Under Model C selection an unresolved stream fails closed (a stream must
+    // resolve a workspace); otherwise the no-workspace case is the legitimate
+    // apex/global stream (self-hosted always resolves the bootstrap workspace,
+    // so it is a hosted apex stream only) and serves the topic-contained fallback.
+    use crate::middleware::cookie_auth::{GateOutcome, UnresolvedPolicy, WorkspaceCarrier};
+    let unresolved = if crate::middleware::workspace_context::selection_resolution_enabled() {
+        UnresolvedPolicy::Deny
+    } else {
+        UnresolvedPolicy::AllowRlsBackstop
     };
-
-    // Pin + membership-gate the resolved workspace so the caller's visibility
-    // (their role + per-ticket checks) resolves under RLS, and they can't
-    // subscribe to another tenant's live SyncActions stream. The pool clears
-    // app.workspace_id on checkout, so without the pin an admin is downgraded
-    // to member visibility. SSE bypasses the cookie/dual-auth middleware, so
-    // the gate that middleware runs for REST is invoked explicitly here.
-    //
-    // The gate runs immediately after the pin with no tenant-content read in
-    // between, so pinning a client-selected workspace cannot leak. Keep the
-    // per-topic visibility reads (parse_topics_authorized below) after this.
-    if let Some(workspace_id) = workspace_id {
-        crate::handlers::helpers::pin_workspace(&mut conn, workspace_id);
-        crate::middleware::cookie_auth::require_workspace_membership(
-            &mut conn,
-            workspace_id,
-            user.uuid,
-        )?;
-    } else if crate::middleware::workspace_context::selection_resolution_enabled() {
-        // Under Model C selection a stream MUST resolve (and be gated on) a
-        // workspace; an unresolved one is a misrouted or forged connection, not
-        // a legitimate apex stream, so fail closed rather than serve the
-        // topic-contained user+global fallback below. (Self-hosted always
-        // resolves the bootstrap workspace, so this branch is a hosted apex
-        // stream only.)
-        return Ok(errors::forbidden("Not a member of this workspace"));
-    }
+    let workspace_id = match crate::middleware::cookie_auth::resolve_pin_and_gate(
+        &mut conn,
+        &user_info,
+        WorkspaceCarrier::ConnectionToken {
+            token_workspace: user_info.workspace_uuid,
+            req: &req,
+        },
+        unresolved,
+    )? {
+        GateOutcome::Scoped(ctx) => Some(ctx.workspace_id),
+        GateOutcome::Unscoped => None,
+    };
 
     // Resolve subscription set. The client may declare interest via
     // `?topics=user,global,ticket-42` (comma-separated). When absent,

--- a/backend/src/middleware/cookie_auth.rs
+++ b/backend/src/middleware/cookie_auth.rs
@@ -29,44 +29,65 @@ use actix_web::HttpMessage;
 /// enforces the boundary.
 pub const PORTAL_SCOPE: &str = "portal";
 
-/// Item U: resolve-then-gate the request's workspace.
-///
-/// The request's ORIGIN is authoritative for tenant scope, and resolution is
-/// keyed on it:
-///
-/// - **Origin-derived** (customer portal `<slug>.nosdesk.app`, custom domains,
-///   and the self-hosted bootstrap): the `WorkspaceContextMiddleware` already
-///   put a `WorkspaceContext` in extensions from the Host. When present it wins
-///   outright. A client cannot override its own origin's tenant via a header,
-///   so on a tenant origin the selection header is never consulted (it could
-///   otherwise 403 on a stray slug and is a cross-tenant confusion vector).
-/// - **Selection-derived** (the single-origin agent app at `app.nosdesk.com`,
-///   behind `NOSDESK_WORKSPACE_SELECTION`): consulted ONLY when the origin
-///   resolved to no workspace — i.e. the agent origin, whose Host is on a
-///   different base domain and so never matches a tenant. The client names the
-///   workspace in the `X-Nosdesk-Workspace` header; the gate resolves it,
-///   membership-checks it, and inserts the resulting `WorkspaceContext`.
-///
-/// Either way the same membership 403 gate fires: the user must be a member of
-/// the resolved workspace or the request is `403 Forbidden` rather than falling
-/// through into the app with RLS-filtered-to-empty queries.
-///
-/// Skipped (Ok) when neither path yields a workspace (apex / public routes that
-/// pin nothing); those routes don't touch tenant tables and the strict RLS
-/// policy is the secondary guard.
-///
-/// Called by every authentication middleware (cookie auth + dual auth) so the
-/// gate fires on every authenticated entry path.
-pub fn enforce_workspace_membership(
-    req: &ServiceRequest,
+/// Where a connection surface's tenant scope comes from. Each surface supplies
+/// exactly ONE; [`resolve_pin_and_gate`] owns turning it into a pinned, gated
+/// workspace. Adding a surface means adding a carrier arm here rather than
+/// re-implementing resolve + pin + gate (and risking forgetting one).
+pub enum WorkspaceCarrier<'a> {
+    /// REST cookie/bearer: the Host-derived `WorkspaceContext` in extensions
+    /// wins (customer portal, custom domains, self-hosted bootstrap); else the
+    /// `X-Nosdesk-Workspace` selection slug (single-origin agent app). A client
+    /// cannot override its own origin's tenant with a header, so the header is
+    /// consulted ONLY when the origin resolved to no workspace.
+    RequestOrigin(&'a ServiceRequest),
+    /// A connection surface (SSE, collab WS) that authenticates outside the
+    /// middleware. `token_workspace` is the workspace uuid the connection names
+    /// (the SSE token's binding, or the collab docId's workspace when there is
+    /// no Host context); when `None`, the Host-derived context on the request is
+    /// authoritative. This encodes "an explicit workspace selection wins, else
+    /// fall back to the request origin" for both surfaces.
+    ConnectionToken {
+        token_workspace: Option<uuid::Uuid>,
+        req: &'a actix_web::HttpRequest,
+    },
+}
+
+/// What to do when a carrier resolves to NO workspace. Fail-closed by default: a
+/// new surface reaching for [`UnresolvedPolicy::Deny`] (the value collab uses,
+/// the simplest example to copy) gets the safe behaviour.
+/// [`UnresolvedPolicy::AllowRlsBackstop`] is the deliberately-named opt-in,
+/// legitimate ONLY where per-query RLS is the real boundary (REST, where the
+/// Host is authoritative) or where selection is off (legacy Host-derived SSE);
+/// every use MUST carry a justifying comment at the call site.
+pub enum UnresolvedPolicy {
+    Deny,
+    AllowRlsBackstop,
+}
+
+/// Outcome of [`resolve_pin_and_gate`].
+pub enum GateOutcome {
+    /// The caller is a member of a resolved workspace; `conn` is now pinned to
+    /// it and the caller may read tenant content. Carries the resolved context.
+    Scoped(crate::extractors::WorkspaceContext),
+    /// Only via [`UnresolvedPolicy::AllowRlsBackstop`]: no workspace resolved,
+    /// nothing pinned.
+    Unscoped,
+}
+
+/// The single connection-authentication funnel: resolve the carrier's workspace,
+/// pin it, then membership-gate it, in that order (no tenant read between pin
+/// and gate, so pinning a client-selected workspace cannot leak). Portal-scope
+/// tokens are refused (a different principal realm). This is the ONLY public
+/// path to the membership gate, so a new surface cannot be wired without it.
+pub fn resolve_pin_and_gate(
     conn: &mut DbConnection,
     claims: &Claims,
-) -> Result<(), Error> {
+    carrier: WorkspaceCarrier<'_>,
+    unresolved: UnresolvedPolicy,
+) -> Result<GateOutcome, Error> {
     // A customer-portal token is a different principal realm and must never
-    // authenticate an agent / management request. This gate is the single
-    // chokepoint both agent auth paths (cookie + dual) share, so refusing
-    // portal scope here walls it off everywhere at once. Belt-and-suspenders
-    // behind the separate portal cookie names and the separate portal origin.
+    // authenticate an agent / management request; refusing it here walls it off
+    // on every surface that funnels through the gate.
     if claims.scope == PORTAL_SCOPE {
         warn!(user = %claims.sub, "Portal-scope token rejected on the agent surface");
         return Err(actix_web::error::ErrorForbidden(
@@ -74,36 +95,102 @@ pub fn enforce_workspace_membership(
         ));
     }
 
-    // Origin-derived context wins when present (tenant portal / custom domain /
-    // self-hosted bootstrap). Only when the origin resolved to no workspace
-    // (the agent origin) do we consult the selection header. Resolving
-    // selection eagerly would 403 a tenant-origin request that carries a stray
-    // header, so the ordering here is load-bearing, not just precedence.
-    let host_derived = req
-        .extensions()
-        .get::<crate::extractors::WorkspaceContext>()
-        .map(|w| w.workspace_id);
-
-    let (workspace_id, selected) = match host_derived {
-        Some(id) => (id, None),
-        None => match selected_workspace_context(req, conn)? {
-            Some(ctx) => (ctx.workspace_id, Some(ctx)),
-            // No tenant scope to authorize against (agent apex / public route).
-            None => return Ok(()),
+    match resolve_carrier(conn, carrier)? {
+        Some(ctx) => {
+            // A workspace-scoped request whose subject doesn't parse is
+            // malformed; fail closed (auth already validated the token, so this
+            // is unreachable in practice, but the gate must never fail open).
+            let user_uuid = uuid::Uuid::parse_str(&claims.sub)
+                .map_err(|_| actix_web::error::ErrorForbidden("Not a member of this workspace"))?;
+            crate::handlers::helpers::pin_workspace(conn, ctx.workspace_id);
+            require_workspace_membership(conn, ctx.workspace_id, user_uuid)?;
+            Ok(GateOutcome::Scoped(ctx))
+        }
+        None => match unresolved {
+            UnresolvedPolicy::Deny => Err(actix_web::error::ErrorForbidden(
+                "Not a member of this workspace",
+            )),
+            UnresolvedPolicy::AllowRlsBackstop => Ok(GateOutcome::Unscoped),
         },
-    };
+    }
+}
 
-    // A workspace-scoped request whose subject doesn't parse is malformed; fail
-    // closed rather than skip the gate (auth already validated the token, so
-    // this is unreachable in practice, but the gate must never fail open).
-    let user_uuid = uuid::Uuid::parse_str(&claims.sub)
-        .map_err(|_| actix_web::error::ErrorForbidden("Not a member of this workspace"))?;
-    require_workspace_membership(conn, workspace_id, user_uuid)?;
+/// Resolve a carrier to its workspace context. `Ok(None)` = no workspace
+/// identifier at all (the caller's [`UnresolvedPolicy`] decides); `Err(403)` = a
+/// PROVIDED identifier that is unknown (existence not leaked).
+fn resolve_carrier(
+    conn: &mut DbConnection,
+    carrier: WorkspaceCarrier<'_>,
+) -> Result<Option<crate::extractors::WorkspaceContext>, Error> {
+    match carrier {
+        WorkspaceCarrier::RequestOrigin(req) => {
+            if let Some(ctx) = req
+                .extensions()
+                .get::<crate::extractors::WorkspaceContext>()
+                .cloned()
+            {
+                return Ok(Some(ctx));
+            }
+            selected_workspace_context(req, conn)
+        }
+        WorkspaceCarrier::ConnectionToken {
+            token_workspace,
+            req,
+        } => match token_workspace {
+            Some(uuid) => resolve_provided_uuid(conn, uuid).map(Some),
+            None => Ok(req
+                .extensions()
+                .get::<crate::extractors::WorkspaceContext>()
+                .cloned()),
+        },
+    }
+}
 
-    // Membership confirmed: publish the selection-derived context so downstream
-    // handlers and pins read the selected workspace, not a Host-derived one.
-    if let Some(ctx) = selected {
-        req.extensions_mut().insert(ctx);
+/// Resolve a provided workspace uuid, mapping an unknown uuid to the same 403 a
+/// non-member gets (no existence leak).
+fn resolve_provided_uuid(
+    conn: &mut DbConnection,
+    uuid: uuid::Uuid,
+) -> Result<crate::extractors::WorkspaceContext, Error> {
+    match crate::middleware::workspace_context::resolve_workspace_uuid(conn, uuid) {
+        Ok(Some(ctx)) => Ok(ctx),
+        Ok(None) => Err(actix_web::error::ErrorForbidden(
+            "Not a member of this workspace",
+        )),
+        Err(e) => {
+            error!(error = ?e, "Workspace uuid resolution failed");
+            Err(actix_web::error::ErrorInternalServerError(
+                "Workspace resolution failed",
+            ))
+        }
+    }
+}
+
+/// The REST membership gate: resolve the request's workspace (Host-derived, else
+/// selection slug), pin it, and gate it. Fail-open when no workspace resolves —
+/// the Host is authoritative for tenant scope and the per-query RLS policy is
+/// the backstop, so apex / public routes fall through. Called by both agent auth
+/// middlewares (cookie + dual) so the gate fires on every authenticated entry.
+pub fn enforce_workspace_membership(
+    req: &ServiceRequest,
+    conn: &mut DbConnection,
+    claims: &Claims,
+) -> Result<(), Error> {
+    match resolve_pin_and_gate(
+        conn,
+        claims,
+        WorkspaceCarrier::RequestOrigin(req),
+        // AllowRlsBackstop: REST is Host-authoritative + RLS-backstopped, so an
+        // unresolved workspace is a legitimate apex / public route.
+        UnresolvedPolicy::AllowRlsBackstop,
+    )? {
+        // Publish the resolved (possibly selection-derived) context so
+        // downstream handlers + pins read the selected workspace. Re-inserting a
+        // Host-derived context is a harmless no-op.
+        GateOutcome::Scoped(ctx) => {
+            req.extensions_mut().insert(ctx);
+        }
+        GateOutcome::Unscoped => {}
     }
     Ok(())
 }
@@ -146,16 +233,18 @@ fn selected_workspace_context(
 }
 
 /// Fail-closed membership check: `Ok(())` iff `user_uuid` is a member of
-/// `workspace_id`, else a 403 (500 on lookup error). Shared by the request gate
-/// above and the SSE / collab-WS handlers, which authenticate outside the
-/// middleware and so must call this explicitly.
+/// `workspace_id`, else a 403 (500 on lookup error). This is the raw gate behind
+/// [`resolve_pin_and_gate`]; **agent surfaces (REST / SSE / collab) reach it only
+/// through that funnel**, so a new connection surface can't be wired without
+/// resolve + pin + gate. The customer portal (a distinct principal realm with
+/// its own origin + `PORTAL_SCOPE`) is the one intentional direct caller.
 ///
 /// RLS-pinned read: `workspace_members`' policy is
 /// `workspace_id = current_setting('app.workspace_id')`, so on a raw pooled
 /// connection (GUC scrubbed on checkout by ResettingManager) a real member would read as "not a
 /// member". Running the lookup through `with_actor_context` pins the read to
 /// `workspace_id`. Callers that have already session-pinned the SAME workspace
-/// (SSE/collab via `pin_request_workspace`) are unaffected: the actor workspace
+/// (the funnel via `pin_workspace`) are unaffected: the actor workspace
 /// equals the pin, so subsequent reads stay correctly scoped.
 pub fn require_workspace_membership(
     conn: &mut DbConnection,

--- a/backend/src/middleware/workspace_context.rs
+++ b/backend/src/middleware/workspace_context.rs
@@ -140,6 +140,18 @@ pub fn resolve_selected_context(
     Ok(workspace_repo::find_by_slug(conn, slug)?.map(workspace_to_context))
 }
 
+/// Resolve a workspace **uuid** (the carrier for the SSE connection token and
+/// the collab docId) to a [`WorkspaceContext`]. `Ok(None)` for an unknown uuid;
+/// the caller maps that to the same 403 a non-member gets so existence does not
+/// leak. Like [`resolve_selected_context`], the `workspaces` table resolves
+/// without a pinned GUC (it is the resolution table).
+pub fn resolve_workspace_uuid(
+    conn: &mut crate::db::DbConnection,
+    uuid: uuid::Uuid,
+) -> diesel::QueryResult<Option<WorkspaceContext>> {
+    Ok(workspace_repo::find_by_uuid(conn, uuid)?.map(workspace_to_context))
+}
+
 /// Deployment topology. Drives whether workspace context comes
 /// from a process-wide bootstrap (self-hosted) or per-request
 /// subdomain resolution (hosted SaaS).


### PR DESCRIPTION
## Architectural hardening (auth-boundary review, Part 1 — the last piece)

The workspace-membership gate was a predicate each connection surface had to remember to invoke, resolving the workspace carrier + ordering pin-before-gate itself — which is exactly why SSE/collab historically diverged. This makes "resolve → pin → gate" a single path.

**Behaviour-preserving refactor.** No gap closed, no behavior changed — the value is structural: a new connection surface goes through the funnel instead of re-implementing (and risking forgetting) the gate.

## Change
- `cookie_auth::resolve_pin_and_gate(conn, claims, carrier, policy)` with a `WorkspaceCarrier` (`RequestOrigin` / `ConnectionToken`) and an `UnresolvedPolicy` where **`Deny` is the default a new surface copies** and `AllowRlsBackstop` is a named, comment-required opt-in. Fail-open vs fail-closed is a value, not a thing to remember.
- `enforce_workspace_membership` is now the thin REST wrapper (`AllowRlsBackstop` — RLS is the backstop). SSE and collab call the funnel directly, preserving their exact policies:
  - REST: fail-open (Host authoritative + RLS backstop).
  - SSE: fail-closed only under Model C selection, else the topic-contained apex fallback.
  - Collab: always `Deny`, with the Host context authoritative when present (the docId is cross-checked, not re-resolved — this preserved the exact old behavior, caught by an integration test that uses a synthetic docId uuid).
- `require_workspace_membership` stays the raw gate; the customer portal (a separate principal realm) is its one intentional direct caller.

## Tests
The request / SSE / collab / portal / membership-gate integration tests are unchanged and green. Full backend suite green (65 binaries).