### PR TITLE
Notifications Step 2: admin/workspace defaults (3-layer inheritance)

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -1933,7 +1933,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e75b2483e97a5a7da73ac68a05b629f9c53cff58d8ed1c77866079e18b00dba5"
 dependencies = [
  "digest 0.10.7",
- "spin 0.10.0",
+ "spin 0.10.1",
 ]
 
 [[package]]
@@ -6266,9 +6266,9 @@ checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 
 [[package]]
 name = "spin"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
 
 [[package]]
 name = "spki"

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -3798,7 +3798,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
- "spin 0.9.8",
+ "spin 0.9.9",
 ]
 
 [[package]]
@@ -6260,9 +6260,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 
 [[package]]
 name = "spin"

--- a/backend/migrations/2026-07-15-000001_workspace_notification_defaults/down.sql
+++ b/backend/migrations/2026-07-15-000001_workspace_notification_defaults/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE workspace_notification_defaults;

--- a/backend/migrations/2026-07-15-000001_workspace_notification_defaults/up.sql
+++ b/backend/migrations/2026-07-15-000001_workspace_notification_defaults/up.sql
@@ -1,0 +1,36 @@
+-- Admin-configurable, workspace-wide notification defaults — the missing middle
+-- layer of the 3-tier inheritance:
+--
+--   system default (notification_types.default_channels)
+--     -> workspace default (this table; set by a workspace Admin)
+--       -> user override (notification_preferences)
+--
+-- A user inherits the workspace default and may override it, UNLESS the admin
+-- marked the cell `locked` (mandatory — e.g. sla_breached emails).
+--
+-- Unlike notification_preferences (which lacks a natural workspace_id and needs
+-- an audit-trigger workaround), this table has a first-class workspace_id, so
+-- RLS works naturally.
+CREATE TABLE workspace_notification_defaults (
+    id serial PRIMARY KEY,
+    workspace_id integer NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+    notification_type_id integer NOT NULL REFERENCES notification_types(id) ON DELETE CASCADE,
+    channel varchar(20) NOT NULL,
+    frequency text NOT NULL DEFAULT 'instant'
+        CHECK (frequency IN ('instant', 'digest', 'off')),
+    locked boolean NOT NULL DEFAULT false,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    UNIQUE (workspace_id, notification_type_id, channel)
+);
+
+CREATE INDEX idx_workspace_notification_defaults_lookup
+    ON workspace_notification_defaults (workspace_id, notification_type_id, channel);
+
+-- Workspace isolation, mirroring notification_preferences' policy shape.
+ALTER TABLE workspace_notification_defaults ENABLE ROW LEVEL SECURITY;
+ALTER TABLE workspace_notification_defaults FORCE ROW LEVEL SECURITY;
+CREATE POLICY workspace_notification_defaults_workspace_isolation
+    ON workspace_notification_defaults
+    USING (workspace_id = (NULLIF(current_setting('app.workspace_id', true), ''))::integer)
+    WITH CHECK (workspace_id = (NULLIF(current_setting('app.workspace_id', true), ''))::integer);

--- a/backend/migrations/2026-07-15-000001_workspace_notification_defaults/up.sql
+++ b/backend/migrations/2026-07-15-000001_workspace_notification_defaults/up.sql
@@ -27,6 +27,20 @@ CREATE TABLE workspace_notification_defaults (
 CREATE INDEX idx_workspace_notification_defaults_lookup
     ON workspace_notification_defaults (workspace_id, notification_type_id, channel);
 
+-- Ownership + runtime-role grants. A NEW table must set these explicitly:
+-- migrations may run as a role other than nosdesk_admin, so the schema-wide
+-- `ALTER DEFAULT PRIVILEGES FOR ROLE nosdesk_admin` (which only covers tables
+-- CREATED BY nosdesk_admin) does not reach a table created by the migration
+-- runner. Without the owner change, nosdesk_admin (the BYPASSRLS role the
+-- workspace backup/export runs under) can't see the table via
+-- `information_schema` and the export refuses it; without the grant, the
+-- RLS-enforced runtime role nosdesk_app can't read/write it. Mirrors the
+-- inbound_addresses pattern in the post-v1011 squash.
+ALTER TABLE public.workspace_notification_defaults OWNER TO nosdesk_admin;
+ALTER SEQUENCE public.workspace_notification_defaults_id_seq OWNER TO nosdesk_admin;
+GRANT SELECT, INSERT, DELETE, UPDATE ON TABLE public.workspace_notification_defaults TO nosdesk_app;
+GRANT ALL ON SEQUENCE public.workspace_notification_defaults_id_seq TO nosdesk_app;
+
 -- Workspace isolation, mirroring notification_preferences' policy shape.
 ALTER TABLE workspace_notification_defaults ENABLE ROW LEVEL SECURITY;
 ALTER TABLE workspace_notification_defaults FORCE ROW LEVEL SECURITY;

--- a/backend/src/handlers/notifications.rs
+++ b/backend/src/handlers/notifications.rs
@@ -8,10 +8,12 @@ use chrono::{DateTime, Utc};
 use crate::handlers::{errors, helpers};
 use serde::Deserialize;
 
-use crate::models::Claims;
+use crate::middleware::request_context::RequestContext;
+use crate::models::{Claims, WorkspaceRole};
 use crate::services::notifications::{
     NotificationChannel, NotificationFrequency, NotificationService, NotificationTypeCode,
 };
+use crate::utils::rbac::require_workspace_role;
 
 /// Query parameters for fetching notifications
 #[derive(Debug, Deserialize)]
@@ -94,10 +96,108 @@ pub fn config(cfg: &mut web::ServiceConfig) {
             "/notifications/preferences",
             web::put().to(update_preference),
         )
+        // Workspace-admin defaults (the middle inheritance layer). Admin-gated.
+        .route(
+            "/admin/notification-defaults",
+            web::get().to(get_workspace_notification_defaults),
+        )
+        .route(
+            "/admin/notification-defaults",
+            web::put().to(update_workspace_notification_default),
+        )
         .route(
             "/notifications/delete",
             web::post().to(delete_notifications),
         );
+}
+
+/// Current caller's workspace (from the actor context pinned by auth middleware).
+fn actor_workspace_id(req: &HttpRequest) -> Option<i32> {
+    req.extensions()
+        .get::<RequestContext>()
+        .map(|c| c.actor.workspace_id)
+        .unwrap_or(None)
+}
+
+/// Request body for setting a workspace notification default cell.
+#[derive(Debug, Deserialize)]
+pub struct UpdateWorkspaceDefaultRequest {
+    pub notification_type: String,
+    pub channel: String,
+    pub frequency: String,
+    #[serde(default)]
+    pub locked: bool,
+}
+
+/// GET /api/admin/notification-defaults — the workspace's default matrix.
+/// Admin-only (manages workspace settings).
+pub async fn get_workspace_notification_defaults(
+    req: HttpRequest,
+    notification_service: web::Data<NotificationService>,
+) -> HttpResponse {
+    if let Err(e) = require_workspace_role(&req, WorkspaceRole::Admin) {
+        return e;
+    }
+    let Some(workspace_id) = actor_workspace_id(&req) else {
+        return errors::unauthorized("Authentication required");
+    };
+
+    match notification_service
+        .preferences()
+        .get_workspace_defaults(workspace_id)
+        .await
+    {
+        Ok(defaults) => HttpResponse::Ok().json(defaults),
+        Err(e) => HttpResponse::InternalServerError().json(serde_json::json!({ "error": e })),
+    }
+}
+
+/// PUT /api/admin/notification-defaults — set one workspace default cell.
+/// Admin-only.
+pub async fn update_workspace_notification_default(
+    req: HttpRequest,
+    notification_service: web::Data<NotificationService>,
+    body: web::Json<UpdateWorkspaceDefaultRequest>,
+) -> HttpResponse {
+    if let Err(e) = require_workspace_role(&req, WorkspaceRole::Admin) {
+        return e;
+    }
+    let Some(workspace_id) = actor_workspace_id(&req) else {
+        return errors::unauthorized("Authentication required");
+    };
+
+    let notification_type = match NotificationTypeCode::from_str(&body.notification_type) {
+        Some(t) => t,
+        None => {
+            return errors::bad_request(format!(
+                "Invalid notification type: {}",
+                body.notification_type
+            ))
+        }
+    };
+    let channel = match NotificationChannel::from_str(&body.channel) {
+        Some(c) => c,
+        None => return errors::bad_request(format!("Invalid channel: {}", body.channel)),
+    };
+    let frequency = match NotificationFrequency::from_str(&body.frequency) {
+        Some(f) => f,
+        None => return errors::bad_request(format!("Invalid frequency: {}", body.frequency)),
+    };
+
+    match notification_service
+        .preferences()
+        .set_workspace_default(
+            workspace_id,
+            &notification_type,
+            channel,
+            frequency,
+            body.locked,
+        )
+        .await
+    {
+        Ok(_) => HttpResponse::Ok().json(serde_json::json!({ "success": true })),
+        Err(e) => HttpResponse::InternalServerError().json(serde_json::json!({ "error": e })),
+    }
 }
 
 /// Get user's notifications

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -5551,6 +5551,22 @@ pub struct NotificationPreferenceResponse {
     pub category: String,
     pub channels: std::collections::HashMap<String, bool>,
     pub frequencies: std::collections::HashMap<String, String>,
+    /// Channels the workspace admin has `locked` for this type — the user
+    /// cannot override these (the UI disables the cell). Additive.
+    pub locked: std::collections::HashMap<String, bool>,
+}
+
+/// API response for a workspace admin's notification DEFAULTS (grouped by type).
+/// `frequencies` is the workspace default per channel (falling back to the
+/// system default); `locked` marks cells users cannot override.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct WorkspaceNotificationDefaultResponse {
+    pub notification_type: String,
+    pub notification_name: String,
+    pub description: Option<String>,
+    pub category: String,
+    pub frequencies: std::collections::HashMap<String, String>,
+    pub locked: std::collections::HashMap<String, bool>,
 }
 
 /// API response for a notification

--- a/backend/src/schema.rs
+++ b/backend/src/schema.rs
@@ -2137,6 +2137,20 @@ diesel::table! {
 }
 
 diesel::table! {
+    workspace_notification_defaults (id) {
+        id -> Int4,
+        workspace_id -> Int4,
+        notification_type_id -> Int4,
+        #[max_length = 20]
+        channel -> Varchar,
+        frequency -> Text,
+        locked -> Bool,
+        created_at -> Timestamptz,
+        updated_at -> Timestamptz,
+    }
+}
+
+diesel::table! {
     workspaces (id) {
         id -> Int4,
         uuid -> Uuid,
@@ -2407,6 +2421,8 @@ diesel::joinable!(workspace_ldap_settings -> workspaces (workspace_id));
 diesel::joinable!(workspace_ldap_sync_state -> workspaces (workspace_id));
 diesel::joinable!(workspace_members -> users (user_uuid));
 diesel::joinable!(workspace_members -> workspaces (workspace_id));
+diesel::joinable!(workspace_notification_defaults -> notification_types (notification_type_id));
+diesel::joinable!(workspace_notification_defaults -> workspaces (workspace_id));
 diesel::joinable!(yjs_snapshots -> workspaces (workspace_id));
 
 diesel::allow_tables_to_appear_in_same_query!(
@@ -2527,6 +2543,7 @@ diesel::allow_tables_to_appear_in_same_query!(
     workspace_ldap_settings,
     workspace_ldap_sync_state,
     workspace_members,
+    workspace_notification_defaults,
     workspaces,
     yjs_snapshots,
 );

--- a/backend/src/services/notifications/preferences.rs
+++ b/backend/src/services/notifications/preferences.rs
@@ -1,6 +1,17 @@
 //! Notification preferences service
 //!
-//! Manages user notification preferences with caching for performance.
+//! Resolves effective delivery per (user, workspace, type, channel) across the
+//! three-layer inheritance and manages both user overrides and admin
+//! (workspace) defaults, with an in-memory cache for the hot delivery path.
+//!
+//! **Inheritance (highest wins):**
+//!   1. system default — `notification_types.default_channels` (a listed
+//!      channel means `instant`, else `off`)
+//!   2. workspace default — `workspace_notification_defaults` (admin-set)
+//!   3. user override — `notification_preferences`
+//!
+//! A `locked` workspace-default cell cannot be overridden by the user
+//! (mandatory notifications). See `docs/notification-preferences-and-push-design`.
 
 use chrono::Utc;
 use diesel::prelude::*;
@@ -10,15 +21,24 @@ use tokio::sync::RwLock;
 use uuid::Uuid;
 
 use crate::db::Pool;
-use crate::models::{NotificationPreferenceResponse, NotificationType as NotificationTypeModel};
+use crate::models::{
+    NotificationPreferenceResponse, NotificationType as NotificationTypeModel,
+    WorkspaceNotificationDefaultResponse,
+};
 
 use super::types::{NotificationChannel, NotificationFrequency, NotificationTypeCode};
 
-/// Manages user notification preferences with caching
+/// The channels the resolver considers. Push joins here when it ships.
+const RESOLVED_CHANNELS: [NotificationChannel; 2] =
+    [NotificationChannel::InApp, NotificationChannel::Email];
+
+/// Manages notification preferences + workspace defaults with caching.
 pub struct PreferenceService {
     pool: Pool,
-    /// Cache: user_uuid -> (notification_type_code -> Vec<enabled_channels>)
-    cache: Arc<RwLock<HashMap<Uuid, HashMap<String, Vec<NotificationChannel>>>>>,
+    /// Cache keyed by (user, workspace) → type code → the channels that resolve
+    /// to `instant` (i.e. deliver now). Workspace is part of the key because a
+    /// user's effective delivery depends on the workspace's admin defaults.
+    cache: Arc<RwLock<HashMap<(Uuid, i32), HashMap<String, Vec<NotificationChannel>>>>>,
 }
 
 impl PreferenceService {
@@ -29,92 +49,141 @@ impl PreferenceService {
         }
     }
 
-    /// Get enabled channels for a user and notification type
+    /// Channels to deliver *immediately* (`instant`) for this user, in this
+    /// workspace, for this type. `digest` rows are collected later by the digest
+    /// batcher; `off` never delivers.
     pub async fn get_enabled_channels(
         &self,
         user_uuid: &Uuid,
+        workspace_id: i32,
         notification_type: &NotificationTypeCode,
     ) -> Result<Vec<NotificationChannel>, String> {
         let type_code = notification_type.as_str().to_string();
+        let key = (*user_uuid, workspace_id);
 
-        // Check cache first
         {
             let cache = self.cache.read().await;
-            if let Some(user_prefs) = cache.get(user_uuid) {
+            if let Some(user_prefs) = cache.get(&key) {
                 if let Some(channels) = user_prefs.get(&type_code) {
                     return Ok(channels.clone());
                 }
             }
         }
 
-        // Query database
-        let channels = self.load_preferences_from_db(user_uuid, &type_code).await?;
+        let channels = self
+            .load_preferences_from_db(user_uuid, workspace_id, &type_code)
+            .await?;
 
-        // Update cache
         {
             let mut cache = self.cache.write().await;
             cache
-                .entry(*user_uuid)
-                .or_insert_with(HashMap::new)
+                .entry(key)
+                .or_default()
                 .insert(type_code, channels.clone());
         }
 
         Ok(channels)
     }
 
-    /// Load preferences from database, falling back to defaults
+    /// Resolve the `instant` channels for one (user, workspace, type) across the
+    /// full inheritance.
     async fn load_preferences_from_db(
         &self,
         user_uuid_val: &Uuid,
+        workspace_id_val: i32,
         type_code: &str,
     ) -> Result<Vec<NotificationChannel>, String> {
-        use crate::schema::notification_preferences::dsl::*;
-        use crate::schema::notification_types;
+        use crate::schema::{
+            notification_preferences as np, notification_types as nt,
+            workspace_notification_defaults as wnd,
+        };
 
-        // notification_preferences is RLS-enabled (Phase 3c.2);
-        // this service is a background dispatcher. background_run
-        // wraps the lookup chain in a bypass-elevated txn.
-        let (type_info, prefs) = crate::sync::session::background_run(
+        // RLS-enabled tables read by a background dispatcher → bypass txn.
+        let (default_channels, ws_defaults, user_prefs) = crate::sync::session::background_run(
             &self.pool,
             "background:notification_pref_load",
             |conn| {
-                let type_info: (i32, serde_json::Value) = notification_types::table
-                    .filter(notification_types::code.eq(type_code))
-                    .select((notification_types::id, notification_types::default_channels))
+                let (type_id, default_channels): (i32, serde_json::Value) = nt::table
+                    .filter(nt::code.eq(type_code))
+                    .select((nt::id, nt::default_channels))
                     .first(conn)?;
-                let prefs: Vec<(String, bool, Option<String>)> = notification_preferences
-                    .filter(user_uuid.eq(user_uuid_val))
-                    .filter(notification_type_id.eq(type_info.0))
-                    .select((channel, enabled, frequency))
+                let ws_defaults: Vec<(String, String, bool)> = wnd::table
+                    .filter(wnd::workspace_id.eq(workspace_id_val))
+                    .filter(wnd::notification_type_id.eq(type_id))
+                    .select((wnd::channel, wnd::frequency, wnd::locked))
                     .load(conn)
                     .unwrap_or_default();
-                Ok::<_, diesel::result::Error>((type_info, prefs))
+                let user_prefs: Vec<(String, bool, Option<String>)> = np::table
+                    .filter(np::user_uuid.eq(user_uuid_val))
+                    .filter(np::notification_type_id.eq(type_id))
+                    .select((np::channel, np::enabled, np::frequency))
+                    .load(conn)
+                    .unwrap_or_default();
+                Ok::<_, diesel::result::Error>((default_channels, ws_defaults, user_prefs))
             },
         )
         .map_err(|e| format!("Failed to load notification preferences: {e}"))?;
 
-        let (_type_id, default_channels) = type_info;
+        let system_defaults = self.parse_default_channels(&default_channels);
+        let ws_map = Self::ws_default_map(ws_defaults);
+        let user_map = Self::user_pref_map(user_prefs);
 
-        // No user rows → the type's default channels, which mean "instant".
-        if prefs.is_empty() {
-            return Ok(self.parse_default_channels(&default_channels));
-        }
-
-        // Only channels whose effective frequency is `instant` deliver *now*.
-        // `digest` rows are collected later by the digest batcher; `off` never
-        // delivers. Effective frequency coalesces the `frequency` column with
-        // the legacy `enabled` boolean (see NotificationFrequency::from_row).
-        Ok(prefs
+        Ok(RESOLVED_CHANNELS
             .into_iter()
-            .filter(|(_, en, freq)| {
-                NotificationFrequency::from_row(freq.as_deref(), *en)
+            .filter(|ch| {
+                Self::resolve_channel(ch, &system_defaults, &ws_map, &user_map).0
                     == NotificationFrequency::Instant
             })
-            .filter_map(|(chan, _, _)| NotificationChannel::from_str(&chan))
             .collect())
     }
 
-    /// Parse default channels from JSONB value
+    /// Effective `(frequency, locked)` for one channel across the inheritance.
+    fn resolve_channel(
+        channel: &NotificationChannel,
+        system_defaults: &[NotificationChannel],
+        ws_map: &HashMap<String, (NotificationFrequency, bool)>,
+        user_map: &HashMap<String, NotificationFrequency>,
+    ) -> (NotificationFrequency, bool) {
+        let key = channel.as_str();
+        // Base = workspace default if set, else the system default (listed
+        // channel → instant, else off).
+        let (base, locked) = match ws_map.get(key) {
+            Some((freq, locked)) => (*freq, *locked),
+            None => {
+                let f = if system_defaults.contains(channel) {
+                    NotificationFrequency::Instant
+                } else {
+                    NotificationFrequency::Off
+                };
+                (f, false)
+            }
+        };
+        // Locked cells ignore the user override; otherwise the user's row wins.
+        let effective = if locked {
+            base
+        } else {
+            user_map.get(key).copied().unwrap_or(base)
+        };
+        (effective, locked)
+    }
+
+    fn ws_default_map(
+        rows: Vec<(String, String, bool)>,
+    ) -> HashMap<String, (NotificationFrequency, bool)> {
+        rows.into_iter()
+            .filter_map(|(c, f, l)| NotificationFrequency::from_str(&f).map(|freq| (c, (freq, l))))
+            .collect()
+    }
+
+    fn user_pref_map(
+        rows: Vec<(String, bool, Option<String>)>,
+    ) -> HashMap<String, NotificationFrequency> {
+        rows.into_iter()
+            .map(|(c, en, freq)| (c, NotificationFrequency::from_row(freq.as_deref(), en)))
+            .collect()
+    }
+
+    /// Parse default channels from the type's JSONB array.
     fn parse_default_channels(&self, defaults: &serde_json::Value) -> Vec<NotificationChannel> {
         defaults
             .as_array()
@@ -125,11 +194,13 @@ impl PreferenceService {
             .collect()
     }
 
-    /// Update a user preference cell (and invalidate cache). Dual-writes the
-    /// new `frequency` and the legacy `enabled` boolean so an old instance
-    /// mid-rollout still gates correctly. `digest` is coerced to `instant` on
-    /// channels that don't batch (in_app/push) — a digest row there would never
-    /// be delivered by anything.
+    async fn clear_cache(&self) {
+        self.cache.write().await.clear();
+    }
+
+    /// Update a user preference cell. Dual-writes the new `frequency` and the
+    /// legacy `enabled` bool. `digest` coerces to `instant` on channels that
+    /// don't batch (in_app/push).
     pub async fn set_preference(
         &self,
         user_uuid_val: &Uuid,
@@ -149,11 +220,8 @@ impl PreferenceService {
         let enabled_val = frequency_val.to_enabled();
 
         // notification_preferences carries an audit trigger but has no
-        // workspace_id of its own, so resolve the user's primary
-        // workspace and pin it on the actor; otherwise the trigger's
-        // audit_log insert defaults workspace_id to NULL and fails.
-        // The lookup runs under bypass (admin role) so it needs no
-        // ambient workspace itself.
+        // workspace_id of its own; resolve the user's primary workspace to pin
+        // the actor so the trigger's audit_log insert has a workspace_id.
         let resolved_workspace = crate::sync::session::background_run(
             &self.pool,
             "background:notification_pref_set",
@@ -194,22 +262,14 @@ impl PreferenceService {
         })
         .map_err(|e| format!("Failed to update preference: {e}"))?;
 
-        // Invalidate cache for this user
-        {
-            let mut cache = self.cache.write().await;
-            cache.remove(user_uuid_val);
-        }
-
+        self.clear_cache().await;
         Ok(())
     }
 
-    /// One-click unsubscribe (B2 / RFC 8058): turn OFF the email channel for
-    /// EVERY notification type for this user, so notification mail stops while
-    /// transactional mail (password reset, invitation) is unaffected. Inserts a
-    /// disabled row per type (or flips an existing one) so a type added later
-    /// still respects the opt-out's per-type rows. Preferences are global per
-    /// user; the resolved workspace only pins the audit trigger (the table's
-    /// unique key carries no workspace_id).
+    /// One-click unsubscribe (RFC 8058): set the email channel to `off` for every
+    /// type for this user, so notification mail stops while transactional mail is
+    /// unaffected. Preferences are global per user; the resolved workspace only
+    /// pins the audit trigger.
     pub async fn disable_all_email(&self, user_uuid_val: &Uuid) -> Result<(), String> {
         let resolved_workspace = crate::sync::session::background_run(
             &self.pool,
@@ -237,76 +297,85 @@ impl PreferenceService {
         })
         .map_err(|e| format!("Failed to disable email notifications: {e}"))?;
 
-        {
-            let mut cache = self.cache.write().await;
-            cache.remove(user_uuid_val);
-        }
+        self.clear_cache().await;
         Ok(())
     }
 
-    /// Get all preferences for a user (for settings UI)
+    /// Full per-type matrix for the USER settings UI — the *effective* frequency
+    /// per channel (workspace default as base, user override on top, locked
+    /// forced), plus which cells are admin-locked. Resolves the user's primary
+    /// workspace so the inherited defaults are correct.
     pub async fn get_all_preferences(
         &self,
         user_uuid_val: &Uuid,
     ) -> Result<Vec<NotificationPreferenceResponse>, String> {
-        use crate::schema::notification_preferences::dsl::*;
-        use crate::schema::notification_types;
+        use crate::schema::{
+            notification_preferences as np, notification_types as nt,
+            workspace_notification_defaults as wnd,
+        };
 
-        // notification_preferences is RLS-enabled; wrap in
-        // background_run for bypass.
-        let (types, user_prefs) = crate::sync::session::background_run(
+        let (types, ws_defaults, user_prefs) = crate::sync::session::background_run(
             &self.pool,
             "background:notification_pref_get_all",
             |conn| {
-                let types: Vec<NotificationTypeModel> = notification_types::table
-                    .order(notification_types::id)
-                    .load(conn)?;
-                let user_prefs: Vec<(i32, String, bool, Option<String>)> = notification_preferences
-                    .filter(user_uuid.eq(user_uuid_val))
-                    .select((notification_type_id, channel, enabled, frequency))
+                let workspace_id_val = crate::repository::workspaces::primary_workspace_for_user(
+                    conn,
+                    *user_uuid_val,
+                )?;
+                let types: Vec<NotificationTypeModel> = nt::table.order(nt::id).load(conn)?;
+                let ws_defaults: Vec<(i32, String, String, bool)> = wnd::table
+                    .filter(wnd::workspace_id.eq(workspace_id_val))
+                    .select((
+                        wnd::notification_type_id,
+                        wnd::channel,
+                        wnd::frequency,
+                        wnd::locked,
+                    ))
                     .load(conn)
                     .unwrap_or_default();
-                Ok::<_, diesel::result::Error>((types, user_prefs))
+                let user_prefs: Vec<(i32, String, bool, Option<String>)> = np::table
+                    .filter(np::user_uuid.eq(user_uuid_val))
+                    .select((
+                        np::notification_type_id,
+                        np::channel,
+                        np::enabled,
+                        np::frequency,
+                    ))
+                    .load(conn)
+                    .unwrap_or_default();
+                Ok::<_, diesel::result::Error>((types, ws_defaults, user_prefs))
             },
         )
         .map_err(|e| format!("Failed to load notification preferences: {e}"))?;
 
-        // Build response grouped by notification type. `freq_map` holds the new
-        // per-channel frequency; `channels` mirrors it as a legacy enabled bool
-        // (`!= off`). Both seed from the type's defaults (a default channel =
-        // `instant`, else `off`), then override with the user's rows.
         let mut responses = Vec::new();
         for notif_type in types {
-            let mut freq_map: HashMap<String, NotificationFrequency> = HashMap::new();
+            let system_defaults = self.parse_default_channels(&notif_type.default_channels);
+            let ws_map = Self::ws_default_map(
+                ws_defaults
+                    .iter()
+                    .filter(|(tid, _, _, _)| *tid == notif_type.id)
+                    .map(|(_, c, f, l)| (c.clone(), f.clone(), *l))
+                    .collect(),
+            );
+            let user_map = Self::user_pref_map(
+                user_prefs
+                    .iter()
+                    .filter(|(tid, _, _, _)| *tid == notif_type.id)
+                    .map(|(_, c, en, freq)| (c.clone(), *en, freq.clone()))
+                    .collect(),
+            );
 
-            let defaults = self.parse_default_channels(&notif_type.default_channels);
-            for chan in &[NotificationChannel::InApp, NotificationChannel::Email] {
-                let freq = if defaults.contains(chan) {
-                    NotificationFrequency::Instant
-                } else {
-                    NotificationFrequency::Off
-                };
-                freq_map.insert(chan.as_str().to_string(), freq);
+            let mut channels = HashMap::new();
+            let mut frequencies = HashMap::new();
+            let mut locked = HashMap::new();
+            for ch in RESOLVED_CHANNELS {
+                let (freq, is_locked) =
+                    Self::resolve_channel(&ch, &system_defaults, &ws_map, &user_map);
+                channels.insert(ch.as_str().to_string(), freq.to_enabled());
+                frequencies.insert(ch.as_str().to_string(), freq.as_str().to_string());
+                locked.insert(ch.as_str().to_string(), is_locked);
             }
-
-            // Override with the user's stored rows (coalescing frequency/enabled).
-            for (type_id, chan, en, freq) in &user_prefs {
-                if *type_id == notif_type.id {
-                    freq_map.insert(
-                        chan.clone(),
-                        NotificationFrequency::from_row(freq.as_deref(), *en),
-                    );
-                }
-            }
-
-            let channels = freq_map
-                .iter()
-                .map(|(c, f)| (c.clone(), f.to_enabled()))
-                .collect();
-            let frequencies = freq_map
-                .iter()
-                .map(|(c, f)| (c.clone(), f.as_str().to_string()))
-                .collect();
 
             responses.push(NotificationPreferenceResponse {
                 notification_type: notif_type.code,
@@ -315,9 +384,200 @@ impl PreferenceService {
                 category: notif_type.category,
                 channels,
                 frequencies,
+                locked,
             });
         }
 
         Ok(responses)
+    }
+
+    /// Full per-type matrix for the ADMIN defaults UI — the workspace default
+    /// per channel (falling back to the system default) + `locked`.
+    pub async fn get_workspace_defaults(
+        &self,
+        workspace_id_val: i32,
+    ) -> Result<Vec<WorkspaceNotificationDefaultResponse>, String> {
+        use crate::schema::{notification_types as nt, workspace_notification_defaults as wnd};
+
+        let (types, ws_defaults) = crate::sync::session::background_run(
+            &self.pool,
+            "background:notification_ws_defaults_get",
+            |conn| {
+                let types: Vec<NotificationTypeModel> = nt::table.order(nt::id).load(conn)?;
+                let ws_defaults: Vec<(i32, String, String, bool)> = wnd::table
+                    .filter(wnd::workspace_id.eq(workspace_id_val))
+                    .select((
+                        wnd::notification_type_id,
+                        wnd::channel,
+                        wnd::frequency,
+                        wnd::locked,
+                    ))
+                    .load(conn)
+                    .unwrap_or_default();
+                Ok::<_, diesel::result::Error>((types, ws_defaults))
+            },
+        )
+        .map_err(|e| format!("Failed to load workspace notification defaults: {e}"))?;
+
+        let mut responses = Vec::new();
+        for notif_type in types {
+            let system_defaults = self.parse_default_channels(&notif_type.default_channels);
+            let ws_map = Self::ws_default_map(
+                ws_defaults
+                    .iter()
+                    .filter(|(tid, _, _, _)| *tid == notif_type.id)
+                    .map(|(_, c, f, l)| (c.clone(), f.clone(), *l))
+                    .collect(),
+            );
+
+            let mut frequencies = HashMap::new();
+            let mut locked = HashMap::new();
+            for ch in RESOLVED_CHANNELS {
+                // No user layer here — the workspace default IS the value, else
+                // the system default.
+                let (freq, is_locked) = match ws_map.get(ch.as_str()) {
+                    Some((f, l)) => (*f, *l),
+                    None => {
+                        let f = if system_defaults.contains(&ch) {
+                            NotificationFrequency::Instant
+                        } else {
+                            NotificationFrequency::Off
+                        };
+                        (f, false)
+                    }
+                };
+                frequencies.insert(ch.as_str().to_string(), freq.as_str().to_string());
+                locked.insert(ch.as_str().to_string(), is_locked);
+            }
+
+            responses.push(WorkspaceNotificationDefaultResponse {
+                notification_type: notif_type.code,
+                notification_name: notif_type.name,
+                description: notif_type.description,
+                category: notif_type.category,
+                frequencies,
+                locked,
+            });
+        }
+
+        Ok(responses)
+    }
+
+    /// Set (admin) a workspace default cell. `digest` coerces to `instant` on
+    /// non-batching channels. Clears the whole cache (a default change affects
+    /// every user in the workspace).
+    pub async fn set_workspace_default(
+        &self,
+        workspace_id_val: i32,
+        notification_type: &NotificationTypeCode,
+        channel_val: NotificationChannel,
+        frequency_val: NotificationFrequency,
+        locked_val: bool,
+    ) -> Result<(), String> {
+        use crate::schema::notification_types;
+        use crate::schema::workspace_notification_defaults::dsl::*;
+
+        let frequency_val =
+            if frequency_val == NotificationFrequency::Digest && !channel_val.supports_digest() {
+                NotificationFrequency::Instant
+            } else {
+                frequency_val
+            };
+
+        let mut conn = self
+            .pool
+            .get()
+            .map_err(|e| format!("Failed to acquire connection: {e}"))?;
+        let actor =
+            crate::sync::actor::ActorContext::system("background:notification_ws_default_set")
+                .with_workspace(workspace_id_val);
+        crate::sync::session::with_actor_bypass_context(&mut conn, &actor, |conn| {
+            let type_id: i32 = notification_types::table
+                .filter(notification_types::code.eq(notification_type.as_str()))
+                .select(notification_types::id)
+                .first(conn)?;
+            diesel::insert_into(workspace_notification_defaults)
+                .values((
+                    workspace_id.eq(workspace_id_val),
+                    notification_type_id.eq(type_id),
+                    channel.eq(channel_val.as_str()),
+                    frequency.eq(frequency_val.as_str()),
+                    locked.eq(locked_val),
+                    created_at.eq(Utc::now().naive_utc()),
+                    updated_at.eq(Utc::now().naive_utc()),
+                ))
+                .on_conflict((workspace_id, notification_type_id, channel))
+                .do_update()
+                .set((
+                    frequency.eq(frequency_val.as_str()),
+                    locked.eq(locked_val),
+                    updated_at.eq(Utc::now().naive_utc()),
+                ))
+                .execute(conn)?;
+            Ok::<_, diesel::result::Error>(())
+        })
+        .map_err(|e| format!("Failed to set workspace notification default: {e}"))?;
+
+        self.clear_cache().await;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ch(s: &str) -> NotificationChannel {
+        NotificationChannel::from_str(s).unwrap()
+    }
+
+    #[test]
+    fn resolves_to_system_default_when_no_workspace_or_user() {
+        // in_app is a system default (instant); email is not (off).
+        let sys = vec![NotificationChannel::InApp];
+        let ws = HashMap::new();
+        let user = HashMap::new();
+        assert_eq!(
+            PreferenceService::resolve_channel(&ch("in_app"), &sys, &ws, &user),
+            (NotificationFrequency::Instant, false)
+        );
+        assert_eq!(
+            PreferenceService::resolve_channel(&ch("email"), &sys, &ws, &user),
+            (NotificationFrequency::Off, false)
+        );
+    }
+
+    #[test]
+    fn workspace_default_overrides_system() {
+        let sys = vec![]; // email off by system
+        let mut ws = HashMap::new();
+        ws.insert("email".to_string(), (NotificationFrequency::Digest, false));
+        let user = HashMap::new();
+        assert_eq!(
+            PreferenceService::resolve_channel(&ch("email"), &sys, &ws, &user),
+            (NotificationFrequency::Digest, false)
+        );
+    }
+
+    #[test]
+    fn user_override_wins_unless_locked() {
+        let sys = vec![];
+        let mut ws = HashMap::new();
+        let mut user = HashMap::new();
+        user.insert("email".to_string(), NotificationFrequency::Off);
+
+        // Unlocked workspace default → the user's override wins.
+        ws.insert("email".to_string(), (NotificationFrequency::Instant, false));
+        assert_eq!(
+            PreferenceService::resolve_channel(&ch("email"), &sys, &ws, &user).0,
+            NotificationFrequency::Off
+        );
+
+        // Locked workspace default → the user cannot override it.
+        ws.insert("email".to_string(), (NotificationFrequency::Instant, true));
+        assert_eq!(
+            PreferenceService::resolve_channel(&ch("email"), &sys, &ws, &user),
+            (NotificationFrequency::Instant, true)
+        );
     }
 }

--- a/backend/src/services/notifications/service.rs
+++ b/backend/src/services/notifications/service.rs
@@ -71,10 +71,16 @@ impl NotificationService {
             return Ok(());
         }
 
-        // 1. Check if user should receive this notification type at all
+        // 1. Which channels deliver this type immediately for the recipient, in
+        //    this notification's workspace (resolves user + workspace-admin +
+        //    system inheritance).
         let enabled_channels = self
             .preference_service
-            .get_enabled_channels(&payload.recipient_uuid, &payload.notification_type)
+            .get_enabled_channels(
+                &payload.recipient_uuid,
+                payload.workspace_id,
+                &payload.notification_type,
+            )
             .await?;
 
         if enabled_channels.is_empty() {


### PR DESCRIPTION
Adds the missing middle layer of the notification inheritance (design: `docs/notification-preferences-and-push-design-2026-07-15.md`):

**system default → workspace default (admin) → user override**

A user inherits the workspace admin's default and may override it — unless the admin marked the cell `locked` (mandatory, e.g. `sla_breached`).

## Migration
- `workspace_notification_defaults(workspace_id, notification_type_id, channel, frequency, locked)`, unique per `(workspace, type, channel)`, RLS workspace-isolated. First-class `workspace_id` → RLS works without the `notification_preferences` audit-trigger workaround.

## Resolution
- `preferences.rs` rewritten around `resolve_channel()` → effective `(frequency, locked)` per channel across all three layers; a `locked` workspace cell overrides the user.
- Cache now keyed by `(user, workspace)` (effective delivery depends on workspace defaults); writes clear it.
- `get_all_preferences` returns effective `frequencies` + a `locked` map so the user UI can disable mandatory cells.
- `notify()` threads the notification's `workspace_id` into resolution.

## Admin API
- `GET/PUT /api/admin/notification-defaults`, gated on `WorkspaceRole::Admin`, workspace from the actor context. `digest` coerces to `instant` on non-batching channels.

## Tests
Unit tests for the resolver (system fallback, workspace override, user override, **locked-wins**) — pure logic, no DB.

## Not in this PR (follow-ons)
- Vue admin-defaults UI + user select-UI upgrade; push channel + sender; mobile native; digest batcher.

**Written without a local compiler** (machine busy with MLX training) — **CI is the compile/test check**. If anything reddens I'll fix from the CI output.