### PR TITLE
Logging roadmap: error_kind taxonomy, tail sampling, more wide-event instrumentation

### DIFF
--- a/backend/src/handlers/errors.rs
+++ b/backend/src/handlers/errors.rs
@@ -323,6 +323,43 @@ pub enum ApiError {
     Pool(#[from] r2d2::Error),
 }
 
+/// Stable, low-cardinality machine code for an [`ApiError`], attached to the
+/// response extensions so the canonical wide event can report `error_kind`
+/// without every handler restating it. Distinct from `status_code`: it
+/// separates e.g. a unique-violation 409 from a plain conflict, and a pool
+/// outage 503 from a service-unavailable 503 — so `group by error_kind` is
+/// possible. Read by `middleware::request_context::emit_canonical_event`.
+#[derive(Clone, Copy)]
+pub struct ErrorKind(pub &'static str);
+
+impl ApiError {
+    /// Stable machine code for this error (never free text — safe to log/index).
+    pub fn kind(&self) -> &'static str {
+        match self {
+            ApiError::BadRequest(_) => "bad_request",
+            ApiError::Unauthorized(_) => "unauthorized",
+            ApiError::Forbidden(_) => "forbidden",
+            ApiError::NotFound(_) => "not_found",
+            ApiError::Conflict(_) => "conflict",
+            ApiError::Internal(_) => "internal",
+            ApiError::ServiceUnavailable(_) => "service_unavailable",
+            ApiError::Database(diesel::result::Error::NotFound) => "not_found",
+            ApiError::Database(diesel::result::Error::DatabaseError(kind, _)) => {
+                use diesel::result::DatabaseErrorKind as Kind;
+                match kind {
+                    Kind::UniqueViolation => "db_unique_violation",
+                    Kind::ForeignKeyViolation | Kind::NotNullViolation | Kind::CheckViolation => {
+                        "db_constraint_violation"
+                    }
+                    _ => "db_error",
+                }
+            }
+            ApiError::Database(_) => "db_error",
+            ApiError::Pool(_) => "pool_unavailable",
+        }
+    }
+}
+
 impl ResponseError for ApiError {
     fn status_code(&self) -> StatusCode {
         match self {
@@ -350,7 +387,7 @@ impl ResponseError for ApiError {
     }
 
     fn error_response(&self) -> HttpResponse {
-        match self {
+        let mut resp = match self {
             ApiError::BadRequest(m) => bad_request(m.clone()),
             ApiError::Unauthorized(m) => unauthorized(m.clone()),
             ApiError::Forbidden(m) => forbidden(m.clone()),
@@ -363,6 +400,12 @@ impl ResponseError for ApiError {
                 error!(error = ?e, "DB pool acquire failed");
                 service_unavailable("Database connection unavailable, please retry")
             }
-        }
+        };
+        // Stash the stable kind on the response so the canonical wide event
+        // reports `error_kind` for every `?`-propagated error, no per-handler
+        // stamping. (Direct `HttpResponse::…` returns bypass this — acceptable;
+        // the ApiError path is the systematic one.)
+        resp.extensions_mut().insert(ErrorKind(self.kind()));
+        resp
     }
 }

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -135,6 +135,7 @@ pub use passkeys::{
 use actix_web::{http::StatusCode, web, HttpMessage, HttpResponse, Responder};
 use serde_json::json;
 
+use crate::middleware::request_context::record_canonical;
 use crate::utils::error_response::json_error;
 use crate::utils::locale::request_locale;
 use std::sync::Arc;
@@ -383,6 +384,9 @@ pub async fn add_comment_to_ticket(
     match create_result {
         Ok(comment) => {
             debug!(comment_id = comment.id, "Created comment");
+            record_canonical(&req, "ticket_id", ticket_id);
+            record_canonical(&req, "comment_id", comment.id);
+            record_canonical(&req, "outcome", "comment_added");
 
             // Auto-watch on first comment. Industry default
             // (GitHub, Linear) — once a user engages with a

--- a/backend/src/handlers/tickets.rs
+++ b/backend/src/handlers/tickets.rs
@@ -606,6 +606,7 @@ pub async fn create_ticket(
     search_service: web::Data<Arc<SearchService>>,
     auth: AuthContext,
     ticket: web::Json<NewTicket>,
+    req: HttpRequest,
 ) -> impl Responder {
     let new_ticket = ticket.into_inner();
 
@@ -730,6 +731,8 @@ pub async fn create_ticket(
             // The new ticket reaches clients through the sync pool (the
             // repository write emits `ticket.created`); no discrete SSE.
 
+            record_canonical(&req, "ticket_id", ticket.id);
+            record_canonical(&req, "outcome", "created");
             HttpResponse::Created().json(ticket)
         }
         Err(_) => errors::internal("Failed to create ticket"),
@@ -742,6 +745,7 @@ pub async fn update_ticket(
     mut tc: TenantConn,
     access: TicketAccess,
     ticket: web::Json<NewTicket>,
+    req: HttpRequest,
 ) -> impl Responder {
     let ticket_id = access.ticket_id;
     let new_ticket = ticket.into_inner();
@@ -758,7 +762,11 @@ pub async fn update_ticket(
     }
 
     match tc.run(|conn| repository::update_ticket(conn, ticket_id, new_ticket)) {
-        Ok(ticket) => HttpResponse::Ok().json(ticket),
+        Ok(ticket) => {
+            record_canonical(&req, "ticket_id", ticket_id);
+            record_canonical(&req, "outcome", "updated");
+            HttpResponse::Ok().json(ticket)
+        }
         Err(e) => errors::internal(format!("Failed to update ticket: {e}")),
     }
 }
@@ -770,6 +778,7 @@ pub async fn delete_ticket(
     storage: crate::extractors::ScopedStorage,
     search_service: web::Data<Arc<SearchService>>,
     path: web::Path<i32>,
+    req: HttpRequest,
 ) -> impl Responder {
     if !auth.is_workspace_admin() {
         return errors::forbidden("Forbidden: Only administrators can delete tickets");
@@ -797,6 +806,8 @@ pub async fn delete_ticket(
                 // The deletion reaches clients through the sync pool (the
                 // repository write emits `ticket.deleted`); no discrete SSE.
 
+                record_canonical(&req, "ticket_id", ticket_id);
+                record_canonical(&req, "outcome", "deleted");
                 HttpResponse::NoContent().finish()
             } else {
                 errors::not_found_msg("Ticket not found")

--- a/backend/src/middleware/request_context.rs
+++ b/backend/src/middleware/request_context.rs
@@ -15,7 +15,7 @@
 //! present, so the request_id remains on every log line emitted
 //! during the request.
 
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Instant;
 
 use actix_web::body::MessageBody;
@@ -136,6 +136,52 @@ impl RootSpanBuilder for NosdeskRootSpanBuilder {
     }
 }
 
+/// Requests at/above this latency are always kept by the sampler — slow
+/// requests are the interesting ones (tail sampling, loggingsucks.com).
+const SLOW_REQUEST_MS: u64 = 1_000;
+
+/// Fraction of successful, fast requests whose canonical event is emitted.
+/// `LOG_SAMPLE_RATE` in `[0.0, 1.0]`; default `1.0` — keep everything, so this
+/// is an inert lever until an operator dials it down for log-volume cost.
+/// Parsed once (env doesn't change at runtime).
+fn sample_rate() -> f64 {
+    static RATE: OnceLock<f64> = OnceLock::new();
+    *RATE.get_or_init(|| {
+        std::env::var("LOG_SAMPLE_RATE")
+            .ok()
+            .and_then(|s| s.parse::<f64>().ok())
+            .map(|r| r.clamp(0.0, 1.0))
+            .unwrap_or(1.0)
+    })
+}
+
+/// Tail-sampling decision: always keep errors (`status >= 400`) and slow
+/// requests; sample the fast-success remainder. Reads the process [`sample_rate`].
+fn keep_canonical(status: u16, latency_ms: u64, request_id: &str) -> bool {
+    keep_canonical_at(status, latency_ms, request_id, sample_rate())
+}
+
+/// Testable core of [`keep_canonical`] with the rate passed in. Deterministic
+/// on `request_id` (FNV-1a → uniform bucket in `[0,10000)`) so a request is
+/// wholly kept or dropped, and a given id samples identically every time.
+fn keep_canonical_at(status: u16, latency_ms: u64, request_id: &str, rate: f64) -> bool {
+    if status >= 400 || latency_ms >= SLOW_REQUEST_MS {
+        return true;
+    }
+    if rate >= 1.0 {
+        return true;
+    }
+    if rate <= 0.0 {
+        return false;
+    }
+    let mut h: u64 = 0xcbf2_9ce4_8422_2325;
+    for b in request_id.as_bytes() {
+        h ^= *b as u64;
+        h = h.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    (h % 10_000) < (rate * 10_000.0) as u64
+}
+
 /// Emit the canonical per-request wide event. One flat line, self-contained
 /// (no span nesting), so a Loki/LogQL `| json | workspace_id="7" | status_code>=500`
 /// query works directly. Static per-process context (region, version, machine
@@ -159,6 +205,14 @@ fn emit_canonical_event<B>(outcome: &Result<ServiceResponse<B>, Error>) {
     }
     let status = resp.status().as_u16();
     let method = req.method().as_str();
+    // Stable error taxonomy for `?`-propagated ApiErrors, stashed on the
+    // response by `ApiError::error_response`. Stamped into the bag below so it
+    // rides `_canonical` (present only on errors, never a noisy "" on 2xx).
+    let error_kind = resp
+        .response()
+        .extensions()
+        .get::<crate::handlers::errors::ErrorKind>()
+        .map(|k| k.0);
 
     // Extract owned values so the extensions borrow is released before the
     // event macro. Absent-auth requests get stable sentinels (workspace 0,
@@ -180,9 +234,12 @@ fn emit_canonical_event<B>(outcome: &Result<ServiceResponse<B>, Error>) {
             .get::<RequestStart>()
             .map(|s| s.0.elapsed().as_millis() as u64)
             .unwrap_or(0);
-        // The accumulated business-dimension bag, serialised. The redaction
-        // layer flattens it (per-key, through the allowlist) back into
-        // top-level fields on this one event.
+        // Fold the error taxonomy into the business bag, then serialise. The
+        // redaction layer flattens the bag (per-key, through the allowlist)
+        // back into top-level fields on this one event.
+        if let (Some(ek), Some(cc)) = (error_kind, ext.get::<CanonicalContext>()) {
+            cc.record("error_kind", ek);
+        }
         let canonical = ext
             .get::<CanonicalContext>()
             .and_then(|c| c.snapshot_json());
@@ -195,6 +252,11 @@ fn emit_canonical_event<B>(outcome: &Result<ServiceResponse<B>, Error>) {
             canonical,
         )
     };
+
+    // Tail sampling: always keep errors + slow requests; sample the rest.
+    if !keep_canonical(status, latency_ms, &request_id) {
+        return;
+    }
 
     tracing::info!(
         target: "nosdesk::request",
@@ -427,6 +489,58 @@ mod tests {
     #[test]
     fn snapshot_json_is_none_when_empty() {
         assert!(CanonicalContext::default().snapshot_json().is_none());
+    }
+
+    #[test]
+    fn sampler_always_keeps_errors_and_slow_even_at_zero_rate() {
+        // Errors kept regardless of rate.
+        assert!(keep_canonical_at(500, 5, "req-a", 0.0));
+        assert!(keep_canonical_at(404, 5, "req-a", 0.0));
+        // Slow requests kept regardless of rate.
+        assert!(keep_canonical_at(200, SLOW_REQUEST_MS, "req-a", 0.0));
+    }
+
+    #[test]
+    fn sampler_rate_bounds_are_keep_all_and_drop_all() {
+        // rate 1.0 keeps every fast success; rate 0.0 drops them.
+        assert!(keep_canonical_at(200, 5, "req-a", 1.0));
+        assert!(!keep_canonical_at(200, 5, "req-a", 0.0));
+    }
+
+    #[test]
+    fn sampler_is_deterministic_and_roughly_proportional() {
+        // Same id + rate → same decision every call.
+        let d = keep_canonical_at(200, 5, "stable-id", 0.5);
+        assert_eq!(d, keep_canonical_at(200, 5, "stable-id", 0.5));
+        // ~50% of distinct ids kept at rate 0.5 (loose bounds — just proves the
+        // hash spreads and the threshold bites).
+        let kept = (0..2000)
+            .filter(|i| keep_canonical_at(200, 5, &format!("id-{i}"), 0.5))
+            .count();
+        assert!((700..=1300).contains(&kept), "kept {kept}/2000 at rate 0.5");
+    }
+
+    #[test]
+    fn canonical_event_reports_error_kind_from_response_ext() {
+        use crate::handlers::errors::ErrorKind;
+        let events = run_capturing(|| {
+            let req = TestRequest::get().uri("/api/tickets/42").to_srv_request();
+            req.extensions_mut().insert(RequestStart(Instant::now()));
+            req.extensions_mut().insert(CanonicalContext::default());
+            let mut resp = HttpResponse::NotFound().finish();
+            resp.extensions_mut().insert(ErrorKind("not_found"));
+            let outcome: Result<ServiceResponse<BoxBody>, Error> = Ok(req.into_response(resp));
+            emit_canonical_event(&outcome);
+        });
+        let ev = events
+            .iter()
+            .find(|e| e.target == "nosdesk::request")
+            .expect("canonical event should fire");
+        let canonical = ev.fields.get("_canonical").expect("_canonical present");
+        assert!(
+            canonical.contains("\"error_kind\":\"not_found\""),
+            "got {canonical}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Follows #105 (canonical wide event), working the roadmap in `docs/logging-review-2026-07-14.md`. Three commits.

## error_kind taxonomy + tail sampling (`b41eddbb`)
- `ApiError::kind()` → stable low-cardinality codes (`bad_request`, `not_found`, `db_unique_violation`, `db_constraint_violation`, `pool_unavailable`, …). `error_response` attaches it to the response extensions; the canonical event folds `error_kind` into `_canonical` (present only on errors). Covers every `?`-propagated error with no per-handler stamping — `group by error_kind` now separates a unique-violation 409 from a plain conflict, a pool-outage 503 from a service-unavailable 503.
- **Tail sampling** (`keep_canonical`): always keep errors (`status>=400`) + slow requests (`>=1000ms`); sample the fast-success remainder at `LOG_SAMPLE_RATE` (default `1.0` = keep all, an inert cost lever until dialled down). Deterministic per `request_id` (FNV-1a).

## More wide-event instrumentation (`0f1a9fa6`)
`record_canonical` outcomes on the primary mutations: `create_ticket` (created), `update_ticket` (updated), `delete_ticket` (deleted), `add_comment_to_ticket` (comment_added, +comment_id). Handlers lacking `HttpRequest` gained a `req` param (standard actix extractor, no behaviour change).

## Tests
error_kind on the canonical event; sampler determinism/bounds/keep-errors-and-slow; all mechanism + guardrail tests green; clippy + fmt clean.