### PR TITLE
feat(notifications): snooze endpoint with auto-unsnooze

### DIFF
--- a/backend/src/handlers/notifications.rs
+++ b/backend/src/handlers/notifications.rs
@@ -3,6 +3,7 @@
 //! Endpoints for managing user notifications and preferences.
 
 use actix_web::{web, HttpMessage, HttpRequest, HttpResponse};
+use chrono::{DateTime, Utc};
 
 use crate::handlers::{errors, helpers};
 use serde::Deserialize;
@@ -30,6 +31,15 @@ pub struct MarkReadRequest {
 #[derive(Debug, Deserialize)]
 pub struct DeleteNotificationsRequest {
     pub notification_ids: Vec<i32>,
+}
+
+/// Request body for snoozing notifications until a given time.
+#[derive(Debug, Deserialize)]
+pub struct SnoozeRequest {
+    pub notification_ids: Vec<i32>,
+    /// ISO-8601 instant; the items stay hidden from the active inbox
+    /// until this time, then auto-unsnooze.
+    pub until: DateTime<Utc>,
 }
 
 /// Request body for updating a preference
@@ -60,6 +70,10 @@ pub fn config(cfg: &mut web::ServiceConfig) {
         .route(
             "/notifications/unarchive",
             web::post().to(unarchive_notifications),
+        )
+        .route(
+            "/notifications/snooze",
+            web::post().to(snooze_notifications),
         )
         .route(
             "/notifications/read",
@@ -279,6 +293,37 @@ pub async fn unarchive_notifications(
 
     match notification_service
         .set_archived(&user_uuid, &body.notification_ids, false)
+        .await
+    {
+        Ok(count) => HttpResponse::Ok().json(serde_json::json!({
+            "success": true,
+            "count": count
+        })),
+        Err(e) => HttpResponse::InternalServerError().json(serde_json::json!({ "error": e })),
+    }
+}
+
+/// Snooze notifications until a given time (hides them from the active
+/// inbox until then; they auto-unsnooze).
+///
+/// POST /api/notifications/snooze
+pub async fn snooze_notifications(
+    req: HttpRequest,
+    notification_service: web::Data<NotificationService>,
+    body: web::Json<SnoozeRequest>,
+) -> HttpResponse {
+    let claims = match req.extensions().get::<Claims>() {
+        Some(c) => c.clone(),
+        None => return HttpResponse::Unauthorized().finish(),
+    };
+
+    let user_uuid = match uuid::Uuid::parse_str(&claims.sub) {
+        Ok(u) => u,
+        Err(_) => return errors::bad_request("Invalid user UUID"),
+    };
+
+    match notification_service
+        .snooze(&user_uuid, &body.notification_ids, body.until.naive_utc())
         .await
     {
         Ok(count) => HttpResponse::Ok().json(serde_json::json!({

--- a/backend/src/route_registration_tests.rs
+++ b/backend/src/route_registration_tests.rs
@@ -43,6 +43,7 @@ async fn notifications_config_routes_registered() {
             ("POST", "/notifications/unread"),
             ("POST", "/notifications/archive"),
             ("POST", "/notifications/unarchive"),
+            ("POST", "/notifications/snooze"),
             ("POST", "/notifications/read"),
             ("POST", "/notifications/read-all"),
             ("GET", "/notifications/preferences"),

--- a/backend/src/services/notifications/service.rs
+++ b/backend/src/services/notifications/service.rs
@@ -433,6 +433,13 @@ impl NotificationService {
                     .filter(is_read.eq(false))
                     // Archived items drop out of the active inbox.
                     .filter(archived_at.is_null())
+                    // Snoozed items stay hidden until their time passes
+                    // (auto-unsnooze by the read filter, no extra write).
+                    .filter(
+                        snoozed_until
+                            .is_null()
+                            .or(snoozed_until.le(Utc::now().naive_utc())),
+                    )
                     .order(created_at.desc())
                     .limit(limit)
                     .select((
@@ -484,6 +491,12 @@ impl NotificationService {
                     // Archived items drop out of the active inbox (they
                     // remain retrievable once an Archived view exists).
                     .filter(archived_at.is_null())
+                    // Snoozed items stay hidden until their time passes.
+                    .filter(
+                        snoozed_until
+                            .is_null()
+                            .or(snoozed_until.le(Utc::now().naive_utc())),
+                    )
                     .order(created_at.desc())
                     .limit(limit)
                     .offset(offset)
@@ -594,6 +607,12 @@ impl NotificationService {
                     .filter(user_uuid.eq(user_uuid_val))
                     .filter(seen_at.is_null())
                     .filter(archived_at.is_null())
+                    // Snoozed items don't ping the badge until they surface.
+                    .filter(
+                        snoozed_until
+                            .is_null()
+                            .or(snoozed_until.le(Utc::now().naive_utc())),
+                    )
                     .count()
                     .get_result(conn)
             },
@@ -676,6 +695,30 @@ impl NotificationService {
                 .execute(conn)
             },
         )
+        .map_err(|e| format!("Update failed: {e}"))
+    }
+
+    /// Snooze notifications until a given time: hides them from the
+    /// active inbox until `until`, after which the read-side filter
+    /// auto-unsnoozes them (no follow-up write needed). Passing a past
+    /// timestamp effectively unsnoozes immediately.
+    pub async fn snooze(
+        &self,
+        user_uuid_val: &Uuid,
+        notification_ids: &[i32],
+        until: chrono::NaiveDateTime,
+    ) -> Result<usize, String> {
+        use crate::schema::notifications::dsl::*;
+
+        crate::sync::session::background_run(&self.pool, "background:notification_snooze", |conn| {
+            diesel::update(
+                notifications
+                    .filter(user_uuid.eq(user_uuid_val))
+                    .filter(id.eq_any(notification_ids)),
+            )
+            .set(snoozed_until.eq(Some(until)))
+            .execute(conn)
+        })
         .map_err(|e| format!("Update failed: {e}"))
     }
 


### PR DESCRIPTION
Adds the snooze write-action to the phase 1 engagement-state model (the `snoozed_until` column shipped in #100). Backend-only; a snooze UI to drive it is a follow-up.

## Changes
- **`snooze`** service method + **`POST /notifications/snooze`** (body: `notification_ids` + an ISO `until` instant) sets `snoozed_until`.
- **Auto-unsnooze read-filter**: `get_unread`, `get_all`, and the unseen count show a snoozed item only once `snoozed_until` has passed (`snoozed_until IS NULL OR snoozed_until <= now`), so it resurfaces by time with no follow-up write.
- Route covered by the route-registration test.

## Verification
- `cargo test`: 1756 passed, 0 failed.

## Follow-up
Snooze UI (preset menu on the inbox row) to call this endpoint.