### PR TITLE
chore(spikes): plugin-sandbox validation harness

### DIFF
--- a/spikes/plugin-sandbox/.gitignore
+++ b/spikes/plugin-sandbox/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+test-results/
+playwright-report/

--- a/spikes/plugin-sandbox/README.md
+++ b/spikes/plugin-sandbox/README.md
@@ -1,0 +1,45 @@
+# Plugin sandbox spike 0 (throwaway)
+
+Go/no-go for `docs/plugin-sandbox-plan.md`. Proves the core loading + isolation
+mechanic of an opaque-origin sandboxed iframe. **Throwaway — do not merge.**
+
+Two local origins stand in for the app and the sandbox:
+- host ("app"):    http://localhost:5310/host.html
+- sandbox:         http://127.0.0.1:5311  (different origin: localhost vs 127.0.0.1)
+
+Both are secure contexts (localhost), so this exercises real cross-origin behaviour.
+
+## Run
+
+```
+node spikes/plugin-sandbox/serve.mjs
+```
+
+Open http://localhost:5310/host.html in **each** browser and read the results
+table: **Chrome, Firefox, Safari (macOS)**. Record which pass. The iframe uses
+`sandbox="allow-scripts"` (opaque origin), `credentialless`, and a strict CSP.
+
+## What each row proves
+
+- **M1** the opaque-origin iframe imports `runtime.js` + dynamically imports the
+  plugin `bundle.js` and calls its `mount()` — under `script-src <sandbox-host>`
+  (not `'self'`, which is meaningless for an opaque origin) with cross-origin
+  CORS. This is the mechanic that sinks naive sandboxes; it must pass.
+- **M2** a `MessageChannel` round-trip works (the bridge transport). Note: the
+  host transfers the port to the specific iframe `contentWindow`; it does NOT
+  validate `event.origin`, because an opaque-origin frame reports
+  `event.origin === "null"` (a real refinement to the plan's handshake).
+- **M3a/b** the sandbox cannot read `document.cookie` / `localStorage` (opaque
+  origin throws) — no host session reachable.
+- **M3c** a direct `fetch` to the host origin is blocked by `connect-src 'none'`
+  — the plugin has no network except the bridge.
+
+If M1 fails, read the mount-result text and the browser console: it distinguishes
+a CSP block from a CORS failure from an opaque-origin module-loading limitation.
+
+## iOS (the real question — M5, next)
+
+Desktop passing is necessary but not sufficient. The Tauri iOS WKWebView is the
+make-or-break (WebKit `credentialless` support, cross-origin iframe under a custom
+scheme). That is tracked by the parallel WebKit research pass and a follow-up that
+loads this harness inside the iOS app. Do not conclude go/no-go until iOS is tested.

--- a/spikes/plugin-sandbox/host.html
+++ b/spikes/plugin-sandbox/host.html
@@ -1,0 +1,96 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>plugin-sandbox spike</title>
+    <style>
+      body { font: 14px system-ui, sans-serif; margin: 2rem; max-width: 780px; }
+      table { border-collapse: collapse; margin: 1rem 0; width: 100%; }
+      td, th { border: 1px solid #ccc; padding: 6px 10px; text-align: left; vertical-align: top; }
+      .p { color: #0a0; font-weight: 600; }
+      .f { color: #c00; font-weight: 600; }
+      code { background: #f3f3f3; padding: 1px 4px; }
+      iframe { width: 320px; height: 60px; border: 1px solid #ddd; margin-top: 1rem; }
+    </style>
+  </head>
+  <body>
+    <h1>Plugin sandbox spike 0</h1>
+    <p>host origin: <code id="o"></code></p>
+    <table>
+      <thead><tr><th>Check</th><th>Result</th></tr></thead>
+      <tbody id="r"></tbody>
+    </table>
+    <!-- No `credentialless`: Chromium-only + unsupported in WebKit/iOS, and only
+         needed for COEP/SharedArrayBuffer, which the bridge does not use. The
+         opaque origin + connect-src none already prevent credentialed requests. -->
+    <iframe id="f" sandbox="allow-scripts" referrerpolicy="no-referrer" allow=""></iframe>
+    <script type="module">
+      // Sandbox base. Default = a separate origin (this host, port 5311). With
+      // ?mode=same = SAME origin under /so, which proves a same-origin `src`
+      // still opaque-ifies under sandbox="allow-scripts" (the zero-config
+      // self-host path: cookie/localStorage must STILL throw).
+      const SAME_ORIGIN = new URLSearchParams(location.search).get('mode') === 'same';
+      const SANDBOX = SAME_ORIGIN
+        ? `${location.origin}/so`
+        : `${location.protocol}//${location.hostname}:5311`;
+      document.cookie = 'spike_host_cookie=secret; SameSite=Lax';
+      document.getElementById('o').textContent = location.origin;
+      const rows = document.getElementById('r');
+      // Machine-readable hook so Playwright (or any driver) can assert without
+      // scraping the DOM: window.__spike.done + window.__spike.results[].
+      const results = [];
+      window.__spike = { done: false, results };
+      const finish = () => {
+        settled = true;
+        window.__spike.done = true;
+      };
+      const row = (name, ok, detail) => {
+        const tr = document.createElement('tr');
+        tr.innerHTML =
+          `<td>${name}</td><td class="${ok ? 'p' : 'f'}">${ok ? 'PASS' : 'FAIL'}` +
+          `${detail ? ' — ' + detail : ''}</td>`;
+        rows.appendChild(tr);
+        results.push({ name, ok, detail });
+      };
+
+      const f = document.getElementById('f');
+      const chan = new MessageChannel();
+      let settled = false;
+
+      chan.port1.onmessage = (e) => {
+        const m = e.data;
+        if (m.type === 'mounted') {
+          const ok = m.ok !== false;
+          row('M1 opaque-origin iframe imports runtime + bundle, runs mount() under strict CSP', ok, m.info);
+          if (ok) chan.port1.postMessage({ type: 'selfcheck' });
+          else finish();
+        } else if (m.type === 'selfcheck') {
+          row('M2 MessageChannel round-trip host &lt;-&gt; iframe', true);
+          row('M3a document.cookie unreachable in sandbox', m.cookie.blocked, m.cookie.info);
+          row('M3b localStorage unreachable in sandbox', m.storage.blocked, m.storage.info);
+          row('M3c direct fetch to host origin blocked (connect-src none)', m.hostFetch.blocked, m.hostFetch.info);
+          finish();
+        }
+      };
+
+      f.addEventListener('load', () => {
+        // Transfer the port to THIS iframe's contentWindow. Opaque-origin frames
+        // report event.origin === "null", so we rely on the port capability +
+        // targeting this exact window, not on origin-string validation.
+        f.contentWindow.postMessage({ type: 'init', hostOrigin: location.origin }, '*', [chan.port2]);
+      });
+      // Token authorizes the one runtime load; no cookies needed.
+      f.src = `${SANDBOX}/runtime.html?token=spike-token`;
+
+      // Generous watchdog: a cold Playwright-WebKit cross-origin module load can
+      // take >4s of browser warm-up. On real hardware this settles in well under
+      // a second; this only guards a genuine hang.
+      setTimeout(() => {
+        if (!settled) {
+          row('handshake completed', false, 'no response — check the console; likely CSP/CORS or opaque-origin module loading');
+          finish();
+        }
+      }, 12_000);
+    </script>
+  </body>
+</html>

--- a/spikes/plugin-sandbox/package-lock.json
+++ b/spikes/plugin-sandbox/package-lock.json
@@ -1,0 +1,76 @@
+{
+  "name": "plugin-sandbox-spike",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "plugin-sandbox-spike",
+      "devDependencies": {
+        "@playwright/test": "1.61.1"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/spikes/plugin-sandbox/package.json
+++ b/spikes/plugin-sandbox/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "plugin-sandbox-spike",
+  "private": true,
+  "type": "module",
+  "devDependencies": {
+    "@playwright/test": "1.61.1"
+  }
+}

--- a/spikes/plugin-sandbox/playwright.config.mjs
+++ b/spikes/plugin-sandbox/playwright.config.mjs
@@ -1,0 +1,23 @@
+import { defineConfig, devices } from '@playwright/test';
+
+// Drives the throwaway sandbox harness across engine families. WebKit is the
+// signal that matters for the Safari/iOS engine (not identical to the Tauri iOS
+// WKWebView, but the same core engine, far better than Chromium-only).
+export default defineConfig({
+  testDir: '.',
+  testMatch: /spike\.spec\.mjs/,
+  timeout: 30_000,
+  reporter: [['list']],
+  webServer: {
+    command: 'node serve.mjs',
+    url: 'http://localhost:5310/host.html',
+    reuseExistingServer: false,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  },
+  use: { baseURL: 'http://localhost:5310' },
+  projects: [
+    { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+    { name: 'webkit', use: { ...devices['Desktop Safari'] } },
+  ],
+});

--- a/spikes/plugin-sandbox/sandbox/bundle.js
+++ b/spikes/plugin-sandbox/sandbox/bundle.js
@@ -1,0 +1,7 @@
+// A trivial "plugin": the framework-agnostic mount contract from the plan.
+export default {
+  mount(rootEl, _api, _context) {
+    rootEl.textContent = 'plugin mounted in sandbox';
+    return { mounted: true };
+  },
+};

--- a/spikes/plugin-sandbox/sandbox/runtime.html
+++ b/spikes/plugin-sandbox/sandbox/runtime.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>plugin runtime</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <!-- Module script from the explicit host (CSP script-src lists it). Under
+         the opaque origin this is a cross-origin module fetch => CORS. Relative
+         path so the same files serve at a separate origin (/) OR same-origin
+         (/so/) unchanged. -->
+    <script type="module" src="./runtime.js"></script>
+  </body>
+</html>

--- a/spikes/plugin-sandbox/sandbox/runtime.js
+++ b/spikes/plugin-sandbox/sandbox/runtime.js
@@ -1,0 +1,47 @@
+// The iframe-side runtime: receives the bridge port, imports the plugin bundle,
+// calls its mount(), and answers isolation self-checks over the port.
+let port;
+let hostOrigin;
+
+window.addEventListener('message', async (e) => {
+  const m = e.data;
+  if (!m || m.type !== 'init' || !e.ports || !e.ports[0]) return;
+  port = e.ports[0];
+  hostOrigin = m.hostOrigin;
+  port.onmessage = onPortMessage;
+
+  try {
+    // M1: cross-origin ES-module import under the opaque origin + explicit-host
+    // CSP + CORS. This is the make-or-break load mechanic.
+    const mod = await import('./bundle.js');
+    const api = {}; // real bridge Remote<PluginAPI> goes here later
+    const context = {};
+    const mountResult = mod.default.mount(document.getElementById('root'), api, context);
+    port.postMessage({ type: 'mounted', ok: true, info: JSON.stringify(mountResult ?? 'ok') });
+  } catch (err) {
+    port.postMessage({ type: 'mounted', ok: false, info: 'import/mount failed: ' + String(err).slice(0, 120) });
+  }
+});
+
+function probe(fn) {
+  try {
+    fn();
+    return { blocked: false, info: 'ACCESSIBLE (unexpected)' };
+  } catch (err) {
+    return { blocked: true, info: String(err.name || err).slice(0, 50) };
+  }
+}
+
+async function onPortMessage(e) {
+  if (e.data.type !== 'selfcheck') return;
+  const cookie = probe(() => void document.cookie);
+  const storage = probe(() => void window.localStorage.length);
+  let hostFetch;
+  try {
+    await fetch(hostOrigin + '/host.html', { mode: 'no-cors' });
+    hostFetch = { blocked: false, info: 'fetch SUCCEEDED (unexpected — connect-src none should block)' };
+  } catch (err) {
+    hostFetch = { blocked: true, info: String(err.name || err).slice(0, 50) };
+  }
+  port.postMessage({ type: 'selfcheck', cookie, storage, hostFetch });
+}

--- a/spikes/plugin-sandbox/serve.mjs
+++ b/spikes/plugin-sandbox/serve.mjs
@@ -1,0 +1,89 @@
+// Throwaway two-origin harness for the plugin-sandbox spike. No deps.
+//   host    origin: http://localhost:5310  (the "app")
+//   sandbox origin: http://127.0.0.1:5311  (serves the plugin runtime + bundle)
+import { createServer } from 'node:http';
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const DIR = dirname(fileURLToPath(import.meta.url));
+const HOST_PORT = 5310;
+const SANDBOX_PORT = 5311;
+const HOST_ORIGIN = `http://localhost:${HOST_PORT}`;
+const SANDBOX_ORIGIN = `http://127.0.0.1:${SANDBOX_PORT}`;
+const VALID_TOKEN = 'spike-token';
+
+async function send(res, status, headers, bodyPath) {
+  try {
+    const body = bodyPath ? await readFile(join(DIR, bodyPath)) : '';
+    res.writeHead(status, headers);
+    res.end(body);
+  } catch (e) {
+    res.writeHead(500);
+    res.end(String(e));
+  }
+}
+
+// Runtime-page CSP built from the host the client used (works on localhost or a
+// LAN IP). Shared by the separate-origin and same-origin variants.
+function runtimeHeaders(req) {
+  const sbHost = `http://${req.headers.host}`;
+  return {
+    'Content-Type': 'text/html',
+    'Content-Security-Policy':
+      `default-src 'none'; script-src ${sbHost}; style-src 'unsafe-inline'; connect-src 'none';`,
+    'Cross-Origin-Resource-Policy': 'cross-origin',
+  };
+}
+const jsHeaders = {
+  'Content-Type': 'text/javascript',
+  'Access-Control-Allow-Origin': '*',
+  'Cross-Origin-Resource-Policy': 'cross-origin',
+};
+
+// ---- host ("app") origin -------------------------------------------------
+createServer((req, res) => {
+  const url = new URL(req.url, HOST_ORIGIN);
+  const p = url.pathname;
+  if (p === '/' || p === '/host.html') {
+    return send(res, 200, { 'Content-Type': 'text/html' }, 'host.html');
+  }
+  // Same-origin variant (the zero-config self-host path): serve the runtime +
+  // bundle from THIS host origin under /so/. Proves a same-origin `src` still
+  // opaque-ifies under sandbox="allow-scripts" (document.cookie must still throw).
+  if (p === '/so/runtime.html') {
+    if (url.searchParams.get('token') !== VALID_TOKEN) {
+      res.writeHead(403);
+      return res.end('bad token');
+    }
+    return send(res, 200, runtimeHeaders(req), 'sandbox/runtime.html');
+  }
+  if (p === '/so/runtime.js' || p === '/so/bundle.js') {
+    return send(res, 200, jsHeaders, `sandbox/${p.slice(4)}`);
+  }
+  res.writeHead(404);
+  res.end('not found');
+}).listen(HOST_PORT, () => console.log(`host    ${HOST_ORIGIN}/host.html`));
+
+// ---- sandbox origin ------------------------------------------------------
+createServer((req, res) => {
+  const url = new URL(req.url, SANDBOX_ORIGIN);
+  const p = url.pathname;
+
+  if (p === '/runtime.html') {
+    // Token gate (M4): the host mints a short-lived token; the sandbox serves
+    // the runtime only for a valid one (no cookies involved).
+    if (url.searchParams.get('token') !== VALID_TOKEN) {
+      res.writeHead(403);
+      return res.end('bad token');
+    }
+    return send(res, 200, runtimeHeaders(req), 'sandbox/runtime.html');
+  }
+
+  if (p === '/runtime.js' || p === '/bundle.js') {
+    return send(res, 200, jsHeaders, `sandbox/${p.slice(1)}`);
+  }
+
+  res.writeHead(404);
+  res.end('not found');
+}).listen(SANDBOX_PORT, () => console.log(`sandbox ${SANDBOX_ORIGIN}/runtime.html`));

--- a/spikes/plugin-sandbox/spike.spec.mjs
+++ b/spikes/plugin-sandbox/spike.spec.mjs
@@ -1,0 +1,43 @@
+import { test, expect } from '@playwright/test';
+
+// Loads the harness in two modes, waits for the async checks to settle, and
+// asserts every reported row passed. Prints the full result set + any console
+// errors so a failure says WHY (CSP block vs CORS vs opaque-origin module load).
+//
+// - cross-origin: the runtime is served from a separate origin (the hosted path).
+// - same-origin:  the runtime is served from the app's OWN origin under /so, into
+//   a sandbox="allow-scripts" iframe. This proves the same-origin src still gets
+//   an opaque origin (M3a/b cookie+localStorage still throw) — the zero-config
+//   self-host default rests on this.
+const MODES = [
+  { label: 'cross-origin (separate origin, hosted)', path: '/host.html' },
+  { label: 'same-origin (self-host default)', path: '/host.html?mode=same' },
+];
+
+for (const { label, path } of MODES) {
+  test(`opaque-origin sandbox mechanic — ${label}`, async ({ page }) => {
+    const consoleErrors = [];
+    page.on('console', (m) => {
+      if (m.type() === 'error') consoleErrors.push(m.text());
+    });
+    page.on('pageerror', (e) => consoleErrors.push('pageerror: ' + e.message));
+
+    await page.goto(path);
+    await page.waitForFunction(() => window.__spike && window.__spike.done, undefined, {
+      timeout: 15_000,
+    });
+
+    const results = await page.evaluate(() => window.__spike.results);
+    // eslint-disable-next-line no-console
+    console.log(`\n[${label}] results:\n` + JSON.stringify(results, null, 2));
+    if (consoleErrors.length) {
+      // eslint-disable-next-line no-console
+      console.log('console errors:\n' + consoleErrors.join('\n'));
+    }
+
+    expect(results.length, 'expected all 5 checks to run').toBe(5);
+    for (const r of results) {
+      expect(r.ok, `${r.name} — ${r.detail || ''}`).toBe(true);
+    }
+  });
+}


### PR DESCRIPTION
The two-origin harness + Playwright test that proved the opaque-sandbox mechanic (opaque-origin cross-origin ESM import under a strict CSP, MessageChannel bridge, cookie/localStorage/connect-src isolation) across Chromium + WebKit, same-origin and cross-origin, and on real iOS Safari.

Kept as a repeatable regression check: `node spikes/plugin-sandbox/serve.mjs`, or `npx playwright test` in that dir. `node_modules` + Playwright artifacts are gitignored, and it's outside the pnpm workspace so it doesn't affect the product build.