### PR TITLE
Logging follow-ups: dead-dep cleanup + Phase 1 trace correlation (trace_id on the wide event)

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -1232,7 +1232,6 @@ dependencies = [
  "diesel",
  "diesel_migrations",
  "dotenvy",
- "env_logger",
  "fastrand",
  "fluent-bundle",
  "futures",
@@ -2544,29 +2543,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "env_filter"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
-dependencies = [
- "log",
- "regex",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.11.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
-dependencies = [
- "anstream",
- "anstyle",
- "env_filter",
- "jiff",
- "log",
-]
-
-[[package]]
 name = "equator"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3723,30 +3699,6 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
-
-[[package]]
-name = "jiff"
-version = "0.2.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4603d3033e49e2b0e31229fcab20a5d40089c607d975cd9c80551dc69eed9102"
-dependencies = [
- "jiff-static",
- "log",
- "portable-atomic",
- "portable-atomic-util",
- "serde_core",
-]
-
-[[package]]
-name = "jiff-static"
-version = "0.2.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "782d32378dddf207193ac91cefb848ad41abb58195c95168e1291227a0832b47"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "jni"
@@ -5008,15 +4960,6 @@ name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
-
-[[package]]
-name = "portable-atomic-util"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
-dependencies = [
- "portable-atomic",
-]
 
 [[package]]
 name = "postgres-protocol"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -71,7 +71,9 @@ tokio-util = "0.7"  # CancellationToken used by the periodic scheduler + future 
 tokio-postgres = "0.7"
 lazy_static = "1.5.0"        # For static mutable state
 dashmap = "6.1.0"            # Thread-safe concurrent hashmap
-env_logger = "0.11.0"
+# `log` façade only; every call site uses `tracing` (with `tracing-log`
+# bridging the few `log::` calls). `env_logger` was declared but never
+# initialised — the real emitter is the tracing subscriber (see telemetry.rs).
 log = "0.4"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }

--- a/backend/src/handlers/msgraph_integration.rs
+++ b/backend/src/handlers/msgraph_integration.rs
@@ -5291,7 +5291,10 @@ fn parse_microsoft_datetime(datetime_str: &Option<String>) -> Option<chrono::Nai
 }
 
 /// Process a Microsoft user without fetching profile photos (for fast sync)
-#[instrument(level = "debug", skip(conn, stats), fields(user_principal_name = %ms_user.user_principal_name, provider_id))]
+// UPN is email-shaped PII — deliberately NOT a span field (it would only be
+// dropped by the prod allowlist anyway, and is cleartext in dev). Correlate by
+// provider_id instead.
+#[instrument(level = "debug", skip(conn, stats), fields(provider_id))]
 async fn process_microsoft_user_no_photos(
     conn: &mut DbConnection,
     provider_id: i32,

--- a/backend/src/middleware/request_context.rs
+++ b/backend/src/middleware/request_context.rs
@@ -103,6 +103,76 @@ impl RequestContext {
     }
 }
 
+/// W3C Trace Context for **cross-service** correlation (observability Phase 1 —
+/// `docs/decisions/observability-tracing-2026-07-15.md` in the control-plane
+/// repo). `trace_id` is the id shared across every service that touches one
+/// logical operation; `span_id` is this service's leg of it. Both are stamped
+/// on the canonical wide event (already allowlisted), so a provisioning / OIDC
+/// flow that crosses the control plane and this product can be stitched in Loki
+/// with `| json | trace_id="…"` — no Tempo, no OTel SDK yet.
+///
+/// If an inbound request carries a `traceparent` header (the control plane
+/// injects one on its calls here) we adopt its `trace_id` and mint a fresh
+/// `span_id`; otherwise we originate a new trace.
+#[derive(Clone)]
+pub struct TraceContext {
+    pub trace_id: String,
+    pub span_id: String,
+}
+
+fn to_hex(bytes: &[u8]) -> String {
+    use std::fmt::Write;
+    bytes
+        .iter()
+        .fold(String::with_capacity(bytes.len() * 2), |mut s, b| {
+            let _ = write!(s, "{b:02x}");
+            s
+        })
+}
+
+impl TraceContext {
+    /// 16-byte trace id + 8-byte span id, hex-encoded (W3C sizes), from UUIDv4
+    /// randomness (getrandom-backed) — no extra RNG dep.
+    fn generate() -> Self {
+        Self {
+            trace_id: to_hex(Uuid::new_v4().as_bytes()),
+            span_id: to_hex(&Uuid::new_v4().as_bytes()[..8]),
+        }
+    }
+
+    /// Parse a W3C `traceparent` (`version-traceid-spanid-flags`), keep its
+    /// trace id, and mint a fresh span id for our leg. Returns `None` for any
+    /// malformed / all-zero / non-v00 header (fall back to a new trace).
+    fn from_traceparent(header: &str) -> Option<Self> {
+        let parts: Vec<&str> = header.split('-').collect();
+        if parts.len() != 4 || parts[0] != "00" {
+            return None;
+        }
+        let trace_id = parts[1];
+        let is_hex = |s: &str| s.bytes().all(|b| b.is_ascii_hexdigit());
+        if trace_id.len() != 32 || !is_hex(trace_id) || trace_id.bytes().all(|b| b == b'0') {
+            return None;
+        }
+        Some(Self {
+            trace_id: trace_id.to_ascii_lowercase(),
+            span_id: to_hex(&Uuid::new_v4().as_bytes()[..8]),
+        })
+    }
+
+    fn extract_or_generate(req: &ServiceRequest) -> Self {
+        req.headers()
+            .get("traceparent")
+            .and_then(|v| v.to_str().ok())
+            .and_then(Self::from_traceparent)
+            .unwrap_or_else(Self::generate)
+    }
+
+    /// The `traceparent` header value to propagate onward (flags `01` = sampled).
+    pub fn traceparent(&self) -> String {
+        format!("00-{}-{}-01", self.trace_id, self.span_id)
+    }
+}
+
 /// Custom `RootSpanBuilder` that (a) pre-declares `user_uuid`,
 /// `actor_kind`, and `workspace_id` as empty fields on the root span so
 /// auth middlewares can record them post-hoc (via [`record_user_on_span`] /
@@ -117,10 +187,14 @@ pub struct NosdeskRootSpanBuilder;
 impl RootSpanBuilder for NosdeskRootSpanBuilder {
     fn on_request_start(request: &ServiceRequest) -> Span {
         {
+            let trace = TraceContext::extract_or_generate(request);
             let mut ext = request.extensions_mut();
             ext.insert(RequestStart(Instant::now()));
             // Empty business-dimension bag; handlers fill it via record_canonical.
             ext.insert(CanonicalContext::default());
+            // Cross-service trace context (adopted from an inbound traceparent
+            // or freshly originated). Stamped on the canonical event below.
+            ext.insert(trace);
         }
         root_span!(
             request,
@@ -217,7 +291,7 @@ fn emit_canonical_event<B>(outcome: &Result<ServiceResponse<B>, Error>) {
     // Extract owned values so the extensions borrow is released before the
     // event macro. Absent-auth requests get stable sentinels (workspace 0,
     // empty user, "anonymous") so the field set is uniform across every event.
-    let (request_id, workspace_id, user_uuid, actor_kind, latency_ms, canonical) = {
+    let (request_id, workspace_id, user_uuid, actor_kind, latency_ms, canonical, trace_id, span_id) = {
         let ext = req.extensions();
         let request_id = ext
             .get::<RequestId>()
@@ -243,6 +317,12 @@ fn emit_canonical_event<B>(outcome: &Result<ServiceResponse<B>, Error>) {
         let canonical = ext
             .get::<CanonicalContext>()
             .and_then(|c| c.snapshot_json());
+        // Cross-service trace ids (always present — adopted or generated at
+        // request start). Empty strings only if the context somehow wasn't set.
+        let (trace_id, span_id) = ext
+            .get::<TraceContext>()
+            .map(|t| (t.trace_id.clone(), t.span_id.clone()))
+            .unwrap_or_default();
         (
             request_id,
             workspace_id,
@@ -250,6 +330,8 @@ fn emit_canonical_event<B>(outcome: &Result<ServiceResponse<B>, Error>) {
             actor_kind,
             latency_ms,
             canonical,
+            trace_id,
+            span_id,
         )
     };
 
@@ -261,6 +343,8 @@ fn emit_canonical_event<B>(outcome: &Result<ServiceResponse<B>, Error>) {
     tracing::info!(
         target: "nosdesk::request",
         request_id = %request_id,
+        trace_id = %trace_id,
+        span_id = %span_id,
         method = method,
         route = %route,
         status_code = status,
@@ -400,6 +484,14 @@ mod tests {
     }
 
     fn run_capturing(f: impl FnOnce()) -> Vec<CapturedEvent> {
+        // Serialize all capture-based tests: `with_default` sets a *thread-local*
+        // subscriber, but cargo runs tests in parallel, and an emit on a
+        // work-stealing thread can fall back to another test's dispatcher —
+        // occasionally leaking a `nosdesk::request` event across captures. One
+        // process-wide lock removes the race deterministically.
+        static CAPTURE_LOCK: Mutex<()> = Mutex::new(());
+        let _guard = CAPTURE_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+
         let layer = CaptureLayer::default();
         let events = layer.0.clone();
         let subscriber = tracing_subscriber::registry().with(layer);
@@ -489,6 +581,73 @@ mod tests {
     #[test]
     fn snapshot_json_is_none_when_empty() {
         assert!(CanonicalContext::default().snapshot_json().is_none());
+    }
+
+    #[test]
+    fn trace_context_generate_has_w3c_sizes() {
+        let t = TraceContext::generate();
+        assert_eq!(t.trace_id.len(), 32);
+        assert_eq!(t.span_id.len(), 16);
+        assert!(t.trace_id.bytes().all(|b| b.is_ascii_hexdigit()));
+        assert_eq!(
+            t.traceparent(),
+            format!("00-{}-{}-01", t.trace_id, t.span_id)
+        );
+    }
+
+    #[test]
+    fn trace_context_adopts_inbound_traceparent_trace_id_and_mints_span() {
+        let tp = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+        let t = TraceContext::from_traceparent(tp).expect("valid traceparent");
+        assert_eq!(t.trace_id, "4bf92f3577b34da6a3ce929d0e0e4736");
+        // Fresh span id for our leg — NOT the inbound parent span.
+        assert_ne!(t.span_id, "00f067aa0ba902b7");
+        assert_eq!(t.span_id.len(), 16);
+    }
+
+    #[test]
+    fn trace_context_rejects_malformed_traceparents() {
+        for bad in [
+            "",
+            "garbage",
+            "01-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01", // wrong version
+            "00-tooShort-00f067aa0ba902b7-01",
+            "00-00000000000000000000000000000000-00f067aa0ba902b7-01", // all-zero trace id
+            "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7",    // missing flags
+        ] {
+            assert!(
+                TraceContext::from_traceparent(bad).is_none(),
+                "should reject: {bad}"
+            );
+        }
+    }
+
+    #[test]
+    fn canonical_event_carries_trace_id() {
+        let events = run_capturing(|| {
+            let req = TestRequest::get()
+                .uri("/api/tickets/42")
+                .insert_header((
+                    "traceparent",
+                    "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+                ))
+                .to_srv_request();
+            let trace = TraceContext::extract_or_generate(&req);
+            req.extensions_mut().insert(RequestStart(Instant::now()));
+            req.extensions_mut().insert(trace);
+            let outcome: Result<ServiceResponse<BoxBody>, Error> =
+                Ok(req.into_response(HttpResponse::Ok().finish()));
+            emit_canonical_event(&outcome);
+        });
+        let ev = events
+            .iter()
+            .find(|e| e.target == "nosdesk::request")
+            .expect("canonical event should fire");
+        assert_eq!(
+            ev.fields.get("trace_id").map(String::as_str),
+            Some("4bf92f3577b34da6a3ce929d0e0e4736")
+        );
+        assert!(ev.fields.contains_key("span_id"), "span_id present");
     }
 
     #[test]


### PR DESCRIPTION
Two things from the deferred roadmap.

## Cleanup
- Remove the dead `env_logger` dep (declared, never initialised — the tracing subscriber is the sole emitter).
- Stop putting the email-shaped `user_principal_name` on a msgraph `#[instrument]` span.
- (Verified the other flagged `eprintln!`s are intentional — pre-tracing-init / human banner with a structured mirror / test — and left them.)

## Phase 1 trace correlation (roadmap item 10)
Per the observability decision (`nosdesk-com/docs/decisions/observability-tracing-2026-07-15.md`), cross-service correlation over the **existing log pipeline** — no Tempo, no OTel SDK.

- `TraceContext` (W3C `trace_id` + per-service `span_id`) established at request start: adopts an inbound `traceparent`'s trace id (fresh span id) or originates a new trace.
- Stamped on the canonical wide event (`trace_id`/`span_id` already allowlisted). The control plane injects a `traceparent` on its calls here; these internal endpoints extract it (the root-span builder runs on all routes) and stamp the same `trace_id` — so a provisioning/seat flow stitches CP↔product in Loki via `| json | trace_id="…"`, with no new PII surface (rides the allowlist-governed log path).

Also serialised the capture-based unit tests behind a process lock (a third capture test surfaced a latent `with_default` thread-local race under cargo's parallel runner). Batch 13/13 ×3, guardrail green, build clean.