### PR TITLE
chore(deps): bump ammonia 4.1.3 -> 4.1.4 (XSS via SVG animate/set)

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -485,9 +485,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "ammonia"
-version = "4.1.3"
+version = "4.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b9d3370580a12f4b7a10fdcc18b28942c083ba570e3d954fe59d10951b85a2"
+checksum = "dc6d763210e2eb7670d1a5183a08bebefa3f97db2a738a684f2ce00bd49f681d"
 dependencies = [
  "cssparser",
  "html5ever 0.39.0",


### PR DESCRIPTION
Patches the RUSTSEC advisory **"XSS in ammonia via SVG `animate` and `set` animation tags"**, which `cargo deny` now flags, blocking CI on every PR.

Patch bump under the existing `ammonia = "4"` spec (`Cargo.lock` only). Relevant to us since we sanitize SVGs (plugin icons, rendered content), so this is a genuine fix, not just an audit appeasement.

Surfaced by CI on the plugin-sandbox step-1 PR (#125); landing this separately unblocks that and any other open PR.