### PR TITLE
Plugin sandbox step 2: @nosdesk/plugin-sdk (bridge contract + connectToHost)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,6 +184,12 @@ jobs:
       - name: Core boundary guard (@nosdesk/core)
         run: pnpm --filter @nosdesk/core run lint
 
+      - name: Plugin SDK type-check (@nosdesk/plugin-sdk)
+        run: pnpm --filter @nosdesk/plugin-sdk run type-check
+
+      - name: Plugin SDK lint (@nosdesk/plugin-sdk)
+        run: pnpm --filter @nosdesk/plugin-sdk run lint
+
       - name: Audit
         # Advisory only — must not hard-block merges. npm retired the legacy
         # audit endpoint (returns HTTP 410), which older `pnpm audit` still

--- a/packages/plugin-sdk/eslint.config.js
+++ b/packages/plugin-sdk/eslint.config.js
@@ -1,0 +1,10 @@
+// @nosdesk/plugin-sdk runs as browser/iframe code (DOM globals like `window`,
+// `MessageEvent`, `HTMLElement` are expected: it is the iframe-side bridge), so
+// unlike headless @nosdesk/core it does not restrict DOM access. Basic TS lint.
+import tseslint from 'typescript-eslint';
+
+export default tseslint.config({
+  files: ['src/**/*.ts'],
+  languageOptions: { parser: tseslint.parser },
+  extends: [tseslint.configs.recommended],
+});

--- a/packages/plugin-sdk/package.json
+++ b/packages/plugin-sdk/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@nosdesk/plugin-sdk",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Typed contract + iframe-side bridge for Nosdesk sandboxed plugins.",
+  "exports": {
+    ".": "./src/index.ts",
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "type-check": "tsc --noEmit",
+    "lint": "eslint src"
+  },
+  "dependencies": {
+    "comlink": "^4.4.2"
+  },
+  "devDependencies": {
+    "@nosdesk/core": "workspace:*",
+    "@vue/tsconfig": "^0.9.0",
+    "eslint": "^10.2.1",
+    "typescript": "^6.0.0",
+    "typescript-eslint": "^8.59.1"
+  }
+}

--- a/packages/plugin-sdk/src/connect.ts
+++ b/packages/plugin-sdk/src/connect.ts
@@ -1,0 +1,73 @@
+import * as Comlink from 'comlink';
+
+import type { HostApi, PluginContext } from './types';
+
+/** Protocol messages the host posts to the plugin iframe's `contentWindow`. */
+interface HostInitMessage {
+  type: 'nosdesk-plugin-init';
+  context: PluginContext;
+}
+interface HostContextMessage {
+  type: 'nosdesk-plugin-context';
+  context: PluginContext;
+}
+
+/** The ready plugin runtime handed to a plugin's `mount`. */
+export interface PluginRuntime {
+  /** The host API, proxied over the bridge (every call is a round-trip). */
+  api: Comlink.Remote<HostApi>;
+  /** The context snapshot at connect time. */
+  context: PluginContext;
+  /** Subscribe to context snapshots the host pushes after connect; returns an
+   * unsubscribe. */
+  onContextChange(cb: (ctx: PluginContext) => void): () => void;
+}
+
+/**
+ * Iframe-side handshake. Waits for the host to post the init message (carrying
+ * the transferred `MessageChannel` port + the initial context), wraps the port
+ * with Comlink, and resolves the runtime. Thereafter all API traffic flows over
+ * the port; the host pushes context updates as window messages.
+ *
+ * Auth is capability-based, not origin-based: an opaque sandboxed iframe reports
+ * `event.origin === "null"`, so we trust the first init message our parent hands
+ * us (only the host can post to this specific `contentWindow` with the port),
+ * and communicate only over that port afterwards.
+ */
+export function connectToHost(): Promise<PluginRuntime> {
+  return new Promise((resolve) => {
+    const listeners = new Set<(ctx: PluginContext) => void>();
+    let context: PluginContext = { ticket: null, device: null };
+    let connected = false;
+
+    function onMessage(event: MessageEvent) {
+      const data = event.data as HostInitMessage | HostContextMessage | undefined;
+      if (!data || typeof data !== 'object') return;
+
+      if (!connected && data.type === 'nosdesk-plugin-init' && event.ports[0]) {
+        connected = true;
+        context = data.context;
+        const api = Comlink.wrap<HostApi>(event.ports[0]);
+        resolve({
+          api,
+          context,
+          onContextChange(cb) {
+            listeners.add(cb);
+            return () => {
+              listeners.delete(cb);
+            };
+          },
+        });
+      } else if (data.type === 'nosdesk-plugin-context') {
+        context = data.context;
+        for (const cb of listeners) cb(context);
+      }
+    }
+
+    window.addEventListener('message', onMessage);
+  });
+}
+
+/** Re-export so a plugin can wrap its own callbacks (e.g. for `api.on`) when it
+ * needs to pass a function across the bridge. */
+export const proxy = Comlink.proxy;

--- a/packages/plugin-sdk/src/index.ts
+++ b/packages/plugin-sdk/src/index.ts
@@ -1,0 +1,34 @@
+// @nosdesk/plugin-sdk — the typed contract + iframe-side bridge for sandboxed
+// Nosdesk plugins. A plugin's bundle default-exports a { mount } and, inside it,
+// calls connectToHost() to obtain the host API + context.
+//
+//   import { connectToHost } from '@nosdesk/plugin-sdk';
+//   import type { PluginModule } from '@nosdesk/plugin-sdk';
+//
+//   export default {
+//     async mount(root, _api, context) {
+//       const { api } = await connectToHost();
+//       const t = context.ticket ?? (await api.tickets.list())[0];
+//       root.textContent = t ? t.title : 'no ticket';
+//     },
+//   } satisfies PluginModule;
+export { connectToHost, proxy } from './connect';
+export type { PluginRuntime } from './connect';
+
+export type {
+  HostApi,
+  PluginContext,
+  PluginModule,
+  PluginComment,
+  PluginAttachment,
+  PluginCollection,
+  PluginFetchOptions,
+  PluginFetchResponse,
+  PluginEventHandler,
+  // Domain types, re-exported so authors import only from this package.
+  Ticket,
+  Asset,
+  CollectionRow,
+  CollectionListResponse,
+  PluginEvent,
+} from './types';

--- a/packages/plugin-sdk/src/types.ts
+++ b/packages/plugin-sdk/src/types.ts
@@ -1,0 +1,130 @@
+// The typed contract a sandboxed Nosdesk plugin codes against.
+//
+// This is the boundary-safe shape of the host API: every method is async (a
+// postMessage round-trip over the Comlink bridge) and every value is
+// structured-clone-safe. It differs from the app's internal `PluginAPI` in the
+// four places the process boundary forces (see docs/plugin-sandbox-plan.md):
+//   - `fetch` returns a plain object, not a live `Response`.
+//   - `context` is a snapshot passed to `mount` (+ `onContextChange`), not a
+//     live reactive getter.
+//   - `on(...)`'s handler is a callback wrapped by the SDK with Comlink.proxy.
+//   - the host-internal `_setContext` / `_getEventHandlers` are not exposed.
+//
+// Domain types are re-exported from `@nosdesk/core/types` so plugin authors
+// import only from `@nosdesk/plugin-sdk`.
+import type {
+  Ticket,
+  Asset,
+  CollectionRow,
+  CollectionListResponse,
+  PluginEvent,
+} from '@nosdesk/core/types';
+
+export type { Ticket, Asset, CollectionRow, CollectionListResponse, PluginEvent };
+
+/** A comment a plugin adds to a ticket. */
+export interface PluginComment {
+  content: string;
+  is_internal?: boolean;
+}
+
+/** A ticket attachment as exposed to plugins. */
+export interface PluginAttachment {
+  id: number;
+  name: string;
+  url: string;
+  mimeType: string;
+  size: number;
+}
+
+export interface PluginFetchOptions {
+  method?: string;
+  headers?: Record<string, string>;
+  body?: unknown;
+  /** How to encode `body` (default `json`). */
+  content_type?: 'json' | 'form';
+}
+
+/** A plain, structured-clone-safe response from `api.fetch`, NOT a live
+ * `Response` (which cannot cross the bridge). */
+export interface PluginFetchResponse {
+  status: number;
+  headers: Record<string, string>;
+  body: string;
+}
+
+/** A host-event handler. The SDK wraps it with `Comlink.proxy` so it can cross
+ * the bridge. */
+export type PluginEventHandler = (data: unknown) => void | Promise<void>;
+
+/** CRUD over one plugin collection. */
+export interface PluginCollection {
+  create(data: Record<string, unknown>): Promise<CollectionRow | null>;
+  get(uuid: string): Promise<CollectionRow | null>;
+  update(uuid: string, data: Record<string, unknown>): Promise<CollectionRow | null>;
+  delete(uuid: string): Promise<boolean>;
+  list(params?: {
+    limit?: number;
+    offset?: number;
+    filter?: string;
+    sort_by?: string;
+    sort_order?: string;
+  }): Promise<CollectionListResponse>;
+}
+
+/**
+ * The host API a sandboxed plugin calls over the Comlink bridge. Each call is a
+ * round-trip; the host enforces the plugin's manifest permissions per call. A
+ * method rejects (or the sub-API is absent) when a permission isn't granted.
+ */
+export interface HostApi {
+  /** Runtime API version (semver); the major is the breaking-change signal. */
+  readonly version: string;
+  readonly plugin: { uuid: string; name: string; displayName: string; version: string };
+
+  tickets: {
+    get(id: number): Promise<Ticket | null>;
+    list(): Promise<Ticket[]>;
+    addComment(ticketId: number, comment: PluginComment): Promise<boolean>;
+  };
+  devices: {
+    get(id: number): Promise<Asset | null>;
+    list(): Promise<Asset[]>;
+  };
+  attachments: {
+    list(ticketId: number): Promise<PluginAttachment[]>;
+    getBase64(
+      attachmentId: number,
+      ticketId: number,
+    ): Promise<{ data: string; name: string; mimeType: string } | null>;
+  };
+  /** Outbound HTTP via the host's SSRF-guarded, manifest-allowlisted proxy. */
+  fetch(url: string, options?: PluginFetchOptions): Promise<PluginFetchResponse | null>;
+  storage: {
+    get<T>(key: string): Promise<T | null>;
+    set<T>(key: string, value: T): Promise<boolean>;
+    delete(key: string): Promise<boolean>;
+  };
+  /** Access a named collection's CRUD (returns a Comlink-proxied sub-API). */
+  collections(name: string): Promise<PluginCollection>;
+  /** Subscribe to a host event; resolves to an async unsubscribe. */
+  on(event: PluginEvent, handler: PluginEventHandler): Promise<() => Promise<void>>;
+  notify(message: string, type?: 'info' | 'success' | 'warning' | 'error'): Promise<void>;
+  ui: { isPrinting(): Promise<boolean> };
+}
+
+/** The host-provided context, snapshotted into the iframe. It is not a live
+ * object (it can't cross postMessage reactively); updates arrive via
+ * `onContextChange`. */
+export interface PluginContext {
+  ticket: Ticket | null;
+  device: Asset | null;
+}
+
+/** A plugin bundle's default export: the framework-agnostic entry. The runtime
+ * calls `mount` once the bridge is ready; a returned function is the teardown. */
+export interface PluginModule {
+  mount(rootEl: HTMLElement, api: import('comlink').Remote<HostApi>, context: PluginContext):
+    | void
+    | (() => void);
+}

--- a/packages/plugin-sdk/tsconfig.json
+++ b/packages/plugin-sdk/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "@vue/tsconfig/tsconfig.dom.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -287,6 +287,28 @@ importers:
         specifier: ^3.2.0
         version: 3.3.5(typescript@6.0.3)
 
+  packages/plugin-sdk:
+    dependencies:
+      comlink:
+        specifier: ^4.4.2
+        version: 4.4.2
+    devDependencies:
+      '@nosdesk/core':
+        specifier: workspace:*
+        version: link:../core
+      '@vue/tsconfig':
+        specifier: ^0.9.0
+        version: 0.9.1(typescript@6.0.3)(vue@3.5.39(typescript@6.0.3))
+      eslint:
+        specifier: ^10.2.1
+        version: 10.5.0(jiti@2.7.0)
+      typescript:
+        specifier: ^6.0.0
+        version: 6.0.3
+      typescript-eslint:
+        specifier: ^8.59.1
+        version: 8.62.0(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)
+
 packages:
 
   '@alloc/quick-lru@5.2.0':
@@ -1188,6 +1210,9 @@ packages:
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
+
+  comlink@4.4.2:
+    resolution: {integrity: sha512-OxGdvBmJuNKSCMO4NTl1L47VRp6xn2wG4F/2hYzB6tiCb709otOxtEYCSvK80PtjODfXXZu8ds+Nw5kVCjqd2g==}
 
   confbox@0.1.8:
     resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
@@ -3307,6 +3332,8 @@ snapshots:
   combined-stream@1.0.8:
     dependencies:
       delayed-stream: 1.0.0
+
+  comlink@4.4.2: {}
 
   confbox@0.1.8: {}
 


### PR DESCRIPTION
Build-order step 2 (`docs/plugin-sandbox-plan.md`). A new workspace package, `@nosdesk/plugin-sdk`, the typed contract a sandboxed plugin codes against plus the iframe-side handshake that steps 3-5 build on. No app wiring yet (that's steps 3-5).

## What it provides
- **`HostApi`** — the boundary-safe shape of the host API: every method is async (a Comlink round-trip) and structured-clone-safe, with the four process-boundary adaptations from the plan:
  - `fetch` returns a plain `{ status, headers, body }`, not a live `Response`.
  - `context` is a snapshot passed to `mount` (+ `onContextChange`), not a reactive getter.
  - `on(...)` handlers are `Comlink.proxy`-wrapped callbacks.
  - host-internal `_setContext`/`_getEventHandlers` are not exposed.
  Domain types (`Ticket`, `Asset`, `CollectionRow`, ...) are re-exported from `@nosdesk/core` so authors import only from the SDK.
- **`connectToHost()`** — waits for the host's init message (a transferred `MessageChannel` port + the initial context), wraps it with Comlink, and resolves `{ api, context, onContextChange }`. **Capability-based auth** (holding the port), not origin-based, since an opaque sandboxed iframe reports `event.origin === "null"` (a spike finding).
- **`PluginModule`** — the framework-agnostic `export default { mount(root, api, context) }` contract.

## Validation
Type-check + lint clean; both wired into CI (new steps mirroring `@nosdesk/core`). There is no JS test runner in the workspace, so runtime validation of the Comlink handshake lands in **step 3**, when the sandbox runtime calls `connectToHost()` against the real host bridge end to end.