### PR TITLE
perf(dashboard): tighten query caching and defer opt-in widgets

### DIFF
--- a/frontend/src/composables/useTicketVolumeKpis.ts
+++ b/frontend/src/composables/useTicketVolumeKpis.ts
@@ -7,7 +7,7 @@
  */
 import { computed } from 'vue'
 import { useQuery } from '@pinia/colada'
-import { useTimeRange } from '@/composables/useTimeRange'
+import { useTimeRange, type Grain } from '@/composables/useTimeRange'
 import { useDateStore } from '@nosdesk/core/stores/dateStore'
 import {
   analyticsService,
@@ -16,8 +16,30 @@ import {
 
 export type TicketVolumeKpis = KpiSummaryResult
 
+/**
+ * Coarsen an ISO-8601 UTC timestamp to its grain bucket, for the query
+ * KEY only (the request body keeps the precise bounds). Rolling presets
+ * resolve `to` to `new Date()` at millisecond precision, so keying on
+ * the raw value minted a fresh cache entry every mount: the headline KPI
+ * never hit the SWR cache and cold-fetched (skeleton flash) on every
+ * dashboard visit. Flooring to the grain means repeat visits within the
+ * same bucket share one entry. Slicing the UTC ISO is deterministic and
+ * enough for a key (no timezone math needed).
+ */
+function keyBucket(iso: string, grain: Grain): string {
+  switch (grain) {
+    case 'hour':
+      return iso.slice(0, 13) // YYYY-MM-DDTHH
+    case 'month':
+      return iso.slice(0, 7) // YYYY-MM
+    case 'day':
+    case 'week':
+      return iso.slice(0, 10) // YYYY-MM-DD
+  }
+}
+
 export function useTicketVolumeKpis() {
-  const { window: timeWindow, priorWindow, compare } = useTimeRange()
+  const { window: timeWindow, priorWindow, compare, grain } = useTimeRange()
   const dateStore = useDateStore()
 
   const params = computed(() => {
@@ -38,10 +60,10 @@ export function useTicketVolumeKpis() {
       'dashboard',
       'kpi',
       'ticket-volume',
-      params.value.from,
-      params.value.to,
-      params.value.prior_from ?? 'no-prior',
-      params.value.prior_to ?? 'no-prior',
+      keyBucket(params.value.from, grain.value),
+      keyBucket(params.value.to, grain.value),
+      params.value.prior_from ? keyBucket(params.value.prior_from, grain.value) : 'no-prior',
+      params.value.prior_to ? keyBucket(params.value.prior_to, grain.value) : 'no-prior',
       params.value.tz,
     ],
     query: (): Promise<TicketVolumeKpis> => analyticsService.kpiSummary(params.value),

--- a/frontend/src/views/dashboard/ChannelHealthWidget.vue
+++ b/frontend/src/views/dashboard/ChannelHealthWidget.vue
@@ -20,6 +20,10 @@ const t = (k: string, args?: Record<string, string | number>) => fluent.$t(k, ar
 const { data, isPending, isLoading, error } = useQuery({
   key: ['channels', 'list'],
   query: () => channelsService.list(),
+  // Channel config changes only on admin edits, not per navigation.
+  // Hold the cache for 5 min so revisiting the dashboard serves it
+  // without a background refetch; invalidateQueries still bypasses this.
+  staleTime: 5 * 60_000,
 })
 
 const channels = computed<Channel[]>(() => data.value ?? [])

--- a/frontend/src/views/dashboard/KpiRailSkeleton.vue
+++ b/frontend/src/views/dashboard/KpiRailSkeleton.vue
@@ -1,6 +1,9 @@
 <!--
-Skeleton for `KpiRail`. Mirrors the rail's responsive grid so skeleton
-→ data swap produces no layout shift.
+Quiet placeholder for `KpiRail`: a static em-dash where each numeral
+loads (matching KpiTile's own loading state), no pulsing skeleton, in
+line with the house "render chrome immediately" style. Mirrors the
+rail's responsive grid so the placeholder → data swap produces no
+layout shift.
 -->
 <script setup lang="ts">
 withDefaults(defineProps<{ count?: number }>(), { count: 4 })
@@ -16,9 +19,11 @@ withDefaults(defineProps<{ count?: number }>(), { count: 4 })
         :key="i"
         class="flex min-h-0 min-w-0 flex-col bg-surface px-2 py-2 sm:px-3"
       >
-        <div class="h-5 w-8 shrink-0 rounded bg-surface-alt animate-pulse" />
+        <div class="h-5 shrink-0 flex items-center">
+          <span class="text-tertiary tabular-nums leading-none" aria-hidden="true">&mdash;</span>
+        </div>
         <span class="flex-1 min-h-0" aria-hidden="true" />
-        <div class="h-2 w-12 shrink-0 rounded bg-surface-alt animate-pulse" />
+        <div class="h-2 w-12 shrink-0 rounded bg-surface-alt" />
       </div>
     </div>
   </div>

--- a/frontend/src/views/dashboard/MyAssetsWidget.vue
+++ b/frontend/src/views/dashboard/MyAssetsWidget.vue
@@ -31,6 +31,9 @@ const { data, isPending, isLoading, error } = useQuery({
     return (await getAssetsByUser(uuid)).slice(0, 5)
   },
   enabled: () => !!auth.user?.uuid,
+  // A user's assigned devices rarely change within a session; hold
+  // 10 min so dashboard revisits serve cache instead of refetching.
+  staleTime: 10 * 60_000,
 })
 
 const devices = computed<Asset[]>(() => data.value ?? [])

--- a/frontend/src/views/dashboard/RecentlyViewedWidget.vue
+++ b/frontend/src/views/dashboard/RecentlyViewedWidget.vue
@@ -6,34 +6,29 @@ status icon, ID + title chrome. `RecentTicket` doesn't carry priority
 or full requester details, so those columns simply aren't rendered;
 the row's anatomy is preserved by the optional-field pattern.
 
-The query key `['tickets', 'recent']` is shared with the sidebar's
-recent-tickets store. Once that store is migrated to Pinia Colada
-they'll dedup into a single network request per session.
+Reads the shared `recentTickets` store (Pinia Colada, account-scoped
+key) so this widget and the sidebar dedup into one request per session
+and stay in sync on view / remove.
 -->
 <script setup lang="ts">
 import { computed } from 'vue'
 import { useFluent } from 'fluent-vue'
-import { useQuery } from '@pinia/colada'
-import { getRecentTickets, type RecentTicket } from '@nosdesk/core/services/ticketService'
+import { useRecentTicketsStore } from '@/stores/recentTickets'
+import type { RecentTicket } from '@nosdesk/core/types/ticket'
 import DashboardWidgetShell from './DashboardWidgetShell.vue'
 import TicketRow from '@/components/TicketRow.vue'
 
 const fluent = useFluent()
 const t = (k: string, args?: Record<string, string | number>) => fluent.$t(k, args)
 
-// `isPending` = first-ever fetch, `isLoading` = any in-flight
-// request. The shell wants the first-only signal for `loading` so
-// dashboard remounts don't blank cached content while a background
-// refetch runs, see DashboardWidgetShell.
-const { data, isPending, isLoading, error } = useQuery({
-  key: ['tickets', 'recent'],
-  query: () => getRecentTickets(),
-})
+// The store exposes the first-fetch (`isLoading`) and background-
+// refetch (`isRefreshing`) signals the shell wants, so cached content
+// stays visible across dashboard remounts.
+const store = useRecentTicketsStore()
 
-const tickets = computed<RecentTicket[]>(() => (data.value ?? []).slice(0, 5))
-const isRefreshing = computed(() => isLoading.value && data.value !== undefined)
+const tickets = computed<RecentTicket[]>(() => store.recentTickets.slice(0, 5))
 const errorMessage = computed(() =>
-  error.value ? t('dashboard-recently-viewed-error') : null,
+  store.error ? t('dashboard-recently-viewed-error') : null,
 )
 </script>
 
@@ -41,8 +36,8 @@ const errorMessage = computed(() =>
   <DashboardWidgetShell
     :title="t('dashboard-recently-viewed-title')"
     action-to="/tickets"
-    :loading="isPending"
-    :refreshing="isRefreshing"
+    :loading="store.isLoading"
+    :refreshing="store.isRefreshing"
     :error="errorMessage"
     :empty="!errorMessage && tickets.length === 0"
     :empty-title="t('dashboard-recently-viewed-empty-title')"

--- a/frontend/src/views/dashboard/SlaHealthWidget.vue
+++ b/frontend/src/views/dashboard/SlaHealthWidget.vue
@@ -37,15 +37,26 @@ const isRefreshing = computed(() => isLoading.value && data.value !== undefined)
 const errorMessage = computed(() => (error.value ? t('dashboard-sla-health-error') : null))
 
 // Keep the snapshot fresh on the same cadence as the SLA admin
-// counts + the breach-detection job. The shell handles the
-// background-refetch visual so the existing numbers stay readable
-// during the in-flight request.
+// counts + the breach-detection job (breaches are time-driven and
+// emit no ticket mutation, so this poll is the only refresh channel).
+// The shell handles the background-refetch visual so the existing
+// numbers stay readable during the in-flight request. Ticks are
+// skipped while the tab is hidden, and one catch-up refetch fires
+// when it becomes visible again, so a backgrounded dashboard stops
+// polling every 30s.
 let timer: ReturnType<typeof setInterval> | undefined
+function onVisible() {
+  if (document.visibilityState === 'visible') refetch()
+}
 onMounted(() => {
-  timer = setInterval(() => refetch(), SLA_SUMMARY_REFRESH_MS)
+  timer = setInterval(() => {
+    if (document.visibilityState === 'visible') refetch()
+  }, SLA_SUMMARY_REFRESH_MS)
+  document.addEventListener('visibilitychange', onVisible)
 })
 onBeforeUnmount(() => {
   if (timer) clearInterval(timer)
+  document.removeEventListener('visibilitychange', onVisible)
 })
 
 // Four KPIs that read top-to-bottom in priority order: how many

--- a/frontend/src/views/dashboard/StarredDocsWidget.vue
+++ b/frontend/src/views/dashboard/StarredDocsWidget.vue
@@ -22,6 +22,10 @@ const t = (k: string, args?: Record<string, string | number>) => fluent.$t(k, ar
 const { data, isPending, isLoading, error } = useQuery({
   key: ['documentation', 'starred'],
   query: async () => (await getStarredPages()).slice(0, 6),
+  // The starred set is low-churn; hold 10 min so dashboard revisits
+  // serve cache. Toggling a star should invalidate
+  // ['documentation','starred'] to refresh immediately.
+  staleTime: 10 * 60_000,
 })
 
 const pages = computed<StarredPageInfo[]>(() => data.value ?? [])

--- a/frontend/src/views/dashboard/charts/LineChart.vue
+++ b/frontend/src/views/dashboard/charts/LineChart.vue
@@ -295,7 +295,7 @@ const xLabels = computed<XTick[]>(() => {
 </script>
 
 <template>
-  <div ref="containerRef" class="flex flex-col w-full h-full">
+  <div class="flex flex-col w-full h-full">
     <div v-if="loading" class="flex-1 flex items-center justify-center text-tertiary text-xs">
       {{ t('dashboard-line-chart-loading') }}
     </div>

--- a/frontend/src/views/dashboard/charts/TicketFlowChart.vue
+++ b/frontend/src/views/dashboard/charts/TicketFlowChart.vue
@@ -331,7 +331,7 @@ const tooltipStyle = computed(() => {
 </script>
 
 <template>
-  <div ref="containerRef" class="flex flex-col w-full h-full">
+  <div class="flex flex-col w-full h-full">
     <div v-if="loading" class="flex-1 flex items-center justify-center text-tertiary text-xs">
       {{ t('dashboard-line-chart-loading') }}
     </div>

--- a/frontend/src/views/dashboard/charts/VolumeKpiRailSkeleton.vue
+++ b/frontend/src/views/dashboard/charts/VolumeKpiRailSkeleton.vue
@@ -1,3 +1,9 @@
+<!--
+Quiet placeholder for the volume KPI rail: a static em-dash per numeral
+(matching KpiTile's loading state), no pulsing skeleton, in line with
+the house "render chrome immediately" style. Same box heights as the
+populated rail so the swap produces no layout shift.
+-->
 <script setup lang="ts">
 withDefaults(defineProps<{ count?: number }>(), { count: 3 })
 </script>
@@ -9,9 +15,11 @@ withDefaults(defineProps<{ count?: number }>(), { count: 3 })
       :key="i"
       class="flex-1 flex flex-col min-h-0 min-w-0 px-2 py-2 sm:px-3 gap-1"
     >
-      <div class="h-5 w-10 rounded bg-surface-alt animate-pulse shrink-0" />
-      <div class="flex-1 min-h-2 rounded bg-surface-alt animate-pulse" />
-      <div class="h-2.5 w-14 rounded bg-surface-alt animate-pulse shrink-0" />
+      <div class="h-5 shrink-0 flex items-center">
+        <span class="text-tertiary tabular-nums leading-none" aria-hidden="true">&mdash;</span>
+      </div>
+      <div class="flex-1 min-h-2" />
+      <div class="h-2.5 w-14 rounded bg-surface-alt shrink-0" />
     </div>
   </div>
 </template>

--- a/frontend/src/views/dashboard/widgets.ts
+++ b/frontend/src/views/dashboard/widgets.ts
@@ -12,6 +12,7 @@
  * merges new registry entries at the tail of the stored order, so
  * shipping a new widget is a no-op for existing users.
  */
+import { defineAsyncComponent } from 'vue'
 import type { Component } from 'vue'
 import type { DashboardLayout, UserRole } from '@nosdesk/core/types/user'
 import { packGrid } from '@/composables/usePointerSortable'
@@ -19,16 +20,25 @@ import UserAssignedTickets from '@/components/UserAssignedTickets.vue'
 import TicketHeatmap from '@/components/TicketHeatmap.vue'
 import RecentlyViewedWidget from './RecentlyViewedWidget.vue'
 import UnassignedQueueWidget from './UnassignedQueueWidget.vue'
-import StarredDocsWidget from './StarredDocsWidget.vue'
-import MyDevicesWidget from './MyAssetsWidget.vue'
-import ChannelHealthWidget from './ChannelHealthWidget.vue'
 import KnowledgeGapsWidget from './KnowledgeGapsWidget.vue'
 import SlaHealthWidget from './SlaHealthWidget.vue'
 import TicketVolumeWidget from './TicketVolumeWidget.vue'
-import SavedViewWidget from './SavedViewWidget.vue'
-import KpiTile from './charts/KpiTile.vue'
 import TicketFlowChart from './charts/TicketFlowChart.vue'
 import HorizontalBar from './charts/HorizontalBar.vue'
+
+// Opt-in widgets that never appear on a default landing layout (they
+// are off until a user adds them via the picker, or, for
+// SavedViewWidget, pins a saved view): load on demand so they don't
+// ship in the eager dashboard chunk. Each splits into its own small
+// chunk fetched only when actually placed. RecentlyViewed +
+// UnassignedQueue stay statically imported above because the curated
+// staff default (STAFF_VISIBLE) shows them on first paint, so
+// async-loading them would flash a blank cell on landing.
+const StarredDocsWidget = defineAsyncComponent(() => import('./StarredDocsWidget.vue'))
+const MyDevicesWidget = defineAsyncComponent(() => import('./MyAssetsWidget.vue'))
+const ChannelHealthWidget = defineAsyncComponent(() => import('./ChannelHealthWidget.vue'))
+const SavedViewWidget = defineAsyncComponent(() => import('./SavedViewWidget.vue'))
+const KpiTile = defineAsyncComponent(() => import('./charts/KpiTile.vue'))
 
 /**
  * Synthetic widget id prefix for saved-view-backed widgets.


### PR DESCRIPTION
Research-driven pass over the dashboard for data-fetching cache hygiene and component load cost. Findings came from a multi-agent review (28 raised, 19 survived adversarial verification); this ships the confirmed high-value, low-risk set. All changes measured against a production build.

## Data / cache hygiene
- **TicketVolume KPI cache key** now floors `from`/`to`/prior bounds to the query grain (hour/day/month) in the key only, keeping precise bounds in the request body. Previously the key embedded a millisecond `now`, so the headline widget minted a fresh cache entry every mount, never hit the SWR cache, and cold-fetched + flashed a skeleton on every dashboard visit.
- **`staleTime`** added to the low-churn widget queries: channel-health (5 min), starred-docs (10 min), my-assets (10 min). Stops a background refetch per remount; `invalidateQueries` still bypasses it.
- **RecentlyViewedWidget** now reads the shared account-scoped `recentTickets` store instead of a second bare-key `['tickets','recent']` query, so the widget and sidebar dedup into one request and stay in sync.
- **SLA summary poll** gated on `document.visibilityState` with a catch-up refetch on `visibilitychange`, so a backgrounded dashboard stops polling every 30s. (Kept the interval: Pinia Colada has no `refetchInterval`, and this is the only refresh channel for wall-clock-driven breach data.)
- **KPI rail placeholders** (`KpiRailSkeleton`, `VolumeKpiRailSkeleton`) swapped from pulsing skeleton bars to a static em-dash matching `KpiTile`'s own loading state, same box heights so no layout shift.

## Component load
- Dropped the **duplicate outer `containerRef`** on `LineChart` and `TicketFlowChart` (kept on the inner measured box; `useElementSize` re-attaches on the loading→loaded swap).
- **Async-loaded the five opt-in widgets** that never appear on a default landing layout: `StarredDocs`, `MyDevices`, `ChannelHealth`, `SavedView`, `KpiTile`. `RecentlyViewed` + `UnassignedQueue` stay eager because the curated staff default (`STAFF_VISIBLE`) shows them on first paint.

## Verification
- `vue-tsc` clean; production build green.
- Eager `main` chunk **619.76 → 618.09 kB gzip** (-1.7 kB off every cold boot).
- **~8.8 kB gzip** of opt-in widget code (dominated by `SavedViewWidget`, 4.6 kB) now loads only when a widget is placed.

## Deliberately out of scope
Verification confirmed these are low-value or by-design: lazy-loading `DashboardView` itself (conflicts with the instant-nav landing), async-ing default-visible charts (landing pop-in), the live-refresh key scoping (documented decision-9), and the chart resize-recompute items (browser + Vue already coalesce). The app-wide entry-chunk story (`main` size, the 1.5 MB `i18n` chunk, `INEFFECTIVE_DYNAMIC_IMPORT` warnings) is tracked separately.