### PR TITLE
Notifications Step 6: email digest batcher

### DIFF
--- a/backend/src/services/scheduled_jobs.rs
+++ b/backend/src/services/scheduled_jobs.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 
 use anyhow::{Context, Result};
 use diesel::sql_types::{Array, BigInt, Integer, Text, Uuid as SqlUuid};
-use diesel::{sql_query, QueryableByName, RunQueryDsl};
+use diesel::{sql_query, OptionalExtension, QueryableByName, RunQueryDsl};
 use std::collections::HashMap;
 use tracing::{info, warn};
 

--- a/backend/src/services/scheduled_jobs.rs
+++ b/backend/src/services/scheduled_jobs.rs
@@ -17,8 +17,9 @@
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
-use diesel::sql_types::BigInt;
+use diesel::sql_types::{Array, BigInt, Integer, Text, Uuid as SqlUuid};
 use diesel::{sql_query, QueryableByName, RunQueryDsl};
+use std::collections::HashMap;
 use tracing::{info, warn};
 
 use crate::db::{DbConnection, Pool};
@@ -33,6 +34,7 @@ use crate::services::search::SearchService;
 const MSGRAPH_DELTA_SYNC_LOCK: i64 = 0x004e_6f73_4d53_4744;
 const THUMBNAIL_BACKFILL_LOCK: i64 = 0x004e_6f73_5448_4d42;
 const LOAN_REMINDER_LOCK: i64 = 0x004e_6f73_4c6f_616e;
+const NOTIFICATION_DIGEST_LOCK: i64 = 0x004e_6f73_4e44_4947;
 const LDAP_RECONCILE_LOCK: i64 = 0x004e_6f73_4c44_5243;
 // Partition drops (DETACH CONCURRENTLY + DROP) can't run in a transaction,
 // so they can't use the provisioner's transaction-scoped lock; a session
@@ -106,6 +108,128 @@ pub async fn cleanup_expired_refresh_tokens(pool: Pool) -> Result<()> {
         refresh_tokens::cleanup_expired(&mut conn).context("delete expired refresh tokens")?;
     if removed > 0 {
         info!(count = removed, "scheduler: expired refresh tokens pruned");
+    }
+    Ok(())
+}
+
+/// Send email digests: batch the notifications a user set to `email` = `digest`
+/// into one summary email per user. Runs daily, single-machine via the advisory
+/// lock. Idempotent — it marks the source rows `email`-delivered, so a re-run
+/// never re-sends. v1 covers explicit per-user `email=digest` prefs; a
+/// workspace-default of `digest` (rare) is a follow-up.
+pub async fn send_notification_digests(pool: Pool) -> Result<()> {
+    let _lock = match try_job_lock(&pool, NOTIFICATION_DIGEST_LOCK, "notifications.digest")? {
+        Some(lock) => lock,
+        None => {
+            info!("scheduler: notifications.digest skipped — another machine holds the lock");
+            return Ok(());
+        }
+    };
+
+    // Cross-workspace scan (bypass): notifications of a type the user set to
+    // email=digest, not yet email-delivered, within the lookback window.
+    #[derive(QueryableByName)]
+    struct PendingRow {
+        #[diesel(sql_type = Integer)]
+        id: i32,
+        #[diesel(sql_type = SqlUuid)]
+        user_uuid: uuid::Uuid,
+        #[diesel(sql_type = Integer)]
+        workspace_id: i32,
+        #[diesel(sql_type = Text)]
+        title: String,
+    }
+    let pending: Vec<PendingRow> = crate::sync::session::background_run(
+        &pool,
+        "background:notification_digest_scan",
+        |conn| {
+            sql_query(
+                "SELECT n.id, n.user_uuid, n.workspace_id, n.title \
+                 FROM notifications n \
+                 JOIN notification_preferences np \
+                   ON np.user_uuid = n.user_uuid \
+                  AND np.notification_type_id = n.notification_type_id \
+                  AND np.channel = 'email' AND np.frequency = 'digest' \
+                 WHERE n.created_at > now() - interval '7 days' \
+                   AND NOT (n.channels_delivered @> '[\"email\"]'::jsonb) \
+                 ORDER BY n.user_uuid, n.created_at",
+            )
+            .load(conn)
+        },
+    )
+    .map_err(|e| anyhow::anyhow!("digest scan: {e}"))?;
+
+    if pending.is_empty() {
+        return Ok(());
+    }
+
+    // Group by user: (workspace_id, titles, source notification ids).
+    let mut by_user: HashMap<uuid::Uuid, (i32, Vec<String>, Vec<i32>)> = HashMap::new();
+    for r in pending {
+        let e = by_user
+            .entry(r.user_uuid)
+            .or_insert_with(|| (r.workspace_id, Vec::new(), Vec::new()));
+        e.1.push(r.title);
+        e.2.push(r.id);
+    }
+
+    let base_url =
+        std::env::var("FRONTEND_URL").unwrap_or_else(|_| "https://app.nosdesk.com".to_string());
+    let mut conn = pool.get().context("db pool")?;
+    let mut sent = 0usize;
+
+    for (user, (workspace_id, titles, ids)) in by_user {
+        #[derive(QueryableByName)]
+        struct EmailRow {
+            #[diesel(sql_type = Text)]
+            email: String,
+        }
+        let recipient: Option<String> = crate::sync::session::background_run(
+            &pool,
+            "background:notification_digest_email",
+            |conn| {
+                let row: Option<EmailRow> = sql_query(
+                    "SELECT email FROM user_emails \
+                     WHERE user_uuid = $1 AND is_primary = true LIMIT 1",
+                )
+                .bind::<SqlUuid, _>(user)
+                .get_result(conn)
+                .optional()?;
+                Ok(row.map(|e| e.email))
+            },
+        )
+        .map_err(|e| anyhow::anyhow!("digest email lookup: {e}"))?;
+        let Some(recipient) = recipient else {
+            continue;
+        };
+
+        // Enqueue + mark delivered under the user's workspace (outbound_emails +
+        // notifications are RLS + audited).
+        let ws_actor = crate::sync::actor::ActorContext::system("scheduler:notification_digest")
+            .with_workspace(workspace_id);
+        let result =
+            crate::sync::session::with_actor_bypass_context(&mut conn, &ws_actor, |conn| {
+                let row = crate::services::transactional_email::prepare_notification_digest(
+                    &recipient, "Nosdesk", &base_url, &titles,
+                );
+                crate::repository::outbound_emails::enqueue_or_suppress(conn, row)?;
+                sql_query(
+                    "UPDATE notifications \
+                 SET channels_delivered = channels_delivered || '[\"email\"]'::jsonb \
+                 WHERE id = ANY($1)",
+                )
+                .bind::<Array<Integer>, _>(&ids)
+                .execute(conn)?;
+                Ok::<_, diesel::result::Error>(())
+            });
+        match result {
+            Ok(_) => sent += 1,
+            Err(e) => warn!(error = %e, "digest: failed to send for a user"),
+        }
+    }
+
+    if sent > 0 {
+        info!(count = sent, "scheduler: notification digests sent");
     }
     Ok(())
 }

--- a/backend/src/services/transactional_email.rs
+++ b/backend/src/services/transactional_email.rs
@@ -312,6 +312,54 @@ pub fn enqueue_bug_report_alert(
     outbound_emails::enqueue_idempotent(conn, row)
 }
 
+/// Build the notification-DIGEST email: a plain summary of the notifications a
+/// user set to `email` = `digest`, sent once per digest run. WORKSPACE sender
+/// identity, NOTIFICATION mail class (opt-out-able, unlike transactional mail).
+/// `titles` is one line per batched notification. No idempotency key — the
+/// digest is time-windowed and de-duplicated by marking the source rows
+/// email-delivered, so it's enqueued via `enqueue_or_suppress`.
+pub fn prepare_notification_digest(
+    recipient: &str,
+    app_name: &str,
+    base_url: &str,
+    titles: &[String],
+) -> NewOutboundEmail {
+    let from_domain = std::env::var("SMTP_FROM_EMAIL")
+        .ok()
+        .and_then(|e| e.rsplit_once('@').map(|(_, d)| d.to_string()))
+        .unwrap_or_else(|| "nosdesk.local".to_string());
+    let message_id = make_message_id("digest", &from_domain);
+
+    let count = titles.len();
+    let plural = if count == 1 { "" } else { "s" };
+    let subject = format!("{app_name}: {count} new notification{plural}");
+    let list = titles
+        .iter()
+        .map(|t| format!("  • {t}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let body_text =
+        format!("You have {count} new notification{plural}:\n\n{list}\n\nView them: {base_url}\n");
+
+    NewOutboundEmail {
+        channel_id: None,
+        ticket_id: None,
+        comment_id: None,
+        recipient: recipient.to_string(),
+        subject,
+        body_text,
+        body_html: None,
+        message_id,
+        in_reply_to: None,
+        references_list: vec![],
+        headers_json: serde_json::json!({}),
+        correlation_id: None,
+        idempotency_key: None,
+        sender_identity: outbound_email_sender_identity::WORKSPACE.to_string(),
+        mail_class: outbound_email_mail_class::NOTIFICATION.to_string(),
+    }
+}
+
 /// Build the `NewOutboundEmail` row for a customer-portal sign-in link.
 /// Transactional auth mail (no unsubscribe), sent from the WORKSPACE identity
 /// (the tenant's branded portal, falling back to the instance identity when the

--- a/backend/src/workers.rs
+++ b/backend/src/workers.rs
@@ -51,6 +51,17 @@ pub fn spawn_scheduled_jobs(
             move || jobs::cleanup_expired_refresh_tokens(p.clone()),
         );
 
+        // Daily: send notification email digests (batches the notifications a
+        // user set to email=digest into one summary). Single-machine via lock.
+        let p = pool.clone();
+        spawn_periodic(
+            "notifications.digest",
+            Duration::from_secs(24 * 60 * 60),
+            scheduler_shutdown.clone(),
+            scheduler_status.clone(),
+            move || jobs::send_notification_digests(p.clone()),
+        );
+
         // Every 30 min: Microsoft Graph delta sync (skipped at runtime
         // when the provider isn't configured).
         let p = pool.clone();


### PR DESCRIPTION
Completes the frequency feature (design: `docs/notification-preferences-and-push-design-2026-07-15.md`): notifications a user set to `email = digest` are now batched into one daily summary email instead of never being sent.

- `scheduled_jobs::send_notification_digests` — daily periodic job, single-machine via advisory lock. Cross-workspace scan (bypass) for notifications whose type the user set to `email=digest`, not yet email-delivered, within a 7-day lookback; group per user; send one summary via `outbound_emails::enqueue_or_suppress` (respects suppression); mark the source rows email-delivered so a re-run never re-sends (idempotent).
- `transactional_email::prepare_notification_digest` — the summary email (WORKSPACE identity, NOTIFICATION mail class = opt-out-able).
- Registered in `workers.rs` (24h).

v1 covers explicit per-user `email=digest` prefs; a workspace-default of `digest` (rare) is a documented follow-up.

**CI-verified** (local machine on MLX training). This is the last fully-CI-verifiable backend step; the push sender (Step 4, direct APNs+FCM) + mobile (Step 5) are the credential/device-gated follow-ups.