### PR TITLE
Notifications Step 3: push channel + device tokens (provider-agnostic)

### DIFF
--- a/backend/migrations/2026-07-15-000002_user_push_devices/down.sql
+++ b/backend/migrations/2026-07-15-000002_user_push_devices/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE user_push_devices;

--- a/backend/migrations/2026-07-15-000002_user_push_devices/up.sql
+++ b/backend/migrations/2026-07-15-000002_user_push_devices/up.sql
@@ -1,0 +1,40 @@
+-- Registered devices for mobile/web push. A user may have several. The push
+-- channel loads a recipient's ACTIVE tokens (revoked_at IS NULL) and sends a
+-- MINIMAL payload (notification type + entity ref only — no customer content;
+-- the app fetches details after the tap), so Apple/Google never see ticket
+-- text. See docs/notification-preferences-and-push-design-2026-07-15.md.
+CREATE TABLE user_push_devices (
+    id serial PRIMARY KEY,
+    user_uuid uuid NOT NULL REFERENCES users(uuid) ON DELETE CASCADE,
+    workspace_id integer NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+    platform varchar(16) NOT NULL CHECK (platform IN ('ios', 'android', 'web')),
+    token text NOT NULL,
+    app_version text,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    last_seen_at timestamptz NOT NULL DEFAULT now(),
+    revoked_at timestamptz,
+    -- One row per device token; re-registering the same token (reinstall, or a
+    -- token reassigned to another user) upserts onto this key.
+    UNIQUE (token)
+);
+
+CREATE INDEX idx_user_push_devices_active
+    ON user_push_devices (user_uuid)
+    WHERE revoked_at IS NULL;
+
+-- Ownership + runtime-role grants. New tables MUST set these (see
+-- 2026-07-15-000001): without them nosdesk_app can't see the table and the
+-- workspace backup/export refuses it.
+ALTER TABLE public.user_push_devices OWNER TO nosdesk_admin;
+ALTER SEQUENCE public.user_push_devices_id_seq OWNER TO nosdesk_admin;
+GRANT SELECT, INSERT, DELETE, UPDATE ON TABLE public.user_push_devices TO nosdesk_app;
+GRANT ALL ON SEQUENCE public.user_push_devices_id_seq TO nosdesk_app;
+
+-- Workspace isolation.
+ALTER TABLE public.user_push_devices ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.user_push_devices FORCE ROW LEVEL SECURITY;
+CREATE POLICY user_push_devices_workspace_isolation
+    ON user_push_devices
+    USING (workspace_id = (NULLIF(current_setting('app.workspace_id', true), ''))::integer)
+    WITH CHECK (workspace_id = (NULLIF(current_setting('app.workspace_id', true), ''))::integer);

--- a/backend/src/handlers/notifications.rs
+++ b/backend/src/handlers/notifications.rs
@@ -8,6 +8,7 @@ use chrono::{DateTime, Utc};
 use crate::handlers::{errors, helpers};
 use serde::Deserialize;
 
+use crate::db::Pool;
 use crate::middleware::request_context::RequestContext;
 use crate::models::{Claims, WorkspaceRole};
 use crate::services::notifications::{
@@ -105,10 +106,115 @@ pub fn config(cfg: &mut web::ServiceConfig) {
             "/admin/notification-defaults",
             web::put().to(update_workspace_notification_default),
         )
+        // Push device registration (per authenticated user).
+        .route(
+            "/notifications/devices",
+            web::post().to(register_push_device),
+        )
+        .route(
+            "/notifications/devices/{token}",
+            web::delete().to(unregister_push_device),
+        )
         .route(
             "/notifications/delete",
             web::post().to(delete_notifications),
         );
+}
+
+/// Request body to register a push device.
+#[derive(Debug, Deserialize)]
+pub struct RegisterDeviceRequest {
+    /// `ios` | `android` | `web`.
+    pub platform: String,
+    /// The APNs/FCM device token.
+    pub token: String,
+    #[serde(default)]
+    pub app_version: Option<String>,
+}
+
+/// POST /api/notifications/devices — register/refresh this user's push device.
+pub async fn register_push_device(
+    req: HttpRequest,
+    pool: web::Data<Pool>,
+    body: web::Json<RegisterDeviceRequest>,
+) -> HttpResponse {
+    let claims = match req.extensions().get::<Claims>() {
+        Some(c) => c.clone(),
+        None => return HttpResponse::Unauthorized().finish(),
+    };
+    let user_uuid = match uuid::Uuid::parse_str(&claims.sub) {
+        Ok(u) => u,
+        Err(_) => return errors::bad_request("Invalid user UUID"),
+    };
+    let Some(workspace_id) = actor_workspace_id(&req) else {
+        return errors::unauthorized("Authentication required");
+    };
+    if !matches!(body.platform.as_str(), "ios" | "android" | "web") {
+        return errors::bad_request(format!("Invalid platform: {}", body.platform));
+    }
+    let token = body.token.trim();
+    if token.is_empty() {
+        return errors::bad_request("Missing device token");
+    }
+
+    let mut conn = match errors::db_conn(&pool) {
+        Ok(c) => c,
+        Err(resp) => return resp,
+    };
+    let actor =
+        crate::sync::actor::ActorContext::user(user_uuid, None).with_workspace(workspace_id);
+    let res = crate::sync::session::with_actor_bypass_context(&mut conn, &actor, |conn| {
+        crate::repository::push_devices::register(
+            conn,
+            user_uuid,
+            workspace_id,
+            &body.platform,
+            token,
+            body.app_version.as_deref(),
+        )
+    });
+    match res {
+        Ok(_) => HttpResponse::Ok().json(serde_json::json!({ "success": true })),
+        Err(e) => {
+            HttpResponse::InternalServerError().json(serde_json::json!({ "error": e.to_string() }))
+        }
+    }
+}
+
+/// DELETE /api/notifications/devices/{token} — revoke this user's device token.
+pub async fn unregister_push_device(
+    req: HttpRequest,
+    pool: web::Data<Pool>,
+    path: web::Path<String>,
+) -> HttpResponse {
+    let claims = match req.extensions().get::<Claims>() {
+        Some(c) => c.clone(),
+        None => return HttpResponse::Unauthorized().finish(),
+    };
+    let user_uuid = match uuid::Uuid::parse_str(&claims.sub) {
+        Ok(u) => u,
+        Err(_) => return errors::bad_request("Invalid user UUID"),
+    };
+    let Some(workspace_id) = actor_workspace_id(&req) else {
+        return errors::unauthorized("Authentication required");
+    };
+    let token = path.into_inner();
+
+    let mut conn = match errors::db_conn(&pool) {
+        Ok(c) => c,
+        Err(resp) => return resp,
+    };
+    let actor =
+        crate::sync::actor::ActorContext::user(user_uuid, None).with_workspace(workspace_id);
+    let res = crate::sync::session::with_actor_bypass_context(&mut conn, &actor, |conn| {
+        crate::repository::push_devices::revoke(conn, user_uuid, &token)
+    });
+    match res {
+        Ok(_) => HttpResponse::Ok().json(serde_json::json!({ "success": true })),
+        Err(e) => {
+            HttpResponse::InternalServerError().json(serde_json::json!({ "error": e.to_string() }))
+        }
+    }
 }
 
 /// Current caller's workspace (from the actor context pinned by auth middleware).

--- a/backend/src/repository/mod.rs
+++ b/backend/src/repository/mod.rs
@@ -38,6 +38,7 @@ pub mod manufacturers;
 pub mod outbound_emails;
 pub mod passkey_credentials;
 pub mod projects;
+pub mod push_devices;
 pub mod rules;
 pub mod saved_views;
 pub mod search_query_log;

--- a/backend/src/repository/push_devices.rs
+++ b/backend/src/repository/push_devices.rs
@@ -11,8 +11,7 @@ use uuid::Uuid;
 use crate::db::DbConnection;
 use crate::schema::user_push_devices::dsl as d;
 
-// sync-audit-only: push device tokens are server-side push infrastructure; no
-// sync client subscribes to a user's device list.
+// sync-audit-only: server-side push infra; no sync client subscribes to a device list.
 /// Register (or refresh) a device token for a user. Upserts on the token so a
 /// reinstall / a token reassigned to another user lands on one row, and
 /// re-registering un-revokes it.

--- a/backend/src/repository/push_devices.rs
+++ b/backend/src/repository/push_devices.rs
@@ -1,0 +1,86 @@
+//! Push device token store (notification push channel).
+//!
+//! A user may have several devices. The push channel loads a recipient's ACTIVE
+//! tokens (revoked_at IS NULL) to send to; the registration endpoints upsert /
+//! revoke; the sender's invalid-token reports prune dead devices.
+
+use chrono::Utc;
+use diesel::prelude::*;
+use uuid::Uuid;
+
+use crate::db::DbConnection;
+use crate::schema::user_push_devices::dsl as d;
+
+/// Register (or refresh) a device token for a user. Upserts on the token so a
+/// reinstall / a token reassigned to another user lands on one row, and
+/// re-registering un-revokes it.
+pub fn register(
+    conn: &mut DbConnection,
+    user: Uuid,
+    workspace: i32,
+    platform: &str,
+    token: &str,
+    app_version: Option<&str>,
+) -> QueryResult<()> {
+    let now = Utc::now().naive_utc();
+    diesel::insert_into(d::user_push_devices)
+        .values((
+            d::user_uuid.eq(user),
+            d::workspace_id.eq(workspace),
+            d::platform.eq(platform),
+            d::token.eq(token),
+            d::app_version.eq(app_version),
+            d::created_at.eq(now),
+            d::updated_at.eq(now),
+            d::last_seen_at.eq(now),
+        ))
+        .on_conflict(d::token)
+        .do_update()
+        .set((
+            d::user_uuid.eq(user),
+            d::workspace_id.eq(workspace),
+            d::platform.eq(platform),
+            d::app_version.eq(app_version),
+            d::last_seen_at.eq(now),
+            d::updated_at.eq(now),
+            d::revoked_at.eq(None::<chrono::NaiveDateTime>),
+        ))
+        .execute(conn)?;
+    Ok(())
+}
+
+/// Revoke a token for a user (logout / unregister). Rows affected.
+pub fn revoke(conn: &mut DbConnection, user: Uuid, token: &str) -> QueryResult<usize> {
+    let now = Utc::now().naive_utc();
+    diesel::update(
+        d::user_push_devices
+            .filter(d::user_uuid.eq(user))
+            .filter(d::token.eq(token)),
+    )
+    .set((d::revoked_at.eq(now), d::updated_at.eq(now)))
+    .execute(conn)
+}
+
+/// A user's active `(platform, token)` pairs — the push channel's send list.
+pub fn active_tokens_for_user(
+    conn: &mut DbConnection,
+    user: Uuid,
+) -> QueryResult<Vec<(String, String)>> {
+    d::user_push_devices
+        .filter(d::user_uuid.eq(user))
+        .filter(d::revoked_at.is_null())
+        .select((d::platform, d::token))
+        .load(conn)
+}
+
+/// Revoke tokens the provider reported as permanently invalid (APNs 410 / FCM
+/// UNREGISTERED), so we stop sending to dead devices.
+pub fn revoke_tokens(conn: &mut DbConnection, tokens: &[String]) -> QueryResult<usize> {
+    if tokens.is_empty() {
+        return Ok(0);
+    }
+    let now = Utc::now().naive_utc();
+    diesel::update(d::user_push_devices.filter(d::token.eq_any(tokens)))
+        .set((d::revoked_at.eq(now), d::updated_at.eq(now)))
+        .execute(conn)
+}

--- a/backend/src/repository/push_devices.rs
+++ b/backend/src/repository/push_devices.rs
@@ -11,6 +11,8 @@ use uuid::Uuid;
 use crate::db::DbConnection;
 use crate::schema::user_push_devices::dsl as d;
 
+// sync-audit-only: push device tokens are server-side push infrastructure; no
+// sync client subscribes to a user's device list.
 /// Register (or refresh) a device token for a user. Upserts on the token so a
 /// reinstall / a token reassigned to another user lands on one row, and
 /// re-registering un-revokes it.
@@ -49,6 +51,7 @@ pub fn register(
     Ok(())
 }
 
+// sync-audit-only: device-token lifecycle; no sync client subscribes to it.
 /// Revoke a token for a user (logout / unregister). Rows affected.
 pub fn revoke(conn: &mut DbConnection, user: Uuid, token: &str) -> QueryResult<usize> {
     let now = Utc::now().naive_utc();
@@ -73,6 +76,7 @@ pub fn active_tokens_for_user(
         .load(conn)
 }
 
+// sync-audit-only: device-token lifecycle; no sync client subscribes to it.
 /// Revoke tokens the provider reported as permanently invalid (APNs 410 / FCM
 /// UNREGISTERED), so we stop sending to dead devices.
 pub fn revoke_tokens(conn: &mut DbConnection, tokens: &[String]) -> QueryResult<usize> {

--- a/backend/src/repository/tickets.rs
+++ b/backend/src/repository/tickets.rs
@@ -1711,6 +1711,11 @@ mod tests {
             // device is a defensible global UNIQUE — flagged for
             // product decision but not a leak per se.
             "idx_asset_serial_unique",
+            // APNs/FCM push tokens are assigned globally by Apple/Google and
+            // identify one physical device. A token maps to exactly one device
+            // row regardless of workspace (re-registration upserts on it), so
+            // the UNIQUE is intentionally global, not per-workspace.
+            "user_push_devices_token_key",
             // Azure object IDs are GUIDs. Cross-tenant overlap doesn't
             // happen in practice; not a leak.
             "idx_groups_external_id",

--- a/backend/src/schema.rs
+++ b/backend/src/schema.rs
@@ -1895,6 +1895,22 @@ diesel::table! {
 }
 
 diesel::table! {
+    user_push_devices (id) {
+        id -> Int4,
+        user_uuid -> Uuid,
+        workspace_id -> Int4,
+        #[max_length = 16]
+        platform -> Varchar,
+        token -> Text,
+        app_version -> Nullable<Text>,
+        created_at -> Timestamptz,
+        updated_at -> Timestamptz,
+        last_seen_at -> Timestamptz,
+        revoked_at -> Nullable<Timestamptz>,
+    }
+}
+
+diesel::table! {
     user_recovery_codes (id) {
         id -> Int8,
         user_uuid -> Uuid,
@@ -2394,6 +2410,8 @@ diesel::joinable!(tickets -> ticket_categories (category_id));
 diesel::joinable!(tickets -> workflow_states (workflow_state_id));
 diesel::joinable!(tickets -> workspaces (workspace_id));
 diesel::joinable!(user_addresses -> workspaces (workspace_id));
+diesel::joinable!(user_push_devices -> users (user_uuid));
+diesel::joinable!(user_push_devices -> workspaces (workspace_id));
 diesel::joinable!(user_auth_identities -> workspaces (workspace_id));
 diesel::joinable!(user_field_schema -> users (created_by));
 diesel::joinable!(user_field_schema -> workspaces (workspace_id));
@@ -2530,6 +2548,7 @@ diesel::allow_tables_to_appear_in_same_query!(
     user_phone_numbers,
     user_preferences,
     user_profiles,
+    user_push_devices,
     user_recovery_codes,
     user_ticket_views,
     users,

--- a/backend/src/services/notifications/channels/mod.rs
+++ b/backend/src/services/notifications/channels/mod.rs
@@ -5,6 +5,7 @@
 
 pub mod email;
 pub mod in_app;
+pub mod push;
 
 use async_trait::async_trait;
 use std::fmt;

--- a/backend/src/services/notifications/channels/push.rs
+++ b/backend/src/services/notifications/channels/push.rs
@@ -1,0 +1,123 @@
+//! Push delivery channel (mobile/web, APNs/FCM).
+//!
+//! Provider-agnostic: the concrete sender is a [`PushSender`] wired in a later
+//! step. Until one is configured the channel is registered but `is_available`
+//! is false, so push preferences are visible in settings yet inert (nothing is
+//! silently dropped — `notify()` filters out unavailable channels).
+//!
+//! **Privacy:** the payload is minimal — a generic title from the notification
+//! type + an entity ref for the deep-link, never the ticket subject/body. The
+//! app fetches real content after the tap, so Apple/Google/FCM never see
+//! customer data.
+
+use async_trait::async_trait;
+use std::sync::Arc;
+
+use super::super::types::{DeliverableNotification, NotificationChannel};
+use super::{ChannelError, ChannelResult, NotificationDeliveryChannel};
+use crate::db::Pool;
+
+/// A minimal, PII-free push payload.
+#[derive(Debug, Clone)]
+pub struct PushPayload {
+    /// Generic, derived from the notification type (e.g. "Assigned to Ticket").
+    pub title: String,
+    pub notification_type: String,
+    pub entity_type: String,
+    pub entity_id: i32,
+    /// Deep-link target ticket, or 0 for "no ticket link".
+    pub ticket_id: i32,
+}
+
+/// One device to send to.
+#[derive(Debug, Clone)]
+pub struct PushTarget {
+    pub platform: String,
+    pub token: String,
+}
+
+/// Sends a push and reports tokens the provider rejected as unregistered (so
+/// the channel prunes them). APNs/FCM impls land in a later step;
+/// [`NoopPushSender`] is the placeholder.
+#[async_trait]
+pub trait PushSender: Send + Sync {
+    /// True once real credentials are configured — gates the channel.
+    fn is_configured(&self) -> bool;
+    /// Send `payload` to each target; return permanently-invalid tokens to revoke.
+    async fn send(&self, targets: &[PushTarget], payload: &PushPayload) -> Vec<String>;
+}
+
+/// Placeholder sender: not configured, sends nothing. Replaced by APNs/FCM.
+pub struct NoopPushSender;
+
+#[async_trait]
+impl PushSender for NoopPushSender {
+    fn is_configured(&self) -> bool {
+        false
+    }
+    async fn send(&self, _targets: &[PushTarget], _payload: &PushPayload) -> Vec<String> {
+        Vec::new()
+    }
+}
+
+/// The push channel.
+pub struct PushChannel {
+    pool: Pool,
+    sender: Arc<dyn PushSender>,
+}
+
+impl PushChannel {
+    pub fn new(pool: Pool, sender: Arc<dyn PushSender>) -> Self {
+        Self { pool, sender }
+    }
+}
+
+#[async_trait]
+impl NotificationDeliveryChannel for PushChannel {
+    fn channel_type(&self) -> NotificationChannel {
+        NotificationChannel::Push
+    }
+
+    fn is_available(&self) -> bool {
+        self.sender.is_configured()
+    }
+
+    async fn deliver(&self, notification: &DeliverableNotification) -> ChannelResult<()> {
+        let recipient = notification.payload.recipient_uuid;
+
+        // Active device tokens, loaded under bypass: this is a background
+        // dispatcher, and push targets a user across all their devices, so we
+        // don't want RLS to filter by a single workspace pin.
+        let targets: Vec<PushTarget> = crate::sync::session::background_run(
+            &self.pool,
+            "background:push_load_devices",
+            |conn| crate::repository::push_devices::active_tokens_for_user(conn, recipient),
+        )
+        .map_err(|e| ChannelError::DatabaseError(e.to_string()))?
+        .into_iter()
+        .map(|(platform, token)| PushTarget { platform, token })
+        .collect();
+
+        if targets.is_empty() {
+            return Ok(());
+        }
+
+        let payload = PushPayload {
+            title: notification.payload.notification_type.title().to_string(),
+            notification_type: notification.payload.notification_type.as_str().to_string(),
+            entity_type: notification.payload.entity.entity_type().to_string(),
+            entity_id: notification.payload.entity.entity_id(),
+            ticket_id: notification.payload.entity.ticket_id(),
+        };
+
+        let invalid = self.sender.send(&targets, &payload).await;
+        if !invalid.is_empty() {
+            let _ = crate::sync::session::background_run(
+                &self.pool,
+                "background:push_prune_tokens",
+                |conn| crate::repository::push_devices::revoke_tokens(conn, &invalid),
+            );
+        }
+        Ok(())
+    }
+}

--- a/backend/src/services/notifications/preferences.rs
+++ b/backend/src/services/notifications/preferences.rs
@@ -28,9 +28,14 @@ use crate::models::{
 
 use super::types::{NotificationChannel, NotificationFrequency, NotificationTypeCode};
 
-/// The channels the resolver considers. Push joins here when it ships.
-const RESOLVED_CHANNELS: [NotificationChannel; 2] =
-    [NotificationChannel::InApp, NotificationChannel::Email];
+/// The channels the resolver considers (and the settings matrix exposes). Push
+/// defaults to `off` — it's opt-in after the user registers a device + grants
+/// OS permission — so it's never in a type's `default_channels`.
+const RESOLVED_CHANNELS: [NotificationChannel; 3] = [
+    NotificationChannel::InApp,
+    NotificationChannel::Email,
+    NotificationChannel::Push,
+];
 
 /// Manages notification preferences + workspace defaults with caching.
 pub struct PreferenceService {

--- a/backend/src/services/notifications/types.rs
+++ b/backend/src/services/notifications/types.rs
@@ -78,9 +78,9 @@ impl NotificationTypeCode {
 pub enum NotificationChannel {
     InApp,
     Email,
-    // Push is intentionally absent: no delivery adapter is registered or
-    // seeded, so accepting it would silently drop notifications. Re-add it
-    // alongside a PushChannel + seed matrix when push actually ships.
+    /// Mobile/web push (APNs/FCM). Delivered by `channels::push::PushChannel`
+    /// when a push sender is configured; inert (is_available = false) until then.
+    Push,
 }
 
 impl NotificationChannel {
@@ -88,6 +88,7 @@ impl NotificationChannel {
         match self {
             Self::InApp => "in_app",
             Self::Email => "email",
+            Self::Push => "push",
         }
     }
 
@@ -95,6 +96,7 @@ impl NotificationChannel {
         match s {
             "in_app" => Some(Self::InApp),
             "email" => Some(Self::Email),
+            "push" => Some(Self::Push),
             _ => None,
         }
     }
@@ -377,6 +379,16 @@ mod tests {
     fn only_email_supports_digest() {
         assert!(NotificationChannel::Email.supports_digest());
         assert!(!NotificationChannel::InApp.supports_digest());
+        assert!(!NotificationChannel::Push.supports_digest());
+    }
+
+    #[test]
+    fn push_channel_roundtrips() {
+        assert_eq!(
+            NotificationChannel::from_str("push"),
+            Some(NotificationChannel::Push)
+        );
+        assert_eq!(NotificationChannel::Push.as_str(), "push");
     }
 
     #[test]

--- a/backend/src/startup.rs
+++ b/backend/src/startup.rs
@@ -222,6 +222,18 @@ pub fn build_state(
             service.register_channel(email_channel);
         }
 
+        // Push channel: provider-agnostic, registered with the no-op sender for
+        // now (is_available=false → inert) so push preferences exist and device
+        // registration works; it starts delivering once a real APNs/FCM sender
+        // is wired in.
+        let push_channel = Arc::new(
+            crate::services::notifications::channels::push::PushChannel::new(
+                pool.clone(),
+                Arc::new(crate::services::notifications::channels::push::NoopPushSender),
+            ),
+        );
+        service.register_channel(push_channel);
+
         web::Data::new(service)
     };
 


### PR DESCRIPTION
Fulfils the reserved `Push` seam (design: `docs/notification-preferences-and-push-design-2026-07-15.md`). Push is now a real channel in the (type × channel) matrix and users can register devices; actual **sending waits on Step 4's APNs/FCM sender**.

## What's here
- Migration `user_push_devices` (unique token, RLS + owner/grant baked in from the start per Step 2's lesson).
- `NotificationChannel::Push` + added to `RESOLVED_CHANNELS`, so push appears in the settings matrix and resolves. Push defaults **off** (opt-in after device registration + OS permission) → never seeded into `default_channels`; `digest` coerces to `instant` (push doesn't batch).
- `channels/push.rs`: `PushChannel` + a provider-agnostic `PushSender` trait (`NoopPushSender` for now). `is_available = sender.is_configured()` → registered but **inert until a real sender is wired**, so nothing is silently dropped. `deliver()` loads active tokens, builds a **minimal PII-free payload** (type + entity ref only — no ticket content), sends, prunes provider-rejected tokens.
- `repository/push_devices.rs` (register/revoke/active_tokens/revoke_tokens).
- Device API: `POST /notifications/devices`, `DELETE /notifications/devices/{token}` (per-user, workspace-pinned write).

## Follow-ons
Step 4 APNs/FCM sender, Step 5 Tauri mobile, Step 6 digest batcher, + the Vue settings/admin UIs.

**CI-verified** (local machine on MLX training).