### PR TITLE
OIDC RP-initiated logout (end IdP session) + login workspace-selection fix

### DIFF
--- a/backend/migrations/2026-07-18-000000_active_sessions_oidc_id_token/down.sql
+++ b/backend/migrations/2026-07-18-000000_active_sessions_oidc_id_token/down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE active_sessions
+    DROP COLUMN oidc_id_token;

--- a/backend/migrations/2026-07-18-000000_active_sessions_oidc_id_token/up.sql
+++ b/backend/migrations/2026-07-18-000000_active_sessions_oidc_id_token/up.sql
@@ -1,0 +1,11 @@
+-- Store the OIDC id_token minted at login on the session row, so a later
+-- RP-initiated logout can pass it as `id_token_hint` to the provider's
+-- end_session endpoint (Hydra rejects a post_logout_redirect_uri without it).
+-- Only the OIDC login paths (web callback + mobile native-login) populate it;
+-- local/password logins leave it NULL. Cleared implicitly when the session row
+-- is revoked on logout.
+--
+-- Additive + nullable with no backfill, so there is no audit-trigger backfill
+-- hazard; active_sessions carries no audit trigger and no workspace_id anyway.
+ALTER TABLE active_sessions
+    ADD COLUMN oidc_id_token text;

--- a/backend/src/handlers/auth.rs
+++ b/backend/src/handlers/auth.rs
@@ -241,6 +241,7 @@ pub fn create_session_record(
     user_uuid: &Uuid,
     request: &HttpRequest,
     conn: &mut DbConnection,
+    oidc_id_token: Option<&str>,
 ) -> Result<crate::models::ActiveSession, diesel::result::Error> {
     // Resolve the client IP once: stored as INET, and (when a GeoIP
     // database is configured) used for a coarse "City, Country" label.
@@ -266,6 +267,7 @@ pub fn create_session_record(
         location,
         expires_at: chrono::Utc::now().naive_utc() + chrono::Duration::days(7),
         is_current: true,
+        oidc_id_token: oidc_id_token.map(str::to_owned),
     };
 
     crate::repository::active_sessions::create_session(conn, new_session)
@@ -278,7 +280,8 @@ pub(crate) fn complete_login(
     request: &HttpRequest,
     conn: &mut DbConnection,
 ) -> HttpResponse {
-    match establish_login_session(user, request, conn) {
+    // Local / password logins carry no OIDC id_token.
+    match establish_login_session(user, request, conn, None) {
         Ok((response, tokens)) => build_auth_response(request, response, &tokens),
         Err(error_response) => error_response,
     }
@@ -296,8 +299,9 @@ pub(crate) fn complete_login_redirect(
     request: &HttpRequest,
     conn: &mut DbConnection,
     location: &str,
+    oidc_id_token: Option<&str>,
 ) -> HttpResponse {
-    match establish_login_session(user, request, conn) {
+    match establish_login_session(user, request, conn, oidc_id_token) {
         Ok((_response, tokens)) => build_auth_cookie_redirect(&tokens, location),
         Err(error_response) => error_response,
     }
@@ -309,6 +313,7 @@ pub(crate) fn establish_login_session(
     user: crate::models::User,
     request: &HttpRequest,
     conn: &mut DbConnection,
+    oidc_id_token: Option<&str>,
 ) -> Result<(crate::models::LoginResponse, jwt_helpers::LoginTokens), HttpResponse> {
     let user_uuid = user.uuid;
 
@@ -316,7 +321,7 @@ pub(crate) fn establish_login_session(
     // resolves under RLS (workspace_members is workspace-isolated).
     helpers::pin_request_workspace(request, conn);
 
-    let session = match create_session_record(&user_uuid, request, conn) {
+    let session = match create_session_record(&user_uuid, request, conn, oidc_id_token) {
         Ok(s) => s,
         Err(e) => {
             tracing::error!("Failed to create session for user {}: {}", user_uuid, e);
@@ -358,7 +363,7 @@ fn complete_mfa_login(
     // resolves under RLS (workspace_members is workspace-isolated).
     helpers::pin_request_workspace(request, conn);
 
-    let session = match create_session_record(&user_uuid, request, conn) {
+    let session = match create_session_record(&user_uuid, request, conn, None) {
         Ok(s) => s,
         Err(e) => {
             tracing::error!("Failed to create session for user {}: {}", user_uuid, e);
@@ -961,16 +966,52 @@ pub async fn recovery_login(
     )
 }
 
-/// Logout endpoint - revokes session from DB and clears cookies
-pub async fn logout(db_pool: web::Data<crate::db::Pool>, req: HttpRequest) -> impl Responder {
+/// Optional body for `/auth/logout`. When the caller wants RP-initiated
+/// (front-channel) logout at the OIDC provider, it passes the surface's
+/// `redirect_uri` (web: `<origin>/login`; mobile: `nosdesk://auth/logout-callback`)
+/// and gets back a `logout_url` to navigate to.
+#[derive(serde::Deserialize)]
+pub struct LogoutRequest {
+    pub redirect_uri: Option<String>,
+}
+
+/// Logout endpoint - revokes session from DB and clears cookies. When the
+/// session was established via OIDC and the caller supplies a `redirect_uri`,
+/// also returns a front-channel `logout_url` (with the session's stored
+/// id_token as `id_token_hint`) so the client can end the IdP session too.
+pub async fn logout(
+    db_pool: web::Data<crate::db::Pool>,
+    req: HttpRequest,
+    body: Option<web::Json<LogoutRequest>>,
+) -> impl Responder {
     use crate::utils::cookies::{
         delete_access_token_cookie, delete_csrf_token_cookie, delete_refresh_token_cookie,
     };
+
+    let redirect_uri = body.and_then(|b| b.into_inner().redirect_uri);
+    let mut logout_url: Option<String> = None;
 
     // Best-effort session revocation — CASCADE handles linked refresh_tokens
     if let (Ok(claims), Ok(mut conn)) = (JwtUtils::extract_claims(&req), helpers::db_conn(&db_pool))
     {
         if let Some(sid) = claims.session_uuid() {
+            // Build the RP-initiated logout URL BEFORE revoking (revocation
+            // deletes the row and its stored id_token). Only when the caller
+            // asked (redirect_uri) and this session carries an OIDC id_token.
+            // The redirect_uri is not trusted here: it only reaches the IdP's
+            // end_session URL, which Hydra validates against the client's
+            // registered post_logout_redirect_uris.
+            if let Some(redirect_uri) = redirect_uri.as_deref() {
+                if let Ok(session) =
+                    crate::repository::active_sessions::get_session_by_session_id(&mut conn, &sid)
+                {
+                    if let Some(id_token) = session.oidc_id_token.as_deref() {
+                        logout_url =
+                            crate::oidc::generate_logout_url(redirect_uri, Some(id_token), None)
+                                .await;
+                    }
+                }
+            }
             match crate::repository::active_sessions::revoke_session_by_uuid(&mut conn, &sid) {
                 Ok(n) => tracing::info!("Logout: revoked {n} session(s) for sid {sid}"),
                 Err(e) => tracing::warn!("Logout: failed to revoke session {sid}: {e}"),
@@ -998,7 +1039,11 @@ pub async fn logout(db_pool: web::Data<crate::db::Pool>, req: HttpRequest) -> im
         .cookie(delete_csrf_token_cookie())
         .json(json!({
             "success": true,
-            "message": "Logged out successfully"
+            "message": "Logged out successfully",
+            // Null unless this was an OIDC session and a redirect_uri was given.
+            // The client navigates here (web) / opens it in the system browser
+            // (mobile) to end the IdP session too.
+            "logout_url": logout_url
         }))
 }
 
@@ -2161,7 +2206,7 @@ pub async fn mfa_enable_login(
             // Pin the workspace so the response's workspace_role resolves
             // under RLS (workspace_members is workspace-isolated).
             helpers::pin_request_workspace(&http_request, &mut conn);
-            let session = match create_session_record(&user_uuid, &http_request, &mut conn) {
+            let session = match create_session_record(&user_uuid, &http_request, &mut conn, None) {
                 Ok(s) => s,
                 Err(e) => {
                     tracing::error!(
@@ -2534,7 +2579,7 @@ pub async fn refresh_token(
         Some(sid) => sid,
         None => {
             // Token created before this migration — create a new session
-            match create_session_record(&user.uuid, &request, &mut conn) {
+            match create_session_record(&user.uuid, &request, &mut conn, None) {
                 Ok(session) => session.session_id,
                 Err(e) => {
                     tracing::error!("Failed to create session during refresh: {}", e);

--- a/backend/src/handlers/auth_providers.rs
+++ b/backend/src/handlers/auth_providers.rs
@@ -812,6 +812,9 @@ pub async fn oauth_callback(
                         &request,
                         &mut conn,
                         &safe_post_login_location(&state_data.redirect_uri),
+                        // Microsoft logout uses its own endpoint (no id_token_hint
+                        // requirement), so nothing to store here.
+                        None,
                     )
                 }
             }
@@ -849,7 +852,7 @@ pub async fn oauth_callback(
         // hosted mode); it travels in the signed state, tamper-proof.
         match oidc::exchange_code(code, &auth_data, state_data.callback_redirect_uri.clone()).await
         {
-            Ok(user_info) => {
+            Ok((user_info, id_token)) => {
                 // Check if this is a user connection request (vs. a standard login)
                 if is_connection {
                     // Connection request - check if this identity is already linked
@@ -996,6 +999,7 @@ pub async fn oauth_callback(
                         &request,
                         &mut conn,
                         &safe_post_login_location(&state_data.redirect_uri),
+                        Some(&id_token),
                     )
                 }
             }
@@ -1512,7 +1516,13 @@ pub async fn native_oidc_login(
         }
     };
 
-    match crate::handlers::auth::establish_login_session(user, &request, &mut conn) {
+    match crate::handlers::auth::establish_login_session(
+        user,
+        &request,
+        &mut conn,
+        // The verified id_token the app presented, kept for RP-initiated logout.
+        Some(&body.id_token),
+    ) {
         Ok((response, tokens)) => {
             crate::handlers::auth::build_auth_response(&request, response, &tokens)
         }

--- a/backend/src/handlers/passkeys.rs
+++ b/backend/src/handlers/passkeys.rs
@@ -667,12 +667,13 @@ pub async fn finish_passkey_login(
     // (workspace_members is workspace-isolated).
     let user_uuid = user.uuid;
     super::helpers::pin_request_workspace(&req, &mut conn);
-    let session = super::auth::create_session_record(&user_uuid, &req, &mut conn).map_err(|e| {
-        error!(
-            "Failed to create session for passkey login {}: {:?}",
-            user_uuid, e
-        );
-    });
+    let session =
+        super::auth::create_session_record(&user_uuid, &req, &mut conn, None).map_err(|e| {
+            error!(
+                "Failed to create session for passkey login {}: {:?}",
+                user_uuid, e
+            );
+        });
     let session = match session {
         Ok(s) => s,
         Err(_) => return errors::internal("Failed to create authentication session"),
@@ -1319,12 +1320,13 @@ pub async fn finish_passkey_setup_login(
     // (workspace_members is workspace-isolated).
     let user_uuid = user.uuid;
     super::helpers::pin_request_workspace(&req, &mut conn);
-    let session = super::auth::create_session_record(&user_uuid, &req, &mut conn).map_err(|e| {
-        error!(
-            "Failed to create session for passkey setup login {}: {:?}",
-            user_uuid, e
-        );
-    });
+    let session =
+        super::auth::create_session_record(&user_uuid, &req, &mut conn, None).map_err(|e| {
+            error!(
+                "Failed to create session for passkey setup login {}: {:?}",
+                user_uuid, e
+            );
+        });
     let session = match session {
         Ok(s) => s,
         Err(_) => return errors::internal("Failed to create authentication session"),

--- a/backend/src/handlers/portal.rs
+++ b/backend/src/handlers/portal.rs
@@ -141,8 +141,8 @@ fn mint_portal_session(
     request: &HttpRequest,
     conn: &mut DbConnection,
 ) -> Result<PortalSessionCookies, HttpResponse> {
-    let session =
-        crate::handlers::auth::create_session_record(&user.uuid, request, conn).map_err(|e| {
+    let session = crate::handlers::auth::create_session_record(&user.uuid, request, conn, None)
+        .map_err(|e| {
             tracing::error!(error = ?e, "portal session: failed to create session record");
             HttpResponse::InternalServerError().json(json!({
                 "status": "error",

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -3812,6 +3812,10 @@ pub struct ActiveSession {
     pub expires_at: chrono::NaiveDateTime,
     pub is_current: bool,
     pub session_id: Uuid,
+    /// OIDC id_token from login, kept for RP-initiated logout (id_token_hint).
+    /// NULL for local/password logins. Queryable is positional, so this must
+    /// stay last, matching the appended column in the schema.
+    pub oidc_id_token: Option<String>,
 }
 
 /// New active session for creation
@@ -3825,6 +3829,8 @@ pub struct NewActiveSession {
     pub location: Option<String>,
     pub expires_at: chrono::NaiveDateTime,
     pub is_current: bool,
+    /// See `ActiveSession::oidc_id_token`. Set by the OIDC login paths only.
+    pub oidc_id_token: Option<String>,
 }
 
 /// Refresh token for JWT token rotation

--- a/backend/src/oidc.rs
+++ b/backend/src/oidc.rs
@@ -151,8 +151,15 @@ pub async fn generate_logout_url(
         params.push(("state", s.to_string()));
     }
 
-    if let Some(config) = get_config() {
-        params.push(("client_id", config.client_id.clone()));
+    // Only send `client_id` when there is NO `id_token_hint`. With a hint,
+    // Hydra identifies the client from the token, and a `client_id` that
+    // disagrees with the token's audience (e.g. the web client_id here vs a
+    // mobile id_token minted for the native client) is rejected. The hint is
+    // sufficient on its own.
+    if id_token_hint.is_none() {
+        if let Some(config) = get_config() {
+            params.push(("client_id", config.client_id.clone()));
+        }
     }
 
     let query_string: String = params
@@ -454,7 +461,7 @@ pub async fn exchange_code(
     // Per-tenant OAuth callback override (hosted mode); must equal the
     // redirect_uri used at authorize time. `None` uses the configured one.
     callback_redirect: Option<String>,
-) -> Result<OidcUserInfo, String> {
+) -> Result<(OidcUserInfo, String), String> {
     let client = get_oidc_client().await?;
     let config = OidcConfig::from_env()?;
 
@@ -483,12 +490,16 @@ pub async fn exchange_code(
 
     let user_info = extract_user_info(&claims, &config)?;
 
+    // Serialised (compact-JWT) id_token, kept for a later RP-initiated logout
+    // as the `id_token_hint`. The session row is where it comes to rest.
+    let id_token_str = id_token.to_string();
+
     info!(
         "OIDC: Successfully authenticated user with sub: {}",
         user_info.sub
     );
 
-    Ok(user_info)
+    Ok((user_info, id_token_str))
 }
 
 /// Verify an ID token presented by the native (mobile) app and return its user

--- a/backend/src/repository/active_sessions.rs
+++ b/backend/src/repository/active_sessions.rs
@@ -143,6 +143,7 @@ mod tests {
             location: None,
             expires_at: (Utc::now() + chrono::Duration::hours(1)).naive_utc(),
             is_current: false,
+            oidc_id_token: None,
         }
     }
 

--- a/backend/src/schema.rs
+++ b/backend/src/schema.rs
@@ -57,6 +57,7 @@ diesel::table! {
         expires_at -> Timestamptz,
         is_current -> Bool,
         session_id -> Uuid,
+        oidc_id_token -> Nullable<Text>,
     }
 }
 
@@ -2410,8 +2411,6 @@ diesel::joinable!(tickets -> ticket_categories (category_id));
 diesel::joinable!(tickets -> workflow_states (workflow_state_id));
 diesel::joinable!(tickets -> workspaces (workspace_id));
 diesel::joinable!(user_addresses -> workspaces (workspace_id));
-diesel::joinable!(user_push_devices -> users (user_uuid));
-diesel::joinable!(user_push_devices -> workspaces (workspace_id));
 diesel::joinable!(user_auth_identities -> workspaces (workspace_id));
 diesel::joinable!(user_field_schema -> users (created_by));
 diesel::joinable!(user_field_schema -> workspaces (workspace_id));
@@ -2420,6 +2419,8 @@ diesel::joinable!(user_groups -> workspaces (workspace_id));
 diesel::joinable!(user_phone_numbers -> workspaces (workspace_id));
 diesel::joinable!(user_preferences -> users (user_uuid));
 diesel::joinable!(user_profiles -> workspaces (workspace_id));
+diesel::joinable!(user_push_devices -> users (user_uuid));
+diesel::joinable!(user_push_devices -> workspaces (workspace_id));
 diesel::joinable!(user_recovery_codes -> users (user_uuid));
 diesel::joinable!(user_ticket_views -> tickets (ticket_id));
 diesel::joinable!(user_ticket_views -> users (user_uuid));

--- a/backend/tests/bearer_auth.rs
+++ b/backend/tests/bearer_auth.rs
@@ -55,6 +55,7 @@ fn session_jwt(pool: &backend::db::Pool, user: &backend::models::User) -> (uuid:
             location: None,
             expires_at: (chrono::Utc::now() + chrono::Duration::hours(1)).naive_utc(),
             is_current: true,
+            oidc_id_token: None,
         },
     )
     .expect("create active session");

--- a/backend/tests/sync_bootstrap_workspace_scope.rs
+++ b/backend/tests/sync_bootstrap_workspace_scope.rs
@@ -118,6 +118,7 @@ async fn bootstrap_streams_tickets_for_a_non_default_workspace() {
                 location: None,
                 expires_at: (chrono::Utc::now() + chrono::Duration::hours(1)).naive_utc(),
                 is_current: true,
+                oidc_id_token: None,
             },
         )
         .expect("create session");

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -2,7 +2,7 @@ import { createRouter, createWebHistory, type RouteLocationNormalized } from 'vu
 import { withWorkspaceRouting, installWorkspaceGuard, installSlugCarrier, workspaceSlugOf } from './workspaceRouting'
 import { installNavigationTracking } from './navigation'
 import { getWorkspaceRouting } from '@nosdesk/core/services/instanceConfig'
-import { lastWorkspaceSlug } from '@/services/activeWorkspace'
+import { lastWorkspaceSlug, setActiveWorkspaceSlug } from '@/services/activeWorkspace'
 import DashboardView from '../views/DashboardView.vue'
 import TicketView from '../views/TicketView.vue'
 import LoginView from '../views/LoginView.vue'
@@ -1046,6 +1046,32 @@ async function defaultWorkspaceSlug(): Promise<string | null> {
   const last = lastWorkspaceSlug();
   if (last && slugs.includes(last)) return last;
   return store.workspaces[0]?.slug ?? null;
+}
+
+/**
+ * Resolve where to land after a successful login, establishing the
+ * workspace selection eagerly. Login paths call this instead of pushing a
+ * bare `/`.
+ *
+ * Why login must own this: an in-app login (no full page reload — e.g. the
+ * Tauri app signing back in after sign-out, which clears the active-workspace
+ * slug) re-runs the guard's post-login landing against retained module state,
+ * where it can leave the slug unset. Every request then omits the
+ * `X-Nosdesk-Workspace` header and workspace-scoped calls fail closed
+ * (`NoWorkspaceSelected`), which no in-session refresh recovers — only a cold
+ * start does. Resolving + setting the slug here makes it deterministic.
+ *
+ * A `redirect` target from the login guard already carries its workspace slug
+ * (path-mode fullPaths are slugged), so it is honoured as-is; only the bare-`/`
+ * case needs the default workspace resolved. Host mode has no slug concept.
+ */
+export async function resolvePostLoginPath(redirect?: string | null): Promise<string> {
+  if (redirect && redirect !== '/') return redirect;
+  if (getWorkspaceRouting() !== 'path') return '/';
+  const slug = await defaultWorkspaceSlug();
+  if (!slug) return '/'; // no membership: the guard routes to no-workspace-access
+  setActiveWorkspaceSlug(slug);
+  return `/${slug}`;
 }
 
 /**

--- a/frontend/src/services/transport.ts
+++ b/frontend/src/services/transport.ts
@@ -46,6 +46,16 @@ const cookieAuthStrategy: AuthStrategy = {
   // The auth cookies are httpOnly, so JS can't clear them; the server's
   // /auth/logout does. A no-op here keeps the long-standing web behaviour.
   onSessionLost() {},
+  async endSession() {
+    // Clear the JS-accessible auth cookies on intentional sign-out. The
+    // httpOnly access/refresh cookies are cleared server-side by /auth/logout;
+    // csrf_token is not httpOnly, so clearing it here flips `hasSession()`
+    // (and the store's isAuthenticated) false immediately. The access/refresh
+    // lines are retained defensively for any non-httpOnly deployment.
+    document.cookie = 'csrf_token=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT'
+    document.cookie = 'access_token=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT'
+    document.cookie = 'refresh_token=; path=/api/auth/refresh; expires=Thu, 01 Jan 1970 00:00:00 GMT'
+  },
 }
 
 configureTransport({

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -13,6 +13,8 @@ import { translate } from '@/i18n';
 import { extractErrorMessage } from '@/utils/errors';
 import { activeWorkspaceSlug } from '@/services/activeWorkspace';
 import { getWorkspaceRouting } from '@nosdesk/core/services/instanceConfig';
+import { isTauriRuntime } from '@/platform';
+import { transport } from '@nosdesk/core/transport';
 
 // Configure axios to use relative URLs and send cookies
 // This will make requests go to the same server that served the frontend
@@ -488,11 +490,15 @@ export const useAuthStore = defineStore('auth', () => {
       // Continue with frontend logout even if backend call fails
     }
 
-    // Manually clear the csrf_token cookie (not httpOnly, so deletion is possible)
-    // This ensures isAuthenticated becomes false immediately
-    document.cookie = 'csrf_token=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT';
-    document.cookie = 'access_token=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT';
-    document.cookie = 'refresh_token=; path=/api/auth/refresh; expires=Thu, 01 Jan 1970 00:00:00 GMT';
+    // Platform-local session teardown through the transport seam: web clears
+    // the JS-accessible auth cookies (so isAuthenticated flips false at once);
+    // mobile drops the bearer + keychain refresh token and unregisters push.
+    // Keeps the platform specifics in each AuthStrategy, not in this store.
+    try {
+      await transport().auth.endSession();
+    } catch (e) {
+      logger.error('Failed to tear down the local session on logout', e);
+    }
 
     // Clear user data
     user.value = null;
@@ -529,8 +535,13 @@ export const useAuthStore = defineStore('auth', () => {
     // Remove auth provider header
     delete axios.defaults.headers.common['X-Auth-Provider'];
 
-    // For OIDC users, also logout from the identity provider (e.g., Keycloak)
-    if (isOidcUser) {
+    // RP-initiated logout at the IdP is a WEB-only browser navigation. On
+    // native (Tauri) we must not run it: redirecting the in-app webview to the
+    // IdP end_session endpoint strands the user on the provider's hosted page
+    // (a tauri:// post_logout_redirect_uri can never return to the app), and
+    // hosted has no server-side logout flow anyway. Native sign-out is the
+    // local teardown above (endSession) plus routing back to the login screen.
+    if (isOidcUser && !isTauriRuntime()) {
       try {
         const response = await apiClient.post('/auth/oauth/logout', {
           provider_type: 'oidc',

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -478,13 +478,19 @@ export const useAuthStore = defineStore('auth', () => {
     // next successful sign-in (setAuthData / fetchUserData).
     setLoggingOut(true);
 
-    // Check if user logged in via OIDC provider
-    const currentProvider = authProvider.value;
-    const isOidcUser = currentProvider === 'oidc';
+    // Per-surface post-logout redirect for RP-initiated (front-channel) logout.
+    // Web returns to /login; native returns on its custom scheme (which the app
+    // intercepts). The backend only mints a logout_url when this session was an
+    // OIDC one, so no client-side provider check is needed.
+    const redirectUri = isTauriRuntime()
+      ? 'nosdesk://auth/logout-callback'
+      : window.location.origin + '/login';
 
+    // Revoke the session server-side while credentials are still live, and get
+    // back the IdP front-channel logout URL (if this was an OIDC session).
+    let logoutUrl: string | undefined;
     try {
-      // Call backend logout endpoint to clear cookies
-      await authService.logout();
+      ({ logoutUrl } = await authService.logout({ redirectUri }));
     } catch (err) {
       logger.error('Logout request failed:', err);
       // Continue with frontend logout even if backend call fails
@@ -535,31 +541,31 @@ export const useAuthStore = defineStore('auth', () => {
     // Remove auth provider header
     delete axios.defaults.headers.common['X-Auth-Provider'];
 
-    // RP-initiated logout at the IdP is a WEB-only browser navigation. On
-    // native (Tauri) we must not run it: redirecting the in-app webview to the
-    // IdP end_session endpoint strands the user on the provider's hosted page
-    // (a tauri:// post_logout_redirect_uri can never return to the app), and
-    // hosted has no server-side logout flow anyway. Native sign-out is the
-    // local teardown above (endSession) plus routing back to the login screen.
-    if (isOidcUser && !isTauriRuntime()) {
-      try {
-        const response = await apiClient.post('/auth/oauth/logout', {
-          provider_type: 'oidc',
-          redirect_uri: window.location.origin + '/login'
-        });
-
-        if (response.data.logout_url) {
-          // Redirect to OIDC provider's logout endpoint
-          window.location.href = response.data.logout_url;
-          return; // Full redirect in progress, skip router navigation
+    // RP-initiated logout at the IdP, if the session was an OIDC one. Ending
+    // the IdP session (not just the local one) is what stops a re-login from
+    // silently re-authenticating as the same user.
+    if (logoutUrl) {
+      if (isTauriRuntime()) {
+        // Native: open the end_session URL in the system browser (which clears
+        // the shared IdP cookie) and return on the custom scheme. Best-effort:
+        // the local session is already gone, so a cancel/error must not block
+        // routing back to the login screen.
+        try {
+          const { logoutViaOidc } = await import('@nosdesk/mobile');
+          await logoutViaOidc(logoutUrl);
+        } catch (e) {
+          logger.error('Native IdP logout failed', e);
         }
-      } catch (err) {
-        logger.error('OIDC logout request failed:', err);
-        // Continue with normal redirect if OIDC logout fails
+      } else {
+        // Web: full-page navigation to the IdP end_session endpoint, which
+        // redirects back to redirectUri (/login) once the session is ended.
+        window.location.href = logoutUrl;
+        return; // full redirect in progress, skip router navigation
       }
     }
 
-    // Redirect to login page (for non-OIDC users or if OIDC logout fails)
+    // Return to the login screen (non-OIDC sessions, native, or a failed
+    // web redirect).
     router.push('/login');
   }
 

--- a/frontend/src/views/LoginView.vue
+++ b/frontend/src/views/LoginView.vue
@@ -2,6 +2,7 @@
 <script setup lang="ts">
 import { ref, onMounted, nextTick, computed } from "vue";
 import { useRouter, useRoute } from "vue-router";
+import { resolvePostLoginPath } from "@/router";
 import { useAuthStore } from "@/stores/auth";
 import { useMfaSetupStore } from "@nosdesk/core/stores/mfaSetup";
 import { useBrandingStore } from "@/stores/branding";
@@ -394,13 +395,18 @@ const handleOidcLoginClick = async () => {
     try {
       const { loginWithOidc, registerForPush } = await import('@nosdesk/mobile');
       await loginWithOidc();
-      await authStore.fetchUserData();
+      // Force past the 5s fetch cooldown: a fresh session must load the user
+      // even if a pre-sign-out /auth/me attempt is still within the window.
+      await authStore.fetchUserData({ force: true });
       authStore.setAuthProvider('oidc');
       // Session is live — register this device for push (best-effort; never
       // blocks routing into the app).
       void registerForPush();
-      const redirectPath = router.currentRoute.value.query.redirect?.toString() || "/";
-      router.push(redirectPath);
+      const redirectPath = router.currentRoute.value.query.redirect?.toString();
+      // Resolve + set the active workspace before navigating so the first
+      // dashboard request carries the X-Nosdesk-Workspace header. An in-app
+      // login after sign-out otherwise lands with no workspace selected.
+      router.push(await resolvePostLoginPath(redirectPath));
     } catch (error) {
       const err = error as Error;
       errorMessage.value = err.message || "Sign-in failed";

--- a/mobile/src/index.ts
+++ b/mobile/src/index.ts
@@ -10,7 +10,7 @@
  */
 export { bootstrapMobile, type MobileBootstrapOptions } from './bootstrap'
 export { setSession, clearSession, setServer } from './transport'
-export { loginWithOidc } from './oidc'
+export { loginWithOidc, logoutViaOidc } from './oidc'
 export { registerForPush, unregisterForPush, getPendingNotificationRoute } from './push'
 export {
   getStoredServer,

--- a/mobile/src/oidc.ts
+++ b/mobile/src/oidc.ts
@@ -171,3 +171,23 @@ export async function loginWithOidc(): Promise<void> {
   if (!session.access_token || !session.refresh_token) throw new Error('No session returned')
   await setSession(session.access_token, session.refresh_token)
 }
+
+/**
+ * Drive RP-initiated (front-channel) logout at the IdP. Opens the server-built
+ * `end_session` URL in the system browser (`ASWebAuthenticationSession`), which
+ * clears the shared IdP session cookie and returns on our custom scheme
+ * (`nosdesk://auth/logout-callback`, registered as the client's
+ * post_logout_redirect_uri).
+ *
+ * Best-effort by contract: the caller has already cleared the local session, so
+ * a user cancel or any browser error must not throw — sign-out proceeds either
+ * way. We just await the round-trip so the IdP cookie is gone before the app
+ * returns to its login screen.
+ */
+export async function logoutViaOidc(logoutUrl: string): Promise<void> {
+  try {
+    await authenticate({ url: logoutUrl, callbackScheme: CALLBACK_SCHEME })
+  } catch {
+    // Swallowed deliberately — see the doc comment.
+  }
+}

--- a/mobile/src/transport.ts
+++ b/mobile/src/transport.ts
@@ -127,6 +127,12 @@ const bearerAuthStrategy: AuthStrategy = {
     void store?.clear()
     syncAssetProxy()
   },
+  // Intentional sign-out: drop the bearer + keychain refresh token and
+  // unregister this device for push. `clearSession` already does exactly this
+  // teardown, so the seam just delegates to it.
+  endSession() {
+    return clearSession()
+  },
 }
 
 /**

--- a/packages/core/src/services/authService.ts
+++ b/packages/core/src/services/authService.ts
@@ -247,11 +247,18 @@ class AuthService {
   }
 
   /**
-   * Logout the current user (clears httpOnly cookies on server)
+   * Log out the current user: revokes the session server-side (clears httpOnly
+   * cookies on web). When `redirectUri` is passed and the session was
+   * established via OIDC, the server returns a front-channel `logoutUrl` (with
+   * the session's id_token as `id_token_hint`) that the caller navigates to in
+   * order to end the IdP session too. Returns an empty object otherwise.
    */
-  async logout(): Promise<void> {
+  async logout(opts?: { redirectUri?: string }): Promise<{ logoutUrl?: string }> {
     try {
-      await apiClient.post('/auth/logout');
+      const body = opts?.redirectUri ? { redirect_uri: opts.redirectUri } : {};
+      const res = await apiClient.post('/auth/logout', body);
+      const logoutUrl = (res.data as { logout_url?: string | null } | undefined)?.logout_url;
+      return { logoutUrl: logoutUrl ?? undefined };
     } catch (error) {
       logger.error('Logout failed', { error });
       throw error;

--- a/packages/core/src/transport.ts
+++ b/packages/core/src/transport.ts
@@ -36,6 +36,13 @@ export interface AuthStrategy {
   hasSession(): boolean
   /** Tear down local session state after an unrecoverable 401. Web: no-op. */
   onSessionLost(): void
+  /**
+   * Intentional sign-out teardown of the client-held session, distinct from
+   * the involuntary `onSessionLost`. Web: clear the JS-accessible auth cookies.
+   * Mobile: drop the bearer + keychain refresh token and unregister push. The
+   * server-side session revocation happens separately (POST /auth/logout).
+   */
+  endSession(): Promise<void>
 }
 
 export interface TransportConfig {


### PR DESCRIPTION
Ships a working sign-out that ends the IdP (Hydra) session, not just the local product session, across web and native (mobile).

## Changes
- **endSession() transport seam**: sign-out teardown moved behind the AuthStrategy seam (web clears JS-accessible cookies; mobile drops the bearer + keychain refresh token and unregisters push), removing platform conditionals from the auth store.
- **Backend id_token storage**: new nullable `active_sessions.oidc_id_token` (plain additive migration); the web callback + mobile native-login persist it via `establish_login_session`. `/auth/logout` now takes an optional per-surface `redirect_uri` and returns a front-channel `logout_url` (built with `id_token_hint` before revocation); `generate_logout_url` omits `client_id` when a hint is present.
- **Frontend/mobile consume `logout_url`**: web navigates to it; native opens it in `ASWebAuthenticationSession` (`logoutViaOidc`), then returns to the login screen. Fixes the mobile bug where logout drove the webview onto Hydra's hosted page.
- **Login workspace-selection fix**: an in-app login (native, no reload) now resolves + sets the active-workspace slug before navigating (`resolvePostLoginPath`), so the dashboard's first requests carry `X-Nosdesk-Workspace` instead of failing `NoWorkspaceSelected` until a cold restart.

## Requires the control-plane PR
Depends on the `nosdesk-com` `feat/oidc-logout` PR (`/identity/logout` accept handler, `URLS_ERROR`, and `post_logout_redirect_uris` on the clients). Verified end-to-end on staging + on-device (iOS).