### PR TITLE
fix(notifications): read notification preferences from the channels map

### DIFF
--- a/frontend/src/components/settings/NotificationSettings.vue
+++ b/frontend/src/components/settings/NotificationSettings.vue
@@ -120,13 +120,12 @@ const groupedNotificationTypes = computed(() => {
   return groups;
 });
 
-// Get preference value for a specific type/channel combination
+// Get preference value for a specific type/channel combination. The API
+// returns one row per type with a channels map, so read the channel out
+// of that map (defaulting to enabled when the type/channel is absent).
 const getPreference = (typeCode: string, channelCode: string): boolean => {
-  const pref = preferences.value.find(
-    (p) => p.notification_type === typeCode && p.channel === channelCode
-  );
-  // Default to true if no preference exists
-  return pref?.enabled ?? true;
+  const pref = preferences.value.find((p) => p.notification_type === typeCode);
+  return pref?.channels[channelCode] ?? true;
 };
 
 // Check if all preferences for a channel are enabled
@@ -145,20 +144,9 @@ const togglePreference = async (typeCode: string, channelCode: string) => {
   try {
     await updateNotificationPreference(typeCode, channelCode, newValue);
 
-    // Update local state
-    const existingIndex = preferences.value.findIndex(
-      (p) => p.notification_type === typeCode && p.channel === channelCode
-    );
-
-    if (existingIndex >= 0) {
-      preferences.value[existingIndex].enabled = newValue;
-    } else {
-      preferences.value.push({
-        notification_type: typeCode,
-        channel: channelCode,
-        enabled: newValue,
-      });
-    }
+    // Update local state (mutate the type's channels map).
+    const group = preferences.value.find((p) => p.notification_type === typeCode);
+    if (group) group.channels[channelCode] = newValue;
 
     emit('success', t('settings-notifications-preference-update-success'));
   } catch {
@@ -180,20 +168,9 @@ const toggleAllForChannel = async (channelCode: string) => {
     try {
       await updateNotificationPreference(type.code, channelCode, newValue);
 
-      // Update local state
-      const existingIndex = preferences.value.findIndex(
-        (p) => p.notification_type === type.code && p.channel === channelCode
-      );
-
-      if (existingIndex >= 0) {
-        preferences.value[existingIndex].enabled = newValue;
-      } else {
-        preferences.value.push({
-          notification_type: type.code,
-          channel: channelCode,
-          enabled: newValue,
-        });
-      }
+      // Update local state (mutate the type's channels map).
+      const group = preferences.value.find((p) => p.notification_type === type.code);
+      if (group) group.channels[channelCode] = newValue;
     } catch {
       // Continue with other preferences even if one fails
     }

--- a/packages/core/src/services/notificationService.ts
+++ b/packages/core/src/services/notificationService.ts
@@ -8,8 +8,16 @@ import apiClient from '../apiClient';
 
 export interface NotificationPreference {
   notification_type: string;
-  channel: string;
-  enabled: boolean;
+  notification_name: string;
+  description: string | null;
+  category: string;
+  /**
+   * Per-channel enabled state, keyed by channel code (`in_app`, `email`).
+   * Matches the backend `NotificationPreferenceResponse` shape: the API
+   * returns ONE row per type with a channels map, NOT one row per
+   * (type, channel) pair.
+   */
+  channels: Record<string, boolean>;
 }
 
 export interface NotificationPreferencesResponse {


### PR DESCRIPTION
A genuine bug surfaced while reviewing this session's notification work.

The settings screen typed preferences as flat `{ notification_type, channel, enabled }` rows and looked them up with `p.channel === channelCode`. But `GET /notifications/preferences` returns **one row per type with a channels map** (`{ notification_type, category, channels: { in_app, email } }`, per the backend `NotificationPreferenceResponse`). The lookup never matched, so `getPreference` always fell through to its `true` default — **every toggle rendered ON regardless of the user's saved preferences** (writes worked; the on-load read didn't).

## Fix
- Correct the `NotificationPreference` type to the backend's grouped shape.
- `getPreference` and both toggle handlers now read / write `channels[channelCode]`.

Verified against the backend that `get_all_preferences` always populates both `in_app` and `email` in the map (defaults, then user overrides), so the read is exact.

## Verification
- `vue-tsc` + production build clean. Net −15 lines (also drops the find-index/push branches).

## Follow-up
Source all 10 types from the server (the endpoint already returns them + categories; the UI still hardcodes 6) and convert the component to `useQuery` (drops the ungated skeleton).