### PR TITLE
Notifications Step 7: frequency + admin-defaults settings UIs

### DIFF
--- a/frontend/src/components/admin/adminNavData.ts
+++ b/frontend/src/components/admin/adminNavData.ts
@@ -97,6 +97,13 @@ export const adminNavGroups: AdminNavGroup[] = [
         icon: 'email',
         route: '/admin/email',
         keywords: ['email', 'delivery', 'sending', 'smtp', 'domain', 'dkim', 'spf', 'dmarc', 'queue', 'suppressions', 'bounce', 'unsubscribe', 'outbound', 'from']
+      },
+      {
+        titleKey: 'admin-nav-notification-defaults-title',
+        descriptionKey: 'admin-nav-notification-defaults-description',
+        icon: 'bell',
+        route: '/admin/notification-defaults',
+        keywords: ['notifications', 'defaults', 'preferences', 'channels', 'digest', 'push', 'locked', 'workspace', 'frequency']
       }
     ]
   },

--- a/frontend/src/components/settings/NotificationSettings.vue
+++ b/frontend/src/components/settings/NotificationSettings.vue
@@ -2,85 +2,32 @@
 import { ref, onMounted, computed } from 'vue';
 import { useFluent } from 'fluent-vue';
 import { useAuthStore } from '@/stores/auth';
-import ToggleSwitch from '@/components/common/ToggleSwitch.vue';
 import Icon from '@/components/common/Icon.vue';
 import SectionCard from '@/components/common/SectionCard.vue';
 import Button from '@/components/common/Button.vue';
+import BaseDropdown, { type DropdownOption } from '@/components/common/BaseDropdown.vue';
 import {
   getNotificationPreferences,
   updateNotificationPreference,
-  NOTIFICATION_TYPES,
+  channelSupportsDigest,
   NOTIFICATION_CHANNELS,
   type NotificationPreference,
+  type NotificationFrequency,
 } from '@nosdesk/core/services/notificationService';
 import { requestNotificationPermission } from '@/composables/useNotificationSSE';
 
 const fluent = useFluent();
 const t = (key: string, args?: Record<string, string | number>) => fluent.$t(key, args);
 
-// Map backend codes to localization key suffixes
-const TYPE_KEY_SUFFIX: Record<string, string> = {
-  ticket_assigned: 'ticket-assigned',
-  ticket_status_changed: 'ticket-status-changed',
-  comment_added: 'comment-added',
-  mentioned: 'mentioned',
-  ticket_created_requester: 'ticket-created-requester',
-  doc_page_updated: 'doc-page-updated',
-  asset_low_stock: 'asset-low-stock',
+// Fluent returns the key itself when a message is missing; treat that as a
+// miss and fall back to the API-provided (English) string so a not-yet-
+// translated notification type still renders a sensible label.
+const tr = (key: string, fallback: string): string => {
+  const value = t(key);
+  return value === key ? fallback : value;
 };
 
-const CHANNEL_KEY_SUFFIX: Record<string, string> = {
-  in_app: 'in-app',
-  email: 'email',
-};
-
-// Localized notification types
-const localizedTypes = computed(() =>
-  NOTIFICATION_TYPES.map((type) => {
-    const suffix = TYPE_KEY_SUFFIX[type.code] ?? type.code;
-    return {
-      ...type,
-      name: t(`settings-notifications-type-${suffix}-name`),
-      description: t(`settings-notifications-type-${suffix}-description`),
-    };
-  })
-);
-
-// Localized notification channels
-const localizedChannels = computed(() =>
-  NOTIFICATION_CHANNELS.map((channel) => {
-    const suffix = CHANNEL_KEY_SUFFIX[channel.code] ?? channel.code;
-    return {
-      ...channel,
-      name: t(`settings-notifications-channel-${suffix}-name`),
-      description: t(`settings-notifications-channel-${suffix}-description`),
-    };
-  })
-);
-
-// Localized category metadata (icons stay as raw SVG path strings).
-const categoryMeta = computed<Record<string, { label: string; description: string; icon: string }>>(() => ({
-  ticket: {
-    label: t('settings-notifications-category-ticket-label'),
-    description: t('settings-notifications-category-ticket-description'),
-    icon: '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />',
-  },
-  comment: {
-    label: t('settings-notifications-category-comment-label'),
-    description: t('settings-notifications-category-comment-description'),
-    icon: '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />',
-  },
-  mention: {
-    label: t('settings-notifications-category-mention-label'),
-    description: t('settings-notifications-category-mention-description'),
-    icon: '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 12a4 4 0 10-8 0 4 4 0 008 0zm0 0v1.5a2.5 2.5 0 005 0V12a9 9 0 10-9 9" />',
-  },
-  documentation: {
-    label: t('settings-notifications-category-documentation-label'),
-    description: t('settings-notifications-category-documentation-description'),
-    icon: '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />',
-  },
-}));
+const keyFragment = (code: string) => code.replace(/_/g, '-');
 
 const props = defineProps<{
   targetUserUuid?: string;
@@ -88,66 +35,110 @@ const props = defineProps<{
 
 const authStore = useAuthStore();
 
-const isManagingOtherUser = computed(() => {
-  return !!props.targetUserUuid && props.targetUserUuid !== authStore.user?.uuid;
-});
+const isManagingOtherUser = computed(
+  () => !!props.targetUserUuid && props.targetUserUuid !== authStore.user?.uuid
+);
 
-// Loading state
-const isLoading = ref(true);
-const isSaving = ref<string | null>(null);
-
-// Notification preferences from API
-const preferences = ref<NotificationPreference[]>([]);
-
-// Browser notification permission status
-const browserPermission = ref<NotificationPermission>('default');
-
-// Emits for notifications
 const emit = defineEmits<{
   (e: 'success', message: string): void;
   (e: 'error', message: string): void;
 }>();
 
-// Group localized notification types by category so labels react to locale changes.
-const groupedNotificationTypes = computed(() => {
-  const groups: Record<string, typeof localizedTypes.value[number][]> = {};
-  for (const type of localizedTypes.value) {
-    if (!groups[type.category]) {
-      groups[type.category] = [];
+const isLoading = ref(true);
+// Key of the cell currently saving (`${type}-${channel}`), or 'channel:<code>'
+// while a bulk apply runs — used to disable the affected control(s).
+const isSaving = ref<string | null>(null);
+const preferences = ref<NotificationPreference[]>([]);
+const browserPermission = ref<NotificationPermission>('default');
+
+// Localized channel columns (canonical order + which channels exist come from
+// the shared NOTIFICATION_CHANNELS list: in_app, email, push).
+const channels = computed(() =>
+  NOTIFICATION_CHANNELS.map((channel) => ({
+    code: channel.code,
+    name: tr(`settings-notifications-channel-${keyFragment(channel.code)}-name`, channel.name),
+    description: tr(
+      `settings-notifications-channel-${keyFragment(channel.code)}-description`,
+      channel.description
+    ),
+  }))
+);
+
+// Per-category icon (raw SVG path); label/description come from i18n.
+const CATEGORY_ICON: Record<string, string> = {
+  ticket:
+    '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />',
+  comment:
+    '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />',
+  mention:
+    '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 12a4 4 0 10-8 0 4 4 0 008 0zm0 0v1.5a2.5 2.5 0 005 0V12a9 9 0 10-9 9" />',
+  documentation:
+    '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />',
+  asset:
+    '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4" />',
+};
+
+// Group the API preference rows by category, preserving first-seen order so
+// the layout is stable across locales. Labels react to locale via `tr`.
+const groupedPreferences = computed(() => {
+  const groups: { category: string; label: string; icon: string; rows: NotificationPreference[] }[] =
+    [];
+  for (const row of preferences.value) {
+    let group = groups.find((g) => g.category === row.category);
+    if (!group) {
+      group = {
+        category: row.category,
+        label: tr(`settings-notifications-category-${keyFragment(row.category)}-label`, row.category),
+        icon: CATEGORY_ICON[row.category] ?? CATEGORY_ICON.ticket,
+        rows: [],
+      };
+      groups.push(group);
     }
-    groups[type.category].push(type);
+    group.rows.push(row);
   }
   return groups;
 });
 
-// Get preference value for a specific type/channel combination. The API
-// returns one row per type with a channels map, so read the channel out
-// of that map (defaulting to enabled when the type/channel is absent).
-const getPreference = (typeCode: string, channelCode: string): boolean => {
-  const pref = preferences.value.find((p) => p.notification_type === typeCode);
-  return pref?.channels[channelCode] ?? true;
+const typeName = (row: NotificationPreference) =>
+  tr(`settings-notifications-type-${keyFragment(row.notification_type)}-name`, row.notification_name);
+const typeDescription = (row: NotificationPreference) =>
+  tr(
+    `settings-notifications-type-${keyFragment(row.notification_type)}-description`,
+    row.description ?? ''
+  );
+
+// Frequency choices for a channel — `digest` only where the channel batches.
+const frequencyOptions = (channelCode: string): DropdownOption[] => {
+  const options: DropdownOption[] = [
+    { value: 'instant', label: t('settings-notifications-frequency-instant') },
+  ];
+  if (channelSupportsDigest(channelCode)) {
+    options.push({ value: 'digest', label: t('settings-notifications-frequency-digest') });
+  }
+  options.push({ value: 'off', label: t('settings-notifications-frequency-off') });
+  return options;
 };
 
-// Check if all preferences for a channel are enabled
-const isChannelFullyEnabled = (channelCode: string): boolean => {
-  return NOTIFICATION_TYPES.every((type) => getPreference(type.code, channelCode));
-};
+const getFrequency = (row: NotificationPreference, channelCode: string): NotificationFrequency =>
+  row.frequencies[channelCode] ?? 'off';
 
-// Toggle a specific preference
-const togglePreference = async (typeCode: string, channelCode: string) => {
-  const currentValue = getPreference(typeCode, channelCode);
-  const newValue = !currentValue;
-  const key = `${typeCode}-${channelCode}`;
+const isLocked = (row: NotificationPreference, channelCode: string): boolean =>
+  row.locked[channelCode] === true;
 
+const cellKey = (typeCode: string, channelCode: string) => `${typeCode}-${channelCode}`;
+
+const setFrequency = async (
+  row: NotificationPreference,
+  channelCode: string,
+  frequency: NotificationFrequency
+) => {
+  if (isLocked(row, channelCode) || frequency === getFrequency(row, channelCode)) return;
+  const key = cellKey(row.notification_type, channelCode);
   isSaving.value = key;
-
   try {
-    await updateNotificationPreference(typeCode, channelCode, newValue);
-
-    // Update local state (mutate the type's channels map).
-    const group = preferences.value.find((p) => p.notification_type === typeCode);
-    if (group) group.channels[channelCode] = newValue;
-
+    await updateNotificationPreference(row.notification_type, channelCode, frequency);
+    row.frequencies[channelCode] = frequency;
+    row.channels[channelCode] = frequency !== 'off';
     emit('success', t('settings-notifications-preference-update-success'));
   } catch {
     emit('error', t('settings-notifications-preference-update-error'));
@@ -156,56 +147,59 @@ const togglePreference = async (typeCode: string, channelCode: string) => {
   }
 };
 
-// Toggle all preferences for a channel
-const toggleAllForChannel = async (channelCode: string) => {
-  const currentlyEnabled = isChannelFullyEnabled(channelCode);
-  const newValue = !currentlyEnabled;
-
-  for (const type of NOTIFICATION_TYPES) {
-    const key = `${type.code}-${channelCode}`;
-    isSaving.value = key;
-
-    try {
-      await updateNotificationPreference(type.code, channelCode, newValue);
-
-      // Update local state (mutate the type's channels map).
-      const group = preferences.value.find((p) => p.notification_type === type.code);
-      if (group) group.channels[channelCode] = newValue;
-    } catch {
-      // Continue with other preferences even if one fails
-    }
-  }
-
-  isSaving.value = null;
-  const channelLabel =
-    localizedChannels.value.find((c) => c.code === channelCode)?.name ?? channelCode;
-  emit(
-    'success',
-    t('settings-notifications-channel-bulk-success', {
-      channel: channelLabel,
-      state: newValue ? 'enabled' : 'disabled',
-    }),
-  );
+// Aggregate frequency across the unlocked rows of a channel: the shared value,
+// or 'mixed' when rows differ (drives the quick-settings control).
+const channelAggregate = (channelCode: string): NotificationFrequency | 'mixed' => {
+  const freqs = preferences.value
+    .filter((p) => !isLocked(p, channelCode))
+    .map((p) => getFrequency(p, channelCode));
+  if (freqs.length === 0) return 'off';
+  return freqs.every((f) => f === freqs[0]) ? freqs[0] : 'mixed';
 };
 
-// Request browser notification permission
+const quickOptions = (channelCode: string): DropdownOption[] => [
+  ...frequencyOptions(channelCode),
+  { value: 'mixed', label: t('settings-notifications-frequency-mixed'), disabled: true },
+];
+
+const applyAllForChannel = async (channelCode: string, frequency: NotificationFrequency) => {
+  // The 'mixed' quick-settings option is disabled, so only real frequencies
+  // reach here.
+  isSaving.value = `channel:${channelCode}`;
+  let failed = false;
+  for (const row of preferences.value) {
+    if (isLocked(row, channelCode) || getFrequency(row, channelCode) === frequency) continue;
+    try {
+      await updateNotificationPreference(row.notification_type, channelCode, frequency);
+      row.frequencies[channelCode] = frequency;
+      row.channels[channelCode] = frequency !== 'off';
+    } catch {
+      failed = true;
+    }
+  }
+  isSaving.value = null;
+  const channelLabel = channels.value.find((c) => c.code === channelCode)?.name ?? channelCode;
+  if (failed) {
+    emit('error', t('settings-notifications-preference-update-error'));
+  } else {
+    emit('success', t('settings-notifications-channel-bulk-applied', { channel: channelLabel }));
+  }
+};
+
 const requestBrowserPermission = async () => {
   const granted = await requestNotificationPermission();
   browserPermission.value = Notification.permission;
-
-  if (granted) {
-    emit('success', t('settings-notifications-browser-enabled-success'));
-  } else {
-    emit('error', t('settings-notifications-browser-denied-error'));
-  }
+  emit(
+    granted ? 'success' : 'error',
+    granted
+      ? t('settings-notifications-browser-enabled-success')
+      : t('settings-notifications-browser-denied-error')
+  );
 };
 
-// Load preferences on mount
 onMounted(async () => {
   try {
     preferences.value = await getNotificationPreferences();
-
-    // Check browser permission status
     if ('Notification' in window) {
       browserPermission.value = Notification.permission;
     }
@@ -215,6 +209,10 @@ onMounted(async () => {
     isLoading.value = false;
   }
 });
+
+const gridColumns = computed(
+  () => `minmax(0, 1fr) repeat(${channels.value.length}, minmax(6.5rem, 8rem))`
+);
 </script>
 
 <template>
@@ -239,16 +237,12 @@ onMounted(async () => {
         <div class="p-4">
           <div class="flex items-start gap-3">
             <div class="w-9 h-9 bg-accent/15 rounded-lg flex items-center justify-center flex-shrink-0">
-              <span class="text-accent inline-flex">
-                <Icon name="bell" />
-              </span>
+              <span class="text-accent inline-flex"><Icon name="bell" /></span>
             </div>
             <div class="flex-1 min-w-0 flex flex-col gap-2">
               <div class="flex flex-col gap-1">
                 <h3 class="text-sm font-medium text-primary">{{ $t('settings-notifications-browser-banner-title') }}</h3>
-                <p class="text-xs text-secondary">
-                  {{ $t('settings-notifications-browser-banner-description') }}
-                </p>
+                <p class="text-xs text-secondary">{{ $t('settings-notifications-browser-banner-description') }}</p>
               </div>
               <div>
                 <Button size="sm" @click="requestBrowserPermission">
@@ -260,50 +254,55 @@ onMounted(async () => {
         </div>
       </div>
 
-      <!-- Quick Settings Card -->
+      <!-- Quick Settings: bulk-apply one frequency to every type on a channel. -->
       <SectionCard content-padding="p-4 sm:p-6">
         <template #leading>
-          <span class="text-accent inline-flex">
-            <Icon name="settings" />
-          </span>
+          <span class="text-accent inline-flex"><Icon name="settings" /></span>
         </template>
         <template #title>{{ $t('settings-notifications-quick-settings-title') }}</template>
 
         <div class="flex flex-col gap-2">
           <div
-            v-for="channel in localizedChannels"
-            :key="channel.code"
-            class="bg-surface-alt rounded-lg border border-subtle px-3 py-2"
+            v-for="channel in channels"
+            :key="`quick-${channel.code}`"
+            class="bg-surface-alt rounded-lg border border-subtle px-3 py-2.5 flex items-center justify-between gap-3"
           >
-            <ToggleSwitch
-              :model-value="isChannelFullyEnabled(channel.code)"
-              :label="$t('settings-notifications-channel-toggle-all-label', { channel: channel.name })"
-              :description="channel.description"
-              @update:model-value="toggleAllForChannel(channel.code)"
-            />
+            <div class="flex flex-col gap-0.5 min-w-0">
+              <p class="text-sm font-medium text-primary">{{ channel.name }}</p>
+              <p class="text-xs text-tertiary truncate">{{ channel.description }}</p>
+            </div>
+            <div class="w-32 flex-shrink-0">
+              <BaseDropdown
+                size="sm"
+                :model-value="channelAggregate(channel.code) === 'mixed' ? '' : channelAggregate(channel.code)"
+                :options="quickOptions(channel.code)"
+                :placeholder="$t('settings-notifications-frequency-mixed')"
+                :disabled="isSaving === `channel:${channel.code}`"
+                @update:model-value="applyAllForChannel(channel.code, $event as NotificationFrequency)"
+              />
+            </div>
           </div>
         </div>
       </SectionCard>
 
       <!-- Category Cards -->
       <SectionCard
-        v-for="(types, category) in groupedNotificationTypes"
-        :key="category"
+        v-for="group in groupedPreferences"
+        :key="group.category"
         content-padding="p-4 sm:p-6"
       >
         <template #leading>
-          <svg class="w-4 h-4 text-accent flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" v-html="categoryMeta[category]?.icon || ''"></svg>
+          <svg class="w-4 h-4 text-accent flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" v-html="group.icon"></svg>
         </template>
-        <template #title>{{ categoryMeta[category]?.label || category }}</template>
+        <template #title>{{ group.label }}</template>
 
         <div>
-          <!-- Desktop: table-like grid layout -->
+          <!-- Desktop: matrix grid -->
           <div class="hidden sm:flex sm:flex-col sm:gap-3">
-            <!-- Column headers -->
-            <div class="grid items-center gap-4 px-3" :style="{ gridTemplateColumns: `1fr repeat(${localizedChannels.length}, 5rem)` }">
+            <div class="grid items-center gap-4 px-3" :style="{ gridTemplateColumns: gridColumns }">
               <div class="text-xs font-medium text-tertiary uppercase tracking-wide">{{ $t('settings-notifications-column-header') }}</div>
               <div
-                v-for="channel in localizedChannels"
+                v-for="channel in channels"
                 :key="`header-${channel.code}`"
                 class="text-xs font-medium text-tertiary uppercase tracking-wide text-center"
               >
@@ -311,57 +310,78 @@ onMounted(async () => {
               </div>
             </div>
 
-            <!-- Notification type rows -->
             <div class="flex flex-col gap-1.5">
               <div
-                v-for="type in types"
-                :key="type.code"
+                v-for="row in group.rows"
+                :key="row.notification_type"
                 class="grid items-center gap-4 bg-surface-alt rounded-lg border border-subtle px-3 py-2.5"
-                :style="{ gridTemplateColumns: `1fr repeat(${localizedChannels.length}, 5rem)` }"
+                :style="{ gridTemplateColumns: gridColumns }"
               >
                 <div class="flex flex-col gap-0.5 min-w-0">
-                  <p class="text-sm font-medium text-primary">{{ type.name }}</p>
-                  <p class="text-xs text-tertiary truncate">{{ type.description }}</p>
+                  <p class="text-sm font-medium text-primary">{{ typeName(row) }}</p>
+                  <p class="text-xs text-tertiary truncate">{{ typeDescription(row) }}</p>
                 </div>
                 <div
-                  v-for="channel in localizedChannels"
-                  :key="`${type.code}-${channel.code}`"
-                  class="flex justify-center"
+                  v-for="channel in channels"
+                  :key="cellKey(row.notification_type, channel.code)"
+                  class="flex items-center justify-center"
                 >
-                  <ToggleSwitch
-                    :model-value="getPreference(type.code, channel.code)"
-                    :disabled="isSaving === `${type.code}-${channel.code}`"
+                  <div
+                    v-if="isLocked(row, channel.code)"
+                    class="flex items-center gap-1 text-xs text-tertiary"
+                    :title="$t('settings-notifications-locked-hint')"
+                  >
+                    <Icon name="lock" size="xs" />
+                    <span class="capitalize">{{ getFrequency(row, channel.code) }}</span>
+                  </div>
+                  <BaseDropdown
+                    v-else
                     size="sm"
-                    @update:model-value="togglePreference(type.code, channel.code)"
+                    :model-value="getFrequency(row, channel.code)"
+                    :options="frequencyOptions(channel.code)"
+                    :disabled="isSaving === cellKey(row.notification_type, channel.code)"
+                    @update:model-value="setFrequency(row, channel.code, $event as NotificationFrequency)"
                   />
                 </div>
               </div>
             </div>
           </div>
 
-          <!-- Mobile: stacked layout -->
+          <!-- Mobile: stacked -->
           <div class="sm:hidden flex flex-col gap-2">
             <div
-              v-for="type in types"
-              :key="type.code"
+              v-for="row in group.rows"
+              :key="`m-${row.notification_type}`"
               class="bg-surface-alt rounded-lg border border-subtle px-3 py-2.5 flex flex-col gap-2"
             >
               <div class="flex flex-col gap-0.5">
-                <p class="text-sm font-medium text-primary">{{ type.name }}</p>
-                <p class="text-xs text-tertiary">{{ type.description }}</p>
+                <p class="text-sm font-medium text-primary">{{ typeName(row) }}</p>
+                <p class="text-xs text-tertiary">{{ typeDescription(row) }}</p>
               </div>
-              <div class="flex flex-col gap-1.5 pl-1">
+              <div class="flex flex-col gap-1.5">
                 <div
-                  v-for="channel in localizedChannels"
-                  :key="`${type.code}-${channel.code}-mobile`"
+                  v-for="channel in channels"
+                  :key="`${cellKey(row.notification_type, channel.code)}-m`"
+                  class="flex items-center justify-between gap-3"
                 >
-                  <ToggleSwitch
-                    :model-value="getPreference(type.code, channel.code)"
-                    :disabled="isSaving === `${type.code}-${channel.code}`"
-                    :label="channel.name"
-                    size="sm"
-                    @update:model-value="togglePreference(type.code, channel.code)"
-                  />
+                  <span class="text-sm text-secondary">{{ channel.name }}</span>
+                  <div
+                    v-if="isLocked(row, channel.code)"
+                    class="flex items-center gap-1 text-xs text-tertiary"
+                    :title="$t('settings-notifications-locked-hint')"
+                  >
+                    <Icon name="lock" size="xs" />
+                    <span class="capitalize">{{ getFrequency(row, channel.code) }}</span>
+                  </div>
+                  <div v-else class="w-32 flex-shrink-0">
+                    <BaseDropdown
+                      size="sm"
+                      :model-value="getFrequency(row, channel.code)"
+                      :options="frequencyOptions(channel.code)"
+                      :disabled="isSaving === cellKey(row.notification_type, channel.code)"
+                      @update:model-value="setFrequency(row, channel.code, $event as NotificationFrequency)"
+                    />
+                  </div>
                 </div>
               </div>
             </div>
@@ -371,14 +391,14 @@ onMounted(async () => {
 
       <!-- Info Footer -->
       <div class="bg-surface rounded-xl border border-default overflow-hidden">
-        <div class="px-4 py-3">
+        <div class="px-4 py-3 flex flex-col gap-2">
           <div class="flex items-center gap-3">
-            <span class="text-tertiary flex-shrink-0 inline-flex">
-              <Icon name="info" />
-            </span>
-            <p class="text-xs text-secondary">
-              {{ $t('settings-notifications-info-footer') }}
-            </p>
+            <span class="text-tertiary flex-shrink-0 inline-flex"><Icon name="info" /></span>
+            <p class="text-xs text-secondary">{{ $t('settings-notifications-info-footer') }}</p>
+          </div>
+          <div class="flex items-center gap-3">
+            <span class="text-tertiary flex-shrink-0 inline-flex"><Icon name="bell" /></span>
+            <p class="text-xs text-secondary">{{ $t('settings-notifications-push-footer') }}</p>
           </div>
         </div>
       </div>

--- a/frontend/src/components/settings/NotificationSettings.vue
+++ b/frontend/src/components/settings/NotificationSettings.vue
@@ -189,12 +189,11 @@ const applyAllForChannel = async (channelCode: string, frequency: NotificationFr
 const requestBrowserPermission = async () => {
   const granted = await requestNotificationPermission();
   browserPermission.value = Notification.permission;
-  emit(
-    granted ? 'success' : 'error',
-    granted
-      ? t('settings-notifications-browser-enabled-success')
-      : t('settings-notifications-browser-denied-error')
-  );
+  if (granted) {
+    emit('success', t('settings-notifications-browser-enabled-success'));
+  } else {
+    emit('error', t('settings-notifications-browser-denied-error'));
+  }
 };
 
 onMounted(async () => {

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -771,6 +771,12 @@ const router = createRouter({
           meta: { titleKey: 'route-title-admin-branding' }
         },
         {
+          path: 'notification-defaults',
+          name: 'admin-notification-defaults',
+          component: () => import('../views/admin/NotificationDefaultsView.vue'),
+          meta: { titleKey: 'route-title-admin-notification-defaults' }
+        },
+        {
           // Item C/W5: unified audit feed (all three substrates).
           // Reachable by admins and the standalone audit_reviewer role.
           path: 'audit',

--- a/frontend/src/views/admin/NotificationDefaultsView.vue
+++ b/frontend/src/views/admin/NotificationDefaultsView.vue
@@ -1,0 +1,310 @@
+<script setup lang="ts">
+/**
+ * Admin editor for the workspace's notification DEFAULTS — the middle layer of
+ * the system → workspace → user inheritance. Sets the default delivery
+ * frequency per (type, channel) that members inherit, and lets an admin `lock`
+ * a cell so members cannot override it (the ceiling pattern: a locked default
+ * is enforced and shown read-only on each member's own settings).
+ */
+import { ref, onMounted, computed } from 'vue';
+import { useFluent } from 'fluent-vue';
+
+import BackButton from '@/components/common/BackButton.vue';
+import Icon from '@/components/common/Icon.vue';
+import Callout from '@/components/common/Callout.vue';
+import SectionCard from '@/components/common/SectionCard.vue';
+import AlertMessage from '@/components/common/AlertMessage.vue';
+import BaseDropdown, { type DropdownOption } from '@/components/common/BaseDropdown.vue';
+import {
+  getWorkspaceNotificationDefaults,
+  updateWorkspaceNotificationDefault,
+  channelSupportsDigest,
+  NOTIFICATION_CHANNELS,
+  type WorkspaceNotificationDefault,
+  type NotificationFrequency,
+} from '@nosdesk/core/services/notificationService';
+import { useToastStore } from '@nosdesk/core/stores/toast';
+import { extractErrorMessage } from '@/utils/errors';
+
+const fluent = useFluent();
+const t = (key: string, args?: Record<string, string | number>) => fluent.$t(key, args);
+const toast = useToastStore();
+
+// Fluent returns the key when a message is missing; fall back to the API's
+// English string so a not-yet-translated type still renders sensibly.
+const tr = (key: string, fallback: string): string => {
+  const value = t(key);
+  return value === key ? fallback : value;
+};
+const keyFragment = (code: string) => code.replace(/_/g, '-');
+
+const isLoading = ref(true);
+const loadError = ref('');
+const saving = ref<string | null>(null);
+const defaults = ref<WorkspaceNotificationDefault[]>([]);
+
+const channels = computed(() =>
+  NOTIFICATION_CHANNELS.map((channel) => ({
+    code: channel.code,
+    name: tr(`settings-notifications-channel-${keyFragment(channel.code)}-name`, channel.name),
+  }))
+);
+
+const CATEGORY_ICON: Record<string, string> = {
+  ticket:
+    '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />',
+  comment:
+    '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />',
+  mention:
+    '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 12a4 4 0 10-8 0 4 4 0 008 0zm0 0v1.5a2.5 2.5 0 005 0V12a9 9 0 10-9 9" />',
+  documentation:
+    '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />',
+  asset:
+    '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4" />',
+};
+
+const groupedDefaults = computed(() => {
+  const groups: {
+    category: string;
+    label: string;
+    icon: string;
+    rows: WorkspaceNotificationDefault[];
+  }[] = [];
+  for (const row of defaults.value) {
+    let group = groups.find((g) => g.category === row.category);
+    if (!group) {
+      group = {
+        category: row.category,
+        label: tr(`settings-notifications-category-${keyFragment(row.category)}-label`, row.category),
+        icon: CATEGORY_ICON[row.category] ?? CATEGORY_ICON.ticket,
+        rows: [],
+      };
+      groups.push(group);
+    }
+    group.rows.push(row);
+  }
+  return groups;
+});
+
+const typeName = (row: WorkspaceNotificationDefault) =>
+  tr(`settings-notifications-type-${keyFragment(row.notification_type)}-name`, row.notification_name);
+const typeDescription = (row: WorkspaceNotificationDefault) =>
+  tr(
+    `settings-notifications-type-${keyFragment(row.notification_type)}-description`,
+    row.description ?? ''
+  );
+
+const frequencyOptions = (channelCode: string): DropdownOption[] => {
+  const options: DropdownOption[] = [
+    { value: 'instant', label: t('settings-notifications-frequency-instant') },
+  ];
+  if (channelSupportsDigest(channelCode)) {
+    options.push({ value: 'digest', label: t('settings-notifications-frequency-digest') });
+  }
+  options.push({ value: 'off', label: t('settings-notifications-frequency-off') });
+  return options;
+};
+
+const getFrequency = (row: WorkspaceNotificationDefault, channelCode: string): NotificationFrequency =>
+  row.frequencies[channelCode] ?? 'off';
+const isLocked = (row: WorkspaceNotificationDefault, channelCode: string): boolean =>
+  row.locked[channelCode] === true;
+const cellKey = (typeCode: string, channelCode: string) => `${typeCode}-${channelCode}`;
+
+// The backend PUT sets frequency + locked together, so every cell edit sends
+// both — the unchanged one comes from local state.
+const saveCell = async (
+  row: WorkspaceNotificationDefault,
+  channelCode: string,
+  frequency: NotificationFrequency,
+  locked: boolean
+) => {
+  const key = cellKey(row.notification_type, channelCode);
+  saving.value = key;
+  try {
+    await updateWorkspaceNotificationDefault(row.notification_type, channelCode, frequency, locked);
+    row.frequencies[channelCode] = frequency;
+    row.locked[channelCode] = locked;
+    toast.success(t('admin-notification-defaults-saved'));
+  } catch (err) {
+    toast.error(extractErrorMessage(err, t('admin-notification-defaults-error-save')));
+  } finally {
+    saving.value = null;
+  }
+};
+
+const setDefaultFrequency = (
+  row: WorkspaceNotificationDefault,
+  channelCode: string,
+  frequency: NotificationFrequency
+) => {
+  if (frequency === getFrequency(row, channelCode)) return;
+  return saveCell(row, channelCode, frequency, isLocked(row, channelCode));
+};
+const toggleLock = (row: WorkspaceNotificationDefault, channelCode: string) =>
+  saveCell(row, channelCode, getFrequency(row, channelCode), !isLocked(row, channelCode));
+
+onMounted(async () => {
+  try {
+    defaults.value = await getWorkspaceNotificationDefaults();
+  } catch (err) {
+    loadError.value = extractErrorMessage(err, t('admin-notification-defaults-error-load'));
+  } finally {
+    isLoading.value = false;
+  }
+});
+
+const gridColumns = computed(
+  () => `minmax(0, 1fr) repeat(${channels.value.length}, minmax(8.5rem, 10rem))`
+);
+</script>
+
+<template>
+  <div class="flex-1">
+    <div class="flex flex-col gap-4 px-4 sm:px-6 py-4 mx-auto w-full max-w-5xl">
+      <div class="flex flex-col gap-2">
+        <BackButton :fallback-route="'/admin'" :label="t('admin-notification-defaults-back-label')" compact />
+        <div class="flex flex-col gap-1">
+          <h1 class="text-xl sm:text-2xl font-bold text-primary">{{ t('admin-notification-defaults-title') }}</h1>
+          <p class="text-secondary text-sm sm:text-base">{{ t('admin-notification-defaults-description') }}</p>
+        </div>
+      </div>
+
+      <Callout severity="info">
+        <template #header>{{ t('admin-notification-defaults-lock-explainer-title') }}</template>
+        {{ t('admin-notification-defaults-lock-explainer-body') }}
+      </Callout>
+
+      <AlertMessage v-if="loadError" type="error" :message="loadError" />
+
+      <!-- Loading -->
+      <div v-else-if="isLoading" class="bg-surface rounded-xl border border-default overflow-hidden">
+        <div class="p-4 flex flex-col gap-3">
+          <div v-for="i in 4" :key="i" class="h-12 bg-surface-alt rounded-lg animate-pulse"></div>
+        </div>
+      </div>
+
+      <template v-else>
+        <SectionCard
+          v-for="group in groupedDefaults"
+          :key="group.category"
+          content-padding="p-4 sm:p-6"
+        >
+          <template #leading>
+            <svg class="w-4 h-4 text-accent flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" v-html="group.icon"></svg>
+          </template>
+          <template #title>{{ group.label }}</template>
+
+          <div>
+            <!-- Desktop: matrix -->
+            <div class="hidden sm:flex sm:flex-col sm:gap-3">
+              <div class="grid items-center gap-4 px-3" :style="{ gridTemplateColumns: gridColumns }">
+                <div class="text-xs font-medium text-tertiary uppercase tracking-wide">{{ t('settings-notifications-column-header') }}</div>
+                <div
+                  v-for="channel in channels"
+                  :key="`header-${channel.code}`"
+                  class="text-xs font-medium text-tertiary uppercase tracking-wide text-center"
+                >
+                  {{ channel.name }}
+                </div>
+              </div>
+
+              <div class="flex flex-col gap-1.5">
+                <div
+                  v-for="row in group.rows"
+                  :key="row.notification_type"
+                  class="grid items-center gap-4 bg-surface-alt rounded-lg border border-subtle px-3 py-2.5"
+                  :style="{ gridTemplateColumns: gridColumns }"
+                >
+                  <div class="flex flex-col gap-0.5 min-w-0">
+                    <p class="text-sm font-medium text-primary">{{ typeName(row) }}</p>
+                    <p class="text-xs text-tertiary truncate">{{ typeDescription(row) }}</p>
+                  </div>
+                  <div
+                    v-for="channel in channels"
+                    :key="cellKey(row.notification_type, channel.code)"
+                    class="flex items-center gap-1.5"
+                  >
+                    <div class="flex-1 min-w-0">
+                      <BaseDropdown
+                        size="sm"
+                        :model-value="getFrequency(row, channel.code)"
+                        :options="frequencyOptions(channel.code)"
+                        :disabled="saving === cellKey(row.notification_type, channel.code)"
+                        @update:model-value="setDefaultFrequency(row, channel.code, $event as NotificationFrequency)"
+                      />
+                    </div>
+                    <button
+                      type="button"
+                      class="flex items-center justify-center w-7 h-7 rounded-md border transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1 focus-visible:ring-offset-surface"
+                      :class="isLocked(row, channel.code)
+                        ? 'bg-accent/10 border-accent/30 text-accent'
+                        : 'border-subtle text-tertiary hover:text-secondary hover:border-default'"
+                      :disabled="saving === cellKey(row.notification_type, channel.code)"
+                      :aria-pressed="isLocked(row, channel.code)"
+                      :title="isLocked(row, channel.code)
+                        ? t('admin-notification-defaults-locked-title')
+                        : t('admin-notification-defaults-unlocked-title')"
+                      @click="toggleLock(row, channel.code)"
+                    >
+                      <Icon name="lock" size="xs" />
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <!-- Mobile: stacked -->
+            <div class="sm:hidden flex flex-col gap-2">
+              <div
+                v-for="row in group.rows"
+                :key="`m-${row.notification_type}`"
+                class="bg-surface-alt rounded-lg border border-subtle px-3 py-2.5 flex flex-col gap-2"
+              >
+                <div class="flex flex-col gap-0.5">
+                  <p class="text-sm font-medium text-primary">{{ typeName(row) }}</p>
+                  <p class="text-xs text-tertiary">{{ typeDescription(row) }}</p>
+                </div>
+                <div class="flex flex-col gap-1.5">
+                  <div
+                    v-for="channel in channels"
+                    :key="`${cellKey(row.notification_type, channel.code)}-m`"
+                    class="flex items-center justify-between gap-2"
+                  >
+                    <span class="text-sm text-secondary">{{ channel.name }}</span>
+                    <div class="flex items-center gap-1.5">
+                      <div class="w-32">
+                        <BaseDropdown
+                          size="sm"
+                          :model-value="getFrequency(row, channel.code)"
+                          :options="frequencyOptions(channel.code)"
+                          :disabled="saving === cellKey(row.notification_type, channel.code)"
+                          @update:model-value="setDefaultFrequency(row, channel.code, $event as NotificationFrequency)"
+                        />
+                      </div>
+                      <button
+                        type="button"
+                        class="flex items-center justify-center w-7 h-7 rounded-md border transition-colors"
+                        :class="isLocked(row, channel.code)
+                          ? 'bg-accent/10 border-accent/30 text-accent'
+                          : 'border-subtle text-tertiary'"
+                        :disabled="saving === cellKey(row.notification_type, channel.code)"
+                        :aria-pressed="isLocked(row, channel.code)"
+                        :title="isLocked(row, channel.code)
+                          ? t('admin-notification-defaults-locked-title')
+                          : t('admin-notification-defaults-unlocked-title')"
+                        @click="toggleLock(row, channel.code)"
+                      >
+                        <Icon name="lock" size="xs" />
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </SectionCard>
+      </template>
+    </div>
+  </div>
+</template>

--- a/i18n/locales/en-AU/main.ftl
+++ b/i18n/locales/en-AU/main.ftl
@@ -3007,6 +3007,38 @@ settings-notifications-channel-bulk-success = All { $channel } notifications { $
 }
 settings-notifications-info-footer = Email notifications are rate limited to keep your inbox sane. You'll get at most one email per ticket every 5 minutes.
 
+# Notification frequency, push channel + admin defaults (2026-07-16)
+settings-notifications-frequency-instant = Instant
+settings-notifications-frequency-digest = Daily digest
+settings-notifications-frequency-off = Off
+settings-notifications-frequency-mixed = Mixed
+settings-notifications-channel-push-name = Push
+settings-notifications-channel-push-description = Mobile push notifications
+settings-notifications-channel-bulk-applied = All { $channel } notifications updated
+settings-notifications-locked-hint = Set by your workspace admin
+settings-notifications-push-footer = Push notifications are delivered to the Nosdesk mobile app once you've signed in on a device. Set your preference now and it applies automatically.
+settings-notifications-category-asset-label = Assets
+settings-notifications-category-asset-description = Notifications about assets, stock levels and device loans
+settings-notifications-type-sla-breached-name = SLA Breached
+settings-notifications-type-sla-breached-description = When a ticket's response or resolution SLA target is missed
+settings-notifications-type-loan-due-soon-name = Loan Due Soon
+settings-notifications-type-loan-due-soon-description = When a device you have on loan is due back soon
+settings-notifications-type-loan-overdue-name = Loan Overdue
+settings-notifications-type-loan-overdue-description = When a device you have on loan is overdue
+admin-notification-defaults-title = Notification defaults
+admin-notification-defaults-description = Set the default notification delivery for everyone in this workspace. Members inherit these unless you lock a setting.
+admin-notification-defaults-back-label = Back to admin
+admin-notification-defaults-lock-explainer-title = Locking a default
+admin-notification-defaults-lock-explainer-body = Members can change any unlocked setting for themselves. Lock a channel to enforce your default — locked settings appear read-only on each member's own notification preferences.
+admin-notification-defaults-locked-title = Locked — members can't override. Click to unlock.
+admin-notification-defaults-unlocked-title = Unlocked — members can override. Click to lock.
+admin-notification-defaults-saved = Default updated
+admin-notification-defaults-error-save = Couldn't update default
+admin-notification-defaults-error-load = Couldn't load notification defaults
+admin-nav-notification-defaults-title = Notification defaults
+admin-nav-notification-defaults-description = Set workspace-wide notification defaults members inherit
+route-title-admin-notification-defaults = Notification defaults
+
 # Settings: passkeys (PasskeySettings)
 settings-passkey-section-title = Passkeys
 settings-passkey-empty-title = No passkeys registered

--- a/i18n/locales/en-GB/main.ftl
+++ b/i18n/locales/en-GB/main.ftl
@@ -2995,6 +2995,38 @@ settings-notifications-channel-bulk-success = All { $channel } notifications { $
 }
 settings-notifications-info-footer = Email notifications are rate limited to prevent inbox flooding. You'll receive at most one email per ticket every 5 minutes.
 
+# Notification frequency, push channel + admin defaults (2026-07-16)
+settings-notifications-frequency-instant = Instant
+settings-notifications-frequency-digest = Daily digest
+settings-notifications-frequency-off = Off
+settings-notifications-frequency-mixed = Mixed
+settings-notifications-channel-push-name = Push
+settings-notifications-channel-push-description = Mobile push notifications
+settings-notifications-channel-bulk-applied = All { $channel } notifications updated
+settings-notifications-locked-hint = Set by your workspace admin
+settings-notifications-push-footer = Push notifications are delivered to the Nosdesk mobile app once you've signed in on a device. Set your preference now and it applies automatically.
+settings-notifications-category-asset-label = Assets
+settings-notifications-category-asset-description = Notifications about assets, stock levels and device loans
+settings-notifications-type-sla-breached-name = SLA Breached
+settings-notifications-type-sla-breached-description = When a ticket's response or resolution SLA target is missed
+settings-notifications-type-loan-due-soon-name = Loan Due Soon
+settings-notifications-type-loan-due-soon-description = When a device you have on loan is due back soon
+settings-notifications-type-loan-overdue-name = Loan Overdue
+settings-notifications-type-loan-overdue-description = When a device you have on loan is overdue
+admin-notification-defaults-title = Notification defaults
+admin-notification-defaults-description = Set the default notification delivery for everyone in this workspace. Members inherit these unless you lock a setting.
+admin-notification-defaults-back-label = Back to admin
+admin-notification-defaults-lock-explainer-title = Locking a default
+admin-notification-defaults-lock-explainer-body = Members can change any unlocked setting for themselves. Lock a channel to enforce your default — locked settings appear read-only on each member's own notification preferences.
+admin-notification-defaults-locked-title = Locked — members can't override. Click to unlock.
+admin-notification-defaults-unlocked-title = Unlocked — members can override. Click to lock.
+admin-notification-defaults-saved = Default updated
+admin-notification-defaults-error-save = Couldn't update default
+admin-notification-defaults-error-load = Couldn't load notification defaults
+admin-nav-notification-defaults-title = Notification defaults
+admin-nav-notification-defaults-description = Set workspace-wide notification defaults members inherit
+route-title-admin-notification-defaults = Notification defaults
+
 # Settings: passkeys (PasskeySettings)
 settings-passkey-section-title = Passkeys
 settings-passkey-empty-title = No passkeys registered

--- a/i18n/locales/en-US/main.ftl
+++ b/i18n/locales/en-US/main.ftl
@@ -3643,6 +3643,38 @@ settings-notifications-channel-bulk-success = All { $channel } notifications { $
 }
 settings-notifications-info-footer = Email notifications are rate limited to prevent inbox flooding. You'll receive at most one email per ticket every 5 minutes.
 
+# Notification frequency, push channel + admin defaults (2026-07-16)
+settings-notifications-frequency-instant = Instant
+settings-notifications-frequency-digest = Daily digest
+settings-notifications-frequency-off = Off
+settings-notifications-frequency-mixed = Mixed
+settings-notifications-channel-push-name = Push
+settings-notifications-channel-push-description = Mobile push notifications
+settings-notifications-channel-bulk-applied = All { $channel } notifications updated
+settings-notifications-locked-hint = Set by your workspace admin
+settings-notifications-push-footer = Push notifications are delivered to the Nosdesk mobile app once you've signed in on a device. Set your preference now and it applies automatically.
+settings-notifications-category-asset-label = Assets
+settings-notifications-category-asset-description = Notifications about assets, stock levels, and device loans
+settings-notifications-type-sla-breached-name = SLA Breached
+settings-notifications-type-sla-breached-description = When a ticket's response or resolution SLA target is missed
+settings-notifications-type-loan-due-soon-name = Loan Due Soon
+settings-notifications-type-loan-due-soon-description = When a device you have on loan is due back soon
+settings-notifications-type-loan-overdue-name = Loan Overdue
+settings-notifications-type-loan-overdue-description = When a device you have on loan is overdue
+admin-notification-defaults-title = Notification defaults
+admin-notification-defaults-description = Set the default notification delivery for everyone in this workspace. Members inherit these unless you lock a setting.
+admin-notification-defaults-back-label = Back to admin
+admin-notification-defaults-lock-explainer-title = Locking a default
+admin-notification-defaults-lock-explainer-body = Members can change any unlocked setting for themselves. Lock a channel to enforce your default — locked settings appear read-only on each member's own notification preferences.
+admin-notification-defaults-locked-title = Locked — members can't override. Click to unlock.
+admin-notification-defaults-unlocked-title = Unlocked — members can override. Click to lock.
+admin-notification-defaults-saved = Default updated
+admin-notification-defaults-error-save = Couldn't update default
+admin-notification-defaults-error-load = Couldn't load notification defaults
+admin-nav-notification-defaults-title = Notification defaults
+admin-nav-notification-defaults-description = Set workspace-wide notification defaults members inherit
+route-title-admin-notification-defaults = Notification defaults
+
 # Settings: passkeys (PasskeySettings)
 settings-passkey-section-title = Passkeys
 settings-passkey-empty-title = No passkeys registered

--- a/i18n/locales/fr-FR/main.ftl
+++ b/i18n/locales/fr-FR/main.ftl
@@ -3485,6 +3485,38 @@ settings-notifications-channel-bulk-success = Toutes les notifications { $channe
 }
 settings-notifications-info-footer = Les notifications par e-mail sont limitées en fréquence pour éviter de saturer votre boîte de réception. Vous recevrez au plus un e-mail par ticket toutes les 5 minutes.
 
+# Fréquence de notification, canal push + valeurs par défaut admin (2026-07-16)
+settings-notifications-frequency-instant = Instantané
+settings-notifications-frequency-digest = Résumé quotidien
+settings-notifications-frequency-off = Désactivé
+settings-notifications-frequency-mixed = Mixte
+settings-notifications-channel-push-name = Push
+settings-notifications-channel-push-description = Notifications push mobiles
+settings-notifications-channel-bulk-applied = Toutes les notifications { $channel } ont été mises à jour
+settings-notifications-locked-hint = Défini par l'administrateur de votre espace de travail
+settings-notifications-push-footer = Les notifications push sont envoyées à l'application mobile Nosdesk une fois que vous êtes connecté sur un appareil. Définissez votre préférence dès maintenant, elle s'appliquera automatiquement.
+settings-notifications-category-asset-label = Ressources
+settings-notifications-category-asset-description = Notifications concernant les ressources, les niveaux de stock et les prêts d'appareils
+settings-notifications-type-sla-breached-name = SLA non respecté
+settings-notifications-type-sla-breached-description = Lorsqu'un objectif de SLA de réponse ou de résolution d'un ticket n'est pas atteint
+settings-notifications-type-loan-due-soon-name = Prêt à rendre bientôt
+settings-notifications-type-loan-due-soon-description = Lorsqu'un appareil que vous avez en prêt doit être rendu prochainement
+settings-notifications-type-loan-overdue-name = Prêt en retard
+settings-notifications-type-loan-overdue-description = Lorsqu'un appareil que vous avez en prêt est en retard
+admin-notification-defaults-title = Paramètres de notification par défaut
+admin-notification-defaults-description = Définissez la diffusion des notifications par défaut pour tous les membres de cet espace de travail. Les membres en héritent, sauf si vous verrouillez un paramètre.
+admin-notification-defaults-back-label = Retour à l'administration
+admin-notification-defaults-lock-explainer-title = Verrouiller un paramètre par défaut
+admin-notification-defaults-lock-explainer-body = Les membres peuvent modifier tout paramètre non verrouillé les concernant. Verrouillez un canal pour imposer votre valeur par défaut — les paramètres verrouillés apparaissent en lecture seule dans les préférences de notification de chaque membre.
+admin-notification-defaults-locked-title = Verrouillé — les membres ne peuvent pas le modifier. Cliquez pour déverrouiller.
+admin-notification-defaults-unlocked-title = Déverrouillé — les membres peuvent le modifier. Cliquez pour verrouiller.
+admin-notification-defaults-saved = Paramètre par défaut mis à jour
+admin-notification-defaults-error-save = Impossible de mettre à jour le paramètre par défaut
+admin-notification-defaults-error-load = Impossible de charger les paramètres de notification par défaut
+admin-nav-notification-defaults-title = Paramètres de notification par défaut
+admin-nav-notification-defaults-description = Définir les paramètres de notification par défaut de l'espace de travail dont héritent les membres
+route-title-admin-notification-defaults = Paramètres de notification par défaut
+
 # Paramètres : clés d'accès (PasskeySettings)
 settings-passkey-section-title = Clés d'accès
 settings-passkey-empty-title = Aucune clé d'accès enregistrée

--- a/i18n/locales/nl-NL/main.ftl
+++ b/i18n/locales/nl-NL/main.ftl
@@ -3476,6 +3476,38 @@ settings-notifications-channel-bulk-success = Alle { $channel }-meldingen { $sta
 }
 settings-notifications-info-footer = E-mailmeldingen zijn snelheidsbeperkt om uw inbox niet te overspoelen. U ontvangt hoogstens één e-mail per ticket per 5 minuten.
 
+# Meldingsfrequentie, pushkanaal + standaardinstellingen beheerder (2026-07-16)
+settings-notifications-frequency-instant = Direct
+settings-notifications-frequency-digest = Dagelijks overzicht
+settings-notifications-frequency-off = Uit
+settings-notifications-frequency-mixed = Gemengd
+settings-notifications-channel-push-name = Push
+settings-notifications-channel-push-description = Mobiele pushmeldingen
+settings-notifications-channel-bulk-applied = Alle { $channel }-meldingen bijgewerkt
+settings-notifications-locked-hint = Ingesteld door de beheerder van uw werkruimte
+settings-notifications-push-footer = Pushmeldingen worden naar de Nosdesk-mobiele app gestuurd zodra u op een apparaat bent aangemeld. Stel uw voorkeur nu in, deze wordt automatisch toegepast.
+settings-notifications-category-asset-label = Assets
+settings-notifications-category-asset-description = Meldingen over assets, voorraadniveaus en apparaatuitleningen
+settings-notifications-type-sla-breached-name = SLA overschreden
+settings-notifications-type-sla-breached-description = Wanneer de SLA-doelstelling voor reactie of oplossing van een ticket wordt gemist
+settings-notifications-type-loan-due-soon-name = Uitlening bijna te laat
+settings-notifications-type-loan-due-soon-description = Wanneer een apparaat dat u hebt geleend binnenkort moet worden ingeleverd
+settings-notifications-type-loan-overdue-name = Uitlening te laat
+settings-notifications-type-loan-overdue-description = Wanneer een apparaat dat u hebt geleend te laat is
+admin-notification-defaults-title = Standaard meldingsinstellingen
+admin-notification-defaults-description = Stel de standaard meldingsbezorging in voor iedereen in deze werkruimte. Leden erven deze, tenzij u een instelling vergrendelt.
+admin-notification-defaults-back-label = Terug naar beheer
+admin-notification-defaults-lock-explainer-title = Een standaardinstelling vergrendelen
+admin-notification-defaults-lock-explainer-body = Leden kunnen elke niet-vergrendelde instelling voor zichzelf wijzigen. Vergrendel een kanaal om uw standaard af te dwingen — vergrendelde instellingen verschijnen alleen-lezen in de meldingsvoorkeuren van elk lid.
+admin-notification-defaults-locked-title = Vergrendeld — leden kunnen dit niet wijzigen. Klik om te ontgrendelen.
+admin-notification-defaults-unlocked-title = Ontgrendeld — leden kunnen dit wijzigen. Klik om te vergrendelen.
+admin-notification-defaults-saved = Standaardinstelling bijgewerkt
+admin-notification-defaults-error-save = Kan standaardinstelling niet bijwerken
+admin-notification-defaults-error-load = Kan standaard meldingsinstellingen niet laden
+admin-nav-notification-defaults-title = Standaard meldingsinstellingen
+admin-nav-notification-defaults-description = Werkruimtebrede standaard meldingsinstellingen instellen die leden erven
+route-title-admin-notification-defaults = Standaard meldingsinstellingen
+
 # Instellingen: passkeys (PasskeySettings)
 settings-passkey-section-title = Passkeys
 settings-passkey-empty-title = Geen passkeys geregistreerd

--- a/packages/core/src/services/notificationService.ts
+++ b/packages/core/src/services/notificationService.ts
@@ -6,18 +6,60 @@
 
 import apiClient from '../apiClient';
 
+/**
+ * Per-cell delivery frequency (mirrors the backend `NotificationFrequency`):
+ * - `instant` — deliver immediately on this channel
+ * - `digest`  — batch into a periodic summary (email only; see `channelSupportsDigest`)
+ * - `off`     — never deliver on this channel
+ */
+export type NotificationFrequency = 'instant' | 'digest' | 'off';
+
+/** Whether `digest` is a meaningful frequency for a channel. Only the email
+ *  channel batches into a summary; in-app is a live stream and push is
+ *  instant-or-nothing, so the UI must not offer `digest` for those. Mirrors
+ *  the backend `NotificationChannel::supports_digest`. */
+export function channelSupportsDigest(channelCode: string): boolean {
+  return channelCode === 'email';
+}
+
 export interface NotificationPreference {
   notification_type: string;
   notification_name: string;
   description: string | null;
   category: string;
   /**
-   * Per-channel enabled state, keyed by channel code (`in_app`, `email`).
-   * Matches the backend `NotificationPreferenceResponse` shape: the API
-   * returns ONE row per type with a channels map, NOT one row per
-   * (type, channel) pair.
+   * Per-channel enabled state, keyed by channel code (`in_app`, `email`,
+   * `push`). Kept for backward compatibility (`enabled = frequency != off`);
+   * the frequency-aware UI reads `frequencies` instead. The API returns ONE
+   * row per type with these maps, NOT one row per (type, channel) pair.
    */
   channels: Record<string, boolean>;
+  /**
+   * Per-channel effective frequency (`instant` | `digest` | `off`) after the
+   * system → workspace → user inheritance resolution.
+   */
+  frequencies: Record<string, NotificationFrequency>;
+  /**
+   * Channels the workspace admin has locked for this type. A locked cell is
+   * enforced by the workspace default and the user cannot override it — the
+   * UI renders it read-only.
+   */
+  locked: Record<string, boolean>;
+}
+
+/**
+ * A workspace admin's notification DEFAULT for one type (the middle layer of
+ * the system → workspace → user inheritance). `frequencies` is the workspace
+ * default per channel (falling back to the system default); `locked` marks
+ * cells members cannot override. Mirrors `WorkspaceNotificationDefaultResponse`.
+ */
+export interface WorkspaceNotificationDefault {
+  notification_type: string;
+  notification_name: string;
+  description: string | null;
+  category: string;
+  frequencies: Record<string, NotificationFrequency>;
+  locked: Record<string, boolean>;
 }
 
 export interface NotificationPreferencesResponse {
@@ -120,10 +162,17 @@ export const NOTIFICATION_CHANNELS = [
     description: 'Email notifications (rate limited)',
     icon: 'mail',
   },
+  {
+    code: 'push',
+    name: 'Push',
+    description: 'Mobile push notifications',
+    icon: 'bell',
+  },
 ] as const;
 
 /**
- * Get user's notification preferences
+ * Get user's notification preferences (per-type rows with `frequencies` +
+ * `locked` maps). The matrix UI renders directly from these rows.
  */
 export async function getNotificationPreferences(): Promise<NotificationPreference[]> {
   const response = await apiClient.get<NotificationPreference[]>('/notifications/preferences');
@@ -131,17 +180,48 @@ export async function getNotificationPreferences(): Promise<NotificationPreferen
 }
 
 /**
- * Update a notification preference
+ * Set the delivery frequency for one (type, channel) cell of the signed-in
+ * user's preferences. `digest` coerces to `instant` on non-batching channels
+ * server-side.
  */
 export async function updateNotificationPreference(
   notificationType: string,
   channel: string,
-  enabled: boolean
+  frequency: NotificationFrequency
 ): Promise<void> {
   await apiClient.put('/notifications/preferences', {
     notification_type: notificationType,
     channel,
-    enabled,
+    frequency,
+  });
+}
+
+/**
+ * Get the workspace's notification DEFAULTS matrix (admin-only). One row per
+ * type with the effective default frequency + `locked` per channel.
+ */
+export async function getWorkspaceNotificationDefaults(): Promise<WorkspaceNotificationDefault[]> {
+  const response = await apiClient.get<WorkspaceNotificationDefault[]>(
+    '/admin/notification-defaults'
+  );
+  return response.data;
+}
+
+/**
+ * Set one (type, channel) cell of the workspace default matrix (admin-only).
+ * `locked` prevents members from overriding this cell.
+ */
+export async function updateWorkspaceNotificationDefault(
+  notificationType: string,
+  channel: string,
+  frequency: NotificationFrequency,
+  locked: boolean
+): Promise<void> {
+  await apiClient.put('/admin/notification-defaults', {
+    notification_type: notificationType,
+    channel,
+    frequency,
+    locked,
   });
 }
 
@@ -234,6 +314,9 @@ export async function deleteNotifications(notificationIds: number[]): Promise<vo
 export default {
   getNotificationPreferences,
   updateNotificationPreference,
+  getWorkspaceNotificationDefaults,
+  updateWorkspaceNotificationDefault,
+  channelSupportsDigest,
   deleteNotifications,
   getNotifications,
   getUnreadCount,


### PR DESCRIPTION
Completes the **frontend** for the notification-preferences feature (backend shipped in #109–#112). Two Vue screens, both **data-driven from the API** so all ten notification types render (no more stale static six).

## Research-backed design
Industry converges on a **type × channel matrix** with per-cell control, quiet defaults, and — for org defaults — a **visible, intentional lock** ("managed by your organization"; the admin default is the ceiling). Both screens follow that.

## User preferences — `NotificationSettings.vue`
- Per-cell **frequency select** (Instant / Daily digest / Off) replacing the on/off toggle. `digest` is offered **only on email** (`channelSupportsDigest`), mirroring the backend.
- New **Push** channel column (forward-compatible; footnote explains it delivers to the mobile app once signed in on a device).
- **Admin-locked** cells render read-only with a lock affordance + hint ("Set by your workspace admin").
- Quick-settings **bulk-apply** per channel (shows the aggregate, or *Mixed*).

## Admin defaults — `views/admin/NotificationDefaultsView.vue` (new)
- Workspace-wide **default matrix** (the middle inheritance layer): per-cell frequency select + a **lock toggle** per cell, with an explainer of the ceiling semantics.
- Admin-gated via the `/admin` parent route meta; new router route + admin nav item (Communication group).

## Service — `@nosdesk/core/notificationService`
- `NotificationPreference` gains `frequencies` + `locked`; **Push** added to `NOTIFICATION_CHANNELS`; `updateNotificationPreference` now sends `frequency`.
- New `WorkspaceNotificationDefault` type + get/update admin-defaults methods + `channelSupportsDigest` helper.

## i18n
New keys across **all five locales** (en-AU / en-GB / en-US, fr-FR, nl-NL) — full translations, not fallbacks.

## Verification
Ran the frontend CI steps locally — all green: `vue-tsc`, `ESLint + view-root check`, `@nosdesk/core` type-check + boundary lint.