### PR TITLE
Plugin sandbox step 1: sandbox origin + token-served bundles

### DIFF
--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -35,6 +35,12 @@ pub struct Config {
     pub max_payload_size: usize,
     pub frontend_url: String,
     pub additional_origins: Vec<String>,
+    /// Optional separate origin the plugin sandbox runtime is served from
+    /// (`NOSDESK_SANDBOX_ORIGIN`, e.g. `https://plugins.example.com`). Defense in
+    /// depth only: plugins always run in an opaque sandboxed iframe regardless.
+    /// When `None`, the runtime is served from the app origin under
+    /// `/__plugin-sandbox/*` (the zero-config self-host / dev default).
+    pub sandbox_origin: Option<String>,
     /// Tenant domain suffix for hosted-mode CORS (M5 Task 6); `None` self-hosted.
     pub tenant_domain: Option<String>,
     /// Graceful-drain budget for in-flight HTTP requests on shutdown, passed to
@@ -201,6 +207,13 @@ impl Config {
             .and_then(|s| s.parse::<u64>().ok())
             .unwrap_or(25);
 
+        // Optional separate origin for the plugin sandbox runtime (defense in
+        // depth; the opaque iframe isolates plugins regardless). Trailing slash
+        // trimmed so callers can build `<origin>/__plugin-sandbox/...` cleanly.
+        let sandbox_origin = get("NOSDESK_SANDBOX_ORIGIN")
+            .map(|s| s.trim().trim_end_matches('/').to_string())
+            .filter(|s| !s.is_empty());
+
         Ok(Config {
             environment,
             is_production,
@@ -213,6 +226,7 @@ impl Config {
             max_payload_size,
             frontend_url,
             additional_origins,
+            sandbox_origin,
             tenant_domain,
             shutdown_timeout_secs,
         })

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -57,6 +57,7 @@ pub mod passkeys;
 pub mod password_reset;
 pub mod plugin_collections;
 pub mod plugin_events;
+pub mod plugin_sandbox;
 pub mod plugins;
 pub mod portal;
 pub mod projects;

--- a/backend/src/handlers/plugin_sandbox.rs
+++ b/backend/src/handlers/plugin_sandbox.rs
@@ -1,0 +1,193 @@
+//! Plugin sandbox origin (build-order step 1).
+//!
+//! Serves the sandboxed-iframe runtime + token-authorized bundle bytes, plus the
+//! authenticated endpoint that mints a bundle token. Isolation is the opaque
+//! iframe (`sandbox="allow-scripts"`), so these routes work served from the app's
+//! own origin (`/__plugin-sandbox/*`, the self-host/dev default) OR from a
+//! separate `NOSDESK_SANDBOX_ORIGIN` (defense in depth). See
+//! `docs/plans/plugin-sandbox-step1.md`.
+
+use actix_web::{web, HttpMessage, HttpRequest, HttpResponse, Responder};
+use serde::Deserialize;
+use tracing::{error, warn};
+use uuid::Uuid;
+
+use crate::db::Pool;
+use crate::extractors::TenantConn;
+use crate::handlers::errors;
+use crate::middleware::RequestContext;
+use crate::models::Claims;
+use crate::repository::plugins as plugin_repo;
+use crate::services::plugins::bundle_token;
+use crate::sync::session::{self, BackgroundRunError};
+
+const RUNTIME_HTML: &str = include_str!("plugin_sandbox/runtime.html");
+const RUNTIME_JS: &str = include_str!("plugin_sandbox/runtime.js");
+
+/// Where the parent app lives (for CSP `frame-ancestors`).
+fn app_origin() -> String {
+    std::env::var("FRONTEND_URL")
+        .unwrap_or_else(|_| "http://localhost:3000".to_string())
+        .trim_end_matches('/')
+        .to_string()
+}
+
+/// Where the runtime is served: the separate sandbox origin if configured, else
+/// the app origin (same-origin default).
+fn runtime_origin() -> String {
+    std::env::var("NOSDESK_SANDBOX_ORIGIN")
+        .ok()
+        .map(|s| s.trim_end_matches('/').to_string())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(app_origin)
+}
+
+/// GET /api/plugins/{uuid}/bundle-token — authenticated. Mints a short-lived,
+/// workspace + plugin + bundle-hash scoped token the sandbox iframe uses to
+/// fetch this plugin's bundle cross-origin (it can't send the session cookie).
+pub async fn mint_bundle_token(
+    req: HttpRequest,
+    mut tc: TenantConn,
+    path: web::Path<Uuid>,
+) -> impl Responder {
+    if req.extensions().get::<Claims>().is_none() {
+        return errors::unauthorized("Authentication required");
+    }
+    let plugin_uuid = path.into_inner();
+    let Some(workspace_id) = req
+        .extensions()
+        .get::<RequestContext>()
+        .and_then(|c| c.actor.workspace_id)
+    else {
+        return errors::unauthorized("No active workspace");
+    };
+
+    let plugin = match tc.run(|conn| plugin_repo::get_plugin_by_uuid(conn, plugin_uuid)) {
+        Ok(p) => p,
+        Err(diesel::result::Error::NotFound) => return errors::not_found_msg("Plugin not found"),
+        Err(e) => {
+            error!(error = %e, %plugin_uuid, "failed to look up plugin for bundle token");
+            return errors::internal("Failed to look up plugin");
+        }
+    };
+    if !plugin.is_active() {
+        return errors::forbidden("Plugin is not active");
+    }
+    let Some(hash) = plugin.bundle_hash.as_deref() else {
+        return errors::not_found_msg("Plugin has no bundle");
+    };
+
+    match bundle_token::mint(workspace_id, plugin_uuid, hash) {
+        Ok(token) => {
+            let runtime_url = format!(
+                "{}/__plugin-sandbox/runtime.html?t={}",
+                runtime_origin(),
+                token
+            );
+            HttpResponse::Ok().json(serde_json::json!({
+                "token": token,
+                "runtime_url": runtime_url,
+                "expires_in": bundle_token::ttl_secs(),
+            }))
+        }
+        Err(e) => {
+            error!(error = %e, %plugin_uuid, "failed to mint bundle token");
+            errors::internal("Failed to mint bundle token")
+        }
+    }
+}
+
+/// GET /__plugin-sandbox/runtime.html — the sandbox shell (no auth; the bundle
+/// fetch it triggers is token-gated).
+pub async fn serve_runtime_html() -> impl Responder {
+    let csp = format!(
+        "default-src 'none'; script-src {ro}; style-src 'unsafe-inline'; \
+         connect-src 'none'; frame-ancestors {ao};",
+        ro = runtime_origin(),
+        ao = app_origin(),
+    );
+    HttpResponse::Ok()
+        .content_type("text/html; charset=utf-8")
+        .insert_header(("Content-Security-Policy", csp))
+        .insert_header(("X-Content-Type-Options", "nosniff"))
+        .insert_header(("Cross-Origin-Resource-Policy", "cross-origin"))
+        .body(RUNTIME_HTML)
+}
+
+/// GET /__plugin-sandbox/runtime.js — the iframe-side runtime. Cross-origin
+/// module fetch from the opaque document, so it needs CORS.
+pub async fn serve_runtime_js() -> impl Responder {
+    HttpResponse::Ok()
+        .content_type("text/javascript; charset=utf-8")
+        .insert_header(("Access-Control-Allow-Origin", "*"))
+        .insert_header(("X-Content-Type-Options", "nosniff"))
+        .insert_header(("Cross-Origin-Resource-Policy", "cross-origin"))
+        .body(RUNTIME_JS)
+}
+
+#[derive(Deserialize)]
+pub struct BundleQuery {
+    t: String,
+}
+
+/// GET /__plugin-sandbox/bundle?t=<token> — token-authorized bundle bytes,
+/// read under the token's workspace pin (RLS), with a bundle-hash match so a
+/// stale token can't serve a rotated bundle.
+pub async fn serve_bundle(pool: web::Data<Pool>, q: web::Query<BundleQuery>) -> impl Responder {
+    let claims = match bundle_token::verify(&q.t) {
+        Ok(c) => c,
+        Err(e) => {
+            warn!(error = %e, "rejected plugin bundle token");
+            return errors::forbidden("Invalid or expired token");
+        }
+    };
+    let plugin_uuid = claims.plugin_uuid;
+
+    let plugin = match session::run_in_workspace(
+        &pool,
+        "plugin_sandbox:serve_bundle",
+        claims.workspace_id,
+        |conn| plugin_repo::get_plugin_by_uuid(conn, plugin_uuid),
+    ) {
+        Ok(p) => p,
+        Err(BackgroundRunError::Db(diesel::result::Error::NotFound)) => {
+            return errors::not_found_msg("Plugin not found");
+        }
+        Err(e) => {
+            error!(error = %e, %plugin_uuid, "failed to read plugin bundle");
+            return errors::internal("Failed to read plugin bundle");
+        }
+    };
+
+    if !plugin.is_active() {
+        return errors::forbidden("Plugin is not active");
+    }
+    // A rotated/reinstalled bundle mints a new hash; a token pinned to the old
+    // one must not serve the new bytes.
+    if plugin.bundle_hash.as_deref() != Some(claims.bundle_hash.as_str()) {
+        return errors::not_found_msg("Bundle version no longer available");
+    }
+    let Some(bytes) = plugin.bundle_js else {
+        return errors::not_found_msg("Plugin bundle not found");
+    };
+
+    HttpResponse::Ok()
+        .content_type("text/javascript; charset=utf-8")
+        .insert_header(("Access-Control-Allow-Origin", "*"))
+        .insert_header(("X-Content-Type-Options", "nosniff"))
+        .insert_header(("Cross-Origin-Resource-Policy", "cross-origin"))
+        .insert_header(("Cache-Control", "private, max-age=60"))
+        .body(bytes)
+}
+
+/// Mounts the unauthenticated sandbox routes at `/__plugin-sandbox/*`. Register
+/// at the top level (outside the auth/tenant middleware): the runtime is static
+/// and the bundle is token-gated.
+pub fn config(cfg: &mut web::ServiceConfig) {
+    cfg.service(
+        web::scope("/__plugin-sandbox")
+            .route("/runtime.html", web::get().to(serve_runtime_html))
+            .route("/runtime.js", web::get().to(serve_runtime_js))
+            .route("/bundle", web::get().to(serve_bundle)),
+    );
+}

--- a/backend/src/handlers/plugin_sandbox/runtime.html
+++ b/backend/src/handlers/plugin_sandbox/runtime.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Nosdesk plugin</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <!-- Relative path resolves to /__plugin-sandbox/runtime.js on whichever
+         origin served this shell. Under the opaque sandbox origin this is a
+         cross-origin module fetch (CORS). CSP script-src lists the explicit
+         runtime origin (an opaque origin can't use 'self'). -->
+    <script type="module" src="./runtime.js"></script>
+  </body>
+</html>

--- a/backend/src/handlers/plugin_sandbox/runtime.js
+++ b/backend/src/handlers/plugin_sandbox/runtime.js
@@ -1,0 +1,22 @@
+// Minimal step-1 sandbox runtime.
+//
+// Reads the bundle token from the iframe URL, imports the plugin bundle
+// cross-origin (token-authorized, no cookies), and mounts it via the
+// framework-agnostic contract `export default { mount(rootEl, api, context) }`.
+//
+// The Comlink host-API bridge + host-side scope enforcement are steps 3-5;
+// `api`/`context` are placeholders here so a real bundle can already render in
+// the sandbox end to end.
+const token = new URLSearchParams(location.search).get('t');
+const root = document.getElementById('root');
+
+try {
+  if (!token) throw new Error('missing bundle token');
+  const mod = await import(`./bundle?t=${encodeURIComponent(token)}`);
+  if (!mod.default || typeof mod.default.mount !== 'function') {
+    throw new Error('bundle has no default { mount } export');
+  }
+  mod.default.mount(root, /* api */ {}, /* context */ {});
+} catch (e) {
+  root.textContent = 'plugin failed to load: ' + e;
+}

--- a/backend/src/handlers/plugins.rs
+++ b/backend/src/handlers/plugins.rs
@@ -99,6 +99,13 @@ pub fn config(cfg: &mut web::ServiceConfig) {
         "/plugins/{uuid}/bundle",
         web::get().to(crate::handlers::plugins::serve_plugin_bundle),
     )
+    // Mint a short-lived token the sandbox iframe uses to fetch this plugin's
+    // bundle cross-origin (it can't send the session cookie). The sandbox
+    // runtime + token-gated /bundle live at the top-level /__plugin-sandbox scope.
+    .route(
+        "/plugins/{uuid}/bundle-token",
+        web::get().to(crate::handlers::plugin_sandbox::mint_bundle_token),
+    )
     .route(
         "/plugins/{uuid}/icon",
         web::get().to(crate::handlers::plugins::serve_plugin_icon),

--- a/backend/src/middleware/security_headers.rs
+++ b/backend/src/middleware/security_headers.rs
@@ -409,6 +409,16 @@ where
 
         Box::pin(async move {
             let mut res = fut.await?;
+
+            // The plugin sandbox routes serve their own precise headers (a
+            // runtime-specific CSP, CORS, CORP). The app-wide policy must NOT
+            // apply, in particular `X-Frame-Options: DENY` below would block the
+            // sandbox iframe, which is embedded (cross-origin framing that only
+            // CSP `frame-ancestors` can express). Leave them untouched.
+            if path.starts_with("/__plugin-sandbox") {
+                return Ok(res);
+            }
+
             let headers = res.headers_mut();
 
             // Cache-Control: only set defaults when the handler

--- a/backend/src/services/plugins/bundle_token.rs
+++ b/backend/src/services/plugins/bundle_token.rs
@@ -1,0 +1,153 @@
+//! Short-lived, single-bundle, workspace-scoped token authorizing a cross-origin
+//! (cookieless) fetch of one plugin's bundle from the sandbox runtime.
+//!
+//! The sandbox iframe runs on a separate/opaque origin and sends no cookies, so
+//! it cannot use the session. This token is the auth instead: the authenticated
+//! app mints it for a plugin the caller may load; the sandbox `/bundle` route
+//! verifies it, pins the workspace, and reads the bundle under RLS. It is scoped
+//! to one workspace + one plugin + one bundle hash and lives ~60s, so a leak
+//! serves at most that single (already-installed) bundle, briefly.
+
+use jsonwebtoken::{decode, encode, Algorithm, DecodingKey, EncodingKey, Header, Validation};
+use serde::{Deserialize, Serialize};
+use std::time::{SystemTime, UNIX_EPOCH};
+use uuid::Uuid;
+
+use crate::utils::jwt::JWT_SECRET;
+
+/// Fixed discriminator: a session token can't be replayed as a bundle token and
+/// vice-versa (the claim shapes already differ; this is belt-and-suspenders).
+const TYP: &str = "plugin_bundle";
+const TTL_SECS: u64 = 60;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct PluginBundleClaims {
+    pub typ: String,
+    pub workspace_id: i32,
+    pub plugin_uuid: Uuid,
+    /// Pins the token to a bundle version; a rotated bundle invalidates it.
+    pub bundle_hash: String,
+    pub exp: u64,
+    pub iat: u64,
+}
+
+#[derive(Debug)]
+pub enum BundleTokenError {
+    Time,
+    Encode(jsonwebtoken::errors::Error),
+    Decode(jsonwebtoken::errors::Error),
+    WrongType,
+}
+
+impl std::fmt::Display for BundleTokenError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Time => write!(f, "system time error"),
+            Self::Encode(e) => write!(f, "encode error: {e}"),
+            Self::Decode(e) => write!(f, "decode error: {e}"),
+            Self::WrongType => write!(f, "token is not a plugin_bundle token"),
+        }
+    }
+}
+
+pub fn mint(
+    workspace_id: i32,
+    plugin_uuid: Uuid,
+    bundle_hash: &str,
+) -> Result<String, BundleTokenError> {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|_| BundleTokenError::Time)?
+        .as_secs();
+    let claims = PluginBundleClaims {
+        typ: TYP.to_string(),
+        workspace_id,
+        plugin_uuid,
+        bundle_hash: bundle_hash.to_string(),
+        exp: now + TTL_SECS,
+        iat: now,
+    };
+    encode(
+        &Header::default(),
+        &claims,
+        &EncodingKey::from_secret(JWT_SECRET.as_bytes()),
+    )
+    .map_err(BundleTokenError::Encode)
+}
+
+pub fn verify(token: &str) -> Result<PluginBundleClaims, BundleTokenError> {
+    let mut v = Validation::new(Algorithm::HS256);
+    v.validate_exp = true;
+    v.validate_aud = false; // our tokens carry no audience
+    v.leeway = 30;
+    let data =
+        decode::<PluginBundleClaims>(token, &DecodingKey::from_secret(JWT_SECRET.as_bytes()), &v)
+            .map_err(BundleTokenError::Decode)?;
+    if data.claims.typ != TYP {
+        return Err(BundleTokenError::WrongType);
+    }
+    Ok(data.claims)
+}
+
+/// The token's fixed lifetime (seconds), so the mint endpoint can tell the
+/// client how soon to load.
+pub const fn ttl_secs() -> u64 {
+    TTL_SECS
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn set_secret() {
+        // JWT_SECRET is a lazy_static reading env; ensure it's present for tests.
+        if std::env::var("JWT_SECRET").is_err() {
+            std::env::set_var("JWT_SECRET", "test-secret-for-bundle-token");
+        }
+    }
+
+    #[test]
+    fn roundtrips_and_carries_scope() {
+        set_secret();
+        let uuid = Uuid::now_v7();
+        let t = mint(42, uuid, "abc123").expect("mint");
+        let c = verify(&t).expect("verify");
+        assert_eq!(c.workspace_id, 42);
+        assert_eq!(c.plugin_uuid, uuid);
+        assert_eq!(c.bundle_hash, "abc123");
+        assert_eq!(c.typ, TYP);
+        assert!(c.exp > c.iat);
+    }
+
+    #[test]
+    fn rejects_wrong_typ() {
+        set_secret();
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        let forged = PluginBundleClaims {
+            typ: "full".to_string(), // pretend to be a session-ish token
+            workspace_id: 1,
+            plugin_uuid: Uuid::now_v7(),
+            bundle_hash: "x".to_string(),
+            exp: now + 60,
+            iat: now,
+        };
+        let t = encode(
+            &Header::default(),
+            &forged,
+            &EncodingKey::from_secret(JWT_SECRET.as_bytes()),
+        )
+        .unwrap();
+        assert!(matches!(verify(&t), Err(BundleTokenError::WrongType)));
+    }
+
+    #[test]
+    fn rejects_tampered_signature() {
+        set_secret();
+        let mut t = mint(1, Uuid::now_v7(), "h").expect("mint");
+        t.push('x'); // corrupt the signature segment
+        assert!(verify(&t).is_err());
+    }
+}

--- a/backend/src/services/plugins/mod.rs
+++ b/backend/src/services/plugins/mod.rs
@@ -3,6 +3,7 @@
 //! Services for plugin functionality including external request proxying
 //! and provisioning.
 
+pub mod bundle_token;
 pub mod install;
 pub mod lifecycle;
 pub mod local_key;

--- a/backend/src/startup.rs
+++ b/backend/src/startup.rs
@@ -796,6 +796,14 @@ pub fn configure_app(
                     .configure(crate::handlers::internal_workspaces::config)
             )
 
+            // === PLUGIN SANDBOX (unauthenticated; token-gated) ===
+            // Serves the sandboxed-iframe runtime + token-authorized bundle bytes
+            // at /__plugin-sandbox/*. Outside /api by design: the sandbox iframe
+            // is credential-less (no cookie), so the bundle is authorized by a
+            // short-lived token, not the session. `SecurityHeaders` skips this
+            // path so the runtime's own CSP (and cross-origin framing) survive.
+            .configure(crate::handlers::plugin_sandbox::config)
+
             // === PROTECTED ROUTES (AUTHENTICATION REQUIRED) ===
             // Supports both cookie-based auth (browser) and Bearer token auth (API clients)
             .service(

--- a/backend/tests/plugin_bundle_isolation.rs
+++ b/backend/tests/plugin_bundle_isolation.rs
@@ -1,0 +1,58 @@
+//! `serve_bundle` (the sandbox `/bundle` route) reads the plugin under the
+//! token's workspace pin (RLS), exactly as `run_in_workspace` does. So a bundle
+//! token scoped to workspace A cannot serve workspace B's plugin, even if its
+//! `plugin_uuid` were pointed there: the pinned read returns nothing. Combined
+//! with the mint endpoint only issuing tokens for plugins in the caller's own
+//! (RLS-scoped) workspace, cross-tenant bundle access is closed at both ends.
+//!
+//! This mirrors the handler's read (`with_actor_context` is the core of
+//! `run_in_workspace`) against the two-workspace fixture's seeded plugins.
+
+#![allow(clippy::expect_used)]
+
+use uuid::Uuid;
+
+use backend::repository::plugins as plugin_repo;
+use backend::sync::actor::ActorContext;
+use backend::sync::session::with_actor_context;
+
+mod common;
+
+/// The plugin `serve_bundle` would see for a token scoped to `ws_id`.
+fn read_pinned(
+    conn: &mut backend::db::DbConnection,
+    ws_id: i32,
+    plugin_uuid: Uuid,
+) -> diesel::QueryResult<backend::models::Plugin> {
+    let actor = ActorContext::system("test:plugin_bundle_read").with_workspace(ws_id);
+    with_actor_context::<_, diesel::result::Error>(conn, &actor, |c| {
+        plugin_repo::get_plugin_by_uuid(c, plugin_uuid)
+    })
+}
+
+#[test]
+fn a_token_cannot_serve_another_workspaces_bundle() {
+    common::ensure_test_keyring();
+    let db = common::TestDb::new();
+    let mut conn = db.conn();
+    let ws = common::seed_two_workspaces(&mut conn);
+
+    // A token scoped to workspace B serves B's plugin (the happy path).
+    assert!(
+        read_pinned(&mut conn, ws.b.workspace_id, ws.b.plugin_uuid).is_ok(),
+        "workspace B's own token must read B's plugin"
+    );
+
+    // A token scoped to workspace A, pointed at B's plugin uuid, reads nothing:
+    // RLS scopes the pinned read to A, where B's plugin does not exist.
+    assert!(
+        matches!(
+            read_pinned(&mut conn, ws.a.workspace_id, ws.b.plugin_uuid),
+            Err(diesel::result::Error::NotFound)
+        ),
+        "a workspace-A pin must not read workspace B's plugin"
+    );
+
+    // Sanity: the two seeded plugins are distinct.
+    assert_ne!(ws.a.plugin_uuid, ws.b.plugin_uuid);
+}


### PR DESCRIPTION
Build-order step 1 of the plugin sandbox (`docs/plugin-sandbox-plan.md`, `docs/plans/plugin-sandbox-step1.md`). **Backend foundation only**; the frontend `PluginSandboxFrame` + Comlink bridge are steps 3-5. The loading mechanic was proven end to end by spike 0 (Chromium, WebKit, real iOS Safari).

## What this adds
- **`bundle_token`** — a short-lived HS256 `typ="plugin_bundle"` token (`workspace_id` + `plugin_uuid` + `bundle_hash` + `exp~60s`), minted by an authenticated endpoint. It replaces the session cookie the credential-less sandbox iframe can't send. Cross-token misuse is prevented by the distinct claim shape + a `typ` guard.
- **`GET /api/plugins/{uuid}/bundle-token`** — authenticated; RLS-scoped plugin lookup, `is_active` + `bundle_hash` present, returns `{ token, runtime_url, expires_in }`.
- **`/__plugin-sandbox/{runtime.html,runtime.js,bundle}`** — unauthenticated, token-gated, top-level (outside `/api`). `/bundle` verifies the token, **pins the workspace, reads under RLS**, and enforces a `bundle_hash` match + `is_active`.
- **`NOSDESK_SANDBOX_ORIGIN` (optional)** — unset serves the runtime from the app origin under `/__plugin-sandbox/*` (self-host/dev default, fully sandboxed by the opaque iframe); set uses a separate origin for defense in depth. Same handlers either way.
- **`SecurityHeaders` skips `/__plugin-sandbox`** — its forced `X-Frame-Options: DENY` would block the embedded iframe, and the runtime serves its own precise CSP (`script-src <runtime-origin>; connect-src 'none'; frame-ancestors <app>`), CORS, CORP, nosniff.

## Isolation model
Isolation is the **opaque sandbox, not the origin** (spike-verified same-origin AND cross-origin on Chromium + WebKit). Cross-tenant access is the **token + RLS**: the mint endpoint only issues tokens for the caller's own (RLS-scoped) workspace, and `/bundle` reads under the token's workspace pin. So a workspace-A token cannot serve workspace-B's plugin.

## Tests
- `bundle_token` unit tests (roundtrip, wrong-typ rejected, tampered-sig rejected) — green locally.
- `tests/plugin_bundle_isolation.rs` — two-workspace bundle-serving isolation, a workspace-A pin cannot read workspace-B's plugin (mirrors `serve_bundle`'s RLS-pinned read). **Note:** this DB-backed test runs in CI (its postgres service); local docker was unavailable at commit time.

Compiles clean; clippy clean on the touched files.