### PR TITLE
Ticket deep-linking (iOS Universal Links) + mobile first-login/sync fixes

### DIFF
--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -76,6 +76,7 @@ pub mod unsubscribe;
 pub mod user_contact;
 pub mod users;
 pub mod webhooks;
+pub mod well_known;
 pub mod workflow_states;
 pub mod workspace_email;
 pub mod workspace_export;

--- a/backend/src/handlers/well_known.rs
+++ b/backend/src/handlers/well_known.rs
@@ -1,0 +1,132 @@
+//! `.well-known` endpoints for mobile deep-linking (iOS Universal Links +
+//! Android App Links).
+//!
+//! Served unauthenticated on every tenant origin (`<slug>.nosdesk.app`,
+//! `<slug>.nosdesk.dev`, ...), ahead of the SPA catch-all, so a scanned ticket
+//! QR (`https://<slug>.nosdesk.app/tickets/<id>`) opens the app if installed.
+//! Because all tenant subdomains are served by this one backend, a single
+//! host-agnostic handler covers every tenant.
+//!
+//! Both files must be plain JSON over HTTPS with **no redirect** — Apple and
+//! Google fetch them directly and reject a redirected or non-JSON response.
+//! `.json()` sets `Content-Type: application/json`, which is what both expect.
+
+use actix_web::{HttpResponse, Responder};
+use serde_json::json;
+
+const DEFAULT_IOS_APP_ID: &str = "S6DDZ86325.com.nosdesk.app";
+const DEFAULT_ANDROID_PACKAGE: &str = "com.nosdesk.app";
+
+/// `GET /.well-known/apple-app-site-association` — claims the ticket paths for
+/// the iOS app. `appIDs` = `<TEAM_ID>.<BUNDLE_ID>`; the two components cover
+/// host mode (`/tickets/:id`) and path mode (`/<slug>/tickets/:id`). Overridable
+/// via `NOSDESK_IOS_APP_ID` (same app for staging + prod, so it rarely changes).
+pub async fn apple_app_site_association() -> impl Responder {
+    let app_id =
+        std::env::var("NOSDESK_IOS_APP_ID").unwrap_or_else(|_| DEFAULT_IOS_APP_ID.to_string());
+    HttpResponse::Ok().json(json!({
+        "applinks": {
+            "details": [
+                {
+                    "appIDs": [app_id],
+                    "components": [
+                        { "/": "/tickets/*", "comment": "Ticket detail (host mode)" },
+                        { "/": "/*/tickets/*", "comment": "Ticket detail (path mode, workspace-slug prefix)" }
+                    ]
+                }
+            ]
+        }
+    }))
+}
+
+/// `GET /.well-known/assetlinks.json` — Android App Links statement. The release
+/// signing cert's SHA-256 fingerprint(s) come from `NOSDESK_ANDROID_CERT_SHA256`
+/// (comma-separated). Until that is set, the statement lists no fingerprints and
+/// Android App Links stay unverified (iOS is unaffected); the route still exists
+/// so setting the env var is all that's needed to light Android up.
+pub async fn assetlinks() -> impl Responder {
+    let package = std::env::var("NOSDESK_ANDROID_PACKAGE")
+        .unwrap_or_else(|_| DEFAULT_ANDROID_PACKAGE.to_string());
+    let fingerprints: Vec<String> = std::env::var("NOSDESK_ANDROID_CERT_SHA256")
+        .unwrap_or_default()
+        .split(',')
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect();
+    HttpResponse::Ok().json(json!([
+        {
+            "relation": ["delegate_permission/common.handle_all_urls"],
+            "target": {
+                "namespace": "android_app",
+                "package_name": package,
+                "sha256_cert_fingerprints": fingerprints
+            }
+        }
+    ]))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use actix_web::http::header::CONTENT_TYPE;
+    use actix_web::{test, web, App};
+
+    #[actix_web::test]
+    async fn aasa_is_json_claiming_ticket_paths() {
+        let app = test::init_service(App::new().route(
+            "/.well-known/apple-app-site-association",
+            web::get().to(apple_app_site_association),
+        ))
+        .await;
+        let resp = test::call_service(
+            &app,
+            test::TestRequest::get()
+                .uri("/.well-known/apple-app-site-association")
+                .to_request(),
+        )
+        .await;
+        assert!(resp.status().is_success());
+        // Apple rejects a non-JSON content type.
+        assert_eq!(
+            resp.headers().get(CONTENT_TYPE).unwrap(),
+            "application/json"
+        );
+        let body: serde_json::Value = test::read_body_json(resp).await;
+        let details = &body["applinks"]["details"][0];
+        assert!(details["appIDs"][0]
+            .as_str()
+            .unwrap()
+            .ends_with("com.nosdesk.app"));
+        let paths: Vec<&str> = details["components"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|c| c["/"].as_str().unwrap())
+            .collect();
+        assert!(paths.contains(&"/tickets/*"));
+        assert!(paths.contains(&"/*/tickets/*"));
+    }
+
+    #[actix_web::test]
+    async fn assetlinks_is_android_statement() {
+        let app = test::init_service(
+            App::new().route("/.well-known/assetlinks.json", web::get().to(assetlinks)),
+        )
+        .await;
+        let resp = test::call_service(
+            &app,
+            test::TestRequest::get()
+                .uri("/.well-known/assetlinks.json")
+                .to_request(),
+        )
+        .await;
+        assert!(resp.status().is_success());
+        let body: serde_json::Value = test::read_body_json(resp).await;
+        assert_eq!(body[0]["target"]["namespace"], "android_app");
+        assert_eq!(body[0]["target"]["package_name"], "com.nosdesk.app");
+        assert_eq!(
+            body[0]["relation"][0],
+            "delegate_permission/common.handle_all_urls"
+        );
+    }
+}

--- a/backend/src/startup.rs
+++ b/backend/src/startup.rs
@@ -653,6 +653,14 @@ pub fn configure_app(
             // Public instance config (routing topology) read at SPA startup
             .route("/api/config", web::get().to(crate::handlers::app_config::get_public_config))
 
+            // Mobile deep-linking association files (iOS Universal Links +
+            // Android App Links). Unauthenticated, served on every tenant
+            // origin ahead of the SPA catch-all so a scanned ticket QR opens
+            // the app. Must be JSON with no redirect (Apple/Google fetch them
+            // directly). See handlers::well_known.
+            .route("/.well-known/apple-app-site-association", web::get().to(crate::handlers::well_known::apple_app_site_association))
+            .route("/.well-known/assetlinks.json", web::get().to(crate::handlers::well_known::assetlinks))
+
             // Inbound-email webhook (hosted): AWS SNS POSTs here when SES
             // receives forwarded mail. Unauthenticated by necessity (SNS is
             // server-to-server); the handler verifies the SNS signature.

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -134,6 +134,66 @@ if (isTauriRuntime()) {
   })
 }
 
+// Ticket deep links (iOS Universal Links / Android App Links). Same shape as
+// the push route above: resolve where the tapped/scanned URL goes, waiting for
+// the session on a cold start. v1 rule: a ticket link whose host is the server
+// we're connected to opens the ticket in-app; a different tenant, or a server
+// we're not connected to, opens in the system browser.
+if (isTauriRuntime()) {
+  onMounted(async () => {
+    try {
+      const { getInitialDeepLink, onDeepLink, openInBrowser, getStoredServer } =
+        await import('@nosdesk/mobile')
+      await router.isReady()
+
+      const handleDeepLink = (rawUrl: string) => {
+        let url: URL
+        try {
+          url = new URL(rawUrl)
+        } catch {
+          return
+        }
+        const isTicket = /\/tickets\/\d+/.test(url.pathname)
+        let sameServer = false
+        const server = getStoredServer()
+        if (server) {
+          try {
+            sameServer = new URL(server).host === url.host
+          } catch {
+            /* malformed stored server: treat as not matching */
+          }
+        }
+        if (!isTicket || !sameServer) {
+          void openInBrowser(rawUrl)
+          return
+        }
+        // Same tenant: open in-app. Navigate now if signed in, else once the
+        // session resolves (cold start, or after signing into this server).
+        const go = () => void router.push(url.pathname)
+        if (authStore.isAuthenticated) {
+          go()
+        } else {
+          const stop = watch(
+            () => authStore.isAuthenticated,
+            (authed) => {
+              if (authed) {
+                stop()
+                void nextTick(go)
+              }
+            },
+          )
+        }
+      }
+
+      const initial = await getInitialDeepLink()
+      if (initial) handleDeepLink(initial)
+      await onDeepLink(handleDeepLink)
+    } catch {
+      // Deep-linking is best-effort; never block app startup.
+    }
+  })
+}
+
 // State for navbar collapse
 const navbarCollapsed = ref(false)
 const handleNavCollapse = (collapsed: boolean) => {

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -40,6 +40,9 @@ import { useBrandingStore } from '@/stores/branding'
 import { loadPlugins, initializeEventDispatcher } from '@/plugins'
 import { useAuthStore } from '@/stores/auth'
 import { usePageActionsStore } from '@nosdesk/core/stores/pageActions'
+import { useMyWorkspacesStore } from '@/stores/myWorkspaces'
+import { activeWorkspaceSlug } from '@/services/activeWorkspace'
+import { getWorkspaceRouting, fetchInstanceConfig } from '@nosdesk/core/services/instanceConfig'
 
 const fluent = useFluent()
 const t = (k: string, args?: Record<string, string | number>) => fluent.$t(k, args)
@@ -51,7 +54,7 @@ const brandingStore = useBrandingStore()
 useFavicon(() => brandingStore.faviconUrl)
 
 const route = useRoute()
-const { isSwitchingWorkspace } = useWorkspaceSwitch()
+const { isSwitchingWorkspace, switchWorkspace } = useWorkspaceSwitch()
 const router = useRouter()
 const isBlankLayout = computed(() => route.meta.layout === 'blank')
 
@@ -167,11 +170,44 @@ if (isTauriRuntime()) {
           void openInBrowser(rawUrl)
           return
         }
-        // Same tenant: open in-app. Navigate now if signed in, else once the
+        // Same server: open in-app. Navigate now if signed in, else once the
         // session resolves (cold start, or after signing into this server).
-        const go = () => void router.push(url.pathname)
+        const go = async () => {
+          // In path mode the first path segment is the target workspace slug.
+          // A link into a workspace other than the one currently loaded needs a
+          // real switch (teardown + re-hydrate the sync pool for the target),
+          // not a bare push, which would leave the pool keyed to the previous
+          // tenant and 404 the ticket. Host mode carries no slug in the path;
+          // same-origin already implies the same tenant, so a push is correct.
+          await fetchInstanceConfig()
+          if (getWorkspaceRouting() !== 'path') {
+            void router.push(url.pathname)
+            return
+          }
+          const targetSlug = url.pathname.split('/')[1] || null
+          if (!targetSlug || targetSlug === activeWorkspaceSlug()) {
+            void router.push(url.pathname)
+            return
+          }
+          const store = useMyWorkspacesStore()
+          if (store.workspaces.length === 0) {
+            try {
+              await store.refetch()
+            } catch {
+              /* fall through: the membership check below opens the web fallback */
+            }
+          }
+          const entry = store.workspaces.find((w) => w.slug === targetSlug)
+          if (!entry) {
+            // Not a member of the target workspace: open on the web rather than
+            // bouncing to no-workspace-access in-app.
+            void openInBrowser(rawUrl)
+            return
+          }
+          await switchWorkspace(entry, url.pathname)
+        }
         if (authStore.isAuthenticated) {
-          go()
+          void go()
         } else {
           const stop = watch(
             () => authStore.isAuthenticated,

--- a/frontend/src/composables/useDashboardStats.ts
+++ b/frontend/src/composables/useDashboardStats.ts
@@ -16,6 +16,7 @@ import { useAuthStore } from '@/stores/auth'
 import { useDashboardLayoutStore } from '@/stores/dashboardLayout'
 import { WIDGET_REGISTRY, type DashboardStatsGroup } from '@/views/dashboard/widgets'
 import { getStats, type StatsBundle } from '@/services/dashboardService'
+import { workspaceReady } from '@/services/activeWorkspace'
 
 export interface DashboardStatsHandle {
   bundle: ComputedRef<StatsBundle | undefined>
@@ -63,8 +64,10 @@ export function useDashboardStats(): DashboardStatsHandle {
   const query = useQuery({
     key: () => ['dashboard', 'stats', userUuid.value, include.value.join(',')],
     query: () => getStats({ include: include.value, user: userUuid.value }),
-    // Don't fire when there's nobody to fetch for or nothing to compute.
-    enabled: () => !!userUuid.value && include.value.length > 0,
+    // Hold until a workspace is selected (path mode) so the query doesn't fire
+    // header-less and fail NoWorkspaceSelected; also nothing to fetch/compute.
+    enabled: () =>
+      workspaceReady() && !!userUuid.value && include.value.length > 0,
   })
 
   // `status === 'pending'` means no data has ever resolved into the

--- a/frontend/src/composables/useWorkspaceSwitch.ts
+++ b/frontend/src/composables/useWorkspaceSwitch.ts
@@ -24,7 +24,15 @@ const isSwitchingWorkspace = ref(false);
 export function useWorkspaceSwitch() {
   const router = useRouter();
 
-  async function switchWorkspace(entry: MyWorkspaceEntry): Promise<void> {
+  /**
+   * Switch to `entry`. Lands on the workspace home by default, or on
+   * `destinationPath` (already slug-prefixed, e.g. a ticket deep link
+   * `/acme/tickets/8`) when the caller wants to arrive somewhere specific.
+   */
+  async function switchWorkspace(
+    entry: MyWorkspaceEntry,
+    destinationPath?: string,
+  ): Promise<void> {
     if (getWorkspaceRouting() !== 'path') {
       navigateToWorkspace(entry);
       return;
@@ -37,10 +45,11 @@ export function useWorkspaceSwitch() {
       await nextTick();
       const { resetWorkspaceScopedState } = await import('@/stores/workspaceReset');
       await resetWorkspaceScopedState();
-      // Navigate to the new workspace's home. The prefix guard sets the active
-      // slug and the hydrate guard re-bootstraps + re-attaches SSE for it (the
-      // pool's IDB handle was closed by the reset, so it starts clean).
-      await router.push(`/${entry.slug}`);
+      // Navigate to the target (workspace home, or a specific deep-link path).
+      // The prefix guard sets the active slug and the hydrate guard re-bootstraps
+      // + re-attaches SSE for it (the pool's IDB handle was closed by the reset,
+      // so it starts clean).
+      await router.push(destinationPath ?? `/${entry.slug}`);
       const { useBrandingStore } = await import('@/stores/branding');
       await useBrandingStore().loadBranding();
     } catch (e) {

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -1,7 +1,7 @@
 import { createRouter, createWebHistory, type RouteLocationNormalized } from 'vue-router'
 import { withWorkspaceRouting, installWorkspaceGuard, installSlugCarrier, workspaceSlugOf } from './workspaceRouting'
 import { installNavigationTracking } from './navigation'
-import { getWorkspaceRouting } from '@nosdesk/core/services/instanceConfig'
+import { fetchInstanceConfig, getWorkspaceRouting } from '@nosdesk/core/services/instanceConfig'
 import { lastWorkspaceSlug, setActiveWorkspaceSlug } from '@/services/activeWorkspace'
 import DashboardView from '../views/DashboardView.vue'
 import TicketView from '../views/TicketView.vue'
@@ -1067,11 +1067,28 @@ async function defaultWorkspaceSlug(): Promise<string | null> {
  */
 export async function resolvePostLoginPath(redirect?: string | null): Promise<string> {
   if (redirect && redirect !== '/') return redirect;
+  // Never decide on the pre-fetch 'host' default: a hosted (path-mode) instance
+  // would then skip slug resolution and land on a bare '/' with no workspace.
+  await fetchInstanceConfig();
   if (getWorkspaceRouting() !== 'path') return '/';
   const slug = await defaultWorkspaceSlug();
   if (!slug) return '/'; // no membership: the guard routes to no-workspace-access
   setActiveWorkspaceSlug(slug);
   return `/${slug}`;
+}
+
+/**
+ * Navigate to the post-login landing. Every login surface calls this instead of
+ * pushing a path itself, so the workspace is resolved once and the `?redirect=`
+ * target is honoured uniformly. Pass an explicit target (e.g. OAuth's stored
+ * path) to override the query, or `null` to ignore it.
+ */
+export async function landAfterLogin(redirect?: string | null): Promise<void> {
+  const target =
+    redirect === undefined
+      ? router.currentRoute.value.query.redirect?.toString()
+      : (redirect ?? undefined);
+  await router.push(await resolvePostLoginPath(target));
 }
 
 /**

--- a/frontend/src/services/activeWorkspace.ts
+++ b/frontend/src/services/activeWorkspace.ts
@@ -69,7 +69,7 @@ addRequestHeaderProvider(workspaceHeaders);
  * `getWorkspaceRouting()` is read non-reactively on purpose: routing is settled
  * before `instanceConfigResolvedRef` flips, so gating on the latter is enough.
  */
-const workspaceReadyRef = computed<boolean>(() => {
+export const workspaceReadyRef = computed<boolean>(() => {
   if (!instanceConfigResolvedRef.value) return false;
   if (getWorkspaceRouting() !== 'path') return true;
   return slug.value !== null;

--- a/frontend/src/services/activeWorkspace.ts
+++ b/frontend/src/services/activeWorkspace.ts
@@ -9,8 +9,12 @@
  * set in path mode; `null` in host mode means no header is sent and the backend
  * resolves the workspace from the Host, as today.
  */
-import { readonly, ref, type Ref } from 'vue';
+import { computed, readonly, ref, type Ref } from 'vue';
 import { addRequestHeaderProvider } from '@nosdesk/core/transport';
+import {
+  getWorkspaceRouting,
+  instanceConfigResolvedRef,
+} from '@nosdesk/core/services/instanceConfig';
 
 const LAST_WORKSPACE_KEY = 'nosdesk:last-workspace';
 
@@ -53,6 +57,28 @@ export function workspaceHeaders(): Record<string, string> {
 // workspace guard imports this module before any request fires, so the workspace
 // header is available early — ahead of the diagnostics provider apiConfig adds.
 addRequestHeaderProvider(workspaceHeaders);
+
+/**
+ * Reactive gate for whether a workspace-scoped request may fire yet. Workspace-
+ * scoped Colada queries read it in `enabled` so nothing fires header-less in the
+ * first-login window (auth flips true before the slug is set), which would fail
+ * closed as `NoWorkspaceSelected`. Not ready until `/api/config` resolves (the
+ * 'host' default is not an answer); host mode is ready once resolved (backend
+ * resolves from Host); path mode is ready once a slug is selected.
+ *
+ * `getWorkspaceRouting()` is read non-reactively on purpose: routing is settled
+ * before `instanceConfigResolvedRef` flips, so gating on the latter is enough.
+ */
+const workspaceReadyRef = computed<boolean>(() => {
+  if (!instanceConfigResolvedRef.value) return false;
+  if (getWorkspaceRouting() !== 'path') return true;
+  return slug.value !== null;
+});
+
+/** Non-reactive read of the workspace-ready gate, for use outside a template. */
+export function workspaceReady(): boolean {
+  return workspaceReadyRef.value;
+}
 
 /** The last workspace slug this device was on, for the post-login landing. */
 export function lastWorkspaceSlug(): string | null {

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -5,7 +5,7 @@ import axios from 'axios';
 import apiClient from '@nosdesk/core/apiClient';
 import { setLoggingOut } from '@/services/apiConfig';
 import authService from '@nosdesk/core/services/authService';
-import router from '@/router';
+import router, { landAfterLogin } from '@/router';
 import type { User, LoginCredentials } from '@nosdesk/core/types';
 import { useThemeStore } from './theme';
 import { useDateStore } from '@nosdesk/core/stores/dateStore';
@@ -256,7 +256,8 @@ export const useAuthStore = defineStore('auth', () => {
       // Handle successful login (cookies set by backend, csrf_token in response)
       if (response.data.success && response.data.csrf_token) {
         setAuthData(response.data.user);
-        router.push('/');
+        // Land on the resolved workspace (path mode), honouring any ?redirect=.
+        await landAfterLogin();
         return true;
       }
 
@@ -314,8 +315,8 @@ export const useAuthStore = defineStore('auth', () => {
           userName: user.value?.name
         });
 
-        logger.debug('🔐 MFA Login: Attempting redirect to /');
-        await router.push('/');
+        logger.debug('🔐 MFA Login: Attempting redirect');
+        await landAfterLogin();
         logger.debug('🔐 MFA Login: Redirect completed');
         return true;
       }
@@ -422,7 +423,7 @@ export const useAuthStore = defineStore('auth', () => {
           setAuthData(response.user);
           mfaSetupRequired.value = false;
           mfaUserUuid.value = '';
-          router.push('/');
+          await landAfterLogin();
           return true;
         }
         

--- a/frontend/src/stores/notifications.ts
+++ b/frontend/src/stores/notifications.ts
@@ -46,6 +46,7 @@ import {
   type Notification,
 } from '@nosdesk/core/services/notificationService'
 import { onSyncActions } from '@nosdesk/core/sync/observers'
+import { workspaceReady } from '@/services/activeWorkspace'
 
 const PAGE_SIZE = 20
 
@@ -80,6 +81,8 @@ export function useNotificationsList() {
       lastPage.length === PAGE_SIZE
         ? allPages.flat().length
         : null,
+    // Hold until a workspace is selected (see useUnreadCount).
+    enabled: () => workspaceReady(),
   })
 }
 
@@ -89,6 +92,9 @@ export function useUnreadCount() {
   return useQuery({
     key: NOTIFICATIONS_KEYS.unreadCount(),
     query: () => getUnreadCount(),
+    // Hold until a workspace is selected so the always-mounted bell doesn't fire
+    // header-less on first login (NoWorkspaceSelected).
+    enabled: () => workspaceReady(),
   })
 }
 
@@ -100,6 +106,8 @@ export function useUnseenCount() {
   return useQuery({
     key: NOTIFICATIONS_KEYS.unseenCount(),
     query: () => getUnseenCount(),
+    // Hold until a workspace is selected (see useUnreadCount).
+    enabled: () => workspaceReady(),
   })
 }
 

--- a/frontend/src/sync/lifecycle.ts
+++ b/frontend/src/sync/lifecycle.ts
@@ -49,6 +49,24 @@ const state: LifecycleState = {
   memoryOnly: false,
 }
 
+/** Memory-only counts as hydrated (it still bootstraps and serves; only
+ *  warm-start persistence is lost). Gating subscribe/runBootstrap/pullDelta on
+ *  `state.handle` alone stranded memory-only groups empty until a force-quit. */
+function isHydrated(): boolean {
+  return state.handle !== null || state.memoryOnly
+}
+
+/**
+ * Bootstrap every group that subscribed before hydrate() finished. subscribe()
+ * adds the group to the pool's set but defers its fetch when the runtime isn't
+ * hydrated yet; this drains that backlog once hydration completes (IDB or
+ * memory-only), so an early subscriber isn't left empty until the next tearDown.
+ */
+function bootstrapDeferredGroups(): void {
+  const groups = Array.from(pool.getSubscribedGroups())
+  if (groups.length > 0) void runBootstrap(groups)
+}
+
 /**
  * Single-flight sync-runtime bootstrap. `fetchServerIdentity` + `hydrate` +
  * `attachSseBridge` are one-time setup, but they can be reached concurrently —
@@ -183,6 +201,9 @@ export async function hydrate(
     state.memoryOnly = true
     queue.setIdbHandle(null)
     startDeltaPollFallback()
+    // Memory-only is still a hydrated runtime: drain any group that subscribed
+    // while IDB open was in flight so it bootstraps rather than staying empty.
+    bootstrapDeferredGroups()
     return
   }
 
@@ -255,6 +276,9 @@ export async function hydrate(
   // where SSE is wedged behind a corporate proxy or the EventSource
   // is mid-reconnect. Idempotent — only starts a single timer.
   startDeltaPollFallback()
+
+  // Drain groups that subscribed before hydrate() finished (see subscribe()).
+  bootstrapDeferredGroups()
 }
 
 /** Fetch the server's compiled schema hash and database instance id.
@@ -311,7 +335,10 @@ export async function fetchServerIdentity(): Promise<{
 export async function subscribe(group: string): Promise<void> {
   if (pool.getSubscribedGroups().has(group)) return
   pool.subscribe(group)
-  if (!state.handle) {
+  if (!isHydrated()) {
+    // Not hydrated yet: hydrate() replays the subscribed set once it finishes
+    // (bootstrapDeferredGroups), so this group still loads. Memory-only counts
+    // as hydrated, so this branch is only the genuine pre-hydrate window.
     logger.warn('subscribe() called before hydrate(); deferring bootstrap', { group })
     return
   }
@@ -324,7 +351,7 @@ export async function subscribe(group: string): Promise<void> {
  * a periodic-poll fallback when SSE is wedged.
  */
 export async function pullDelta(): Promise<void> {
-  if (!state.handle) return
+  if (!isHydrated()) return
   const groups = Array.from(pool.getSubscribedGroups())
   if (groups.length === 0) return
   const from = pool.getLastSyncId()
@@ -363,7 +390,10 @@ export async function pullDelta(): Promise<void> {
  * full subscription list) and for incremental group expansion.
  */
 async function runBootstrap(groups: string[]): Promise<void> {
-  if (!state.handle) return
+  // Bootstrap fills the in-memory pool; it needs a hydrated runtime, NOT an IDB
+  // handle. In memory-only mode the persistence writes below are individually
+  // skipped, but the fetch + pool.upsert still run so views populate.
+  if (!isHydrated()) return
   const url = `/sync/bootstrap?groups=${encodeURIComponent(groups.join(','))}&schema=${encodeURIComponent(state.schemaHash)}`
   let res: Response
   try {
@@ -437,10 +467,14 @@ async function runBootstrap(groups: string[]): Promise<void> {
         // Bootstrap finished successfully — persist any tail and
         // advance the cursor.
         await flushPersistBatch()
-        if (bootstrapMeta && state.handle) {
+        if (bootstrapMeta) {
+          // Advance the in-memory cursor always; persist it only when IDB is
+          // available (memory-only keeps the cursor in the pool for delta polls).
           pool.setCursor(bootstrapMeta.last_xid8, bootstrapMeta.last_sync_id)
-          await idb.setLastSyncId(state.handle, bootstrapMeta.last_sync_id)
-          await idb.setLastXid8(state.handle, bootstrapMeta.last_xid8)
+          if (state.handle) {
+            await idb.setLastSyncId(state.handle, bootstrapMeta.last_sync_id)
+            await idb.setLastXid8(state.handle, bootstrapMeta.last_xid8)
+          }
         }
       } else if ('__error__' in line) {
         logger.error('bootstrap streamed error envelope', { line })

--- a/frontend/src/sync/lifecycle.ts
+++ b/frontend/src/sync/lifecycle.ts
@@ -11,6 +11,7 @@
  * - `tearDown()` releases the IndexedDB handle and resets the pool;
  *   called on sign-out.
  */
+import { watch } from 'vue'
 import { logger } from '@nosdesk/core/utils/logger'
 import * as pool from '@nosdesk/core/sync/pool'
 import * as idb from './idb'
@@ -21,7 +22,7 @@ import { notifySyncActions } from '@nosdesk/core/sync/observers'
 import { applyWorkspaceCapabilities } from '@/composables/useWorkspaceCapabilities'
 import { purgeAllCollabDocs } from '@/utils/collabLocalCache'
 import { apiBaseUrl, transport } from '@nosdesk/core/transport'
-import { workspaceHeaders } from '@/services/activeWorkspace'
+import { workspaceHeaders, workspaceReady, workspaceReadyRef } from '@/services/activeWorkspace'
 import type {
   BootstrapLine,
   BootstrapMeta,
@@ -56,16 +57,37 @@ function isHydrated(): boolean {
   return state.handle !== null || state.memoryOnly
 }
 
+/** A workspace-scoped fetch (bootstrap/delta) may only fire once the runtime is
+ *  hydrated AND a workspace is selected. `workspaceReady()` is the same gate the
+ *  Colada queries use (true in host mode, or once the path-mode slug is set);
+ *  without it the sync engine sends header-less requests that fail 400
+ *  NoWorkspaceSelected, the 10s delta poll spamming them all session. */
+function canFetchWorkspace(): boolean {
+  return isHydrated() && workspaceReady()
+}
+
 /**
- * Bootstrap every group that subscribed before hydrate() finished. subscribe()
- * adds the group to the pool's set but defers its fetch when the runtime isn't
- * hydrated yet; this drains that backlog once hydration completes (IDB or
- * memory-only), so an early subscriber isn't left empty until the next tearDown.
+ * Bootstrap every subscribed group. Called after hydrate() and whenever the
+ * workspace becomes ready, to drain groups whose fetch subscribe() deferred
+ * (it adds the group to the pool's set but defers the fetch when the runtime
+ * isn't hydrated or no workspace is selected), so none is left empty until the
+ * next tearDown.
  */
 function bootstrapDeferredGroups(): void {
   const groups = Array.from(pool.getSubscribedGroups())
   if (groups.length > 0) void runBootstrap(groups)
 }
+
+// Re-fire once a workspace is selected: an early subscribe (or a hydrate that
+// finished before the slug was set) deferred its bootstrap and the delta poll
+// was skipped. Draining here makes arriving at a ready workspace immediate
+// rather than waiting up to one poll interval.
+watch(workspaceReadyRef, (ready) => {
+  if (ready && isHydrated()) {
+    bootstrapDeferredGroups()
+    void pullDelta()
+  }
+})
 
 /**
  * Single-flight sync-runtime bootstrap. `fetchServerIdentity` + `hydrate` +
@@ -335,11 +357,11 @@ export async function fetchServerIdentity(): Promise<{
 export async function subscribe(group: string): Promise<void> {
   if (pool.getSubscribedGroups().has(group)) return
   pool.subscribe(group)
-  if (!isHydrated()) {
-    // Not hydrated yet: hydrate() replays the subscribed set once it finishes
-    // (bootstrapDeferredGroups), so this group still loads. Memory-only counts
-    // as hydrated, so this branch is only the genuine pre-hydrate window.
-    logger.warn('subscribe() called before hydrate(); deferring bootstrap', { group })
+  if (!canFetchWorkspace()) {
+    // Runtime not hydrated, or no workspace selected yet: the group stays in the
+    // pool set and its bootstrap is drained by bootstrapDeferredGroups once
+    // hydrate finishes or the workspace becomes ready (see the watch above).
+    logger.warn('subscribe() deferred: runtime not ready', { group })
     return
   }
   await runBootstrap([group])
@@ -351,7 +373,7 @@ export async function subscribe(group: string): Promise<void> {
  * a periodic-poll fallback when SSE is wedged.
  */
 export async function pullDelta(): Promise<void> {
-  if (!isHydrated()) return
+  if (!canFetchWorkspace()) return
   const groups = Array.from(pool.getSubscribedGroups())
   if (groups.length === 0) return
   const from = pool.getLastSyncId()
@@ -390,10 +412,10 @@ export async function pullDelta(): Promise<void> {
  * full subscription list) and for incremental group expansion.
  */
 async function runBootstrap(groups: string[]): Promise<void> {
-  // Bootstrap fills the in-memory pool; it needs a hydrated runtime, NOT an IDB
-  // handle. In memory-only mode the persistence writes below are individually
-  // skipped, but the fetch + pool.upsert still run so views populate.
-  if (!isHydrated()) return
+  // Needs a hydrated runtime AND a selected workspace (not an IDB handle). In
+  // memory-only mode the persistence writes below are individually skipped, but
+  // the fetch + pool.upsert still run so views populate.
+  if (!canFetchWorkspace()) return
   const url = `/sync/bootstrap?groups=${encodeURIComponent(groups.join(','))}&schema=${encodeURIComponent(state.schemaHash)}`
   let res: Response
   try {

--- a/frontend/src/views/LoginView.vue
+++ b/frontend/src/views/LoginView.vue
@@ -2,7 +2,7 @@
 <script setup lang="ts">
 import { ref, onMounted, nextTick, computed } from "vue";
 import { useRouter, useRoute } from "vue-router";
-import { resolvePostLoginPath } from "@/router";
+import { landAfterLogin } from "@/router";
 import { useAuthStore } from "@/stores/auth";
 import { useMfaSetupStore } from "@nosdesk/core/stores/mfaSetup";
 import { useBrandingStore } from "@/stores/branding";
@@ -247,11 +247,11 @@ const handleMfaPaste = (event: ClipboardEvent) => {
 // Apply a successful passkey login and redirect. The passkey response
 // carries a slimmer user shape than the canonical User type; the auth
 // store hydrates the rest from /me on its first authenticated fetch.
-const completePasskeyLogin = (result: PasskeyLoginResult) => {
+const completePasskeyLogin = async (result: PasskeyLoginResult) => {
   authStore.user = result.user as unknown as typeof authStore.user;
   authStore.setAuthProvider('local');
-  const redirectPath = router.currentRoute.value.query.redirect?.toString() || "/";
-  router.push(redirectPath);
+  // Lands on the resolved workspace (path mode), honouring any ?redirect=.
+  await landAfterLogin();
 };
 
 const handlePasskeyLogin = async () => {
@@ -266,7 +266,7 @@ const handlePasskeyLogin = async () => {
     const result = await loginWithPasskey(emailToUse);
 
     if (result) {
-      completePasskeyLogin(result);
+      await completePasskeyLogin(result);
     } else if (passkeyError.value) {
       errorMessage.value = passkeyError.value;
     }
@@ -284,7 +284,7 @@ const handlePasskeyLogin = async () => {
 // unaffected. Started once the login form is confirmed to be showing.
 const startConditionalPasskeyLogin = async () => {
   const result = await loginWithPasskeyConditional();
-  if (result) completePasskeyLogin(result);
+  if (result) await completePasskeyLogin(result);
 };
 
 // Handle passkey MFA verification (after password login, passkey is the second factor)
@@ -305,8 +305,7 @@ const handlePasskeyMfaVerify = async () => {
       authStore.passkeyMfaRequired = false;
       authStore.mfaUserUuid = '';
 
-      const redirectPath = router.currentRoute.value.query.redirect?.toString() || "/";
-      router.push(redirectPath);
+      await landAfterLogin();
     } else if (passkeyError.value) {
       errorMessage.value = passkeyError.value;
     }
@@ -343,8 +342,7 @@ const handleRecoveryLogin = async () => {
       recoveryMode.value = false;
       recoveryCode.value = '';
 
-      const redirectPath = router.currentRoute.value.query.redirect?.toString() || "/";
-      router.push(redirectPath);
+      await landAfterLogin();
     } else {
       errorMessage.value = response.data.message || 'Recovery code verification failed';
     }
@@ -397,16 +395,19 @@ const handleOidcLoginClick = async () => {
       await loginWithOidc();
       // Force past the 5s fetch cooldown: a fresh session must load the user
       // even if a pre-sign-out /auth/me attempt is still within the window.
+      // This must run BEFORE resolving the workspace: resolvePostLoginPath reads
+      // the myWorkspaces store, whose query is gated on isAuthenticated, which
+      // fetchUserData is what flips true.
       await authStore.fetchUserData({ force: true });
       authStore.setAuthProvider('oidc');
       // Session is live — register this device for push (best-effort; never
       // blocks routing into the app).
       void registerForPush();
-      const redirectPath = router.currentRoute.value.query.redirect?.toString();
-      // Resolve + set the active workspace before navigating so the first
-      // dashboard request carries the X-Nosdesk-Workspace header. An in-app
-      // login after sign-out otherwise lands with no workspace selected.
-      router.push(await resolvePostLoginPath(redirectPath));
+      // Resolve + set the active workspace before navigating so views mount with
+      // the slug (and thus the X-Nosdesk-Workspace header). The brief window
+      // between the auth flip above and the slug being set is covered by the
+      // workspaceReady gate on always-mounted queries (notifications, dashboard).
+      await landAfterLogin();
     } catch (error) {
       const err = error as Error;
       errorMessage.value = err.message || "Sign-in failed";

--- a/frontend/src/views/MFASetupView.vue
+++ b/frontend/src/views/MFASetupView.vue
@@ -197,6 +197,7 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, onUnmounted } from 'vue';
 import { useRouter, useRoute } from 'vue-router';
+import { landAfterLogin } from '@/router';
 import { useFluent } from 'fluent-vue';
 import { useAuthStore } from '@/stores/auth';
 import { useMfaSetupStore } from '@nosdesk/core/stores/mfaSetup';
@@ -278,7 +279,7 @@ onMounted(async () => {
   if (authStore.user && !authStore.mfaSetupRequired) {
     console.log('✅ User already authenticated, redirecting to dashboard');
     mfaSetupStore.clearCredentials();
-    router.push('/');
+    await landAfterLogin();
     return;
   }
 
@@ -350,23 +351,23 @@ const handlePasskeySetupError = (error: string) => {
 // Handle additional method setup success
 const handleAdditionalSetupSuccess = async (message: string) => {
   if (message === 'setup-complete' || message === 'Passkey created successfully') {
-    finishSetup();
+    void finishSetup();
   }
 };
 
 // Handle back button
 const handleBack = () => {
   if (mfaMethod.value === 'passkey-additional' || mfaMethod.value === 'totp-additional') {
-    finishSetup();
+    void finishSetup();
   } else {
     mfaMethod.value = 'choose';
   }
 };
 
 // Finish setup and redirect
-const finishSetup = () => {
+const finishSetup = async () => {
   mfaSetupStore.clearCredentials();
-  router.push('/');
+  await landAfterLogin();
 };
 
 // Navigation back to login

--- a/frontend/src/views/auth/OAuthCallbackView.vue
+++ b/frontend/src/views/auth/OAuthCallbackView.vue
@@ -3,6 +3,7 @@ import { ref, onMounted, computed } from 'vue'
 import { useFluent } from 'fluent-vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useAuthStore } from '@/stores/auth'
+import { resolvePostLoginPath } from '@/router'
 import apiClient from '@nosdesk/core/apiClient'
 import { useMicrosoftAuth } from '@/composables/useMicrosoftAuth'
 import AuthCallbackCard, { type ErrorInfo } from '@/components/auth/AuthCallbackCard.vue'
@@ -162,7 +163,9 @@ onMounted(async () => {
       }
       sessionStorage.removeItem('authRedirect')
 
-      setTimeout(() => router.push(redirectPath), 500)
+      // Resolve the workspace so path mode lands on `/<slug>` (host mode: `/`).
+      const target = await resolvePostLoginPath(redirectPath)
+      setTimeout(() => router.push(target), 500)
     } else {
       error.value = t('auth-callback-error-invalid-response')
       detailedError.value = JSON.stringify(data, null, 2)

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -17,6 +17,7 @@
     "@tauri-apps/plugin-deep-link": "^2.0.0",
     "@tauri-apps/plugin-haptics": "^2.0.0",
     "@tauri-apps/plugin-http": "^2.0.0",
+    "@tauri-apps/plugin-opener": "^2.0.0",
     "axios": "^1.6.2",
     "tauri-plugin-web-auth-api": "^1.0.0"
   },

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@nosdesk/core": "workspace:*",
     "@tauri-apps/api": "^2.0.0",
+    "@tauri-apps/plugin-deep-link": "^2.0.0",
     "@tauri-apps/plugin-haptics": "^2.0.0",
     "@tauri-apps/plugin-http": "^2.0.0",
     "axios": "^1.6.2",

--- a/mobile/src-tauri/Cargo.lock
+++ b/mobile/src-tauri/Cargo.lock
@@ -90,6 +90,7 @@ dependencies = [
  "tauri-plugin-haptics",
  "tauri-plugin-http",
  "tauri-plugin-log",
+ "tauri-plugin-opener",
  "tauri-plugin-push",
  "tauri-plugin-secure-store",
  "tauri-plugin-web-auth",
@@ -100,6 +101,137 @@ name = "arrayvec"
 version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f02882884d3e1bc524fb12c79f107f6ad0e1cfd498c536ffb494301740995dfe"
+
+[[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
 
 [[package]]
 name = "atk"
@@ -206,6 +338,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
  "objc2",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
 ]
 
 [[package]]
@@ -459,6 +604,15 @@ checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "memchr",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -920,6 +1074,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "env_filter"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -944,6 +1125,37 @@ dependencies = [
  "serde",
  "serde_core",
  "typeid",
+]
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -1081,6 +1293,19 @@ name = "futures-io"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
@@ -1469,6 +1694,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1767,6 +1998,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
+name = "is-docker"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "is-wsl"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
+dependencies = [
+ "is-docker",
+ "once_cell",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1940,6 +2190,12 @@ checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -2330,6 +2586,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "open"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0b3d059e795d52b8a72fef45658620edd4d9c359b338564aa14391ffa511ed5"
+dependencies = [
+ "dunce",
+ "is-wsl",
+ "libc",
+]
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2343,6 +2610,16 @@ checksum = "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79"
 dependencies = [
  "dlv-list",
  "hashbrown 0.14.5",
+]
+
+[[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -2369,6 +2646,12 @@ dependencies = [
  "libc",
  "system-deps",
 ]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -2459,6 +2742,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2501,6 +2795,20 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3028,6 +3336,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.13.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rustls"
 version = "0.23.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3361,6 +3682,16 @@ name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
 
 [[package]]
 name = "simd-adler32"
@@ -3877,6 +4208,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-opener"
+version = "2.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17e1bea14edce6b793a04e2417e3fd924b9bc4faae83cdee7d714156cceeed29"
+dependencies = [
+ "dunce",
+ "glob",
+ "objc2-app-kit",
+ "objc2-foundation",
+ "open",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+ "url",
+ "windows",
+ "zbus",
+]
+
+[[package]]
 name = "tauri-plugin-push"
 version = "0.1.0"
 dependencies = [
@@ -4006,6 +4359,19 @@ dependencies = [
  "dunce",
  "embed-resource",
  "toml 1.1.2+spec-1.1.0",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.3",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4408,6 +4774,17 @@ name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
+name = "uds_windows"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "unic-char-property"
@@ -5384,6 +5761,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "zbus"
+version = "5.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe18fb60dc696039e738717b76eaea21e7a4489bbb1885020b43c94236d7e98a"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-lite",
+ "hex",
+ "libc",
+ "ordered-stream",
+ "rustix",
+ "serde",
+ "serde_repr",
+ "tracing",
+ "uds_windows",
+ "uuid",
+ "windows-sys 0.61.2",
+ "winnow 1.0.3",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe96480bed92df2b442a1a30df364e12d08eed03aeb061f2b8dc6afb2be91119"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8bf88b4a3ff53e883001e0e0115b297a9d53c31b9c1edd2bfdd853e3428624e"
+dependencies = [
+ "serde",
+ "winnow 1.0.3",
+ "zvariant",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5468,3 +5906,43 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zvariant"
+version = "5.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee2a0bcd2a907786a456fff45aaaaf54c9ba5f50b71ae9ec1a4edd200c94911"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "winnow 1.0.3",
+ "zvariant_derive",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "5.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38a708216a18780796770bfe3f4739c7c83a3e8f789b755534bbbc06e4e23e12"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90cb9383f9b45290407a1258b202d3f8f01db719eb60b4e4055c6375af4fc7c7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 2.0.118",
+ "winnow 1.0.3",
+]

--- a/mobile/src-tauri/Cargo.lock
+++ b/mobile/src-tauri/Cargo.lock
@@ -86,6 +86,7 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-build",
+ "tauri-plugin-deep-link",
  "tauri-plugin-haptics",
  "tauri-plugin-http",
  "tauri-plugin-log",
@@ -461,6 +462,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "tiny-keccak",
+]
+
+[[package]]
 name = "cookie"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -571,6 +592,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -777,6 +804,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "dlv-list"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
+dependencies = [
+ "const-random",
 ]
 
 [[package]]
@@ -1410,6 +1446,12 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
@@ -1540,7 +1582,7 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
- "windows-registry",
+ "windows-registry 0.6.1",
 ]
 
 [[package]]
@@ -2294,6 +2336,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "ordered-multimap"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79"
+dependencies = [
+ "dlv-list",
+ "hashbrown 0.14.5",
+]
+
+[[package]]
 name = "pango"
 version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2931,6 +2983,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "rust-ini"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "796e8d2b6696392a43bea58116b667fb4c29727dc5abd27d6acf338bb4f688c7"
+dependencies = [
+ "cfg-if",
+ "ordered-multimap",
 ]
 
 [[package]]
@@ -3710,6 +3772,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-deep-link"
+version = "2.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ee75bc5627f77bfdf40c913255ebc258117b10ebe2b2239a1a1cf40b0b58aa"
+dependencies = [
+ "dunce",
+ "plist",
+ "rust-ini",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.18",
+ "tracing",
+ "url",
+ "windows-registry 0.5.3",
+ "windows-result 0.3.4",
+]
+
+[[package]]
 name = "tauri-plugin-fs"
 version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4008,6 +4091,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4253,7 +4345,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4827,6 +4931,17 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
+dependencies = [
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
 ]
 
 [[package]]

--- a/mobile/src-tauri/Cargo.toml
+++ b/mobile/src-tauri/Cargo.toml
@@ -32,6 +32,12 @@ tauri-plugin-haptics = "2"
 # System-browser OAuth (ASWebAuthenticationSession / Custom Tabs) for the native
 # OIDC login against the central IdP (see mobile/src/oidc.ts).
 tauri-plugin-web-auth = "1"
+# iOS Universal Links / Android App Links: routes a scanned ticket QR
+# (https://<slug>.nosdesk.app/tickets/<id>) into the app. The associated-domains
+# entitlement (gen/apple) + App Links intent-filter (gen/android) + the backend
+# /.well-known files are the OS-level source of truth; mobile/src does the
+# per-tenant routing in onOpenUrl.
+tauri-plugin-deep-link = "2"
 # Keystore/Keychain-backed secure storage for the refresh token, native iOS +
 # Android plugin code (see ../tauri-plugin-secure-store).
 tauri-plugin-secure-store = { path = "../tauri-plugin-secure-store" }

--- a/mobile/src-tauri/Cargo.toml
+++ b/mobile/src-tauri/Cargo.toml
@@ -38,6 +38,9 @@ tauri-plugin-web-auth = "1"
 # /.well-known files are the OS-level source of truth; mobile/src does the
 # per-tenant routing in onOpenUrl.
 tauri-plugin-deep-link = "2"
+# Open a URL in the system browser: the cross-tenant / not-connected fallback
+# for a ticket deep link the app can't open in place (see mobile/src/deepLink.ts).
+tauri-plugin-opener = "2"
 # Keystore/Keychain-backed secure storage for the refresh token, native iOS +
 # Android plugin code (see ../tauri-plugin-secure-store).
 tauri-plugin-secure-store = { path = "../tauri-plugin-secure-store" }

--- a/mobile/src-tauri/capabilities/default.json
+++ b/mobile/src-tauri/capabilities/default.json
@@ -19,6 +19,13 @@
     "secure-store:default",
     "haptics:allow-impact-feedback",
     "push:default",
-    "deep-link:default"
+    "deep-link:default",
+    {
+      "identifier": "opener:allow-open-url",
+      "comment": "Cross-tenant deep-link fallback: open the ticket URL in the system browser. HTTPS only.",
+      "allow": [
+        { "url": "https://*" }
+      ]
+    }
   ]
 }

--- a/mobile/src-tauri/capabilities/default.json
+++ b/mobile/src-tauri/capabilities/default.json
@@ -18,6 +18,7 @@
     "web-auth:allow-authenticate",
     "secure-store:default",
     "haptics:allow-impact-feedback",
-    "push:default"
+    "push:default",
+    "deep-link:default"
   ]
 }

--- a/mobile/src-tauri/gen/android/app/src/main/AndroidManifest.xml
+++ b/mobile/src-tauri/gen/android/app/src/main/AndroidManifest.xml
@@ -40,6 +40,21 @@
                 <category android:name="android.intent.category.BROWSABLE" />
                 <data android:scheme="nosdesk" />
             </intent-filter>
+            <!-- App Links: ticket deep links (https://<slug>.nosdesk.app/tickets/...).
+                 iOS Universal Links (associated-domains entitlement + AASA) are the
+                 primary path; Android is best-effort. NOTE: android:autoVerify of a
+                 wildcard host is not reliably verifiable (Android verifies concrete
+                 hosts via /.well-known/assetlinks.json), so with the wildcard the
+                 link may open via a chooser rather than directly. Reliable Android
+                 verification would need concrete tenant hosts or the central-link-
+                 domain approach (see the plan). -->
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="https" android:host="*.nosdesk.app" android:pathPrefix="/tickets" />
+                <data android:scheme="https" android:host="*.nosdesk.dev" android:pathPrefix="/tickets" />
+            </intent-filter>
         </activity>
 
         <provider

--- a/mobile/src-tauri/gen/apple/app_iOS/app_iOS.entitlements
+++ b/mobile/src-tauri/gen/apple/app_iOS/app_iOS.entitlements
@@ -4,13 +4,10 @@
 <dict>
 	<key>aps-environment</key>
 	<string>development</string>
-	<!-- Universal Links: a scanned ticket QR (https://<slug>.nosdesk.app/tickets/<id>)
-	     opens the app. Wildcard covers every tenant subdomain; Apple fetches the
-	     AASA from each host, which the single product backend serves. -->
 	<key>com.apple.developer.associated-domains</key>
 	<array>
-		<string>applinks:*.nosdesk.app</string>
-		<string>applinks:*.nosdesk.dev</string>
+		<string>applinks:app.nosdesk.com</string>
+		<string>applinks:app.nosdesk.dev</string>
 	</array>
 </dict>
 </plist>

--- a/mobile/src-tauri/gen/apple/app_iOS/app_iOS.entitlements
+++ b/mobile/src-tauri/gen/apple/app_iOS/app_iOS.entitlements
@@ -4,5 +4,13 @@
 <dict>
 	<key>aps-environment</key>
 	<string>development</string>
+	<!-- Universal Links: a scanned ticket QR (https://<slug>.nosdesk.app/tickets/<id>)
+	     opens the app. Wildcard covers every tenant subdomain; Apple fetches the
+	     AASA from each host, which the single product backend serves. -->
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>applinks:*.nosdesk.app</string>
+		<string>applinks:*.nosdesk.dev</string>
+	</array>
 </dict>
 </plist>

--- a/mobile/src-tauri/src/lib.rs
+++ b/mobile/src-tauri/src/lib.rs
@@ -7,6 +7,9 @@ pub fn run() {
     .plugin(tauri_plugin_http::init())
     // System-browser OAuth (ASWebAuthenticationSession) for native OIDC login.
     .plugin(tauri_plugin_web_auth::init())
+    // iOS Universal Links / Android App Links for ticket deep links; the JS
+    // side listens via onOpenUrl (see mobile/src). Config in tauri.conf.json.
+    .plugin(tauri_plugin_deep_link::init())
     // Keystore/Keychain-backed storage for the auth refresh token.
     .plugin(tauri_plugin_secure_store::init())
     // APNs/FCM push device-token registration (iOS live, Android stubbed).

--- a/mobile/src-tauri/src/lib.rs
+++ b/mobile/src-tauri/src/lib.rs
@@ -10,6 +10,8 @@ pub fn run() {
     // iOS Universal Links / Android App Links for ticket deep links; the JS
     // side listens via onOpenUrl (see mobile/src). Config in tauri.conf.json.
     .plugin(tauri_plugin_deep_link::init())
+    // System-browser opener for the cross-tenant deep-link fallback.
+    .plugin(tauri_plugin_opener::init())
     // Keystore/Keychain-backed storage for the auth refresh token.
     .plugin(tauri_plugin_secure_store::init())
     // APNs/FCM push device-token registration (iOS live, Android stubbed).

--- a/mobile/src-tauri/tauri.conf.json
+++ b/mobile/src-tauri/tauri.conf.json
@@ -41,8 +41,8 @@
   "plugins": {
     "deep-link": {
       "mobile": [
-        { "scheme": ["https"], "host": "*.nosdesk.app", "pathPrefix": ["/tickets"], "appLink": true },
-        { "scheme": ["https"], "host": "*.nosdesk.dev", "pathPrefix": ["/tickets"], "appLink": true }
+        { "scheme": ["https"], "host": "app.nosdesk.com", "appLink": true },
+        { "scheme": ["https"], "host": "app.nosdesk.dev", "appLink": true }
       ]
     }
   }

--- a/mobile/src-tauri/tauri.conf.json
+++ b/mobile/src-tauri/tauri.conf.json
@@ -37,5 +37,13 @@
     "android": {
       "debugApplicationIdSuffix": ".debug"
     }
+  },
+  "plugins": {
+    "deep-link": {
+      "mobile": [
+        { "scheme": ["https"], "host": "*.nosdesk.app", "pathPrefix": ["/tickets"], "appLink": true },
+        { "scheme": ["https"], "host": "*.nosdesk.dev", "pathPrefix": ["/tickets"], "appLink": true }
+      ]
+    }
   }
 }

--- a/mobile/src/deepLink.ts
+++ b/mobile/src/deepLink.ts
@@ -1,0 +1,48 @@
+/**
+ * Ticket deep links (iOS Universal Links / Android App Links).
+ *
+ * The native plugin delivers the tapped/scanned URL; the frontend decides where
+ * it goes (see the handler in App.vue). v1 rule: a ticket link whose host is the
+ * server we're connected to opens the ticket in-app (waiting for the session on
+ * a cold start / after login); anything else (a different tenant, a server we're
+ * not connected to) opens in the system browser.
+ */
+import { getCurrent, onOpenUrl } from '@tauri-apps/plugin-deep-link'
+import { openUrl } from '@tauri-apps/plugin-opener'
+
+/** The URL the app was cold-started with via a deep link, or null. */
+export async function getInitialDeepLink(): Promise<string | null> {
+  try {
+    const urls = await getCurrent()
+    return urls?.[0] ?? null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Subscribe to deep links opened while the app is running. Resolves to an
+ * unlisten function. Best-effort: never throws (a listener failure must not
+ * break app startup).
+ */
+export async function onDeepLink(handler: (url: string) => void): Promise<() => void> {
+  try {
+    return await onOpenUrl((urls) => {
+      for (const u of urls) handler(u)
+    })
+  } catch {
+    return () => {}
+  }
+}
+
+/**
+ * Open a URL in the system browser: the cross-tenant / not-connected fallback
+ * for a ticket link the app can't open in place. Best-effort.
+ */
+export async function openInBrowser(url: string): Promise<void> {
+  try {
+    await openUrl(url)
+  } catch {
+    // A failed browser hand-off must not throw.
+  }
+}

--- a/mobile/src/index.ts
+++ b/mobile/src/index.ts
@@ -12,6 +12,7 @@ export { bootstrapMobile, type MobileBootstrapOptions } from './bootstrap'
 export { setSession, clearSession, setServer } from './transport'
 export { loginWithOidc, logoutViaOidc } from './oidc'
 export { registerForPush, unregisterForPush, getPendingNotificationRoute } from './push'
+export { getInitialDeepLink, onDeepLink, openInBrowser } from './deepLink'
 export {
   getStoredServer,
   clearStoredServer,

--- a/mobile/src/transport.ts
+++ b/mobile/src/transport.ts
@@ -17,6 +17,7 @@ import {
   configureTransport,
   type AuthStrategy,
 } from '@nosdesk/core/transport'
+import { resetInstanceConfig } from '@nosdesk/core/services/instanceConfig'
 import { apiBaseUrlFor, collabWsBaseUrlFor, storeServer } from './serverConfig'
 import type { SecureStore } from './secureStore'
 
@@ -150,6 +151,11 @@ export async function configureServer(origin: string): Promise<void> {
     auth: bearerAuthStrategy,
   })
   syncAssetProxy()
+  // The instance config (routing topology) is server-specific. Forget any value
+  // resolved against the previous/default server so the next fetch resolves it
+  // against THIS one, else a stale/failed 'host' result strands path-mode
+  // servers with no workspace slug (every workspace request → NoWorkspaceSelected).
+  resetInstanceConfig()
 }
 
 /**

--- a/packages/core/src/services/instanceConfig.ts
+++ b/packages/core/src/services/instanceConfig.ts
@@ -5,6 +5,7 @@
  * the URL before it wires up routing. Instance-global (identical for every
  * workspace); per-workspace config lives behind auth.
  */
+import { readonly, ref, type Ref } from 'vue';
 import apiClient from '../apiClient';
 import { logger } from '../utils/logger';
 
@@ -42,11 +43,18 @@ let inboundForwardingEnabled = false;
 // is judged in the 'host' default and wrongly 404'd while the fetch is in flight.
 let configPromise: Promise<void> | null = null;
 
+// Reactive latch: flips true once the fetch SUCCEEDS (a failure clears the memo
+// to retry, see fetchInstanceConfig). Lets the workspace-ready gate tell "still
+// the 'host' default because we haven't resolved yet" from a real answer, so it
+// never acts on the pre-fetch default. Owned here (the fetch's owner) so nothing
+// fires a premature /config request just to observe completion.
+const configResolved = ref(false);
+
 /**
- * Fetch instance config once at bootstrap. The endpoint is public, so this is
- * safe before auth. Failures are swallowed and leave the 'host' default, so a
- * config blip can never strand the app on a route topology it can't serve.
- * Idempotent: repeat calls return the same in-flight/settled promise.
+ * Fetch instance config once per server. The endpoint is public, so it's safe
+ * before auth. Idempotent: repeat calls share one in-flight/settled promise. A
+ * failed fetch clears the memo so the next call retries instead of latching the
+ * 'host' default; resetInstanceConfig() re-arms it when the server changes.
  */
 export function fetchInstanceConfig(): Promise<void> {
   if (!configPromise) {
@@ -62,13 +70,40 @@ export function fetchInstanceConfig(): Promise<void> {
         if (typeof data?.inbound_forwarding_enabled === 'boolean') {
           inboundForwardingEnabled = data.inbound_forwarding_enabled;
         }
+        configResolved.value = true;
       } catch (e) {
-        logger.error('Failed to fetch instance config; defaulting workspace_routing=host', e);
+        logger.error('Failed to fetch instance config; will retry on next call', e);
+        // A failed fetch must NOT latch the 'host' default for the session. Clear
+        // the memo so the next caller (e.g. the router guard, once the mobile
+        // base URL is configured) retries. Leaving configResolved false keeps
+        // workspace-ready gates closed rather than firing header-less.
+        configPromise = null;
       }
     })();
   }
   return configPromise;
 }
+
+/**
+ * Forget the cached instance config so the next {@link fetchInstanceConfig}
+ * re-resolves it. The config is SERVER-SPECIFIC (routing topology differs per
+ * instance), so the mobile transport calls this whenever it points at a new
+ * server: without it, a value fetched against the default/bootstrap server (or a
+ * pre-server-selection failed fetch) would leak across and strand the app in the
+ * wrong routing mode for the whole session.
+ */
+export function resetInstanceConfig(): void {
+  configPromise = null;
+  configResolved.value = false;
+  workspaceRouting = 'host';
+  deploymentMode = 'self_hosted';
+  inboundForwardingEnabled = false;
+}
+
+/** Reactive: `true` once {@link fetchInstanceConfig} has settled (success or
+ *  failure). Consumers gating on the routing mode read this so they don't act
+ *  on the pre-fetch 'host' default. */
+export const instanceConfigResolvedRef: Readonly<Ref<boolean>> = readonly(configResolved);
 
 /** Where the workspace lives in the URL. 'host' until the config resolves. */
 export function getWorkspaceRouting(): WorkspaceRouting {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -221,6 +221,9 @@ importers:
       '@tauri-apps/api':
         specifier: ^2.0.0
         version: 2.11.1
+      '@tauri-apps/plugin-deep-link':
+        specifier: ^2.0.0
+        version: 2.4.9
       '@tauri-apps/plugin-haptics':
         specifier: ^2.0.0
         version: 2.3.2
@@ -806,6 +809,9 @@ packages:
     resolution: {integrity: sha512-EElQe8z8uD7Pi5++tJ/UfEwWuK08rd3oCDYdeIbJAb6pZRrxlqmoF5gh5H5YvzmUPhS4IRCaLSsQhvWkrfK+GQ==}
     engines: {node: '>= 10'}
     hasBin: true
+
+  '@tauri-apps/plugin-deep-link@2.4.9':
+    resolution: {integrity: sha512-u0SKOUHnJ1wqeqXsDFq2+kASCBj9xxbG0g9XZWPy9SOmU4wXtp6b/wiYpm6oH6/5fBTQsLqnLhIvqLBRpgHJlA==}
 
   '@tauri-apps/plugin-haptics@2.3.2':
     resolution: {integrity: sha512-TqvBR5JoPodDQWPXsNymmyqp37dOpunZOdVVbx5xOAxki7rVwiCMvoEPdtJQNIrU+dQDfkQYZ2oDBVOu4hf+ig==}
@@ -2837,6 +2843,10 @@ snapshots:
       '@tauri-apps/cli-win32-arm64-msvc': 2.11.3
       '@tauri-apps/cli-win32-ia32-msvc': 2.11.3
       '@tauri-apps/cli-win32-x64-msvc': 2.11.3
+
+  '@tauri-apps/plugin-deep-link@2.4.9':
+    dependencies:
+      '@tauri-apps/api': 2.11.1
 
   '@tauri-apps/plugin-haptics@2.3.2':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -230,6 +230,9 @@ importers:
       '@tauri-apps/plugin-http':
         specifier: ^2.0.0
         version: 2.5.9
+      '@tauri-apps/plugin-opener':
+        specifier: ^2.0.0
+        version: 2.5.4
       axios:
         specifier: ^1.6.2
         version: 1.18.1
@@ -818,6 +821,9 @@ packages:
 
   '@tauri-apps/plugin-http@2.5.9':
     resolution: {integrity: sha512-lCiY0+vs4HvIUSvZrBs8TC3TiCB0MOPRmiUjTq4prW7SlcJE2jdLeT6KBsJrT9Tlplufl7W1pY6SFAO3gCWxDA==}
+
+  '@tauri-apps/plugin-opener@2.5.4':
+    resolution: {integrity: sha512-1HnPkb+AmgO29HBazm4uPLKB+r7zzcTBW1d0fyYp1uP+jwtpoiNDGKMMzz58SFp49nOIrxdE3aUJtT57lfO9CQ==}
 
   '@tsconfig/node10@1.0.12':
     resolution: {integrity: sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==}
@@ -2853,6 +2859,10 @@ snapshots:
       '@tauri-apps/api': 2.11.1
 
   '@tauri-apps/plugin-http@2.5.9':
+    dependencies:
+      '@tauri-apps/api': 2.11.1
+
+  '@tauri-apps/plugin-opener@2.5.4':
     dependencies:
       '@tauri-apps/api': 2.11.1
 


### PR DESCRIPTION
## What

Ticket QR deep-linking on mobile via iOS Universal Links / Android App Links, plus the mobile first-login and sync fixes surfaced while testing it on device.

### Deep-linking
- Backend serves `/.well-known/apple-app-site-association` + `/assetlinks.json` (`well_known.rs`), scoped to `/tickets/*` and `/*/tickets/*` (host and path mode).
- `tauri-plugin-deep-link` wired with **specific-host** applinks (`app.nosdesk.com` + `app.nosdesk.dev`), not wildcards. Wildcard applinks don't reliably associate on iOS; the entitlement is generated from `tauri.conf.json`, which is the source of truth (hand-editing `app_iOS.entitlements` is overwritten by the build).
- In-app handler: a same-server ticket link opens in-app; a cross-workspace link does a real workspace switch (teardown + re-hydrate the sync pool) rather than a bare push; anything else falls back to the system browser.

### Mobile first-login fix
Fresh-install first login failed to load all workspace-scoped data until an app restart. Instance config (`workspace_routing`) was memoized against the default bootstrap server and never re-fetched against the user's actual server, leaving the app in `host` mode with no workspace slug, so every workspace request returned 400 `NoWorkspaceSelected` (notifications/account-scoped endpoints still worked). Fix: re-resolve instance config per server (`resetInstanceConfig()` in `configureServer`), retry on failed fetch instead of latching `host`, and gate workspace-scoped queries on a `workspaceReady` signal. Login surfaces consolidated behind one `landAfterLogin()` helper (also fixes password login dropping the `?redirect=` deep-link target).

### Sync engine gate
The sync engine was the only workspace-scoped consumer without the `workspaceReady` gate, so its bootstrap/delta fired header-less and the 10s delta poll returned 400 all session. Now gated on `canFetchWorkspace()` with a re-fire when the workspace becomes ready.

## Testing
- Verified on a physical iPhone: deep link opens the app on the ticket; fresh-install first login loads dashboard/tickets/users without a restart.
- Confirmed via staging server logs: `/api/config` resolves against the correct server, and `/api/sync/delta` flipped from 400 (all session) to sustained 200.

## Follow-ups (not in this PR)
- Cold-start deep-link delivery (native launch-URL buffering) if the empirical cold test shows the URL is dropped.
- Prod AASA reachability on `app.nosdesk.com`; Android release cert SHA-256 for `assetlinks.json`.