### PR TITLE
Logging: close PII channels, fail-safe prod redaction, complete the wide event

### DIFF
--- a/backend/src/handlers/auth.rs
+++ b/backend/src/handlers/auth.rs
@@ -7,6 +7,7 @@ use uuid::Uuid;
 use crate::db::DbConnection;
 use crate::handlers::errors;
 use crate::handlers::helpers;
+use crate::middleware::request_context::record_canonical;
 use crate::models::{LoginRequest, PasswordChangeRequest};
 use crate::repository::{self, user_auth_identities::get_local_password_hash};
 use crate::utils::auth::hash_password;
@@ -614,6 +615,7 @@ pub async fn login(
     match RateLimiter::check_lockout(&redis_url, &lockout_key, MAX_LOGIN_ATTEMPTS).await {
         Ok(Some(remaining_seconds)) => {
             warn!(email = %login_data.email, remaining_seconds, "Login attempt on locked account");
+            record_canonical(&request, "outcome", "account_locked");
             return errors::too_many_requests(
                 format!(
                     "Account temporarily locked. Try again in {} minutes.",
@@ -710,6 +712,7 @@ pub async fn login(
                 },
             );
             if locked {
+                record_canonical(&request, "outcome", "account_locked");
                 return errors::too_many_requests(
                     format!(
                         "Account locked after too many failed attempts. Try again in {} minutes.",
@@ -718,6 +721,7 @@ pub async fn login(
                     LOCKOUT_DURATION_SECONDS,
                 );
             }
+            record_canonical(&request, "outcome", "invalid_credentials");
             return errors::unauthorized("Invalid email or password");
         }
     };
@@ -728,6 +732,8 @@ pub async fn login(
 
     // Check if user has TOTP MFA enabled - if so, require TOTP verification
     if mfa::user_has_mfa_enabled(&user) {
+        record_canonical(&request, "outcome", "mfa_required");
+        record_canonical(&request, "mfa_required", true);
         let response = jwt_helpers::create_mfa_required_response(user.uuid);
         return HttpResponse::Ok().json(response);
     }
@@ -739,6 +745,7 @@ pub async fn login(
     // only session; now it surfaces as a 5xx and the user retries.
     match mfa::user_has_passkeys(&mut conn, &user.uuid) {
         Ok(true) => {
+            record_canonical(&request, "outcome", "passkey_required");
             let response = jwt_helpers::create_passkey_mfa_required_response(user.uuid);
             return HttpResponse::Ok().json(response);
         }
@@ -752,10 +759,12 @@ pub async fn login(
     // Check MFA policy enforcement (for users without MFA enabled)
     if let Err(_policy_error) = mfa::validate_mfa_policy(&user, &mut conn).await {
         // Instead of blocking, offer MFA setup for users who need it
+        record_canonical(&request, "outcome", "mfa_setup_required");
         let response = jwt_helpers::create_mfa_setup_required_response(user.uuid);
         return HttpResponse::Ok().json(response);
     }
 
+    record_canonical(&request, "outcome", "success");
     complete_login(user, &request, &mut conn)
 }
 

--- a/backend/src/handlers/msgraph_integration.rs
+++ b/backend/src/handlers/msgraph_integration.rs
@@ -5209,12 +5209,14 @@ fn extract_user_emails(ms_user: &MicrosoftGraphUser) -> Vec<(String, String, boo
                         "alias".to_string() // smtp: (lowercase) indicates alias
                     };
                     emails.push((email.clone(), email_type.clone(), true));
-                    trace!("Added proxy email: {} (type: {})", email, email_type);
+                    trace!(email = %email, email_type = %email_type, "Added proxy email");
                 } else {
-                    trace!("Skipped duplicate proxy email: {}", email);
+                    trace!(email = %email, "Skipped duplicate proxy email");
                 }
             } else {
-                trace!("Failed to extract email from proxy address: {}", proxy);
+                // `proxy` field (not allowlisted) is dropped in prod JSON; the
+                // runtime scrub also masks any address in it. Visible in dev.
+                trace!(proxy = %proxy, "Failed to extract email from proxy address");
             }
         }
     }
@@ -5228,9 +5230,9 @@ fn extract_user_emails(ms_user: &MicrosoftGraphUser) -> Vec<(String, String, boo
                 && !emails.iter().any(|(e, _, _)| e == email)
             {
                 emails.push((email.clone(), "other".to_string(), true));
-                trace!("Added other email: {}", email);
+                trace!(email = %email, "Added other email");
             } else {
-                trace!("Skipped invalid or duplicate other email: {}", email);
+                trace!(email = %email, "Skipped invalid or duplicate other email");
             }
         }
     }

--- a/backend/src/handlers/password_reset.rs
+++ b/backend/src/handlers/password_reset.rs
@@ -90,7 +90,10 @@ async fn issue_password_reset(
     let user = match repository::get_user_by_email(&email, &mut conn) {
         Ok(u) => u,
         Err(_) => {
-            info!("Password reset requested for non-existent email: {}", email);
+            // Enumeration-safe: never log the raw email (it survives the
+            // field allowlist because it's in the message string). The
+            // request_id on the canonical event correlates this to the caller.
+            info!("Password reset requested for a non-existent email");
             return Ok(());
         }
     };

--- a/backend/src/handlers/tickets.rs
+++ b/backend/src/handlers/tickets.rs
@@ -10,6 +10,7 @@ use uuid::Uuid;
 
 use crate::extractors::{AuthContext, TenantConn, TicketAccess};
 use crate::handlers::errors;
+use crate::middleware::request_context::record_canonical;
 use crate::models::{
     AssignmentTrigger, Claims, NewTicket, TicketUpdate, TicketsJson, WorkflowStateCategory,
 };
@@ -1016,6 +1017,11 @@ pub async fn create_empty_ticket(
         ticket.clone(),
         article_content,
     );
+
+    // Canonical wide event: fold the outcome into the one per-request line so
+    // "a ticket was created, id N" is queryable without a separate log line.
+    record_canonical(&req, "ticket_id", ticket.id);
+    record_canonical(&req, "outcome", "created");
 
     // Return the complete ticket with article content
     match tc.run(|conn| repository::get_complete_ticket(conn, ticket.id)) {

--- a/backend/src/middleware/request_context.rs
+++ b/backend/src/middleware/request_context.rs
@@ -15,11 +15,13 @@
 //! present, so the request_id remains on every log line emitted
 //! during the request.
 
+use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
 use actix_web::body::MessageBody;
 use actix_web::dev::{ServiceRequest, ServiceResponse};
-use actix_web::{Error, HttpMessage};
+use actix_web::{Error, HttpMessage, HttpRequest};
+use serde_json::{Map, Value};
 use tracing::Span;
 use tracing_actix_web::{root_span, DefaultRootSpanBuilder, RequestId, RootSpanBuilder};
 use uuid::Uuid;
@@ -32,6 +34,54 @@ use crate::sync::actor::{ActorContext, ActorKind};
 /// report `latency_ms` at request end.
 #[derive(Clone, Copy)]
 struct RequestStart(Instant);
+
+/// Request-scoped bag of high-cardinality **business** dimensions that handlers
+/// accumulate through the request — the missing half of the wide-events model.
+///
+/// `tracing` requires every event/span field declared up front, so a handler
+/// can't attach `ticket_id`/`outcome`/… to the canonical event directly. Instead
+/// handlers stamp this bag via [`record_canonical`]; at request end
+/// [`emit_canonical_event`] serialises it into the single `_canonical` field,
+/// and the redaction layer flattens each key back to a top-level field *through
+/// the allowlist* (`utils::tracing_redact`) — so one row carries HTTP dims +
+/// actor + whatever business outcome the handler recorded, and bag fields are
+/// held to the same PII policy as first-class ones.
+///
+/// `Arc<Mutex<…>>` so it's `Clone` (extractable via `web::ReqData`) and can be
+/// stamped from anywhere holding the request, including across `.await`s.
+#[derive(Clone, Default)]
+pub struct CanonicalContext(Arc<Mutex<Map<String, Value>>>);
+
+impl CanonicalContext {
+    /// Stamp one business dimension onto the canonical event. Last write wins.
+    /// The key must be on the `tracing_redact` allowlist or it's dropped at
+    /// emit — keep these to bounded enums / counts / stable IDs, never free text.
+    pub fn record(&self, key: &str, value: impl Into<Value>) {
+        if let Ok(mut map) = self.0.lock() {
+            map.insert(key.to_string(), value.into());
+        }
+    }
+
+    /// Serialise the bag for the `_canonical` field, or `None` when empty (so a
+    /// request that stamped nothing doesn't carry an empty field).
+    fn snapshot_json(&self) -> Option<String> {
+        let map = self.0.lock().ok()?;
+        if map.is_empty() {
+            return None;
+        }
+        serde_json::to_string(&*map).ok()
+    }
+}
+
+/// Stamp a business dimension onto the request's canonical wide event. No-op if
+/// the request has no `CanonicalContext` (only happens outside the normal
+/// middleware stack, e.g. some unit tests). Ergonomic front door for handlers:
+/// `record_canonical(&req, "ticket_id", ticket.id);`
+pub fn record_canonical(req: &HttpRequest, key: &str, value: impl Into<Value>) {
+    if let Some(cc) = req.extensions().get::<CanonicalContext>() {
+        cc.record(key, value);
+    }
+}
 
 /// Per-request context: who's acting, with what correlation id.
 ///
@@ -66,9 +116,12 @@ pub struct NosdeskRootSpanBuilder;
 
 impl RootSpanBuilder for NosdeskRootSpanBuilder {
     fn on_request_start(request: &ServiceRequest) -> Span {
-        request
-            .extensions_mut()
-            .insert(RequestStart(Instant::now()));
+        {
+            let mut ext = request.extensions_mut();
+            ext.insert(RequestStart(Instant::now()));
+            // Empty business-dimension bag; handlers fill it via record_canonical.
+            ext.insert(CanonicalContext::default());
+        }
         root_span!(
             request,
             user_uuid = tracing::field::Empty,
@@ -110,7 +163,7 @@ fn emit_canonical_event<B>(outcome: &Result<ServiceResponse<B>, Error>) {
     // Extract owned values so the extensions borrow is released before the
     // event macro. Absent-auth requests get stable sentinels (workspace 0,
     // empty user, "anonymous") so the field set is uniform across every event.
-    let (request_id, workspace_id, user_uuid, actor_kind, latency_ms) = {
+    let (request_id, workspace_id, user_uuid, actor_kind, latency_ms, canonical) = {
         let ext = req.extensions();
         let request_id = ext
             .get::<RequestId>()
@@ -127,7 +180,20 @@ fn emit_canonical_event<B>(outcome: &Result<ServiceResponse<B>, Error>) {
             .get::<RequestStart>()
             .map(|s| s.0.elapsed().as_millis() as u64)
             .unwrap_or(0);
-        (request_id, workspace_id, user_uuid, actor_kind, latency_ms)
+        // The accumulated business-dimension bag, serialised. The redaction
+        // layer flattens it (per-key, through the allowlist) back into
+        // top-level fields on this one event.
+        let canonical = ext
+            .get::<CanonicalContext>()
+            .and_then(|c| c.snapshot_json());
+        (
+            request_id,
+            workspace_id,
+            user_uuid,
+            actor_kind,
+            latency_ms,
+            canonical,
+        )
     };
 
     tracing::info!(
@@ -140,6 +206,7 @@ fn emit_canonical_event<B>(outcome: &Result<ServiceResponse<B>, Error>) {
         workspace_id = workspace_id,
         user_uuid = %user_uuid,
         actor_kind = actor_kind,
+        _canonical = canonical.as_deref().unwrap_or(""),
         "http_request"
     );
 }
@@ -314,6 +381,52 @@ mod tests {
         // High-cardinality dimensions present (values non-deterministic/PII-safe).
         assert!(ev.fields.contains_key("user_uuid"), "user_uuid present");
         assert!(ev.fields.contains_key("latency_ms"), "latency_ms present");
+    }
+
+    #[test]
+    fn canonical_event_carries_stamped_business_fields() {
+        let events = run_capturing(|| {
+            let req = TestRequest::post().uri("/api/tickets").to_srv_request();
+            req.extensions_mut().insert(RequestStart(Instant::now()));
+            let cc = CanonicalContext::default();
+            cc.record("ticket_id", 42);
+            cc.record("outcome", "created");
+            req.extensions_mut().insert(cc);
+            let resp = req.into_response(HttpResponse::Ok().finish());
+            let outcome: Result<ServiceResponse<BoxBody>, Error> = Ok(resp);
+            emit_canonical_event(&outcome);
+        });
+
+        let ev = events
+            .iter()
+            .find(|e| e.target == "nosdesk::request")
+            .expect("canonical event should fire");
+        // The bag is serialised into `_canonical`; the redaction layer flattens
+        // it per-key at emit (covered by tracing_redact tests). Here we prove the
+        // handler-stamped dims reach the event.
+        let canonical = ev.fields.get("_canonical").expect("_canonical present");
+        assert!(canonical.contains("\"ticket_id\":42"), "got {canonical}");
+        assert!(
+            canonical.contains("\"outcome\":\"created\""),
+            "got {canonical}"
+        );
+    }
+
+    #[test]
+    fn record_canonical_stamps_via_request_extensions() {
+        let req = TestRequest::default().to_http_request();
+        let cc = CanonicalContext::default();
+        req.extensions_mut().insert(cc.clone());
+        record_canonical(&req, "outcome", "ok");
+        record_canonical(&req, "result_count", 5);
+        let json = cc.snapshot_json().expect("bag non-empty");
+        assert!(json.contains("\"outcome\":\"ok\""), "got {json}");
+        assert!(json.contains("\"result_count\":5"), "got {json}");
+    }
+
+    #[test]
+    fn snapshot_json_is_none_when_empty() {
+        assert!(CanonicalContext::default().snapshot_json().is_none());
     }
 
     #[test]

--- a/backend/src/services/admin_setup.rs
+++ b/backend/src/services/admin_setup.rs
@@ -266,7 +266,9 @@ pub fn seed_from_env(conn: &mut DbConnection) -> Result<bool, EnvSeedError> {
     ) {
         Ok(_) => {
             tracing::warn!(
-                "INITIAL_ADMIN_* env config seeded admin {email}. Consider \
+                // `email` field is dropped by the prod allowlist; visible in dev.
+                email = %email,
+                "INITIAL_ADMIN_* env config seeded admin. Consider \
                  unsetting these vars after verifying login; they're idempotent \
                  (users-exist short-circuit) but leaving secrets in env is best avoided."
             );

--- a/backend/src/telemetry.rs
+++ b/backend/src/telemetry.rs
@@ -31,18 +31,26 @@ use tracing_subscriber::{fmt, prelude::*, EnvFilter};
 /// the "served" event. The bare event is suppressed inside the layer by target
 /// check.
 pub fn init() {
+    let is_production = std::env::var("ENVIRONMENT").unwrap_or_default() == "production";
+
     let log_level = std::env::var("RUST_LOG").unwrap_or_else(|_| {
-        let base = if std::env::var("ENVIRONMENT").unwrap_or_default() == "production" {
-            "info"
-        } else {
-            "debug"
-        };
+        let base = if is_production { "info" } else { "debug" };
         format!(
             "{base},tantivy=warn,h2=info,hyper=info,hyper_util=info,rustls=info,mio=info,want=info"
         )
     });
 
-    let json_logs = std::env::var("LOG_FORMAT").ok().as_deref() == Some("json");
+    // Fail-safe: production defaults to the redacting JSON layer even when
+    // LOG_FORMAT is unset. Previously redaction was opt-in via LOG_FORMAT=json
+    // — a var set in no committed config — so a missing env var silently shipped
+    // the un-redacted pretty formatter with raw PII fields. An explicit
+    // LOG_FORMAT still wins in both directions (LOG_FORMAT=pretty forces human
+    // output in prod for a debugging session; LOG_FORMAT=json forces JSON in dev).
+    let json_logs = match std::env::var("LOG_FORMAT").ok().as_deref() {
+        Some("json") => true,
+        Some(_) => false,
+        None => is_production,
+    };
     let env_filter = || EnvFilter::new(&log_level);
     let registry = tracing_subscriber::registry();
     let _ = if json_logs {

--- a/backend/src/utils/mod.rs
+++ b/backend/src/utils/mod.rs
@@ -24,6 +24,7 @@ pub mod mfa;
 pub mod pdf;
 pub mod rate_limit;
 pub mod rbac;
+pub mod redact;
 pub mod redis_yjs_cache;
 pub mod reserved_slugs;
 pub mod reset_tokens;

--- a/backend/src/utils/redact.rs
+++ b/backend/src/utils/redact.rs
@@ -1,0 +1,128 @@
+//! Log-message content scrubbing — the sink-side companion to the field-name
+//! allowlist in [`crate::utils::tracing_redact`].
+//!
+//! The allowlist protects structured *field names*: a field whose name isn't
+//! listed is dropped. But `"message"` is always allowlisted and emitted
+//! verbatim, so PII interpolated into a free-text message — `info!("... {}",
+//! email)` — slips straight through. That's the unguarded channel (it's how a
+//! customer email once shipped from `password_reset`).
+//!
+//! [`scrub`] closes it structurally: every emitted message string passes
+//! through here and has high-confidence, never-legitimately-raw tokens (email
+//! addresses, JWTs) masked at the output boundary — regardless of call-site
+//! discipline. It deliberately does *not* touch dotted-quad IPs (infra IPs in
+//! DB/connection errors are operational, not customer PII — blunt scrubbing
+//! would hurt debuggability) or opaque IDs (UUIDs, `ticket_id` — safe to log).
+//!
+//! The CI guardrail (`tests/logging_pii_guardrail.rs`) is the source-side
+//! companion: it fails the build if PII is interpolated into a log macro in the
+//! first place. Typed redaction at the source, content scrub at the sink, lint
+//! against regressions.
+
+use std::borrow::Cow;
+use std::sync::OnceLock;
+
+use regex::{Captures, Regex};
+
+/// Mask an email for log output: `kyle@nosdesk.com` → `k***@nosdesk.com`. Keeps
+/// the domain (triage/filtering) and the first local-part character (enough to
+/// tell "same user as the previous line") without leaving a harvestable address.
+/// Zero-char / no-`@` inputs return `"***"` rather than risking a panic.
+pub fn mask_email(email: &str) -> String {
+    let Some((local, domain)) = email.split_once('@') else {
+        return "***".to_string();
+    };
+    let head = local.chars().next().unwrap_or('?');
+    format!("{head}***@{domain}")
+}
+
+/// Email: local-part + `@` + a dotted domain. The local-part class excludes
+/// `*`, so an already-masked `k***@domain` is *not* re-matched (idempotent).
+fn email_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| Regex::new(r"[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}").unwrap())
+}
+
+/// JWT / JWS compact serialization: `eyJ…` (base64url of `{"…`) + two more
+/// base64url segments. Catches id_tokens, access/reset/verify tokens that are
+/// JWTs — the whole thing is replaced, header included.
+fn jwt_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| Regex::new(r"eyJ[A-Za-z0-9_\-]+\.[A-Za-z0-9_\-]+\.[A-Za-z0-9_\-]+").unwrap())
+}
+
+/// Mask PII/secret tokens inside a free-text log message. Borrows unchanged
+/// when nothing matches (the overwhelmingly common case), gated by a cheap
+/// substring check before any regex runs.
+pub fn scrub(input: &str) -> Cow<'_, str> {
+    let has_email = input.contains('@');
+    let has_jwt = input.contains("eyJ");
+    if !has_email && !has_jwt {
+        return Cow::Borrowed(input);
+    }
+
+    let mut out: Cow<'_, str> = Cow::Borrowed(input);
+    if has_email {
+        out = apply(out, email_re(), |caps: &Captures| {
+            // Reuse the canonical masker so message emails and structured
+            // `email` fields would mask identically: `k***@domain`.
+            mask_email(caps.get(0).map_or("", |m| m.as_str()))
+        });
+    }
+    if has_jwt {
+        out = apply(out, jwt_re(), |_: &Captures| "[REDACTED_JWT]".to_string());
+    }
+    out
+}
+
+/// Apply a regex replacement to a `Cow`, preserving the borrow when the regex
+/// makes no change (so the no-match fast path never allocates).
+fn apply<'a>(s: Cow<'a, str>, re: &Regex, rep: impl Fn(&Captures) -> String) -> Cow<'a, str> {
+    match re.replace_all(&s, rep) {
+        Cow::Borrowed(_) => s,
+        Cow::Owned(owned) => Cow::Owned(owned),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn masks_email_in_message() {
+        assert_eq!(
+            scrub("Password reset requested for kyle@nosdesk.com"),
+            "Password reset requested for k***@nosdesk.com"
+        );
+    }
+
+    #[test]
+    fn masks_jwt() {
+        let jwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.abc-DEF_123";
+        assert_eq!(scrub(&format!("bearer {jwt}")), "bearer [REDACTED_JWT]");
+    }
+
+    #[test]
+    fn idempotent_and_borrows_when_clean() {
+        assert_eq!(scrub("k***@nosdesk.com"), "k***@nosdesk.com");
+        assert!(matches!(
+            scrub("ticket 42 created workspace_id=7"),
+            Cow::Borrowed(_)
+        ));
+    }
+
+    #[test]
+    fn masks_multiple_emails() {
+        assert_eq!(
+            scrub("merge a@x.com into b@y.org"),
+            "merge a***@x.com into b***@y.org"
+        );
+    }
+
+    #[test]
+    fn mask_email_edge_cases() {
+        assert_eq!(mask_email("a@b.co"), "a***@b.co");
+        assert_eq!(mask_email(""), "***");
+        assert_eq!(mask_email("no-at-sign"), "***");
+    }
+}

--- a/backend/src/utils/tracing_redact.rs
+++ b/backend/src/utils/tracing_redact.rs
@@ -120,6 +120,13 @@ const ALLOWED_FIELDS: &[&str] = &[
     "processed",
     "stamped",
     "total",
+    // canonical wide-event business dimensions — stamped by handlers via
+    // `request_context::record_canonical` and flattened out of the `_canonical`
+    // bag (below). Bounded enums / counts / stable IDs only; no free text.
+    "entity_id",
+    "mfa_required",
+    "outcome",
+    "result_count",
     // HTTP / operational context: the canonical per-request wide event
     // (`nosdesk::request`, see middleware/request_context.rs) + tracing-actix-web.
     "latency_ms",
@@ -245,6 +252,32 @@ struct AllowlistVisitor {
     redacted_count: usize,
 }
 
+impl AllowlistVisitor {
+    /// Flatten the canonical event's `_canonical` JSON object into top-level
+    /// fields, applying the allowlist (and `scrub` on string values) per key —
+    /// so the accumulated business bag is held to the same PII policy as any
+    /// other field. Malformed / non-object payloads are ignored.
+    fn merge_canonical(&mut self, json_str: &str) {
+        if json_str.is_empty() {
+            return;
+        }
+        let Ok(Value::Object(map)) = serde_json::from_str::<Value>(json_str) else {
+            return;
+        };
+        for (k, v) in map {
+            if is_allowed(&k) {
+                let v = match v {
+                    Value::String(s) => Value::String(scrub(&s).into_owned()),
+                    other => other,
+                };
+                self.fields.insert(k, v);
+            } else {
+                self.redacted_count += 1;
+            }
+        }
+    }
+}
+
 impl Visit for AllowlistVisitor {
     fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
         if is_allowed(field.name()) {
@@ -260,6 +293,15 @@ impl Visit for AllowlistVisitor {
     }
 
     fn record_str(&mut self, field: &Field, value: &str) {
+        // The canonical wide event ships its dynamic per-request business
+        // fields as one JSON object under `_canonical` (handlers can't add
+        // arbitrary static tracing fields to it). Flatten each key through the
+        // SAME allowlist + scrub, so a bag field is redacted identically to a
+        // first-class one — a handler can't smuggle PII onto the event this way.
+        if field.name() == "_canonical" {
+            self.merge_canonical(value);
+            return;
+        }
         if is_allowed(field.name()) {
             self.fields
                 .insert(field.name().into(), json!(scrub(value).as_ref()));
@@ -317,6 +359,46 @@ fn is_allowed(name: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The `_canonical` bag is flattened per-key through the allowlist: allowed
+    /// business dims land as top-level fields; anything not allowlisted (a
+    /// handler accidentally stamping PII) is dropped and counted, never emitted.
+    #[test]
+    fn canonical_bag_flattens_through_allowlist() {
+        let mut v = AllowlistVisitor::default();
+        v.merge_canonical(
+            r#"{"ticket_id":42,"outcome":"created","email":"kyle@nosdesk.com","result_count":3}"#,
+        );
+        assert_eq!(v.fields.get("ticket_id"), Some(&json!(42)));
+        assert_eq!(v.fields.get("outcome"), Some(&json!("created")));
+        assert_eq!(v.fields.get("result_count"), Some(&json!(3)));
+        // `email` is not allowlisted → dropped, not emitted, and counted.
+        assert!(!v.fields.contains_key("email"));
+        assert_eq!(v.redacted_count, 1);
+    }
+
+    /// Even an allowlisted string value in the bag is scrubbed (defence in
+    /// depth against a mislabelled field carrying an address).
+    #[test]
+    fn canonical_bag_scrubs_string_values() {
+        let mut v = AllowlistVisitor::default();
+        v.merge_canonical(r#"{"outcome":"sent to kyle@nosdesk.com"}"#);
+        assert_eq!(
+            v.fields.get("outcome"),
+            Some(&json!("sent to k***@nosdesk.com"))
+        );
+    }
+
+    /// Malformed / empty payloads are ignored, not panicked on.
+    #[test]
+    fn canonical_bag_ignores_garbage() {
+        let mut v = AllowlistVisitor::default();
+        v.merge_canonical("");
+        v.merge_canonical("not json");
+        v.merge_canonical("[1,2,3]"); // not an object
+        assert!(v.fields.is_empty());
+        assert_eq!(v.redacted_count, 0);
+    }
 
     /// Positive cases — if this fails, an entry was removed from
     /// `ALLOWED_FIELDS` and a downstream log call just broke.

--- a/backend/src/utils/tracing_redact.rs
+++ b/backend/src/utils/tracing_redact.rs
@@ -52,6 +52,8 @@ use tracing_subscriber::layer::Context;
 use tracing_subscriber::registry::LookupSpan;
 use tracing_subscriber::Layer;
 
+use crate::utils::redact::scrub;
+
 /// Field names whose values are emitted to JSON output. Anything else
 /// is dropped and counted under `redacted`. Order doesn't matter
 /// (linear scan); kept loosely grouped for diffing.
@@ -246,8 +248,12 @@ struct AllowlistVisitor {
 impl Visit for AllowlistVisitor {
     fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
         if is_allowed(field.name()) {
+            // `scrub` masks any email/JWT accidentally interpolated into the
+            // text — the always-allowlisted `message` field arrives here, so
+            // this closes the free-text channel the field-name allowlist can't.
+            let rendered = format!("{value:?}");
             self.fields
-                .insert(field.name().into(), json!(format!("{value:?}")));
+                .insert(field.name().into(), json!(scrub(&rendered).as_ref()));
         } else {
             self.redacted_count += 1;
         }
@@ -255,7 +261,8 @@ impl Visit for AllowlistVisitor {
 
     fn record_str(&mut self, field: &Field, value: &str) {
         if is_allowed(field.name()) {
-            self.fields.insert(field.name().into(), json!(value));
+            self.fields
+                .insert(field.name().into(), json!(scrub(value).as_ref()));
         } else {
             self.redacted_count += 1;
         }

--- a/backend/tests/logging_pii_guardrail.rs
+++ b/backend/tests/logging_pii_guardrail.rs
@@ -1,0 +1,272 @@
+//! CI guardrail against PII/secret interpolation into logs. Scans the crate
+//! source for the two accidental-leak shapes and fails the build if either
+//! appears, so leaks can't reach production between reviews.
+//!
+//! This is the *source-side* backstop; the *runtime* backstop is
+//! `utils::redact::scrub` (masks emails/JWTs in emitted messages) and the
+//! `tracing_redact` field-name allowlist. Belt, suspenders, and a lint.
+//!
+//! Why it matters here specifically: the redaction allowlist protects field
+//! *names*, but `"message"` is always allowlisted and emitted verbatim — so a
+//! customer email/subject/body splatted into a `info!("… {}", x)` message
+//! string ships raw (this is exactly how `password_reset` leaked an email at
+//! INFO). This scan is the thing that catches that class at CI time.
+//!
+//! It intentionally does NOT need a database — a pure static scan, so it runs
+//! on every `cargo test` regardless of DB availability.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Identifiers that must never be format-interpolated raw into a log message.
+/// Values behind these names are PII, secrets, or customer content; log a
+/// masked form (`mask_email`), a stable ID, or nothing instead.
+///
+/// Kept high-confidence on purpose: bare, never-legitimately-raw names. Generic
+/// words (`name`, `content`) are omitted — they log config identifiers far more
+/// often than customer data, and false positives would erode the guardrail.
+const FORBIDDEN_IDENTS: &[&str] = &[
+    // credentials / secrets
+    "password",
+    "new_password",
+    "password_cleartext",
+    "plaintext",
+    "secret",
+    "client_secret",
+    "api_key",
+    "access_token",
+    "refresh_token",
+    "id_token",
+    "session_token",
+    "csrf_token",
+    "totp_secret",
+    "recovery_code",
+    "backup_code",
+    // PII
+    "email",
+    "user_email",
+    "requester_email",
+    // customer content (a helpdesk's tickets/messages are sensitive)
+    "subject",
+    "ticket_subject",
+    "ticket_body",
+    "message_body",
+    "comment_body",
+];
+
+fn src_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("src")
+}
+
+fn rs_files(dir: &Path, out: &mut Vec<PathBuf>) {
+    for entry in fs::read_dir(dir).expect("read_dir src").flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            rs_files(&path, out);
+        } else if path.extension().is_some_and(|e| e == "rs") {
+            out.push(path);
+        }
+    }
+}
+
+/// Blank out `//` line and `/* */` block comments (respecting string/char
+/// literals) so documentation that *mentions* the anti-pattern — e.g. a module
+/// doc showing `info!("user={}", email)` as the thing to avoid — doesn't trip
+/// the scan. Comment bytes become spaces so byte offsets are preserved.
+fn strip_comments(content: &str) -> String {
+    let bytes = content.as_bytes();
+    let mut out = content.to_string();
+    let buf = unsafe { out.as_bytes_mut() };
+    let (mut in_str, mut in_char, mut escape) = (false, false, false);
+    let mut i = 0;
+    while i < bytes.len() {
+        let c = bytes[i];
+        if in_str || in_char {
+            if escape {
+                escape = false;
+            } else if c == b'\\' {
+                escape = true;
+            } else if (in_str && c == b'"') || (in_char && c == b'\'') {
+                in_str = false;
+                in_char = false;
+            }
+            i += 1;
+            continue;
+        }
+        match c {
+            b'"' => in_str = true,
+            b'\'' => in_char = true,
+            b'/' if i + 1 < bytes.len() && bytes[i + 1] == b'/' => {
+                while i < bytes.len() && bytes[i] != b'\n' {
+                    buf[i] = b' ';
+                    i += 1;
+                }
+                continue;
+            }
+            b'/' if i + 1 < bytes.len() && bytes[i + 1] == b'*' => {
+                while i + 1 < bytes.len() && !(bytes[i] == b'*' && bytes[i + 1] == b'/') {
+                    if bytes[i] != b'\n' {
+                        buf[i] = b' ';
+                    }
+                    i += 1;
+                }
+                if i + 1 < bytes.len() {
+                    buf[i] = b' ';
+                    buf[i + 1] = b' ';
+                    i += 2;
+                }
+                continue;
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    out
+}
+
+/// Extract the argument text of every `info!/warn!/error!/debug!/trace!`
+/// (optionally `log::`/`tracing::`-prefixed) call — the substring between the
+/// macro's outer parens — via a balanced-paren scan that skips string/char
+/// literals. Scoping the checks to these spans keeps struct literals
+/// (`Foo { subject: … }`), URL/email-body `format!`s, and operator `println!`s
+/// from tripping the guardrail: only genuine log calls are scanned.
+fn log_macro_arg_spans(content: &str) -> Vec<String> {
+    use regex::Regex;
+    let head = Regex::new(r"(?:log::|tracing::)?(?:info|warn|error|debug|trace)!\s*\(").unwrap();
+    let mut spans = Vec::new();
+    for m in head.find_iter(content) {
+        let rest = &content[m.end()..]; // just past the opening '('
+        let mut depth = 1i32;
+        let (mut in_str, mut in_char, mut escape) = (false, false, false);
+        let mut end = rest.len();
+        for (i, c) in rest.char_indices() {
+            if escape {
+                escape = false;
+                continue;
+            }
+            match (in_str, in_char, c) {
+                (true, _, '\\') | (_, true, '\\') => escape = true,
+                (true, _, '"') => in_str = false,
+                (_, true, '\'') => in_char = false,
+                (true, _, _) | (_, true, _) => {}
+                (_, _, '"') => in_str = true,
+                (_, _, '\'') => in_char = true,
+                (_, _, '(') => depth += 1,
+                (_, _, ')') => {
+                    depth -= 1;
+                    if depth == 0 {
+                        end = i + c.len_utf8(); // include the closing ')'
+                        break;
+                    }
+                }
+                _ => {}
+            }
+        }
+        spans.push(rest[..end].to_string());
+    }
+    spans
+}
+
+/// The first string literal in a macro-arg span — the format string.
+fn first_string_literal(span: &str) -> Option<&str> {
+    let start = span.find('"')? + 1;
+    let rest = &span[start..];
+    let mut escape = false;
+    for (i, c) in rest.char_indices() {
+        if escape {
+            escape = false;
+        } else if c == '\\' {
+            escape = true;
+        } else if c == '"' {
+            return Some(&rest[..i]);
+        }
+    }
+    None
+}
+
+/// Two leak shapes, scoped to log-macro call sites:
+///
+/// 1. **Inline capture** — `{email}` / `{subject:?}` *inside the format string*.
+///    A capture in the literal is a variable substitution; a struct literal
+///    can't appear inside a string, so this can't collide with `Foo { subject }`.
+/// 2. **Positional** — `warn!("… {} …", email)`: an empty `{}` placeholder plus
+///    a forbidden *bare* trailing arg (`,\s*&?IDENT\s*[,)]`), so `mask_email(&email)`
+///    and struct-field `subject:` are not flagged. Field-access forms like
+///    `user.email` are intentionally NOT caught here (the runtime `scrub` masks
+///    those); this scan targets the unambiguous bare-identifier footgun.
+fn violations_in(content: &str) -> Vec<String> {
+    use regex::Regex;
+    let alt = FORBIDDEN_IDENTS.join("|");
+    let inline = Regex::new(&format!(r"\{{\s*({alt})\s*(?::[^}}]*)?\}}")).unwrap();
+    let positional = Regex::new(&format!(
+        r#"(?s)"[^"]*\{{\}}[^"]*"[^;]*?,\s*&?({alt})\s*[,)]"#
+    ))
+    .unwrap();
+
+    let mut hits = Vec::new();
+    for span in log_macro_arg_spans(content) {
+        if let Some(fmt) = first_string_literal(&span) {
+            for caps in inline.captures_iter(fmt) {
+                hits.push(format!("inline capture `{{{}}}`", &caps[1]));
+            }
+        }
+        for caps in positional.captures_iter(&span) {
+            hits.push(format!("positional log arg `{}`", &caps[1]));
+        }
+    }
+    hits
+}
+
+#[test]
+fn no_pii_or_secret_interpolation_in_logs() {
+    let mut files = Vec::new();
+    rs_files(&src_dir(), &mut files);
+    assert!(!files.is_empty(), "found no source files to scan");
+
+    let mut failures = Vec::new();
+    for file in &files {
+        let raw = fs::read_to_string(file).expect("read source");
+        let content = strip_comments(&raw);
+        for hit in violations_in(&content) {
+            failures.push(format!("{}: {hit}", file.display()));
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "PII/secret/customer-content interpolated into a log message — mask it \
+         (mask_email), log a stable ID, or drop it:\n  {}",
+        failures.join("\n  ")
+    );
+}
+
+/// The guardrail must actually detect the shapes it claims to — otherwise a
+/// regex typo would render it a silent no-op that always passes.
+#[test]
+fn guardrail_detects_known_bad_patterns() {
+    assert!(!violations_in(r#"info!("user {email} signed in");"#).is_empty());
+    assert!(!violations_in(r#"warn!("login for {}", email);"#).is_empty());
+    assert!(!violations_in(r#"error!("reset {new_password:?}");"#).is_empty());
+    assert!(!violations_in(r#"trace!("Added proxy email: {}", email);"#).is_empty());
+    assert!(!violations_in(r#"info!("ticket {}", subject);"#).is_empty());
+    assert!(!violations_in("warn!(\n  \"verify {}\",\n  access_token,\n);").is_empty());
+
+    // …and must NOT flag the safe forms the codebase actually uses:
+    assert!(violations_in(r#"info!("no active user for that email");"#).is_empty());
+    assert!(violations_in(r#"info!(email = %login.email, "login");"#).is_empty());
+    assert!(violations_in(r#"info!("reset: {}", mask_email(&email));"#).is_empty());
+    assert!(violations_in(r#"warn!("rate limited: path={}", req.path());"#).is_empty());
+    assert!(violations_in(r#"error!(error = ?e, "db pool failed");"#).is_empty());
+}
+
+/// Comment-stripping must neutralise doc examples but keep real code on the same
+/// or following lines, and must not treat `//` inside a string as a comment.
+#[test]
+fn strip_comments_blanks_comments_but_keeps_code() {
+    let doc = "//! avoid: info!(\"user={}\", email)\nlet x = 1;";
+    assert!(violations_in(&strip_comments(doc)).is_empty());
+    let mixed = "// note\nwarn!(\"login {}\", email);";
+    assert!(!violations_in(&strip_comments(mixed)).is_empty());
+    let url = r#"info!("fetching https://api.example.com/{}", email);"#;
+    assert!(!violations_in(&strip_comments(url)).is_empty());
+}


### PR DESCRIPTION
Hardens backend logging following a review against the wide-events / [loggingsucks.com](https://loggingsucks.com) model (full review: `docs/logging-review-2026-07-14.md`, local/untracked). Two commits.

## 1 — Close PII channels + fail-safe prod redaction (`e9df3af9`)

**Critical**
- `password_reset.rs`: stop logging a raw customer email at INFO — it was in the message string, so the field allowlist never redacted it (shipped cleartext).
- `telemetry.rs`: production now **defaults** to the redacting JSON layer even when `LOG_FORMAT` is unset. It was gated on `LOG_FORMAT=json`, a var set in no committed config — so an unset var silently ran the un-redacted pretty formatter with raw PII fields. Explicit `LOG_FORMAT` still overrides both ways.

**Structural (ported from the control plane)**
- `utils/redact.rs`: `scrub()` masks emails + JWTs embedded in log *messages*, wired into `RedactingJsonLayer`'s str/debug visitors — closes the "message is the unguarded channel" gap regardless of call-site discipline. Fast-paths (borrows) on the common no-match line.
- `tests/logging_pii_guardrail.rs`: CI scan that fails the build on PII/secret/customer-content interpolation into a log macro (comment-stripped, scoped to log-macro call sites, self-tested). Found + fixed 5 residual email leaks in `msgraph_integration.rs` + `admin_setup.rs` (moved to allowlist-dropped structured fields).

## 2 — Complete the canonical wide event (`215c8cfa`)

The canonical per-request event carried only HTTP + actor dims; business outcomes were scattered across separate lines. This adds the "accumulate through the request, emit once" half.

- `CanonicalContext`: request-scoped `Arc<Mutex<Map>>` bag in actix extensions; handlers stamp via `record_canonical(&req, key, value)`.
- `emit_canonical_event` serialises the bag into one `_canonical` field; `RedactingJsonLayer` flattens it per-key back to top-level fields **through the same allowlist + scrub** — so business dims are queryable on the one event and held to the identical PII policy (a handler can't smuggle PII onto the event via the bag).
- tracing's static-field model can't attach dynamic per-request fields to an event; the bag + flatten is how you get variable dimensionality while keeping the allowlist as the single PII gate.
- Exemplars (the rest are incremental one-liners): `create_empty_ticket` (`ticket_id`, `outcome`), `login` (`outcome` ∈ success/mfa_required/passkey_required/mfa_setup_required/account_locked/invalid_credentials, `mfa_required`).

## Tests
Redact unit tests, canonical bag flatten/scrub/serialisation, request-context mechanism, and the guardrail (self-test + full-source scan) all green; clippy + fmt clean; full backend builds.