### PR TITLE
Notifications: context-enriched push + admin content-level toggle

### DIFF
--- a/backend/src/handlers/notifications.rs
+++ b/backend/src/handlers/notifications.rs
@@ -106,6 +106,15 @@ pub fn config(cfg: &mut web::ServiceConfig) {
             "/admin/notification-defaults",
             web::put().to(update_workspace_notification_default),
         )
+        // Workspace push content level (detailed vs private). Admin-gated.
+        .route(
+            "/admin/notification-content",
+            web::get().to(get_notification_content_level),
+        )
+        .route(
+            "/admin/notification-content",
+            web::put().to(set_notification_content_level),
+        )
         // Push device registration (per authenticated user).
         .route(
             "/notifications/devices",
@@ -303,6 +312,82 @@ pub async fn update_workspace_notification_default(
     {
         Ok(_) => HttpResponse::Ok().json(serde_json::json!({ "success": true })),
         Err(e) => HttpResponse::InternalServerError().json(serde_json::json!({ "error": e })),
+    }
+}
+
+/// Request body for setting the workspace push content level.
+#[derive(Debug, Deserialize)]
+pub struct UpdateContentLevelRequest {
+    /// `detailed` (rich context) | `private` ("tap to view").
+    pub detail: String,
+}
+
+/// GET /api/admin/notification-content — the workspace's push content level.
+/// Admin-only.
+pub async fn get_notification_content_level(
+    req: HttpRequest,
+    pool: web::Data<Pool>,
+) -> HttpResponse {
+    if let Err(e) = require_workspace_role(&req, WorkspaceRole::Admin) {
+        return e;
+    }
+    let Some(workspace_id) = actor_workspace_id(&req) else {
+        return errors::unauthorized("Authentication required");
+    };
+    let mut conn = match errors::db_conn(&pool) {
+        Ok(c) => c,
+        Err(resp) => return resp,
+    };
+    match crate::repository::workspaces::get_notification_push_detail(&mut conn, workspace_id) {
+        Ok(detailed) => HttpResponse::Ok().json(serde_json::json!({
+            "detail": if detailed { "detailed" } else { "private" }
+        })),
+        Err(e) => {
+            HttpResponse::InternalServerError().json(serde_json::json!({ "error": e.to_string() }))
+        }
+    }
+}
+
+/// PUT /api/admin/notification-content — set the workspace push content level.
+/// Admin-only.
+pub async fn set_notification_content_level(
+    req: HttpRequest,
+    pool: web::Data<Pool>,
+    body: web::Json<UpdateContentLevelRequest>,
+) -> HttpResponse {
+    if let Err(e) = require_workspace_role(&req, WorkspaceRole::Admin) {
+        return e;
+    }
+    let detailed = match body.detail.as_str() {
+        "detailed" => true,
+        "private" => false,
+        other => return errors::bad_request(format!("Invalid detail: {other}")),
+    };
+    let claims = match req.extensions().get::<Claims>() {
+        Some(c) => c.clone(),
+        None => return HttpResponse::Unauthorized().finish(),
+    };
+    let user_uuid = match uuid::Uuid::parse_str(&claims.sub) {
+        Ok(u) => u,
+        Err(_) => return errors::bad_request("Invalid user UUID"),
+    };
+    let Some(workspace_id) = actor_workspace_id(&req) else {
+        return errors::unauthorized("Authentication required");
+    };
+    let mut conn = match errors::db_conn(&pool) {
+        Ok(c) => c,
+        Err(resp) => return resp,
+    };
+    let actor =
+        crate::sync::actor::ActorContext::user(user_uuid, None).with_workspace(workspace_id);
+    let res = crate::sync::session::with_actor_bypass_context(&mut conn, &actor, |conn| {
+        crate::repository::workspaces::set_notification_push_detail(conn, workspace_id, detailed)
+    });
+    match res {
+        Ok(_) => HttpResponse::Ok().json(serde_json::json!({ "success": true })),
+        Err(e) => {
+            HttpResponse::InternalServerError().json(serde_json::json!({ "error": e.to_string() }))
+        }
     }
 }
 

--- a/backend/src/repository/workspaces.rs
+++ b/backend/src/repository/workspaces.rs
@@ -365,6 +365,44 @@ pub fn set_seat_limit(
         .execute(conn)
 }
 
+/// Whether the workspace's push notifications carry rich context (`detailed`,
+/// the default) or only the generic type label (`private`, "tap to view").
+/// Read from `settings.notification_push_detail`; absent/unknown → detailed.
+pub fn get_notification_push_detail(
+    conn: &mut DbConnection,
+    workspace_id: i32,
+) -> QueryResult<bool> {
+    let settings: Option<serde_json::Value> = workspaces::table
+        .filter(workspaces::id.eq(workspace_id))
+        .select(workspaces::settings)
+        .first(conn)
+        .optional()?;
+    Ok(settings
+        .as_ref()
+        .and_then(|s| s.get("notification_push_detail"))
+        .and_then(|v| v.as_str())
+        != Some("private"))
+}
+
+// sync-audit-only: server-side workspace notification preference on the global `workspaces` meta-table; not on any tenant's live-sync stream
+/// Set the workspace's push content level (admin): `true` = detailed (rich
+/// context), `false` = private ("tap to view"). Merges into the `settings`
+/// JSONB via `jsonb_set` so other keys are preserved.
+pub fn set_notification_push_detail(
+    conn: &mut DbConnection,
+    workspace_id: i32,
+    detailed: bool,
+) -> QueryResult<usize> {
+    let value = if detailed { "detailed" } else { "private" };
+    diesel::sql_query(
+        "UPDATE workspaces SET settings = jsonb_set(COALESCE(settings, '{}'::jsonb), \
+         '{notification_push_detail}', to_jsonb($1::text)) WHERE id = $2",
+    )
+    .bind::<diesel::sql_types::Text, _>(value)
+    .bind::<diesel::sql_types::Integer, _>(workspace_id)
+    .execute(conn)
+}
+
 /// Resolve the workspace that should be the audit-context root for a
 /// credential-verified-but-pre-session action on this user (MFA
 /// enable at login, password-reset confirm, invitation accept). In

--- a/backend/src/services/notifications/channels/push.rs
+++ b/backend/src/services/notifications/channels/push.rs
@@ -5,10 +5,13 @@
 //! is false, so push preferences are visible in settings yet inert (nothing is
 //! silently dropped — `notify()` filters out unavailable channels).
 //!
-//! **Privacy:** the payload is minimal — a generic title from the notification
-//! type + an entity ref for the deep-link, never the ticket subject/body. The
-//! app fetches real content after the tap, so Apple/Google/FCM never see
-//! customer data.
+//! **Privacy:** the payload carries CONTEXT, never message content. In the
+//! workspace's `detailed` mode (admin default): the ticket subject + a "who did
+//! what" line (`push_body`) — the same information already in the notification
+//! email. In `private` mode: only the generic type label ("tap to view"). A
+//! comment's text, etc. is never sent in either mode. Lock-screen exposure is
+//! handled by the OS (iOS "Show Previews: When Unlocked"; Android `visibility:
+//! PRIVATE`). Set via `workspaces.settings.notification_push_detail`.
 
 use async_trait::async_trait;
 use std::sync::Arc;
@@ -17,11 +20,16 @@ use super::super::types::{DeliverableNotification, NotificationChannel};
 use super::{ChannelError, ChannelResult, NotificationDeliveryChannel};
 use crate::db::Pool;
 
-/// A minimal, PII-free push payload.
+/// A push payload. Content is context-only (never the message body itself):
+/// in the workspace's `detailed` mode `title` is the ticket subject and `body`
+/// is a "who did what" line; in `private` mode `title` is the generic type
+/// label and `body` is `None` ("tap to view"). Either way it carries no comment
+/// text — the same exposure as the notification email.
 #[derive(Debug, Clone)]
 pub struct PushPayload {
-    /// Generic, derived from the notification type (e.g. "Assigned to Ticket").
     pub title: String,
+    /// Context line ("Alice mentioned you"); `None` in the workspace's private mode.
+    pub body: Option<String>,
     pub notification_type: String,
     pub entity_type: String,
     pub entity_id: i32,
@@ -102,9 +110,42 @@ impl NotificationDeliveryChannel for PushChannel {
             return Ok(());
         }
 
+        // Workspace admin content level: `detailed` (default) enriches the push
+        // with context — the ticket subject + a "who did what" line; `private`
+        // sends only the generic type label ("tap to view"). Never the message
+        // body itself, in either mode.
+        let detailed = crate::sync::session::background_run(
+            &self.pool,
+            "background:push_ws_content_level",
+            |conn| {
+                crate::repository::workspaces::get_notification_push_detail(
+                    conn,
+                    notification.payload.workspace_id,
+                )
+            },
+        )
+        .unwrap_or(true);
+
+        let ntype = &notification.payload.notification_type;
+        let (title, body) = if detailed {
+            let ctx = notification.payload.entity.context_title();
+            let title = if ctx.trim().is_empty() {
+                ntype.title().to_string()
+            } else {
+                ctx
+            };
+            (
+                title,
+                Some(ntype.push_body(&notification.payload.actor.name)),
+            )
+        } else {
+            (ntype.title().to_string(), None)
+        };
+
         let payload = PushPayload {
-            title: notification.payload.notification_type.title().to_string(),
-            notification_type: notification.payload.notification_type.as_str().to_string(),
+            title,
+            body,
+            notification_type: ntype.as_str().to_string(),
             entity_type: notification.payload.entity.entity_type().to_string(),
             entity_id: notification.payload.entity.entity_id(),
             ticket_id: notification.payload.entity.ticket_id(),

--- a/backend/src/services/notifications/channels/push_sender.rs
+++ b/backend/src/services/notifications/channels/push_sender.rs
@@ -173,8 +173,16 @@ impl ApnsClient {
             }
         };
 
+        // `alert.body` is present only in the workspace's `detailed` mode. Lock-
+        // screen privacy relies on the OS "Show Previews: When Unlocked" default
+        // (there is no server-side hide-on-lock flag for a standard iOS alert).
+        let mut alert = serde_json::Map::new();
+        alert.insert("title".into(), json!(payload.title));
+        if let Some(body_text) = &payload.body {
+            alert.insert("body".into(), json!(body_text));
+        }
         let body = json!({
-            "aps": { "alert": { "title": payload.title }, "sound": "default" },
+            "aps": { "alert": alert, "sound": "default" },
             "nd_type": payload.notification_type,
             "entity_type": payload.entity_type,
             "entity_id": payload.entity_id,
@@ -356,11 +364,19 @@ impl FcmClient {
             }
         };
 
-        // FCM data values must be strings.
+        // `notification.body` only in the workspace's `detailed` mode. FCM data
+        // values must be strings. `visibility: PRIVATE` hides the content on the
+        // Android secure lock screen (a redacted public version shows instead).
+        let mut notif = serde_json::Map::new();
+        notif.insert("title".into(), json!(payload.title));
+        if let Some(body_text) = &payload.body {
+            notif.insert("body".into(), json!(body_text));
+        }
         let body = json!({
             "message": {
                 "token": device_token,
-                "notification": { "title": payload.title },
+                "notification": notif,
+                "android": { "notification": { "visibility": "PRIVATE" } },
                 "data": {
                     "nd_type": payload.notification_type,
                     "entity_type": payload.entity_type,
@@ -536,6 +552,7 @@ mod tests {
         }];
         let payload = PushPayload {
             title: "t".to_string(),
+            body: Some("Assigned to you".to_string()),
             notification_type: "ticket_assigned".to_string(),
             entity_type: "ticket".to_string(),
             entity_id: 1,

--- a/backend/src/services/notifications/types.rs
+++ b/backend/src/services/notifications/types.rs
@@ -70,6 +70,44 @@ impl NotificationTypeCode {
             Self::LoanOverdue => "Loan Overdue",
         }
     }
+
+    /// Short "who did what" line for a context-enriched push body — combined with
+    /// the entity's `context_title()` it reads e.g. "Alice mentioned you" under
+    /// the ticket subject. Never includes message content. `actor` is the person
+    /// who triggered it; empty or "System" collapses to an actor-less phrase.
+    pub fn push_body(&self, actor: &str) -> String {
+        let who = match actor.trim() {
+            "" | "System" => None,
+            name => Some(name),
+        };
+        match self {
+            Self::TicketAssigned => match who {
+                Some(a) => format!("Assigned to you by {a}"),
+                None => "Assigned to you".to_string(),
+            },
+            Self::CommentAdded => match who {
+                Some(a) => format!("{a} commented"),
+                None => "New comment".to_string(),
+            },
+            Self::Mentioned => match who {
+                Some(a) => format!("{a} mentioned you"),
+                None => "You were mentioned".to_string(),
+            },
+            Self::TicketStatusChanged => match who {
+                Some(a) => format!("Status changed by {a}"),
+                None => "Status changed".to_string(),
+            },
+            Self::TicketCreatedRequester => "Ticket created".to_string(),
+            Self::DocPageUpdated => match who {
+                Some(a) => format!("Updated by {a}"),
+                None => "Page updated".to_string(),
+            },
+            Self::AssetLowStock => "Low stock".to_string(),
+            Self::SlaBreached => "SLA target missed".to_string(),
+            Self::LoanDueSoon => "Due back soon".to_string(),
+            Self::LoanOverdue => "Overdue".to_string(),
+        }
+    }
 }
 
 /// Delivery channel types
@@ -217,6 +255,20 @@ impl NotificationEntity {
             Self::Comment { ticket_id, .. } => *ticket_id,
             Self::DocumentationPage { .. } => 0,
             Self::Asset { .. } => 0,
+        }
+    }
+
+    /// The human "what this is about" title for a context-enriched push: the
+    /// ticket subject / page title / asset name. This is context, NEVER the
+    /// message content itself (e.g. a comment's text), so an enriched push
+    /// exposes only the subject line + who acted — the same information already
+    /// present in the notification email.
+    pub fn context_title(&self) -> String {
+        match self {
+            Self::Ticket { title, .. } => title.clone(),
+            Self::Comment { ticket_title, .. } => ticket_title.clone(),
+            Self::DocumentationPage { title, .. } => title.clone(),
+            Self::Asset { name, .. } => name.clone(),
         }
     }
 }

--- a/frontend/src/views/admin/NotificationDefaultsView.vue
+++ b/frontend/src/views/admin/NotificationDefaultsView.vue
@@ -15,13 +15,17 @@ import Callout from '@/components/common/Callout.vue';
 import SectionCard from '@/components/common/SectionCard.vue';
 import AlertMessage from '@/components/common/AlertMessage.vue';
 import BaseDropdown, { type DropdownOption } from '@/components/common/BaseDropdown.vue';
+import SegmentedControl from '@/components/common/SegmentedControl.vue';
 import {
   getWorkspaceNotificationDefaults,
   updateWorkspaceNotificationDefault,
+  getNotificationContentLevel,
+  setNotificationContentLevel,
   channelSupportsDigest,
   NOTIFICATION_CHANNELS,
   type WorkspaceNotificationDefault,
   type NotificationFrequency,
+  type NotificationContentLevel,
 } from '@nosdesk/core/services/notificationService';
 import { useToastStore } from '@nosdesk/core/stores/toast';
 import { extractErrorMessage } from '@/utils/errors';
@@ -42,6 +46,30 @@ const isLoading = ref(true);
 const loadError = ref('');
 const saving = ref<string | null>(null);
 const defaults = ref<WorkspaceNotificationDefault[]>([]);
+
+// Push content level (workspace-wide): detailed context vs private "tap to view".
+const contentLevel = ref<NotificationContentLevel>('detailed');
+const contentSaving = ref(false);
+const contentOptions = computed(() => [
+  { value: 'detailed', label: t('admin-notification-content-detailed') },
+  { value: 'private', label: t('admin-notification-content-private') },
+]);
+
+const setContentLevel = async (level: NotificationContentLevel) => {
+  if (level === contentLevel.value) return;
+  const previous = contentLevel.value;
+  contentLevel.value = level;
+  contentSaving.value = true;
+  try {
+    await setNotificationContentLevel(level);
+    toast.success(t('admin-notification-content-saved'));
+  } catch (err) {
+    contentLevel.value = previous;
+    toast.error(extractErrorMessage(err, t('admin-notification-content-error')));
+  } finally {
+    contentSaving.value = false;
+  }
+};
 
 const channels = computed(() =>
   NOTIFICATION_CHANNELS.map((channel) => ({
@@ -146,7 +174,12 @@ const toggleLock = (row: WorkspaceNotificationDefault, channelCode: string) =>
 
 onMounted(async () => {
   try {
-    defaults.value = await getWorkspaceNotificationDefaults();
+    const [rows, level] = await Promise.all([
+      getWorkspaceNotificationDefaults(),
+      getNotificationContentLevel().catch(() => 'detailed' as NotificationContentLevel),
+    ]);
+    defaults.value = rows;
+    contentLevel.value = level;
   } catch (err) {
     loadError.value = extractErrorMessage(err, t('admin-notification-defaults-error-load'));
   } finally {
@@ -174,6 +207,25 @@ const gridColumns = computed(
         <template #header>{{ t('admin-notification-defaults-lock-explainer-title') }}</template>
         {{ t('admin-notification-defaults-lock-explainer-body') }}
       </Callout>
+
+      <!-- Push content level: detailed context vs private "tap to view". -->
+      <SectionCard content-padding="p-4 sm:p-6">
+        <template #leading>
+          <span class="text-accent inline-flex"><Icon name="bell" /></span>
+        </template>
+        <template #title>{{ t('admin-notification-content-title') }}</template>
+        <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <p class="text-sm text-secondary">{{ t('admin-notification-content-description') }}</p>
+          <div class="flex-shrink-0" :class="{ 'opacity-60 pointer-events-none': contentSaving }">
+            <SegmentedControl
+              :model-value="contentLevel"
+              :options="contentOptions"
+              :aria-label="t('admin-notification-content-title')"
+              @update:model-value="setContentLevel($event as NotificationContentLevel)"
+            />
+          </div>
+        </div>
+      </SectionCard>
 
       <AlertMessage v-if="loadError" type="error" :message="loadError" />
 

--- a/i18n/locales/en-AU/main.ftl
+++ b/i18n/locales/en-AU/main.ftl
@@ -3038,6 +3038,12 @@ admin-notification-defaults-error-load = Couldn't load notification defaults
 admin-nav-notification-defaults-title = Notification defaults
 admin-nav-notification-defaults-description = Set workspace-wide notification defaults members inherit
 route-title-admin-notification-defaults = Notification defaults
+admin-notification-content-title = Push notification detail
+admin-notification-content-description = How much a mobile push shows. Detailed includes the ticket subject and who acted (never the message text); Private shows only the type — members tap to view.
+admin-notification-content-detailed = Detailed
+admin-notification-content-private = Private
+admin-notification-content-saved = Notification detail updated
+admin-notification-content-error = Couldn't update notification detail
 
 # Settings: passkeys (PasskeySettings)
 settings-passkey-section-title = Passkeys

--- a/i18n/locales/en-GB/main.ftl
+++ b/i18n/locales/en-GB/main.ftl
@@ -3026,6 +3026,12 @@ admin-notification-defaults-error-load = Couldn't load notification defaults
 admin-nav-notification-defaults-title = Notification defaults
 admin-nav-notification-defaults-description = Set workspace-wide notification defaults members inherit
 route-title-admin-notification-defaults = Notification defaults
+admin-notification-content-title = Push notification detail
+admin-notification-content-description = How much a mobile push shows. Detailed includes the ticket subject and who acted (never the message text); Private shows only the type — members tap to view.
+admin-notification-content-detailed = Detailed
+admin-notification-content-private = Private
+admin-notification-content-saved = Notification detail updated
+admin-notification-content-error = Couldn't update notification detail
 
 # Settings: passkeys (PasskeySettings)
 settings-passkey-section-title = Passkeys

--- a/i18n/locales/en-US/main.ftl
+++ b/i18n/locales/en-US/main.ftl
@@ -3674,6 +3674,12 @@ admin-notification-defaults-error-load = Couldn't load notification defaults
 admin-nav-notification-defaults-title = Notification defaults
 admin-nav-notification-defaults-description = Set workspace-wide notification defaults members inherit
 route-title-admin-notification-defaults = Notification defaults
+admin-notification-content-title = Push notification detail
+admin-notification-content-description = How much a mobile push shows. Detailed includes the ticket subject and who acted (never the message text); Private shows only the type — members tap to view.
+admin-notification-content-detailed = Detailed
+admin-notification-content-private = Private
+admin-notification-content-saved = Notification detail updated
+admin-notification-content-error = Couldn't update notification detail
 
 # Settings: passkeys (PasskeySettings)
 settings-passkey-section-title = Passkeys

--- a/i18n/locales/fr-FR/main.ftl
+++ b/i18n/locales/fr-FR/main.ftl
@@ -3516,6 +3516,12 @@ admin-notification-defaults-error-load = Impossible de charger les paramètres d
 admin-nav-notification-defaults-title = Paramètres de notification par défaut
 admin-nav-notification-defaults-description = Définir les paramètres de notification par défaut de l'espace de travail dont héritent les membres
 route-title-admin-notification-defaults = Paramètres de notification par défaut
+admin-notification-content-title = Détail des notifications push
+admin-notification-content-description = Ce qu'affiche une notification push mobile. Détaillé inclut le sujet du ticket et l'auteur de l'action (jamais le texte du message) ; Privé n'affiche que le type — les membres appuient pour voir.
+admin-notification-content-detailed = Détaillé
+admin-notification-content-private = Privé
+admin-notification-content-saved = Détail des notifications mis à jour
+admin-notification-content-error = Impossible de mettre à jour le détail des notifications
 
 # Paramètres : clés d'accès (PasskeySettings)
 settings-passkey-section-title = Clés d'accès

--- a/i18n/locales/nl-NL/main.ftl
+++ b/i18n/locales/nl-NL/main.ftl
@@ -3507,6 +3507,12 @@ admin-notification-defaults-error-load = Kan standaard meldingsinstellingen niet
 admin-nav-notification-defaults-title = Standaard meldingsinstellingen
 admin-nav-notification-defaults-description = Werkruimtebrede standaard meldingsinstellingen instellen die leden erven
 route-title-admin-notification-defaults = Standaard meldingsinstellingen
+admin-notification-content-title = Detail van pushmeldingen
+admin-notification-content-description = Hoeveel een mobiele pushmelding toont. Gedetailleerd bevat het ticketonderwerp en wie de actie deed (nooit de berichttekst); Privé toont alleen het type — leden tikken om te bekijken.
+admin-notification-content-detailed = Gedetailleerd
+admin-notification-content-private = Privé
+admin-notification-content-saved = Meldingsdetail bijgewerkt
+admin-notification-content-error = Kan meldingsdetail niet bijwerken
 
 # Instellingen: passkeys (PasskeySettings)
 settings-passkey-section-title = Passkeys

--- a/packages/core/src/services/notificationService.ts
+++ b/packages/core/src/services/notificationService.ts
@@ -225,6 +225,25 @@ export async function updateWorkspaceNotificationDefault(
   });
 }
 
+/** Workspace push content level: `detailed` (ticket subject + who acted) or
+ *  `private` (generic label, "tap to view"). Admin-controlled. */
+export type NotificationContentLevel = 'detailed' | 'private';
+
+/** Get the workspace's push content level (admin-only). */
+export async function getNotificationContentLevel(): Promise<NotificationContentLevel> {
+  const response = await apiClient.get<{ detail: NotificationContentLevel }>(
+    '/admin/notification-content'
+  );
+  return response.data.detail;
+}
+
+/** Set the workspace's push content level (admin-only). */
+export async function setNotificationContentLevel(
+  detail: NotificationContentLevel
+): Promise<void> {
+  await apiClient.put('/admin/notification-content', { detail });
+}
+
 /**
  * Get user's notifications
  */
@@ -316,6 +335,8 @@ export default {
   updateNotificationPreference,
   getWorkspaceNotificationDefaults,
   updateWorkspaceNotificationDefault,
+  getNotificationContentLevel,
+  setNotificationContentLevel,
   channelSupportsDigest,
   deleteNotifications,
   getNotifications,


### PR DESCRIPTION
Push notifications now carry **context** instead of just a generic type label — "Printer offline" / "Alice mentioned you" — while staying privacy-respecting.

## Design (per the research + discussion)
- **Context, never message content.** The push shows the ticket subject (`entity.context_title()`) + a "who did what" line (`type.push_body()`) — the *same* information already in the notification email. A comment's text is never sent.
- **Workspace admin toggle** `notification_push_detail` (rides `workspaces.settings` JSONB — **no migration**): **Detailed** (default) vs **Private** ("tap to view", the old minimal payload). For workspaces with genuinely sensitive tickets (HR, security, regulated).
- **Lock screen handled by the OS**: iOS relies on the "Show Previews: When Unlocked" default (no server-side hide flag exists for standard alerts); Android gets `visibility: PRIVATE`.

## Why not Signal-grade (a Notification Service Extension)?
The identical content already flows through **email/SES**, which traverses more intermediaries than a push. Building an on-device fetch/decrypt extension to hide a ticket subject from Apple while it's plaintext in an email would be privacy theater — disproportionate to the gain for internal helpdesk data. The admin toggle is the cheap, right-sized control.

## Changes
- `types.rs`: `entity.context_title()` + `type.push_body(actor)`.
- `channels/push.rs`: level-aware payload (detailed context vs minimal).
- `channels/push_sender.rs`: APNs `alert.body`, FCM `notification.body` + `visibility: PRIVATE`.
- `repository/workspaces.rs`: `get/set_notification_push_detail` (write has the `sync-audit-only` marker).
- `handlers/notifications.rs`: admin `GET/PUT /api/admin/notification-content`.
- Frontend: `getNotificationContentLevel`/`setNotificationContentLevel` + a SegmentedControl in the admin defaults view + i18n across all 5 locales.

## Verification
`cargo check --all-targets`, `@nosdesk/core` + frontend `vue-tsc`, frontend ESLint + view-root — all clean locally. No migration.