### PR TITLE
Harden BYPASSRLS background paths + scope the notification bell per-workspace

### DIFF
--- a/backend/src/handlers/inbound_dead_letters.rs
+++ b/backend/src/handlers/inbound_dead_letters.rs
@@ -56,6 +56,7 @@ pub async fn list(req: HttpRequest, pool: web::Data<Pool>) -> HttpResponse {
     }
 
     let since = chrono::Utc::now().naive_utc() - chrono::Duration::days(7);
+    // cross-tenant: inbound_dead_letters is an untenanted platform-admin table.
     let result = crate::sync::session::background_run(&pool, "inbound:list_dead_letters", |conn| {
         let rows = repo::list_recent(conn, DEFAULT_LIMIT.min(MAX_LIMIT))?;
         let count_7d = repo::count_since(conn, since)?;

--- a/backend/src/handlers/inbound_email.rs
+++ b/backend/src/handlers/inbound_email.rs
@@ -124,6 +124,7 @@ pub async fn receive(
     let resolved = match &token {
         Some(tok) => {
             let tok = tok.clone();
+            // cross-tenant: token to workspace routing: the workspace is unknown until the forwarding token resolves.
             match crate::sync::session::background_run(
                 &pool,
                 "inbound:resolve_token",
@@ -158,6 +159,7 @@ pub async fn receive(
             match &managed_slug_candidate {
                 Some(slug) => {
                     let slug = slug.clone();
+                    // cross-tenant: slug to workspace routing: the workspace is unknown until the slug resolves.
                     match crate::sync::session::background_run(
                         &pool,
                         "inbound:resolve_slug",
@@ -332,6 +334,7 @@ fn record_dead_letter(
         s3_key: object_key.to_string(),
         reason: reason.to_string(),
     };
+    // cross-tenant: inbound_dead_letters is an untenanted platform table.
     match crate::sync::session::background_run(pool, "inbound:dead_letter", move |conn| {
         inbound_dead_letters::record(conn, row)
     }) {

--- a/backend/src/handlers/invitation.rs
+++ b/backend/src/handlers/invitation.rs
@@ -237,6 +237,7 @@ pub async fn accept_invitation(
     // otherwise the runtime role reads no membership and the accept 500s.
     // Fail loud if the user genuinely has no membership.
     let workspace_id =
+        // cross-tenant: pre-session workspace resolution: only the invited user is known here.
         match crate::sync::session::background_run(&db_pool, "background:invitation_accept", |c| {
             crate::repository::workspaces::primary_workspace_for_user(c, user.uuid)
         }) {

--- a/backend/src/handlers/notifications.rs
+++ b/backend/src/handlers/notifications.rs
@@ -413,11 +413,16 @@ pub async fn get_notifications(
     let offset = helpers::clamp_offset(query.offset);
     let unread_only = query.unread_only.unwrap_or(false);
 
+    let Some(workspace_id) = actor_workspace_id(&req) else {
+        return errors::unauthorized("Authentication required");
+    };
     let result = if unread_only {
-        notification_service.get_unread(&user_uuid, limit).await
+        notification_service
+            .get_unread(&user_uuid, workspace_id, limit)
+            .await
     } else {
         notification_service
-            .get_all(&user_uuid, limit, offset)
+            .get_all(&user_uuid, workspace_id, limit, offset)
             .await
     };
 
@@ -446,7 +451,13 @@ pub async fn get_unread_count(
         Err(_) => return errors::bad_request("Invalid user UUID"),
     };
 
-    match notification_service.get_unread_count(&user_uuid).await {
+    let Some(workspace_id) = actor_workspace_id(&req) else {
+        return errors::unauthorized("Authentication required");
+    };
+    match notification_service
+        .get_unread_count(&user_uuid, workspace_id)
+        .await
+    {
         Ok(count) => HttpResponse::Ok().json(serde_json::json!({ "count": count })),
         Err(e) => HttpResponse::InternalServerError().json(serde_json::json!({
             "error": e
@@ -473,7 +484,13 @@ pub async fn get_unseen_count(
         Err(_) => return errors::bad_request("Invalid user UUID"),
     };
 
-    match notification_service.get_unseen_count(&user_uuid).await {
+    let Some(workspace_id) = actor_workspace_id(&req) else {
+        return errors::unauthorized("Authentication required");
+    };
+    match notification_service
+        .get_unseen_count(&user_uuid, workspace_id)
+        .await
+    {
         Ok(count) => HttpResponse::Ok().json(serde_json::json!({ "count": count })),
         Err(e) => HttpResponse::InternalServerError().json(serde_json::json!({
             "error": e
@@ -499,7 +516,13 @@ pub async fn mark_all_seen(
         Err(_) => return errors::bad_request("Invalid user UUID"),
     };
 
-    match notification_service.mark_all_seen(&user_uuid).await {
+    let Some(workspace_id) = actor_workspace_id(&req) else {
+        return errors::unauthorized("Authentication required");
+    };
+    match notification_service
+        .mark_all_seen(&user_uuid, workspace_id)
+        .await
+    {
         Ok(count) => HttpResponse::Ok().json(serde_json::json!({
             "success": true,
             "count": count
@@ -528,8 +551,11 @@ pub async fn mark_notifications_unread(
         Err(_) => return errors::bad_request("Invalid user UUID"),
     };
 
+    let Some(workspace_id) = actor_workspace_id(&req) else {
+        return errors::unauthorized("Authentication required");
+    };
     match notification_service
-        .mark_unread(&user_uuid, &body.notification_ids)
+        .mark_unread(&user_uuid, workspace_id, &body.notification_ids)
         .await
     {
         Ok(count) => HttpResponse::Ok().json(serde_json::json!({
@@ -558,8 +584,11 @@ pub async fn archive_notifications(
         Err(_) => return errors::bad_request("Invalid user UUID"),
     };
 
+    let Some(workspace_id) = actor_workspace_id(&req) else {
+        return errors::unauthorized("Authentication required");
+    };
     match notification_service
-        .set_archived(&user_uuid, &body.notification_ids, true)
+        .set_archived(&user_uuid, workspace_id, &body.notification_ids, true)
         .await
     {
         Ok(count) => HttpResponse::Ok().json(serde_json::json!({
@@ -588,8 +617,11 @@ pub async fn unarchive_notifications(
         Err(_) => return errors::bad_request("Invalid user UUID"),
     };
 
+    let Some(workspace_id) = actor_workspace_id(&req) else {
+        return errors::unauthorized("Authentication required");
+    };
     match notification_service
-        .set_archived(&user_uuid, &body.notification_ids, false)
+        .set_archived(&user_uuid, workspace_id, &body.notification_ids, false)
         .await
     {
         Ok(count) => HttpResponse::Ok().json(serde_json::json!({
@@ -619,8 +651,16 @@ pub async fn snooze_notifications(
         Err(_) => return errors::bad_request("Invalid user UUID"),
     };
 
+    let Some(workspace_id) = actor_workspace_id(&req) else {
+        return errors::unauthorized("Authentication required");
+    };
     match notification_service
-        .snooze(&user_uuid, &body.notification_ids, body.until.naive_utc())
+        .snooze(
+            &user_uuid,
+            workspace_id,
+            &body.notification_ids,
+            body.until.naive_utc(),
+        )
         .await
     {
         Ok(count) => HttpResponse::Ok().json(serde_json::json!({
@@ -649,8 +689,11 @@ pub async fn mark_notifications_read(
         Err(_) => return errors::bad_request("Invalid user UUID"),
     };
 
+    let Some(workspace_id) = actor_workspace_id(&req) else {
+        return errors::unauthorized("Authentication required");
+    };
     match notification_service
-        .mark_read(&user_uuid, &body.notification_ids)
+        .mark_read(&user_uuid, workspace_id, &body.notification_ids)
         .await
     {
         Ok(count) => HttpResponse::Ok().json(serde_json::json!({
@@ -680,7 +723,13 @@ pub async fn mark_all_notifications_read(
         Err(_) => return errors::bad_request("Invalid user UUID"),
     };
 
-    match notification_service.mark_all_read(&user_uuid).await {
+    let Some(workspace_id) = actor_workspace_id(&req) else {
+        return errors::unauthorized("Authentication required");
+    };
+    match notification_service
+        .mark_all_read(&user_uuid, workspace_id)
+        .await
+    {
         Ok(count) => HttpResponse::Ok().json(serde_json::json!({
             "success": true,
             "count": count
@@ -799,8 +848,11 @@ pub async fn delete_notifications(
         Err(_) => return errors::bad_request("Invalid user UUID"),
     };
 
+    let Some(workspace_id) = actor_workspace_id(&req) else {
+        return errors::unauthorized("Authentication required");
+    };
     match notification_service
-        .delete_notifications(&user_uuid, &body.notification_ids)
+        .delete_notifications(&user_uuid, workspace_id, &body.notification_ids)
         .await
     {
         Ok(count) => HttpResponse::Ok().json(serde_json::json!({

--- a/backend/src/handlers/password_reset.rs
+++ b/backend/src/handlers/password_reset.rs
@@ -151,6 +151,7 @@ async fn issue_password_reset(
     // (RLS-isolated) and is inherently cross-tenant here (we only have the
     // email, no request workspace), so it runs elevated. A user with no
     // membership gets no email rather than a NULL-workspace insert failure.
+    // cross-tenant: pre-auth resolution: only the email is known; the branding read and enqueue below run pinned.
     let workspace = match crate::sync::session::background_run(
         &pool,
         "background:password_reset",

--- a/backend/src/services/channels/registry.rs
+++ b/backend/src/services/channels/registry.rs
@@ -493,11 +493,14 @@ async fn classify_error(channel: &Channel, err: &ChannelError, deps: &RegistryDe
 }
 
 async fn record_last_error(channel: &Channel, msg: &str, deps: &RegistryDeps) {
-    // channels is RLS-enabled; channel supervisor is platform-
-    // level (manages every workspace's channels), so bypass.
-    if let Err(e) = crate::sync::session::background_run(
+    // The channel belongs to one workspace, so pin to it: the re-read and the
+    // runtime_state update then run RLS-scoped (and carry the workspace/actor
+    // context an audited write needs) instead of a blanket bypass that could
+    // touch another tenant's channel row.
+    if let Err(e) = crate::sync::session::run_in_workspace(
         &deps.pool,
         "background:channel_record_last_error",
+        channel.workspace_id,
         |conn| write_last_error(conn, channel, Some(msg)),
     ) {
         warn!(channel = channel.id, error = %e, "failed to persist last_error");

--- a/backend/src/services/channels/supervisor.rs
+++ b/backend/src/services/channels/supervisor.rs
@@ -120,6 +120,7 @@ async fn run(
     // RLS-enabled; the supervisor is platform-level (manages every
     // workspace's enabled channels), so background_run with bypass
     // is correct.
+    // cross-tenant: the supervisor hydrates every tenant's channels.
     match crate::sync::session::background_run(
         &deps.pool,
         "background:channel_supervisor_hydrate",
@@ -169,6 +170,7 @@ async fn reconcile(id: i32, registry: &mut ChannelRegistry, deps: &RegistryDeps)
 
     // channels is RLS-enabled; reconcile is cross-tenant
     // (supervisor manages every workspace's channels).
+    // cross-tenant: platform supervisor loads a channel by id before its workspace is known.
     let channel = match crate::sync::session::background_run(
         &deps.pool,
         "background:channel_supervisor_reconcile",

--- a/backend/src/services/dkim_verification.rs
+++ b/backend/src/services/dkim_verification.rs
@@ -175,6 +175,7 @@ pub struct ReverifyStats {
 /// Runs as a scheduled job. Lists verified workspaces under a bypass connection
 /// (cross-workspace scan), then re-verifies each one workspace-pinned.
 pub async fn reverify_all(pool: &Pool) -> Result<ReverifyStats, VerifyError> {
+    // cross-tenant: cross-workspace scan of verified domains; each is then verified via run_in_workspace.
     let ids = crate::sync::session::background_run(pool, "dkim-reverify-list", |conn| {
         ws_settings::verified_domain_workspace_ids(conn)
     })

--- a/backend/src/services/email_queue/worker.rs
+++ b/backend/src/services/email_queue/worker.rs
@@ -95,6 +95,7 @@ pub async fn run_one_drain(
     // that drains across whatever rows are ready; no request-bound
     // workspace pin exists here.
     let claimed =
+        // cross-tenant: queue drain claims outbound rows across every tenant.
         crate::sync::session::background_run(&pool, "background:email_queue_claim", |conn| {
             repo::claim_batch(conn, repo::DEFAULT_BATCH_SIZE, LEASE_SECONDS)
         })
@@ -120,6 +121,7 @@ pub async fn run_one_drain(
     let ws_services = if workspace_ids.is_empty() {
         std::collections::HashMap::new()
     } else {
+        // cross-tenant: resolves sender identities for a batch spanning multiple workspaces.
         crate::sync::session::background_run(&pool, "background:email_queue_resolve", |conn| {
             resolver.resolve_batch(conn, &workspace_ids)
         })
@@ -167,6 +169,7 @@ pub async fn run_one_drain(
             let suppressed = if row.mail_class
                 == crate::models::outbound_email_mail_class::NOTIFICATION
             {
+                // cross-tenant: email_suppressions is a global list (keyed by address, no workspace).
                 crate::sync::session::background_run(
                     &pool,
                     "background:email_queue_suppress_check",

--- a/backend/src/services/notifications/channels/push.rs
+++ b/backend/src/services/notifications/channels/push.rs
@@ -96,6 +96,7 @@ impl NotificationDeliveryChannel for PushChannel {
         // Active device tokens, loaded under bypass: this is a background
         // dispatcher, and push targets a user across all their devices, so we
         // don't want RLS to filter by a single workspace pin.
+        // cross-tenant: a user's push devices span workspaces; targets load across all of them.
         let targets: Vec<PushTarget> = crate::sync::session::background_run(
             &self.pool,
             "background:push_load_devices",
@@ -114,9 +115,10 @@ impl NotificationDeliveryChannel for PushChannel {
         // with context — the ticket subject + a "who did what" line; `private`
         // sends only the generic type label ("tap to view"). Never the message
         // body itself, in either mode.
-        let detailed = crate::sync::session::background_run(
+        let detailed = crate::sync::session::run_in_workspace(
             &self.pool,
             "background:push_ws_content_level",
+            notification.payload.workspace_id,
             |conn| {
                 crate::repository::workspaces::get_notification_push_detail(
                     conn,
@@ -153,6 +155,7 @@ impl NotificationDeliveryChannel for PushChannel {
 
         let invalid = self.sender.send(&targets, &payload).await;
         if !invalid.is_empty() {
+            // cross-tenant: device-token cleanup spans the user's devices across workspaces.
             let _ = crate::sync::session::background_run(
                 &self.pool,
                 "background:push_prune_tokens",

--- a/backend/src/services/notifications/preferences.rs
+++ b/backend/src/services/notifications/preferences.rs
@@ -103,7 +103,16 @@ impl PreferenceService {
             workspace_notification_defaults as wnd,
         };
 
-        // RLS-enabled tables read by a background dispatcher → bypass txn.
+        // notification_preferences is GLOBAL per user: its unique key is
+        // (user_uuid, notification_type_id, channel) with workspace_id excluded,
+        // so a user has ONE override row (stamped under their primary workspace)
+        // that applies across all their workspaces. Reading it under an RLS pin
+        // to some other active workspace would filter that row out (the table
+        // FORCEs a workspace_id = app.workspace_id policy) and silently drop the
+        // user's prefs. So read under bypass; the per-workspace
+        // workspace_notification_defaults is scoped by the explicit workspace_id
+        // filter in the query below.
+        // cross-tenant: notification_preferences is global per user (unique key excludes workspace_id); wnd is filtered by workspace_id in the query.
         let (default_channels, ws_defaults, user_prefs) = crate::sync::session::background_run(
             &self.pool,
             "background:notification_pref_load",
@@ -227,6 +236,7 @@ impl PreferenceService {
         // notification_preferences carries an audit trigger but has no
         // workspace_id of its own; resolve the user's primary workspace to pin
         // the actor so the trigger's audit_log insert has a workspace_id.
+        // cross-tenant: pre-write workspace resolution: only the user is known; the upsert below runs pinned.
         let resolved_workspace = crate::sync::session::background_run(
             &self.pool,
             "background:notification_pref_set",
@@ -276,6 +286,7 @@ impl PreferenceService {
     /// unaffected. Preferences are global per user; the resolved workspace only
     /// pins the audit trigger.
     pub async fn disable_all_email(&self, user_uuid_val: &Uuid) -> Result<(), String> {
+        // cross-tenant: pre-write workspace resolution: only the user is known; the write below runs pinned.
         let resolved_workspace = crate::sync::session::background_run(
             &self.pool,
             "background:notification_unsubscribe",
@@ -319,6 +330,7 @@ impl PreferenceService {
             workspace_notification_defaults as wnd,
         };
 
+        // cross-tenant: resolves the user's primary workspace (only the user is known at this call).
         let (types, ws_defaults, user_prefs) = crate::sync::session::background_run(
             &self.pool,
             "background:notification_pref_get_all",
@@ -404,9 +416,13 @@ impl PreferenceService {
     ) -> Result<Vec<WorkspaceNotificationDefaultResponse>, String> {
         use crate::schema::{notification_types as nt, workspace_notification_defaults as wnd};
 
-        let (types, ws_defaults) = crate::sync::session::background_run(
+        // Pin to the workspace: RLS scopes the workspace-defaults read to it,
+        // making the isolation structural rather than resting on the manual
+        // workspace_id filter. notification_types is a global catalog (no RLS).
+        let (types, ws_defaults) = crate::sync::session::run_in_workspace(
             &self.pool,
             "background:notification_ws_defaults_get",
+            workspace_id_val,
             |conn| {
                 let types: Vec<NotificationTypeModel> = nt::table.order(nt::id).load(conn)?;
                 let ws_defaults: Vec<(i32, String, String, bool)> = wnd::table

--- a/backend/src/services/notifications/service.rs
+++ b/backend/src/services/notifications/service.rs
@@ -178,7 +178,11 @@ impl NotificationService {
                     );
                     // Mark channel as delivered
                     if let Err(e) = self
-                        .mark_channel_delivered(notification_id, channel_type)
+                        .mark_channel_delivered(
+                            notification_id,
+                            deliverable.payload.workspace_id,
+                            channel_type,
+                        )
                         .await
                     {
                         tracing::warn!(error = %e, "Failed to mark channel as delivered");
@@ -345,14 +349,17 @@ impl NotificationService {
     async fn mark_channel_delivered(
         &self,
         notification_id: i32,
+        workspace_id_val: i32,
         channel: NotificationChannel,
     ) -> Result<(), String> {
         use crate::schema::notifications::dsl::*;
 
-        // cross-tenant: mark-delivered by notification id; the delivery pipeline does not thread the workspace through. TODO: plumb payload.workspace_id and pin.
-        crate::sync::session::background_run(
+        // Scoped to the notification's workspace (RLS on notifications), matching
+        // the create and read paths.
+        crate::sync::session::run_in_workspace(
             &self.pool,
             "background:notification_channel_delivered",
+            workspace_id_val,
             |conn| {
                 // Get current channels_delivered
                 let current: Notification = notifications.find(notification_id).first(conn)?;
@@ -426,15 +433,16 @@ impl NotificationService {
     pub async fn get_unread(
         &self,
         user_uuid_val: &Uuid,
+        workspace_id_val: i32,
         limit: i64,
     ) -> Result<Vec<NotificationResponse>, String> {
         use crate::schema::notification_types;
         use crate::schema::notifications::dsl::*;
 
-        // cross-tenant: user-global inbox: read by user_uuid across the user's workspaces (a bell is per-user, not per-workspace).
-        let results: Vec<(Notification, String)> = crate::sync::session::background_run(
+        let results: Vec<(Notification, String)> = crate::sync::session::run_in_workspace(
             &self.pool,
             "background:notification_get_unread",
+            workspace_id_val,
             |conn| {
                 notifications
                     .inner_join(notification_types::table)
@@ -484,16 +492,17 @@ impl NotificationService {
     pub async fn get_all(
         &self,
         user_uuid_val: &Uuid,
+        workspace_id_val: i32,
         limit: i64,
         offset: i64,
     ) -> Result<Vec<NotificationResponse>, String> {
         use crate::schema::notification_types;
         use crate::schema::notifications::dsl::*;
 
-        // cross-tenant: user-global inbox read, keyed by user_uuid across the user's workspaces.
-        let results: Vec<(Notification, String)> = crate::sync::session::background_run(
+        let results: Vec<(Notification, String)> = crate::sync::session::run_in_workspace(
             &self.pool,
             "background:notification_get_all",
+            workspace_id_val,
             |conn| {
                 notifications
                     .inner_join(notification_types::table)
@@ -540,13 +549,17 @@ impl NotificationService {
     }
 
     /// Get unread notification count for a user
-    pub async fn get_unread_count(&self, user_uuid_val: &Uuid) -> Result<i64, String> {
+    pub async fn get_unread_count(
+        &self,
+        user_uuid_val: &Uuid,
+        workspace_id_val: i32,
+    ) -> Result<i64, String> {
         use crate::schema::notifications::dsl::*;
 
-        // cross-tenant: user-global inbox count, keyed by user_uuid across the user's workspaces.
-        crate::sync::session::background_run(
+        crate::sync::session::run_in_workspace(
             &self.pool,
             "background:notification_unread_count",
+            workspace_id_val,
             |conn| {
                 notifications
                     .filter(user_uuid.eq(user_uuid_val))
@@ -564,14 +577,15 @@ impl NotificationService {
     pub async fn mark_read(
         &self,
         user_uuid_val: &Uuid,
+        workspace_id_val: i32,
         notification_ids: &[i32],
     ) -> Result<usize, String> {
         use crate::schema::notifications::dsl::*;
 
-        // cross-tenant: user-global inbox write (mark-read by user_uuid across workspaces).
-        crate::sync::session::background_run(
+        crate::sync::session::run_in_workspace(
             &self.pool,
             "background:notification_mark_read",
+            workspace_id_val,
             |conn| {
                 diesel::update(
                     notifications
@@ -586,13 +600,17 @@ impl NotificationService {
     }
 
     /// Mark all notifications as read for a user
-    pub async fn mark_all_read(&self, user_uuid_val: &Uuid) -> Result<usize, String> {
+    pub async fn mark_all_read(
+        &self,
+        user_uuid_val: &Uuid,
+        workspace_id_val: i32,
+    ) -> Result<usize, String> {
         use crate::schema::notifications::dsl::*;
 
-        // cross-tenant: user-global inbox write (mark-all-read by user_uuid across workspaces).
-        crate::sync::session::background_run(
+        crate::sync::session::run_in_workspace(
             &self.pool,
             "background:notification_mark_all_read",
+            workspace_id_val,
             |conn| {
                 diesel::update(
                     notifications
@@ -609,13 +627,17 @@ impl NotificationService {
     /// Count unseen, active (not archived) notifications for a user.
     /// Drives the bell badge: opening the panel marks items seen and
     /// clears the badge without marking each one read (seen != read).
-    pub async fn get_unseen_count(&self, user_uuid_val: &Uuid) -> Result<i64, String> {
+    pub async fn get_unseen_count(
+        &self,
+        user_uuid_val: &Uuid,
+        workspace_id_val: i32,
+    ) -> Result<i64, String> {
         use crate::schema::notifications::dsl::*;
 
-        // cross-tenant: user-global inbox count (unseen) keyed by user_uuid across workspaces.
-        crate::sync::session::background_run(
+        crate::sync::session::run_in_workspace(
             &self.pool,
             "background:notification_unseen_count",
+            workspace_id_val,
             |conn| {
                 notifications
                     .filter(user_uuid.eq(user_uuid_val))
@@ -637,13 +659,17 @@ impl NotificationService {
     /// Mark all of a user's unseen notifications as seen (badge clear on
     /// panel/inbox open). Distinct from mark-all-read: seeing clears the
     /// badge; reading is a separate, explicit per-item action.
-    pub async fn mark_all_seen(&self, user_uuid_val: &Uuid) -> Result<usize, String> {
+    pub async fn mark_all_seen(
+        &self,
+        user_uuid_val: &Uuid,
+        workspace_id_val: i32,
+    ) -> Result<usize, String> {
         use crate::schema::notifications::dsl::*;
 
-        // cross-tenant: user-global inbox write (mark-all-seen by user_uuid across workspaces).
-        crate::sync::session::background_run(
+        crate::sync::session::run_in_workspace(
             &self.pool,
             "background:notification_mark_all_seen",
+            workspace_id_val,
             |conn| {
                 diesel::update(
                     notifications
@@ -662,14 +688,15 @@ impl NotificationService {
     pub async fn mark_unread(
         &self,
         user_uuid_val: &Uuid,
+        workspace_id_val: i32,
         notification_ids: &[i32],
     ) -> Result<usize, String> {
         use crate::schema::notifications::dsl::*;
 
-        // cross-tenant: user-global inbox write (mark-unread by user_uuid across workspaces).
-        crate::sync::session::background_run(
+        crate::sync::session::run_in_workspace(
             &self.pool,
             "background:notification_mark_unread",
+            workspace_id_val,
             |conn| {
                 diesel::update(
                     notifications
@@ -689,15 +716,16 @@ impl NotificationService {
     pub async fn set_archived(
         &self,
         user_uuid_val: &Uuid,
+        workspace_id_val: i32,
         notification_ids: &[i32],
         archived: bool,
     ) -> Result<usize, String> {
         use crate::schema::notifications::dsl::*;
 
-        // cross-tenant: user-global inbox write (archive by user_uuid across workspaces).
-        crate::sync::session::background_run(
+        crate::sync::session::run_in_workspace(
             &self.pool,
             "background:notification_set_archived",
+            workspace_id_val,
             |conn| {
                 diesel::update(
                     notifications
@@ -722,21 +750,26 @@ impl NotificationService {
     pub async fn snooze(
         &self,
         user_uuid_val: &Uuid,
+        workspace_id_val: i32,
         notification_ids: &[i32],
         until: chrono::NaiveDateTime,
     ) -> Result<usize, String> {
         use crate::schema::notifications::dsl::*;
 
-        // cross-tenant: user-global inbox write (snooze by user_uuid across workspaces).
-        crate::sync::session::background_run(&self.pool, "background:notification_snooze", |conn| {
-            diesel::update(
-                notifications
-                    .filter(user_uuid.eq(user_uuid_val))
-                    .filter(id.eq_any(notification_ids)),
-            )
-            .set(snoozed_until.eq(Some(until)))
-            .execute(conn)
-        })
+        crate::sync::session::run_in_workspace(
+            &self.pool,
+            "background:notification_snooze",
+            workspace_id_val,
+            |conn| {
+                diesel::update(
+                    notifications
+                        .filter(user_uuid.eq(user_uuid_val))
+                        .filter(id.eq_any(notification_ids)),
+                )
+                .set(snoozed_until.eq(Some(until)))
+                .execute(conn)
+            },
+        )
         .map_err(|e| format!("Update failed: {e}"))
     }
 
@@ -744,19 +777,24 @@ impl NotificationService {
     pub async fn delete_notifications(
         &self,
         user_uuid_val: &Uuid,
+        workspace_id_val: i32,
         notification_ids: &[i32],
     ) -> Result<usize, String> {
         use crate::schema::notifications::dsl::*;
 
-        // cross-tenant: user-global inbox write (delete by user_uuid across workspaces).
-        crate::sync::session::background_run(&self.pool, "background:notification_delete", |conn| {
-            diesel::delete(
-                notifications
-                    .filter(user_uuid.eq(user_uuid_val))
-                    .filter(id.eq_any(notification_ids)),
-            )
-            .execute(conn)
-        })
+        crate::sync::session::run_in_workspace(
+            &self.pool,
+            "background:notification_delete",
+            workspace_id_val,
+            |conn| {
+                diesel::delete(
+                    notifications
+                        .filter(user_uuid.eq(user_uuid_val))
+                        .filter(id.eq_any(notification_ids)),
+                )
+                .execute(conn)
+            },
+        )
         .map_err(|e| format!("Delete failed: {e}"))
     }
 }

--- a/backend/src/services/notifications/service.rs
+++ b/backend/src/services/notifications/service.rs
@@ -349,6 +349,7 @@ impl NotificationService {
     ) -> Result<(), String> {
         use crate::schema::notifications::dsl::*;
 
+        // cross-tenant: mark-delivered by notification id; the delivery pipeline does not thread the workspace through. TODO: plumb payload.workspace_id and pin.
         crate::sync::session::background_run(
             &self.pool,
             "background:notification_channel_delivered",
@@ -399,6 +400,7 @@ impl NotificationService {
         // but routing through background_run keeps every method
         // here uniform and the role baseline reset that set_actor
         // performs is harmless for non-tenant reads.
+        // cross-tenant: notification_types is a global system catalog (no workspace).
         let type_id: i32 = crate::sync::session::background_run(
             &self.pool,
             "background:notification_type_lookup",
@@ -429,6 +431,7 @@ impl NotificationService {
         use crate::schema::notification_types;
         use crate::schema::notifications::dsl::*;
 
+        // cross-tenant: user-global inbox: read by user_uuid across the user's workspaces (a bell is per-user, not per-workspace).
         let results: Vec<(Notification, String)> = crate::sync::session::background_run(
             &self.pool,
             "background:notification_get_unread",
@@ -487,6 +490,7 @@ impl NotificationService {
         use crate::schema::notification_types;
         use crate::schema::notifications::dsl::*;
 
+        // cross-tenant: user-global inbox read, keyed by user_uuid across the user's workspaces.
         let results: Vec<(Notification, String)> = crate::sync::session::background_run(
             &self.pool,
             "background:notification_get_all",
@@ -539,6 +543,7 @@ impl NotificationService {
     pub async fn get_unread_count(&self, user_uuid_val: &Uuid) -> Result<i64, String> {
         use crate::schema::notifications::dsl::*;
 
+        // cross-tenant: user-global inbox count, keyed by user_uuid across the user's workspaces.
         crate::sync::session::background_run(
             &self.pool,
             "background:notification_unread_count",
@@ -563,6 +568,7 @@ impl NotificationService {
     ) -> Result<usize, String> {
         use crate::schema::notifications::dsl::*;
 
+        // cross-tenant: user-global inbox write (mark-read by user_uuid across workspaces).
         crate::sync::session::background_run(
             &self.pool,
             "background:notification_mark_read",
@@ -583,6 +589,7 @@ impl NotificationService {
     pub async fn mark_all_read(&self, user_uuid_val: &Uuid) -> Result<usize, String> {
         use crate::schema::notifications::dsl::*;
 
+        // cross-tenant: user-global inbox write (mark-all-read by user_uuid across workspaces).
         crate::sync::session::background_run(
             &self.pool,
             "background:notification_mark_all_read",
@@ -605,6 +612,7 @@ impl NotificationService {
     pub async fn get_unseen_count(&self, user_uuid_val: &Uuid) -> Result<i64, String> {
         use crate::schema::notifications::dsl::*;
 
+        // cross-tenant: user-global inbox count (unseen) keyed by user_uuid across workspaces.
         crate::sync::session::background_run(
             &self.pool,
             "background:notification_unseen_count",
@@ -632,6 +640,7 @@ impl NotificationService {
     pub async fn mark_all_seen(&self, user_uuid_val: &Uuid) -> Result<usize, String> {
         use crate::schema::notifications::dsl::*;
 
+        // cross-tenant: user-global inbox write (mark-all-seen by user_uuid across workspaces).
         crate::sync::session::background_run(
             &self.pool,
             "background:notification_mark_all_seen",
@@ -657,6 +666,7 @@ impl NotificationService {
     ) -> Result<usize, String> {
         use crate::schema::notifications::dsl::*;
 
+        // cross-tenant: user-global inbox write (mark-unread by user_uuid across workspaces).
         crate::sync::session::background_run(
             &self.pool,
             "background:notification_mark_unread",
@@ -684,6 +694,7 @@ impl NotificationService {
     ) -> Result<usize, String> {
         use crate::schema::notifications::dsl::*;
 
+        // cross-tenant: user-global inbox write (archive by user_uuid across workspaces).
         crate::sync::session::background_run(
             &self.pool,
             "background:notification_set_archived",
@@ -716,6 +727,7 @@ impl NotificationService {
     ) -> Result<usize, String> {
         use crate::schema::notifications::dsl::*;
 
+        // cross-tenant: user-global inbox write (snooze by user_uuid across workspaces).
         crate::sync::session::background_run(&self.pool, "background:notification_snooze", |conn| {
             diesel::update(
                 notifications
@@ -736,6 +748,7 @@ impl NotificationService {
     ) -> Result<usize, String> {
         use crate::schema::notifications::dsl::*;
 
+        // cross-tenant: user-global inbox write (delete by user_uuid across workspaces).
         crate::sync::session::background_run(&self.pool, "background:notification_delete", |conn| {
             diesel::delete(
                 notifications

--- a/backend/src/services/outbound_email.rs
+++ b/backend/src/services/outbound_email.rs
@@ -44,6 +44,7 @@ use crate::utils::email::{DkimAlgorithm, DkimSigner, EmailConfig, EmailService, 
 /// shared relay's reputation. Fails OPEN: a lookup error attempts the send
 /// rather than silently dropping it, matching the worker.
 pub fn recipient_is_suppressed(pool: &Pool, recipient: &str) -> bool {
+    // cross-tenant: email_suppressions is a global list (keyed by address, no workspace).
     crate::sync::session::background_run(pool, "background:direct_send_suppress_check", |conn| {
         crate::repository::email_suppressions::is_suppressed(conn, recipient)
     })

--- a/backend/src/services/scheduled_jobs.rs
+++ b/backend/src/services/scheduled_jobs.rs
@@ -139,6 +139,7 @@ pub async fn send_notification_digests(pool: Pool) -> Result<()> {
         #[diesel(sql_type = Text)]
         title: String,
     }
+    // cross-tenant: cross-workspace scan builds the digest work-list; each item is handled per-workspace below.
     let pending: Vec<PendingRow> = crate::sync::session::background_run(
         &pool,
         "background:notification_digest_scan",
@@ -184,6 +185,7 @@ pub async fn send_notification_digests(pool: Pool) -> Result<()> {
             #[diesel(sql_type = Text)]
             email: String,
         }
+        // cross-tenant: user_emails is a global identity table (no workspace to pin to).
         let recipient: Option<String> = crate::sync::session::background_run(
             &pool,
             "background:notification_digest_email",
@@ -390,6 +392,7 @@ pub async fn prune_csp_reports(pool: Pool) -> Result<()> {
     // background_run so the DELETE isn't filtered to zero rows
     // post-DSN-flip.
     let removed =
+        // cross-tenant: cross-workspace retention prune of csp_reports.
         crate::sync::session::background_run(&pool, "scheduler:prune_csp_reports", |conn| {
             crate::repository::csp_reports::prune_older_than(conn, days)
         })
@@ -431,6 +434,7 @@ pub async fn prune_webhook_deliveries(pool: Pool) -> Result<()> {
     let days = retention_days("WEBHOOK_DELIVERY_RETENTION_DAYS", 30);
     // webhook_deliveries is RLS-enabled; cross-tenant prune.
     let removed =
+        // cross-tenant: cross-workspace retention prune of webhook_deliveries.
         crate::sync::session::background_run(&pool, "scheduler:prune_webhook_deliveries", |conn| {
             crate::repository::webhooks::prune_deliveries_older_than(conn, days)
         })
@@ -538,6 +542,7 @@ async fn drop_old_event_partitions(
 /// 60s.
 pub async fn sweep_outbound_email_leases(pool: Pool) -> Result<()> {
     // outbound_emails is RLS-enabled; cross-workspace sweep.
+    // cross-tenant: operational lease sweep across every tenant's outbound queue.
     let swept = crate::sync::session::background_run(
         &pool,
         "scheduler:sweep_outbound_email_leases",

--- a/backend/src/services/search/mod.rs
+++ b/backend/src/services/search/mod.rs
@@ -107,6 +107,7 @@ impl SearchService {
         let doc_count = service.reader.searcher().num_docs();
         if doc_count == 0 {
             info!("Search index is empty, rebuilding from database");
+            // cross-tenant: full reindex spans every tenant.
             match crate::sync::session::background_run(
                 pool,
                 "background:search_initial_index_build",
@@ -255,6 +256,7 @@ impl SearchService {
         use diesel::prelude::*;
 
         let loaded: Option<(models::User, Option<String>, Vec<i32>)> =
+            // cross-tenant: user identity and memberships span workspaces.
             crate::sync::session::background_run(
                 &self.pool,
                 "background:search_reindex_user",
@@ -298,6 +300,7 @@ impl SearchService {
         &self,
         user_uuid: uuid::Uuid,
     ) -> Result<Vec<i32>, Box<dyn std::error::Error + Send + Sync>> {
+        // cross-tenant: membership set spans workspaces.
         let ids = crate::sync::session::background_run(
             &self.pool,
             "background:search_user_memberships",
@@ -332,6 +335,7 @@ impl SearchService {
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         use diesel::OptionalExtension;
         let loaded: Option<(models::Ticket, Option<models::ArticleContent>)> =
+            // cross-tenant: reindex by entity id from the cross-tenant sync stream (workspace not threaded through).
             crate::sync::session::background_run(
                 &self.pool,
                 "background:search_reindex_ticket",
@@ -362,6 +366,7 @@ impl SearchService {
         comment_id: i32,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         use diesel::OptionalExtension;
+        // cross-tenant: reindex by entity id from the cross-tenant sync stream (workspace not threaded through).
         let loaded: Option<(models::Comment, String)> = crate::sync::session::background_run(
             &self.pool,
             "background:search_reindex_comment",
@@ -390,6 +395,7 @@ impl SearchService {
         page_id: i32,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         use diesel::OptionalExtension;
+        // cross-tenant: reindex by entity id from the cross-tenant sync stream (workspace not threaded through).
         let page: Option<models::DocumentationPage> = crate::sync::session::background_run(
             &self.pool,
             "background:search_reindex_documentation",
@@ -409,6 +415,7 @@ impl SearchService {
         device_id: i32,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         use diesel::OptionalExtension;
+        // cross-tenant: reindex by entity id from the cross-tenant sync stream (workspace not threaded through).
         let device: Option<models::Asset> = crate::sync::session::background_run(
             &self.pool,
             "background:search_reindex_device",
@@ -427,6 +434,7 @@ impl SearchService {
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         use crate::schema::projects;
         use diesel::prelude::*;
+        // cross-tenant: reindex by entity id from the cross-tenant sync stream (workspace not threaded through).
         let project: Option<models::Project> = crate::sync::session::background_run(
             &self.pool,
             "background:search_reindex_project",

--- a/backend/src/services/search_replicator.rs
+++ b/backend/src/services/search_replicator.rs
@@ -102,6 +102,7 @@ async fn run(database_url: String, pool: Pool, search: Arc<SearchService>) {
 fn initial_watermark(pool: &Pool) -> Result<i64, anyhow::Error> {
     // sync_actions is RLS-enabled; the replicator reads across every
     // workspace (the index spans tenants), so it bypasses via background_run.
+    // cross-tenant: watermark over the cross-tenant sync_actions feed.
     let max_id: Option<i64> = crate::sync::session::background_run(
         pool,
         "background:search_replicator_watermark",
@@ -175,6 +176,7 @@ async fn drain_since(
         // index writer lock, neither of which is async-friendly.
         let (last_sync_id, count) =
             tokio::task::spawn_blocking(move || -> Result<(Option<i64>, usize), anyhow::Error> {
+                // cross-tenant: pages the cross-tenant sync_actions feed.
                 let rows: Vec<IndexRow> = crate::sync::session::background_run(
                     &pool,
                     "background:search_replicator_drain",

--- a/backend/src/services/sync_outbox.rs
+++ b/backend/src/services/sync_outbox.rs
@@ -165,6 +165,7 @@ fn initial_watermark(pool: &Pool) -> Result<crate::sync::feed::FeedCursor, anyho
     // latest *settled* row by commit order; in-flight rows have a
     // higher xid8 and are delivered once they settle.
     let row: Option<(i64, i64)> =
+        // cross-tenant: watermark over the cross-tenant sync_actions outbox.
         crate::sync::session::background_run(pool, "background:sync_outbox_watermark", |conn| {
             sync_actions::table
                 .filter(crate::sync::feed::below_horizon())
@@ -256,6 +257,7 @@ async fn drain_since(
             // workspace's sync_actions. Commit-safe cursor: only settled
             // rows (xid8 below the horizon), ordered by (xid8, sync_id),
             // strictly after the cursor — see `crate::sync::feed`.
+            // cross-tenant: drains the cross-tenant sync_actions outbox.
             let rows = crate::sync::session::background_run(
                 &pool,
                 "background:sync_outbox_drain",

--- a/backend/src/services/webhooks/service.rs
+++ b/backend/src/services/webhooks/service.rs
@@ -97,6 +97,7 @@ impl WebhookService {
         pool: &Pool,
         delivery_tx: &mpsc::Sender<DeliveryTask>,
     ) -> Result<bool, String> {
+        // cross-tenant: claims outbox rows across every tenant; per-row work pins the workspace inside the txn.
         let (tasks, more): (Vec<DeliveryTask>, bool) = crate::sync::session::background_run(
             pool,
             "background:webhook_outbox_dispatch",
@@ -284,6 +285,7 @@ impl WebhookService {
         // webhook_deliveries + webhooks are RLS-enabled; the retry
         // worker runs cross-workspace. Fetch pending + their
         // webhook rows in one bypass txn.
+        // cross-tenant: reads pending retries across every tenant to build the task list (no tenant writes here).
         let tasks: Vec<DeliveryTask> = crate::sync::session::background_run(
             pool,
             "background:webhook_process_retries",

--- a/backend/tests/background_run_cross_tenant_lint.rs
+++ b/backend/tests/background_run_cross_tenant_lint.rs
@@ -1,0 +1,121 @@
+//! Lint: every `background_run(...)` call carries a `// cross-tenant:` marker
+//! justifying why it uses the BYPASSRLS primitive instead of the workspace-
+//! pinned `run_in_workspace`.
+//!
+//! `background_run` runs its closure on a BYPASSRLS connection, so RLS does NOT
+//! scope its reads by workspace. That is correct ONLY for genuinely
+//! cross-workspace work (a queue drain across every tenant, the search
+//! reindexer, pre-auth workspace resolution, a global/untenanted table). For
+//! single-workspace work it is a footgun: an unfiltered read silently returns
+//! an arbitrary tenant's rows (this is the shape of the B1 cross-tenant webhook
+//! bug). `run_in_workspace(workspace_id, ...)` is the safe default there.
+//!
+//! This lint does NOT try to prove a call is workspace-safe (impossible
+//! statically: the same repo fn is called from both contexts, and a legitimate
+//! cross-tenant drain looks identical to a forgotten filter). Instead it forces
+//! every BYPASSRLS use to be a deliberate, reviewed act: the author must state,
+//! inline, why crossing tenants is correct here. A new `background_run` with no
+//! justification fails CI, which is where the next B1-class omission surfaces.
+//!
+//! ## The marker
+//!
+//! A `// cross-tenant: <reason>` comment in the contiguous comment block
+//! directly above the call:
+//!
+//! ```ignore
+//! // cross-tenant: queue drain claims outbound rows across every tenant.
+//! let batch = background_run(&pool, "background:email_drain", |conn| { ... })?;
+//! ```
+//!
+//! If the work is actually single-workspace, do not add a marker: switch the
+//! call to `run_in_workspace(workspace_id, ...)` so RLS scopes it.
+//!
+//! `src/sync/session.rs` (which defines and unit-tests both primitives) is
+//! exempt.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use walkdir::WalkDir;
+
+/// File that defines `background_run` / `run_in_workspace` and their tests.
+const EXEMPT_RELPATH: &str = "sync/session.rs";
+const MARKER: &str = "cross-tenant:";
+
+#[derive(Debug)]
+struct Violation {
+    relpath: String,
+    line: usize,
+    snippet: String,
+}
+
+fn is_comment(line: &str) -> bool {
+    line.trim_start().starts_with("//")
+}
+
+/// True when the contiguous `//` comment block immediately above `idx`
+/// contains the marker.
+fn has_marker_above(lines: &[&str], idx: usize) -> bool {
+    let mut i = idx;
+    while i > 0 && is_comment(lines[i - 1]) {
+        if lines[i - 1].contains(MARKER) {
+            return true;
+        }
+        i -= 1;
+    }
+    false
+}
+
+#[test]
+fn every_background_run_declares_cross_tenant_justification() {
+    let src_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src");
+    assert!(src_root.exists(), "src not found at {}", src_root.display());
+    let exempt = src_root.join(EXEMPT_RELPATH);
+
+    let mut violations: Vec<Violation> = Vec::new();
+
+    for entry in WalkDir::new(&src_root)
+        .into_iter()
+        .filter_map(Result::ok)
+        .filter(|e| e.path().extension().map(|x| x == "rs").unwrap_or(false))
+    {
+        let path: &Path = entry.path();
+        if path == exempt {
+            continue;
+        }
+        let content = fs::read_to_string(path).unwrap_or_default();
+        let lines: Vec<&str> = content.lines().collect();
+
+        for (idx, raw) in lines.iter().enumerate() {
+            // A call site: contains `background_run(` and is not itself a
+            // comment (skips prose that mentions the primitive).
+            if !raw.contains("background_run(") || is_comment(raw) {
+                continue;
+            }
+            if has_marker_above(&lines, idx) {
+                continue;
+            }
+            violations.push(Violation {
+                relpath: path
+                    .strip_prefix(&src_root)
+                    .unwrap_or(path)
+                    .to_string_lossy()
+                    .into_owned(),
+                line: idx + 1,
+                snippet: raw.trim().to_string(),
+            });
+        }
+    }
+
+    if !violations.is_empty() {
+        let mut msg = String::from(
+            "\nbackground_run() calls missing a `// cross-tenant: <reason>` marker.\n\
+             Either add the marker (justify why crossing tenants is correct) or\n\
+             switch to run_in_workspace(workspace_id, ...) if the work is\n\
+             single-workspace.\n\n",
+        );
+        for v in &violations {
+            msg.push_str(&format!("  src/{}:{}  {}\n", v.relpath, v.line, v.snippet));
+        }
+        panic!("{msg}");
+    }
+}

--- a/backend/tests/notification_workspace_scope.rs
+++ b/backend/tests/notification_workspace_scope.rs
@@ -1,0 +1,118 @@
+//! Proves the notification bell/inbox is scoped to the ACTIVE workspace.
+//!
+//! The inbox service methods filter by `user_uuid` and now run under
+//! `run_in_workspace(active_ws)`, so RLS on `notifications`
+//! (`workspace_id = app.workspace_id`) confines every read / count / mutation
+//! to the active workspace. This is the regression guard for the pre-Model-C
+//! behavior where the bell spanned ALL of a user's workspaces: a user active in
+//! workspace A would see (and could mutate) workspace B's notifications, and
+//! clicking one deep-linked into the wrong workspace.
+
+#![allow(clippy::expect_used)]
+
+use diesel::prelude::*;
+use uuid::Uuid;
+
+use backend::models::NewNotification;
+use backend::sync::actor::ActorContext;
+use backend::sync::session::{with_actor_bypass_context, with_actor_context};
+
+mod common;
+
+fn any_notification_type_id(conn: &mut backend::db::DbConnection) -> i32 {
+    use backend::schema::notification_types;
+    notification_types::table
+        .select(notification_types::id)
+        .order(notification_types::id)
+        .first(conn)
+        .expect("a seeded notification_type exists")
+}
+
+/// Insert a notification pinned to `workspace_id`. `NewNotification` carries no
+/// workspace_id: the column defaults to `app.workspace_id`, which the pin sets,
+/// exactly as `persist_notification` does in production.
+fn insert_notification(
+    conn: &mut backend::db::DbConnection,
+    workspace_id: i32,
+    user: Uuid,
+    type_id: i32,
+    title: &str,
+) {
+    use backend::schema::notifications;
+    let actor = ActorContext::system("test:notif_insert").with_workspace(workspace_id);
+    with_actor_context::<_, diesel::result::Error>(conn, &actor, |c| {
+        diesel::insert_into(notifications::table)
+            .values(NewNotification {
+                uuid: Uuid::now_v7(),
+                user_uuid: user,
+                notification_type_id: type_id,
+                entity_type: "ticket".to_string(),
+                entity_id: 1,
+                title: title.to_string(),
+                body: None,
+                metadata: None,
+                channels_delivered: serde_json::json!([]),
+            })
+            .execute(c)
+    })
+    .expect("insert notification pinned to workspace");
+}
+
+/// Titles visible to a `user_uuid`-filtered read pinned to `workspace_id` — the
+/// exact shape of every inbox method's query under `run_in_workspace`.
+fn titles_pinned(conn: &mut backend::db::DbConnection, ws_id: i32, user: Uuid) -> Vec<String> {
+    use backend::schema::notifications::dsl::*;
+    let actor = ActorContext::system("test:notif_read").with_workspace(ws_id);
+    with_actor_context::<_, diesel::result::Error>(conn, &actor, |c| {
+        notifications
+            .filter(user_uuid.eq(user))
+            .order(id.asc())
+            .select(title)
+            .load::<String>(c)
+    })
+    .expect("read notifications pinned to workspace")
+}
+
+#[test]
+fn inbox_reads_are_scoped_to_the_active_workspace() {
+    common::ensure_test_keyring();
+    let db = common::TestDb::new();
+    let mut conn = db.conn();
+    let ws = common::seed_two_workspaces(&mut conn);
+    let user = ws.a.member_uuid;
+    let type_id = any_notification_type_id(&mut conn);
+
+    insert_notification(&mut conn, ws.a.workspace_id, user, type_id, "in A");
+    insert_notification(&mut conn, ws.b.workspace_id, user, type_id, "in B");
+
+    // The fix: a workspace-pinned, user-filtered read sees only that workspace.
+    assert_eq!(
+        titles_pinned(&mut conn, ws.a.workspace_id, user),
+        vec!["in A".to_string()],
+        "workspace A's bell must show only A's notification"
+    );
+    assert_eq!(
+        titles_pinned(&mut conn, ws.b.workspace_id, user),
+        vec!["in B".to_string()],
+        "workspace B's bell must show only B's notification"
+    );
+
+    // Sanity + pre-fix contrast: both rows exist for this user; an unpinned
+    // BYPASS read (what `background_run` did before this fix) sees BOTH — the
+    // cross-workspace bleed the pin removes.
+    let actor = ActorContext::system("test:notif_bypass");
+    let both = with_actor_bypass_context::<_, diesel::result::Error>(&mut conn, &actor, |c| {
+        use backend::schema::notifications::dsl::*;
+        notifications
+            .filter(user_uuid.eq(user))
+            .order(id.asc())
+            .select(title)
+            .load::<String>(c)
+    })
+    .expect("bypass read");
+    assert_eq!(
+        both,
+        vec!["in A".to_string(), "in B".to_string()],
+        "sanity: both notifications exist; only the workspace pin scopes the bell"
+    );
+}


### PR DESCRIPTION
Two related tenancy hardening commits from a review of the `background_run` (BYPASSRLS) surface.

## `harden(tenancy)`: pin per-workspace background jobs; lint BYPASSRLS uses
`background_run` runs on a BYPASSRLS connection, so RLS does not scope its reads by workspace, correct only for genuinely cross-tenant work, a footgun for single-workspace work (the shape of the B1 cross-tenant webhook bug).

- **Converted 3 single-workspace sites** to `run_in_workspace` so RLS scopes them: the channel `record_last_error` write, the push content-level read, and the workspace notification-defaults read.
- **Added `background_run_cross_tenant_lint`** (models `sync_emit_lint`): every `background_run` call must carry a `// cross-tenant: <reason>` marker or fail CI; annotated every remaining genuine cross-tenant site. A new unjustified bypass now fails CI.
- **`notification_preferences` intentionally left on bypass:** its unique key excludes `workspace_id` (global per user, one row stamped under the primary workspace), so pinning its read would hide the user's override outside their primary workspace. Documented inline.

## `fix(notifications)`: scope the inbox bell to the active workspace
The 11 inbox read/count/mutation methods filtered by `user_uuid` under BYPASSRLS, so a multi-workspace user saw and could mutate **every** workspace's notifications, and clicking one deep-linked into the wrong workspace (the slug carrier injects the *active* slug).

- Pass the active workspace (already pinned by auth middleware, via `actor_workspace_id`) into each inbox method and `mark_channel_delivered`, and run them under `run_in_workspace`. RLS on `notifications` scopes every read/count/mutation to the active workspace, no query change.
- This matches what was already per-workspace: the creation path, the SSE toast path (`TopicKey::Workspace`), and the frontend (X-Nosdesk-Workspace header, cache reset on switch). No frontend change needed; the wrong-workspace deep-link disappears transitively.
- Added `tests/notification_workspace_scope.rs`: a pinned read sees only its workspace's rows; the pre-fix bypass (which saw both) is captured as a regression guard.

## Verification
`cargo check` + clippy clean on touched files; the new isolation test, `background_workspace_pin`, `two_workspace_fixture`, and the full guardrail-lint suite (`background_run_cross_tenant_lint`, `handler_tenant_read_lint`, `handler_direct_write_lint`, `sync_emit_lint`) all pass.