### PR TITLE
Mobile: responsive ticket header + global-search keyboard/gesture handling

### DIFF
--- a/frontend/src/components/GlobalSearch/GlobalSearchModal.vue
+++ b/frontend/src/components/GlobalSearch/GlobalSearchModal.vue
@@ -129,6 +129,68 @@ const resultGroups = ENTITY_DISPLAY_ORDER.map(type => ({
   type,
   key: ENTITY_TYPE_CONFIG[type].key,
 }));
+
+// ---------------------------------------------------------------
+// Swipe-down-to-dismiss (mobile sheet only). Arms only when the
+// results are scrolled to the top so a downward pull dismisses the
+// sheet instead of fighting a mid-list scroll; touch keyboards have
+// no Esc, so this joins the X and the back-gesture as an exit.
+// ---------------------------------------------------------------
+const DISMISS_PX = 80;
+const dragY = ref(0);
+const dragging = ref(false);
+const snapping = ref(false);
+let startY = 0;
+let armed = false;
+
+const dragStyle = computed(() => {
+  if (!dragging.value && !snapping.value && dragY.value === 0) return {};
+  return {
+    transform: `translateY(${dragY.value}px)`,
+    transition: dragging.value ? 'none' : 'transform 0.22s cubic-bezier(0.16,1,0.3,1)',
+  };
+});
+
+const onTouchStart = (e: TouchEvent) => {
+  if (e.touches.length !== 1 || window.innerWidth >= 640) return;
+  startY = e.touches[0].clientY;
+  // Arm only from the top of the results, so scrolling down through the
+  // list never turns into a dismiss.
+  armed = (resultsRef.value?.scrollTop ?? 0) <= 0;
+  dragging.value = false;
+};
+
+const onTouchMove = (e: TouchEvent) => {
+  if (!armed) return;
+  const dy = e.touches[0].clientY - startY;
+  if (dy <= 0) {
+    // Upward: hand it back to normal scrolling.
+    if (!dragging.value) armed = false;
+    return;
+  }
+  dragging.value = true;
+  dragY.value = dy;
+  e.preventDefault();
+};
+
+const onTouchEnd = () => {
+  armed = false;
+  if (!dragging.value) return;
+  dragging.value = false;
+  if (dragY.value > DISMISS_PX) {
+    closeSearch();
+    dragY.value = 0;
+    return;
+  }
+  // Snap back: keep the transform through the transition, then clear it.
+  snapping.value = true;
+  requestAnimationFrame(() => {
+    dragY.value = 0;
+  });
+  window.setTimeout(() => {
+    snapping.value = false;
+  }, 240);
+};
 </script>
 
 <template>
@@ -159,6 +221,11 @@ const resultGroups = ENTITY_DISPLAY_ORDER.map(type => ({
           role="dialog"
           aria-modal="true"
           :aria-label="t('search-global-aria-label')"
+          :style="dragStyle"
+          @touchstart.passive="onTouchStart"
+          @touchmove="onTouchMove"
+          @touchend.passive="onTouchEnd"
+          @touchcancel.passive="onTouchEnd"
         >
           <!-- Search header. Single row, no border on the input. -->
           <div class="flex items-center gap-2.5 px-4 h-12 border-b border-default flex-shrink-0">

--- a/frontend/src/components/GlobalSearch/GlobalSearchModal.vue
+++ b/frontend/src/components/GlobalSearch/GlobalSearchModal.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, watch, nextTick, computed } from 'vue';
+import { ref, watch, computed, onScopeDispose } from 'vue';
 import { useFluent } from 'fluent-vue';
 import { useGlobalSearch, SCOPE_OPTIONS } from '@/composables/useGlobalSearch';
 import { useVisualViewport } from '@/composables/useVisualViewport';
@@ -47,10 +47,8 @@ const {
   navigateToResult,
 } = useGlobalSearch();
 
-// While the palette is open, mirror the visual viewport into CSS vars
-// so the mobile sheet can size itself to the visible area — this is
-// what keeps the footer and results above the on-screen keyboard on
-// iOS/WKWebView, where the layout viewport never resizes.
+// Publish `--keyboard-height` while open, so the mobile input bar can dock just
+// above the keyboard (the only element that moves).
 useVisualViewport(isOpen);
 
 const filterLabels = computed<Record<string, string>>(() => ({
@@ -90,12 +88,12 @@ const scopeRows = computed(() =>
 const inputRef = ref<HTMLInputElement | null>(null);
 const resultsRef = ref<HTMLDivElement | null>(null);
 
-watch(isOpen, async (open) => {
-  if (open) {
-    await nextTick();
-    inputRef.value?.focus();
-  }
-});
+// Take the caret once the sheet is entering. On mobile the keyboard is already
+// up (raised by the primer inside the opening tap), so this only moves focus
+// into the real input, it never has to raise the keyboard itself. `preventScroll`
+// guards WKWebView's scroll-to-input jump (a no-op under the body scroll-lock,
+// but free).
+const focusInput = () => inputRef.value?.focus({ preventScroll: true });
 
 // Scoping from a group header or scope row must not drop focus from
 // the input — the whole point is to keep typing.
@@ -131,43 +129,68 @@ const resultGroups = ENTITY_DISPLAY_ORDER.map(type => ({
 }));
 
 // ---------------------------------------------------------------
-// Swipe-down-to-dismiss (mobile sheet only). Arms only when the
-// results are scrolled to the top so a downward pull dismisses the
-// sheet instead of fighting a mid-list scroll; touch keyboards have
-// no Esc, so this joins the X and the back-gesture as an exit.
+// Swipe-down-to-dismiss + open/close motion (mobile sheet).
+//
+// A full-screen sheet slides on the Y axis (Apple HIG / Material / vaul),
+// not scale-fade like the desktop palette. A downward flick OR a drag past
+// ~20% dismisses, and the close continues from the finger's release point
+// straight off-screen (velocity-aware), never jumping back to origin.
+// Curves: vaul/iOS open `cubic-bezier(.32,.72,0,1)`; an emphasized-accelerate
+// close so the fling momentum carries.
 // ---------------------------------------------------------------
-const DISMISS_PX = 80;
+const OPEN_EASE = 'cubic-bezier(0.32, 0.72, 0, 1)';
+const CLOSE_EASE = 'cubic-bezier(0.3, 0, 0.8, 0.15)';
+const OPEN_MS = 440;
+const VELOCITY_DISMISS = 0.4; // px/ms downward flick
+const DISTANCE_FRACTION = 0.2; // or dragged past 20% of the sheet height
+
+const isMobile = () => window.innerWidth < 640;
+const reduceMotion = () => window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
 const dragY = ref(0);
 const dragging = ref(false);
 const snapping = ref(false);
 let startY = 0;
 let armed = false;
 
+// Downward velocity: EMA of per-frame px/ms, so a late flick still counts.
+let vel = 0;
+let lastDy = 0;
+let lastT = 0;
+let flingVel = 0; // handed to the leave hook on dismiss
+
 const dragStyle = computed(() => {
   if (!dragging.value && !snapping.value && dragY.value === 0) return {};
   return {
     transform: `translateY(${dragY.value}px)`,
     transition: dragging.value ? 'none' : 'transform 0.22s cubic-bezier(0.16,1,0.3,1)',
+    willChange: 'transform',
   };
 });
 
 const onTouchStart = (e: TouchEvent) => {
-  if (e.touches.length !== 1 || window.innerWidth >= 640) return;
+  if (e.touches.length !== 1 || !isMobile()) return;
   startY = e.touches[0].clientY;
-  // Arm only from the top of the results, so scrolling down through the
-  // list never turns into a dismiss.
+  // Arm only from the top of the results, so scrolling down never dismisses.
   armed = (resultsRef.value?.scrollTop ?? 0) <= 0;
   dragging.value = false;
+  vel = 0;
+  lastDy = 0;
+  lastT = performance.now();
 };
 
 const onTouchMove = (e: TouchEvent) => {
   if (!armed) return;
   const dy = e.touches[0].clientY - startY;
   if (dy <= 0) {
-    // Upward: hand it back to normal scrolling.
-    if (!dragging.value) armed = false;
+    if (!dragging.value) armed = false; // upward: hand back to scrolling
     return;
   }
+  const now = performance.now();
+  const dt = now - lastT;
+  if (dt > 0) vel = vel * 0.7 + ((dy - lastDy) / dt) * 0.3;
+  lastDy = dy;
+  lastT = now;
   dragging.value = true;
   dragY.value = dy;
   e.preventDefault();
@@ -177,34 +200,164 @@ const onTouchEnd = () => {
   armed = false;
   if (!dragging.value) return;
   dragging.value = false;
-  if (dragY.value > DISMISS_PX) {
-    closeSearch();
-    dragY.value = 0;
+  const height =
+    (document.querySelector('.search-card') as HTMLElement | null)?.getBoundingClientRect()
+      .height ?? window.innerHeight;
+  if (vel > VELOCITY_DISMISS || dragY.value > height * DISTANCE_FRACTION) {
+    flingVel = Math.max(vel, 0);
+    closeSearch(); // leave hook slides from dragY off-screen; do NOT reset dragY
     return;
   }
-  // Snap back: keep the transform through the transition, then clear it.
+  // Snap back to rest.
   snapping.value = true;
-  requestAnimationFrame(() => {
-    dragY.value = 0;
-  });
-  window.setTimeout(() => {
-    snapping.value = false;
-  }, 240);
+  requestAnimationFrame(() => (dragY.value = 0));
+  window.setTimeout(() => (snapping.value = false), 240);
 };
+
+// ---------------------------------------------------------------
+// Enter/leave motion via WAAPI in JS hooks (the Transition uses
+// `:css=false`). Mobile slides on Y; desktop keeps the scale-pop. The
+// mobile leave starts from the live drag offset so a swipe flows straight
+// into the close, and its duration derives from the fling velocity.
+// ---------------------------------------------------------------
+const cardOf = (el: Element) => el.querySelector('.search-card') as HTMLElement;
+const backdropOf = (el: Element) => el.querySelector('.search-backdrop') as HTMLElement | null;
+
+const onBeforeEnter = (el: Element) => {
+  if (isMobile() && !reduceMotion()) cardOf(el).style.transform = 'translateY(100%)';
+};
+
+const onEnter = (el: Element, done: () => void) => {
+  const card = cardOf(el);
+  const clear = () => {
+    card.style.transform = '';
+    done();
+  };
+  focusInput(); // keyboard is already up on mobile (primer); just take the caret
+  if (reduceMotion()) {
+    clear();
+    return;
+  }
+  const mobile = isMobile();
+  backdropOf(el)?.animate([{ opacity: 0 }, { opacity: 1 }], {
+    duration: mobile ? 280 : 150,
+    easing: 'ease-out',
+    fill: 'backwards',
+  });
+  const anim = mobile
+    ? card.animate([{ transform: 'translateY(100%)' }, { transform: 'translateY(0)' }], {
+        duration: OPEN_MS,
+        easing: OPEN_EASE,
+        fill: 'backwards',
+      })
+    : card.animate(
+        [
+          { opacity: 0, transform: 'scale(0.97) translateY(-6px)' },
+          { opacity: 1, transform: 'none' },
+        ],
+        { duration: 180, easing: 'cubic-bezier(0.16,1,0.3,1)', fill: 'backwards' },
+      );
+  anim.onfinish = clear;
+  anim.oncancel = clear;
+};
+
+const onLeave = (el: Element, done: () => void) => {
+  const card = cardOf(el);
+  const backdrop = backdropOf(el);
+  const finish = () => {
+    dragY.value = 0;
+    flingVel = 0;
+    done();
+  };
+  if (reduceMotion()) {
+    finish();
+    return;
+  }
+  if (isMobile()) {
+    const from = dragY.value;
+    const height = card.getBoundingClientRect().height || window.innerHeight;
+    const remaining = Math.max(height - from, 1);
+    const duration = flingVel > 0.1 ? Math.min(360, Math.max(160, remaining / flingVel)) : 260;
+    backdrop?.animate([{ opacity: 1 }, { opacity: 0 }], {
+      duration: Math.min(duration, 200),
+      easing: 'ease-out',
+      fill: 'forwards',
+    });
+    const anim = card.animate(
+      [{ transform: `translateY(${from}px)` }, { transform: 'translateY(100%)' }],
+      { duration, easing: CLOSE_EASE, fill: 'forwards' },
+    );
+    anim.onfinish = finish;
+    anim.oncancel = finish;
+  } else {
+    backdrop?.animate([{ opacity: 1 }, { opacity: 0 }], {
+      duration: 150,
+      easing: 'ease',
+      fill: 'forwards',
+    });
+    const anim = card.animate(
+      [
+        { opacity: 1, transform: 'none' },
+        { opacity: 0, transform: 'scale(0.98)' },
+      ],
+      { duration: 150, easing: 'ease', fill: 'forwards' },
+    );
+    anim.onfinish = finish;
+    anim.oncancel = finish;
+  }
+};
+
+// ---------------------------------------------------------------
+// Background scroll-lock (mobile). A position:fixed body (not
+// overflow:hidden, which iOS ignores for rubber-band / keyboard
+// pan) stops the layout viewport from panning under the keyboard,
+// which is what otherwise slides the fixed sheet out of the visible
+// band. The overlay is itself position:fixed (Teleported to body),
+// so it escapes the lock and its results list keeps scrolling.
+// ---------------------------------------------------------------
+let restoreScroll: (() => void) | null = null;
+
+const lockBody = () => {
+  if (restoreScroll || window.innerWidth >= 640) return;
+  const y = window.scrollY;
+  const s = document.body.style;
+  const prev = { position: s.position, top: s.top, left: s.left, right: s.right, width: s.width };
+  s.position = 'fixed';
+  s.top = `-${y}px`;
+  s.left = '0';
+  s.right = '0';
+  s.width = '100%';
+  restoreScroll = () => {
+    Object.assign(document.body.style, prev);
+    window.scrollTo(0, y);
+    restoreScroll = null;
+  };
+};
+
+watch(isOpen, (open) => (open ? lockBody() : restoreScroll?.()), { immediate: true });
+onScopeDispose(() => restoreScroll?.());
 </script>
 
 <template>
   <Teleport to="body">
-    <Transition name="search-modal" appear>
+    <Transition
+      :css="false"
+      appear
+      @before-enter="onBeforeEnter"
+      @enter="onEnter"
+      @appear="onEnter"
+      @leave="onLeave"
+    >
       <div
         v-if="isOpen"
-        class="fixed inset-0 z-overlay flex items-start justify-center sm:px-4 sm:pt-[15dvh]"
+        class="search-overlay fixed inset-0 z-overlay flex items-start justify-center sm:px-4 sm:pt-[15dvh]"
       >
         <!-- Backdrop. Subtle blur, click to dismiss. Fully covered by
              the sheet below `sm`, where the header close button takes
-             over dismissal. -->
+             over dismissal. Opacity is animated by the enter/leave hooks
+             (search-backdrop). -->
         <div
-          class="absolute inset-0 bg-black/40 dark:bg-black/60 backdrop-blur-sm"
+          class="search-backdrop absolute inset-0 bg-black/40 dark:bg-black/60 backdrop-blur-sm"
           @click="closeSearch"
         />
 
@@ -227,53 +380,60 @@ const onTouchEnd = () => {
           @touchend.passive="onTouchEnd"
           @touchcancel.passive="onTouchEnd"
         >
-          <!-- Search header. Single row, no border on the input. -->
-          <div class="flex items-center gap-2.5 px-4 h-12 border-b border-default flex-shrink-0">
-            <Icon name="search" size="md" class="flex-shrink-0 text-tertiary" />
+          <!-- Search input bar. Desktop: top header. Mobile: docks to the
+               bottom, above the keyboard (see .search-inputbar), Firefox/Brave
+               style, so the results fill the space above it. The wrapper owns
+               the docking/border/background (and, on mobile, extends its
+               background into the home-indicator safe area); the inner row is a
+               clean fixed-height input line so the safe area never distorts it. -->
+          <div class="search-inputbar flex-shrink-0">
+            <div class="flex items-center gap-2.5 px-4 h-12">
+              <Icon name="search" size="md" class="flex-shrink-0 text-tertiary" />
 
-            <button
-              v-if="activeTypes"
-              @click="clearTypes"
-              class="inline-flex items-center gap-1 px-2 h-6 text-[11px] font-medium rounded-md bg-accent/10 text-accent border border-accent/20 hover:bg-accent/20 transition-colors flex-shrink-0"
-            >
-              {{ scopeLabel(activeTypes) }}
-              <Icon name="close" size="xs" />
-            </button>
+              <button
+                v-if="activeTypes"
+                @click="clearTypes"
+                class="inline-flex items-center gap-1 px-2 h-6 text-[11px] font-medium rounded-md bg-accent/10 text-accent border border-accent/20 hover:bg-accent/20 transition-colors flex-shrink-0"
+              >
+                {{ scopeLabel(activeTypes) }}
+                <Icon name="close" size="xs" />
+              </button>
 
-            <!-- Person filter chip. Composes with the scope chip; the
-                 leading "from" prefix reads as the operator that set it. -->
-            <button
-              v-if="authorFilter"
-              @click="clearAuthor"
-              class="inline-flex items-center gap-1 px-2 h-6 text-[11px] font-medium rounded-md bg-brand-pink/10 text-brand-pink border border-brand-pink/20 hover:bg-brand-pink/20 transition-colors flex-shrink-0 max-w-[10rem]"
-              :title="t('search-global-from-chip', { name: authorFilter.name })"
-            >
-              <Icon name="user" size="xs" class="flex-shrink-0" />
-              <span class="truncate">{{ authorFilter.name }}</span>
-              <Icon name="close" size="xs" class="flex-shrink-0" />
-            </button>
+              <!-- Person filter chip. Composes with the scope chip; the
+                   leading "from" prefix reads as the operator that set it. -->
+              <button
+                v-if="authorFilter"
+                @click="clearAuthor"
+                class="inline-flex items-center gap-1 px-2 h-6 text-[11px] font-medium rounded-md bg-brand-pink/10 text-brand-pink border border-brand-pink/20 hover:bg-brand-pink/20 transition-colors flex-shrink-0 max-w-[10rem]"
+                :title="t('search-global-from-chip', { name: authorFilter.name })"
+              >
+                <Icon name="user" size="xs" class="flex-shrink-0" />
+                <span class="truncate">{{ authorFilter.name }}</span>
+                <Icon name="close" size="xs" class="flex-shrink-0" />
+              </button>
 
-            <input
-              ref="inputRef"
-              v-model="query"
-              type="text"
-              :placeholder="placeholder"
-              class="flex-1 bg-transparent text-primary placeholder-tertiary/60 outline-none text-sm font-medium"
-              autocomplete="off"
-              spellcheck="false"
-            />
+              <input
+                ref="inputRef"
+                v-model="query"
+                type="text"
+                :placeholder="placeholder"
+                class="flex-1 bg-transparent text-primary placeholder-tertiary/60 outline-none text-sm font-medium"
+                autocomplete="off"
+                spellcheck="false"
+              />
 
-            <!-- Mobile-only close. The sheet covers the backdrop and
-                 touch keyboards have no Esc, so the exit affordance
-                 must live in the chrome. -->
-            <button
-              type="button"
-              class="sm:hidden flex-shrink-0 -mr-1 p-1.5 rounded-md text-tertiary hover:text-secondary hover:bg-surface-hover/60 transition-colors"
-              :aria-label="t('search-global-hint-close')"
-              @click="closeSearch"
-            >
-              <Icon name="close" size="sm" />
-            </button>
+              <!-- Mobile-only close. The sheet covers the backdrop and
+                   touch keyboards have no Esc, so the exit affordance
+                   must live in the chrome. -->
+              <button
+                type="button"
+                class="sm:hidden flex-shrink-0 -mr-1 p-1.5 rounded-md text-tertiary hover:text-secondary hover:bg-surface-hover/60 transition-colors"
+                :aria-label="t('search-global-hint-close')"
+                @click="closeSearch"
+              >
+                <Icon name="close" size="sm" />
+              </button>
+            </div>
           </div>
 
           <!-- Results region. Holds all body states; `min-h-0`
@@ -494,53 +654,65 @@ const onTouchEnd = () => {
 </template>
 
 <style scoped>
-/* Mobile: full-height, top-anchored sheet. Height tracks the visual
-   viewport (set by useVisualViewport while open) so the on-screen
-   keyboard shrinks the sheet instead of covering its lower half; the
-   dvh fallback covers browsers without the API and the moments before
-   the first viewport event lands. Safe-area padding keeps the input
-   row out of the status bar / notch (viewport-fit=cover). */
+/* Divider under the input row. This lives on the bar (not the row) because the
+   Tailwind border moved off the row in the split; the mobile block below flips
+   it to a top border since the bar docks to the bottom there. */
+.search-inputbar {
+  border-bottom: 1px solid var(--color-default);
+}
+
+/* Mobile: static full-screen overlay with the input docked to the bottom and
+   riding the keyboard (Firefox/Brave style). Only the input bar tracks the
+   keyboard; the overlay/results never resize, which is what kept every
+   sheet-resizing approach feeling "forced". */
 @media (max-width: 639.98px) {
+  .search-overlay {
+    height: 100dvh;
+  }
+
   .search-card {
-    height: var(--visual-viewport-height, 100dvh);
+    height: 100%;
     max-height: none;
     border-radius: 0;
     padding-top: env(safe-area-inset-top);
+    --input-bar-h: 3rem; /* matches the h-12 input row */
   }
 
-  /* No footer on mobile — the results list runs to the sheet's
-     bottom edge, so it carries the home-indicator clearance itself
-     (when the keyboard is up the sheet already ends above it). */
-  .search-results {
+  /* Input bar docked to the bottom, riding the keyboard via ONE compositor
+     transform (no transition: visualViewport fires throughout the keyboard
+     animation so it tracks 1:1; easing would make it lag). The border flips to
+     the top edge, and it needs an opaque background since it now floats over
+     the results; its padding-bottom extends that background into the
+     home-indicator safe area below the fixed-height row. */
+  .search-inputbar {
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    transform: translateY(calc(-1 * var(--keyboard-height, 0px)));
+    will-change: transform;
+    border-bottom: 0;
+    border-top: 1px solid var(--color-default);
+    background: var(--color-surface);
     padding-bottom: env(safe-area-inset-bottom);
   }
+  /* Keyboard up: the bar rests on the keyboard, so drop the home-indicator inset. */
+  .search-card:has(input:focus, textarea:focus, [contenteditable]:focus) .search-inputbar {
+    padding-bottom: 0;
+  }
+
+  /* Results fill the space above the docked input; pad the bottom so the last
+     row clears the input bar + keyboard. Padding changes don't move the scroll
+     offset, so toggling the keyboard never jumps the list. */
+  .search-results {
+    padding-bottom: calc(
+      var(--input-bar-h) + var(--keyboard-height, 0px) + env(safe-area-inset-bottom)
+    );
+  }
 }
 
-.search-modal-enter-active,
-.search-modal-leave-active {
-  transition: opacity 0.15s ease;
-}
-
-.search-modal-enter-active > div:last-child,
-.search-modal-leave-active > div:last-child {
-  transition: transform 0.18s cubic-bezier(0.16, 1, 0.3, 1), opacity 0.15s ease;
-}
-
-.search-modal-enter-from,
-.search-modal-leave-to {
-  opacity: 0;
-}
-
-.search-modal-enter-from > div:last-child {
-  opacity: 0;
-  transform: scale(0.97) translateY(-6px);
-}
-
-.search-modal-leave-to > div:last-child {
-  opacity: 0;
-  transform: scale(0.98);
-}
-
+/* Enter/leave motion is driven by the WAAPI hooks in <script> (the
+   Transition runs with :css=false), so there are no transition classes here. */
 
 /* Subtle scrollbar on the results area. */
 .overflow-y-auto {

--- a/frontend/src/components/views/TicketsHeader.vue
+++ b/frontend/src/components/views/TicketsHeader.vue
@@ -353,13 +353,17 @@ defineExpose({ openAddFilter })
 
       <div class="flex-1 min-w-2" />
 
-      <!-- Density quick-toggle. Three icon buttons. Hidden below
-           md: — phones don't have meaningful row density choices. -->
-      <ListDensityToggle
-        class="hidden md:inline-flex"
-        :density="density"
-        @set-density="(v) => emit('set-density', v)"
-      />
+      <!-- Density quick-toggle. Three icon buttons. Hidden below md: on a
+           WRAPPER, not the component root: ListDensityToggle's root is
+           `inline-flex`, which fights a merged `hidden` (source order wins, so
+           `hidden` loses and it shows on phones). Same fix as the ViewSwitcher
+           wrappers above. -->
+      <div class="hidden md:inline-flex">
+        <ListDensityToggle
+          :density="density"
+          @set-density="(v) => emit('set-density', v)"
+        />
+      </div>
 
       <!-- Split-view toggle. Two-pane SVG so the icon reads as
            "list + preview" not just generic 'split'. Hidden below
@@ -384,22 +388,24 @@ defineExpose({ openAddFilter })
         </svg>
       </button>
 
-      <!-- Column / density / grouping controls. Power-user chrome,
-           hidden below md: to keep the mobile toolbar shallow. -->
-      <DisplayMenu
-        class="hidden md:inline-flex"
-        :visible="visibleColumns"
-        :density="density"
-        :group-by="groupBy"
-        :can-save-to-view="canSaveLayoutToView"
-        :layout-dirty="layoutDirty"
-        :available-columns="availableColumns"
-        @toggle-column="(id) => emit('toggle-column', id)"
-        @set-density="(v) => emit('set-density', v)"
-        @set-group-by="(v) => emit('set-group-by', v)"
-        @reset="emit('reset-layout')"
-        @save="emit('save-layout-to-view')"
-      />
+      <!-- Column / density / grouping controls. Power-user chrome, hidden below
+           md: on a WRAPPER (DisplayMenu's root is `inline-flex`, see the density
+           wrapper above) to keep the mobile toolbar shallow. -->
+      <div class="hidden md:inline-flex">
+        <DisplayMenu
+          :visible="visibleColumns"
+          :density="density"
+          :group-by="groupBy"
+          :can-save-to-view="canSaveLayoutToView"
+          :layout-dirty="layoutDirty"
+          :available-columns="availableColumns"
+          @toggle-column="(id) => emit('toggle-column', id)"
+          @set-density="(v) => emit('set-density', v)"
+          @set-group-by="(v) => emit('set-group-by', v)"
+          @reset="emit('reset-layout')"
+          @save="emit('save-layout-to-view')"
+        />
+      </div>
 
       <!-- The local "New ticket" button used to live here as a
            fallback for the (broken) site-header Create button.

--- a/frontend/src/composables/keyboardPrimer.ts
+++ b/frontend/src/composables/keyboardPrimer.ts
@@ -1,0 +1,53 @@
+/**
+ * Raise the iOS software keyboard SYNCHRONOUSLY inside the opening tap.
+ *
+ * WKWebView presents the keyboard only when `focus()` runs during a live user
+ * activation (the tap handler). Our real search input is teleported and only
+ * mounts on the next render tick, too late to focus in the gesture, so a later
+ * `focus()` moves the caret without showing the keyboard (the setTimeout bug).
+ *
+ * Fix: focus a persistent, near-invisible "primer" input synchronously from the
+ * opener (`primeKeyboard()` at the top of openSearch). That raises the keyboard
+ * now; when the real input mounts, focusing it just transfers the caret under a
+ * keyboard that is already up (no fresh gesture needed to MOVE focus).
+ */
+let primer: HTMLInputElement | null = null;
+
+function ensurePrimer(): HTMLInputElement {
+  if (primer) return primer;
+  const el = document.createElement('input');
+  el.type = 'text';
+  el.setAttribute('aria-hidden', 'true');
+  el.tabIndex = -1;
+  Object.assign(el.style, {
+    position: 'fixed',
+    top: '0',
+    left: '0',
+    width: '1px',
+    height: '1px',
+    // Must stay "rendered" (not display:none / visibility:hidden), and >=16px so
+    // focusing it doesn't trigger iOS's zoom-on-small-input.
+    fontSize: '16px',
+    opacity: '0.01',
+    color: 'transparent',
+    caretColor: 'transparent',
+    border: '0',
+    padding: '0',
+    background: 'transparent',
+    pointerEvents: 'none',
+    zIndex: '-1',
+  });
+  document.body.appendChild(el);
+  primer = el;
+  return el;
+}
+
+/** Call SYNCHRONOUSLY from the opening gesture (top of openSearch). Touch only. */
+export function primeKeyboard(): void {
+  if (!window.matchMedia('(pointer: coarse)').matches) return;
+  try {
+    ensurePrimer().focus({ preventScroll: true });
+  } catch {
+    // Best-effort: a failure just means the real input's focus shows the keyboard.
+  }
+}

--- a/frontend/src/composables/useGlobalSearch.ts
+++ b/frontend/src/composables/useGlobalSearch.ts
@@ -5,6 +5,7 @@ import { searchService } from '@nosdesk/core/services/searchService';
 import type { SearchResult, SearchResponse, GroupedSearchResults, SearchEntityType, SearchSortOrder } from '@nosdesk/core/types/search';
 import { groupResultsByType, emptyGroupedResults, ENTITY_DISPLAY_ORDER, ENTITY_TYPE_CONFIG } from '@nosdesk/core/types/search';
 import { translate } from '@/i18n';
+import { primeKeyboard } from '@/composables/keyboardPrimer';
 
 /** Mutually exclusive states for the search surface. */
 export type SearchState = 'prompt' | 'searching' | 'results' | 'empty' | 'error';
@@ -289,6 +290,12 @@ export function useGlobalSearch() {
 
   const openSearch = (types?: string) => {
     const wasOpen = isOpen.value;
+    // Raise the keyboard synchronously in the opening tap (the real input mounts
+    // a tick too late to focus in the gesture; iOS only shows the keyboard for a
+    // focus inside user activation). See keyboardPrimer. Only on a fresh open:
+    // re-priming while already open would blur the live input without handing
+    // focus back (no enter transition fires to refocus it).
+    if (!wasOpen) primeKeyboard();
     isOpen.value = true;
     query.value = '';
     activeTypes.value = types;

--- a/frontend/src/composables/useGlobalSearch.ts
+++ b/frontend/src/composables/useGlobalSearch.ts
@@ -127,6 +127,12 @@ const selectedAuthorIndex = ref(0);
 const FROM_TOKEN_RE = /(^|\s)from:(\S*)$/i;
 
 let keyboardListenerRegistered = false;
+let historyListenerRegistered = false;
+// True while closeSearch() must NOT pop the pushed history entry itself: either
+// a popstate (OS/edge-swipe back) already consumed it, or navigateToResult is
+// about to replace it. Without this guard closeSearch would pop again and
+// navigate the page underneath.
+let closingViaHistory = false;
 
 /** Step an index by `delta` within `[0, len)`, wrapping at both ends. */
 function wrapIndex(index: number, len: number, delta: number): number {
@@ -282,6 +288,7 @@ export function useGlobalSearch() {
   };
 
   const openSearch = (types?: string) => {
+    const wasOpen = isOpen.value;
     isOpen.value = true;
     query.value = '';
     activeTypes.value = types;
@@ -289,9 +296,19 @@ export function useGlobalSearch() {
     selectedScopeIndex.value = 0;
     resetAuthor();
     resetResults();
+    // Push a history entry so the OS/edge-swipe back gesture (and Android
+    // hardware back) closes the palette instead of navigating the page under it.
+    if (!wasOpen) {
+      try {
+        history.pushState({ ...history.state, nosdeskSearch: true }, '');
+      } catch {
+        // history unavailable: fall back to the X / Esc affordances.
+      }
+    }
   };
 
   const closeSearch = () => {
+    if (!isOpen.value) return; // idempotent (popstate + X can both fire)
     isOpen.value = false;
     query.value = '';
     activeTypes.value = undefined;
@@ -299,6 +316,16 @@ export function useGlobalSearch() {
     selectedScopeIndex.value = 0;
     resetAuthor();
     resetResults();
+    // Closed by the X / backdrop / Esc (not by a back navigation): pop the
+    // entry openSearch pushed so history stays clean. A popstate-driven close
+    // already consumed it, so skip (else we'd navigate the page underneath).
+    if (!closingViaHistory && history.state?.nosdeskSearch) {
+      try {
+        history.back();
+      } catch {
+        /* no-op */
+      }
+    }
   };
 
   const clearTypes = () => {
@@ -357,8 +384,18 @@ export function useGlobalSearch() {
   );
 
   const navigateToResult = (result: SearchResult) => {
+    // Close WITHOUT popping the pushed entry (that would race the push below),
+    // then overwrite it with the destination so back from the result lands on
+    // the page the palette was opened from, not a reopened palette.
+    const viaSearchEntry = !!history.state?.nosdeskSearch;
+    closingViaHistory = true;
     closeSearch();
-    router.push(result.url);
+    closingViaHistory = false;
+    if (viaSearchEntry) {
+      router.replace(result.url);
+    } else {
+      router.push(result.url);
+    }
   };
 
   // Keyboard navigation
@@ -458,10 +495,24 @@ export function useGlobalSearch() {
     }
   };
 
+  // Back navigation (OS/edge-swipe back, Android hardware back) closes the
+  // palette instead of leaving the page. Paired with the pushState in
+  // openSearch: the pop consumes that entry, so closeSearch must not pop again.
+  const handlePopState = () => {
+    if (!isOpen.value) return;
+    closingViaHistory = true;
+    closeSearch();
+    closingViaHistory = false;
+  };
+
   onMounted(() => {
     if (!keyboardListenerRegistered) {
       window.addEventListener('keydown', handleKeyDown);
       keyboardListenerRegistered = true;
+    }
+    if (!historyListenerRegistered) {
+      window.addEventListener('popstate', handlePopState);
+      historyListenerRegistered = true;
     }
   });
 

--- a/frontend/src/composables/useVisualViewport.ts
+++ b/frontend/src/composables/useVisualViewport.ts
@@ -1,43 +1,38 @@
 import { watch, onUnmounted, type Ref } from 'vue';
 
 /**
- * Mirror the visual viewport into root CSS custom properties so
- * fixed overlays can size themselves to the *visible* area rather
- * than the layout viewport:
+ * While `active`, publish the on-screen keyboard height to one CSS var:
  *
- * - `--visual-viewport-height`: the visible height in px.
- * - `--keyboard-inset`: how much of the layout viewport's bottom is
- *   obscured (on-screen keyboard, mostly), in px.
+ *   --keyboard-height = max(0, innerHeight - visualViewport.height - offsetTop)
  *
- * Why this exists: neither WKWebView (the Tauri mobile shell) nor
- * iOS Safari resizes the layout viewport when the on-screen keyboard
- * opens, so `100dvh` still measures the full screen and anything
- * bottom-anchored disappears behind the keyboard. The visualViewport
- * API is the only web-side signal that tracks it (`interactive-
- * widget=resizes-content` in the viewport meta covers Chrome/Android
- * by resizing the layout viewport instead — there the inset computes
- * to ~0 and the vars are harmlessly redundant).
- *
- * Listeners are bound only while `active` is true — an overlay passes
- * its open state — so the app pays nothing at idle. Consumers style
- * with `var(--visual-viewport-height, 100dvh)`: the fallback keeps
- * every non-listening moment (and browsers without the API) on plain
- * dvh behaviour.
+ * A bottom-docked input translates up by it and the results scroll area pads
+ * its bottom by it, so ONLY the input rides the keyboard (one compositor
+ * transform) and nothing resizes. iOS/WKWebView never resizes the layout
+ * viewport for the keyboard (dvh/`interactive-widget` don't track it), so
+ * visualViewport is the only signal; `innerHeight` is the keyboard-invariant
+ * layout viewport, `vv.height` the visual one, and `offsetTop` covers the pan.
  */
 export function useVisualViewport(active: Ref<boolean>) {
   const root = document.documentElement;
   let bound = false;
+  let raf = 0;
 
-  const update = () => {
+  const apply = () => {
+    raf = 0;
     const vv = window.visualViewport;
     if (!vv) return;
-    // offsetTop accounts for the visible region being pushed down
-    // (pinch-zoom pan, or WKWebView shifting to reveal an input);
-    // subtracting it keeps the inset an honest "hidden at the
-    // bottom" measure.
-    const inset = Math.max(0, window.innerHeight - vv.height - vv.offsetTop);
-    root.style.setProperty('--visual-viewport-height', `${Math.round(vv.height)}px`);
-    root.style.setProperty('--keyboard-inset', `${Math.round(inset)}px`);
+    let kb = Math.round(window.innerHeight - vv.height - vv.offsetTop);
+    // Clamp jitter and the iOS 26 bug where the inset doesn't fully reset on
+    // dismiss (~24px residual, WebKit #297779).
+    if (kb < 24) kb = 0;
+    root.style.setProperty('--keyboard-height', `${kb}px`);
+  };
+
+  // visualViewport events fire many times per keyboard animation; coalesce to
+  // one write per frame so the input rides it smoothly.
+  const update = () => {
+    if (raf) return;
+    raf = requestAnimationFrame(apply);
   };
 
   const bind = () => {
@@ -45,19 +40,20 @@ export function useVisualViewport(active: Ref<boolean>) {
     if (bound || !vv) return;
     vv.addEventListener('resize', update);
     vv.addEventListener('scroll', update);
-    update();
+    apply();
     bound = true;
   };
 
   const unbind = () => {
     const vv = window.visualViewport;
     if (!bound) return;
+    if (raf) {
+      cancelAnimationFrame(raf);
+      raf = 0;
+    }
     vv?.removeEventListener('resize', update);
     vv?.removeEventListener('scroll', update);
-    // Drop the vars so consumers fall back to their dvh defaults
-    // instead of a stale snapshot from the last open.
-    root.style.removeProperty('--visual-viewport-height');
-    root.style.removeProperty('--keyboard-inset');
+    root.style.removeProperty('--keyboard-height');
     bound = false;
   };
 


### PR DESCRIPTION
Three mobile-polish fixes to the ticket list header and global search.

## Ticket header (`f5ce24f1`)
Density toggle + Display controls were showing on phones. Root cause was passing `hidden md:inline-flex` to components whose root already carries `inline-flex`; CSS source order lets `.inline-flex` beat the merged `.hidden`, so the visibility class was silently defeated. Fixed by wrapping the controls in a plain div that carries the responsive visibility.

## Global search dismissal (`5da29987`)
Full-page mobile search couldn't be closed by swipe-down or the edge-swipe-back gesture, only the top-right X. Added:
- History-back-to-close: `openSearch` pushes a history entry so the OS back / edge-swipe gesture closes the sheet instead of navigating the page underneath.
- Velocity-aware swipe-down dismiss: a downward flick or a drag past ~20% closes, continuing from the finger's release point off-screen.

## Global search keyboard (`4927a535`)
The mobile search input now docks to the bottom above the keyboard (Firefox/Brave style): the input rides the keyboard via a single `--keyboard-height` transform while the results and overlay stay static, only one element moves. Highlights:
- **Keyboard raise:** a synchronous "primer" focus inside the opening tap (WKWebView only shows the keyboard for a focus during a live user activation; the teleported real input mounts a tick too late).
- **`useVisualViewport`:** publishes one `--keyboard-height` var (visualViewport is the only keyboard signal in WKWebView; dvh/svh/interactive-widget all no-op), coalesced per frame, clamped for the iOS 26 reset residual.
- **Safe area:** the bar is split into a positioning wrapper (background reaches the home indicator) around a fixed-height input row, so the safe-area inset no longer distorts the bar height.

Verified on-device (iOS): keyboard auto-raises on open, input sits cleanly above the keyboard both keyboard-up and keyboard-down, swipe/back dismissal intact. Type-check, lint, build all clean.