### PR TITLE
Plugin sandbox step 4b-1: host-side bridge in the SDK + proven round-trip

### DIFF
--- a/packages/plugin-sdk/src/host.ts
+++ b/packages/plugin-sdk/src/host.ts
@@ -1,0 +1,48 @@
+import * as Comlink from 'comlink';
+
+import type { HostApi, PluginContext } from './types';
+
+/**
+ * The host end of the plugin bridge. `createRemoteHostApi` exposes a `HostApi`
+ * over a fresh `MessageChannel` and returns the far `port` for the caller to
+ * transfer into the sandboxed iframe (via `postInit`, which the runtime's
+ * `connectToHost` awaits). The bridge is pure transport: per-call permission
+ * enforcement and the workspace pin live inside the `impl` the host passes.
+ */
+export interface HostBridge {
+  /** Transfer this into the iframe with the init message; never expose it
+   * elsewhere (holding the port IS the capability). */
+  readonly port: MessagePort;
+  /** Close the channel and stop serving the API. */
+  dispose(): void;
+}
+
+/** Expose `impl` over a fresh channel; return the port to hand to the iframe. */
+export function createRemoteHostApi(impl: HostApi): HostBridge {
+  const channel = new MessageChannel();
+  Comlink.expose(impl, channel.port1);
+  return {
+    port: channel.port2,
+    dispose() {
+      channel.port1.close();
+      channel.port2.close();
+    },
+  };
+}
+
+/**
+ * Post the init handshake to a sandboxed plugin iframe: the transferred port +
+ * the initial context. `targetOrigin` is `*` by design, an opaque sandboxed
+ * frame has origin `"null"`, so the capability is the transferred port (only the
+ * host can post to this specific `contentWindow`), not an origin string. Call
+ * once the iframe has loaded. Mirrors the message the SDK's `connectToHost`
+ * awaits.
+ */
+export function postInit(target: Window, bridge: HostBridge, context: PluginContext): void {
+  target.postMessage({ type: 'nosdesk-plugin-init', context }, '*', [bridge.port]);
+}
+
+/** Push a fresh context snapshot to an already-connected plugin iframe. */
+export function postContext(target: Window, context: PluginContext): void {
+  target.postMessage({ type: 'nosdesk-plugin-context', context }, '*');
+}

--- a/packages/plugin-sdk/src/index.ts
+++ b/packages/plugin-sdk/src/index.ts
@@ -15,6 +15,10 @@
 export { connectToHost, proxy } from './connect';
 export type { PluginRuntime } from './connect';
 
+// Host-side bridge (used by the app + the bridge harness, not by plugins).
+export { createRemoteHostApi, postInit, postContext } from './host';
+export type { HostBridge } from './host';
+
 export type {
   HostApi,
   PluginContext,

--- a/spikes/plugin-bridge/.gitignore
+++ b/spikes/plugin-bridge/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+test-results/
+playwright-report/

--- a/spikes/plugin-bridge/README.md
+++ b/spikes/plugin-bridge/README.md
@@ -1,0 +1,21 @@
+# plugin-bridge harness
+
+Proves the host↔plugin **Comlink round-trip** for the plugin sandbox, using the
+real `@nosdesk/plugin-sdk` (`createRemoteHostApi` + `connectToHost`) and real
+`@nosdesk/plugin-runtime`, through an opaque-origin sandboxed iframe. Sibling to
+`../plugin-sandbox/` (which proves *isolation*); this one proves the *bridge*.
+
+```bash
+npm install
+npx playwright test        # chromium + webkit
+```
+
+The flow: the host embeds `sandbox="allow-scripts"` iframe → the runtime
+`connectToHost()`s and imports the token'd bundle → the plugin calls
+`api.tickets.get(42)` (host→plugin return) then `api.notify(title)`
+(plugin→host arg). The host stub records the notify arg into `#result` on the
+host origin, so the round-trip is asserted without reaching into the opaque
+frame. `build.mjs` esbuilds all three actors from real source (SDK aliased to
+its TS; comlink resolves from the SDK's node_modules).
+
+2026-07-22: **PASS on Chromium + WebKit.** WebKit is the Safari/iOS signal.

--- a/spikes/plugin-bridge/bridge.spec.mjs
+++ b/spikes/plugin-bridge/bridge.spec.mjs
@@ -1,0 +1,12 @@
+import { test, expect } from '@playwright/test';
+
+// The plugin, inside the opaque sandbox, calls `api.tickets.get(42)` (host ->
+// plugin: a returned value) then `api.notify(title)` (plugin -> host: an
+// argument). The host stub writes the notify arg into `#result` on the host
+// origin. Seeing the host-minted title there proves a full Comlink round-trip
+// crossed the sandbox boundary in both directions.
+test('host<->plugin Comlink round-trip through the opaque sandbox', async ({ page }) => {
+  await page.goto('/host.html');
+  await expect(page.locator('#result')).toHaveText('ticket 42 from host');
+  await expect(page.locator('#host-log')).toHaveText('host: tickets.get(42)');
+});

--- a/spikes/plugin-bridge/build.mjs
+++ b/spikes/plugin-bridge/build.mjs
@@ -1,0 +1,31 @@
+// Build the three bridge actors from real source with esbuild:
+//   dist/runtime.js  <- packages/plugin-runtime/src/runtime.ts  (the REAL runtime)
+//   dist/host.js     <- src/host-entry.ts   (uses the REAL @nosdesk/plugin-sdk host side)
+//   dist/plugin.js   <- src/plugin.ts        (a trivial plugin calling api.*)
+//
+// @nosdesk/plugin-sdk is aliased to its TS source; comlink resolves from the
+// SDK's own node_modules (esbuild walks up from the aliased file). No type
+// erasure surprises: types.ts's domain imports are all `import type`.
+import * as esbuild from 'esbuild';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const DIR = dirname(fileURLToPath(import.meta.url));
+const R = (p) => resolve(DIR, p);
+
+const common = {
+  bundle: true,
+  format: 'esm',
+  target: 'es2022',
+  logLevel: 'info',
+  alias: {
+    '@nosdesk/plugin-sdk': R('../../packages/plugin-sdk/src/index.ts'),
+  },
+};
+
+await Promise.all([
+  esbuild.build({ ...common, entryPoints: [R('../../packages/plugin-runtime/src/runtime.ts')], outfile: R('dist/runtime.js') }),
+  esbuild.build({ ...common, entryPoints: [R('src/host-entry.ts')], outfile: R('dist/host.js') }),
+  esbuild.build({ ...common, entryPoints: [R('src/plugin.ts')], outfile: R('dist/plugin.js') }),
+]);
+console.log('bridge harness built -> dist/');

--- a/spikes/plugin-bridge/package-lock.json
+++ b/spikes/plugin-bridge/package-lock.json
@@ -1,0 +1,561 @@
+{
+  "name": "plugin-bridge-harness",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "plugin-bridge-harness",
+      "devDependencies": {
+        "@playwright/test": "1.61.1",
+        "esbuild": "^0.25.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/spikes/plugin-bridge/package.json
+++ b/spikes/plugin-bridge/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "plugin-bridge-harness",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "node build.mjs",
+    "serve": "node build.mjs && node serve.mjs",
+    "test": "playwright test"
+  },
+  "devDependencies": {
+    "@playwright/test": "1.61.1",
+    "esbuild": "^0.25.0"
+  }
+}

--- a/spikes/plugin-bridge/playwright.config.mjs
+++ b/spikes/plugin-bridge/playwright.config.mjs
@@ -1,0 +1,23 @@
+import { defineConfig, devices } from '@playwright/test';
+
+// Proves the host<->plugin Comlink round-trip using the REAL @nosdesk/plugin-sdk
+// (createRemoteHostApi + connectToHost) and the REAL @nosdesk/plugin-runtime,
+// through an opaque-origin sandboxed iframe. WebKit is the Safari/iOS signal.
+export default defineConfig({
+  testDir: '.',
+  testMatch: /bridge\.spec\.mjs/,
+  timeout: 30_000,
+  reporter: [['list']],
+  webServer: {
+    command: 'node build.mjs && node serve.mjs',
+    url: 'http://localhost:5320/host.html',
+    reuseExistingServer: false,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  },
+  use: { baseURL: 'http://localhost:5320' },
+  projects: [
+    { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+    { name: 'webkit', use: { ...devices['Desktop Safari'] } },
+  ],
+});

--- a/spikes/plugin-bridge/public/host.html
+++ b/spikes/plugin-bridge/public/host.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>plugin bridge harness — host</title>
+  </head>
+  <body data-sandbox-origin="http://127.0.0.1:5321">
+    <h1>plugin bridge harness</h1>
+    <!-- The plugin's notify() arg lands here, on the host origin. -->
+    <div id="result">pending</div>
+    <div id="host-log"></div>
+    <div id="frame-slot"></div>
+    <script type="module" src="./host.js"></script>
+  </body>
+</html>

--- a/spikes/plugin-bridge/public/runtime.html
+++ b/spikes/plugin-bridge/public/runtime.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>plugin runtime</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <!-- The real @nosdesk/plugin-runtime bundle: reads ?t, connectToHost(),
+         imports ./bundle?t=<token>, mounts. Loaded from the explicit sandbox
+         host (CSP script-src lists it); cross-origin module fetch => CORS. -->
+    <script type="module" src="./runtime.js"></script>
+  </body>
+</html>

--- a/spikes/plugin-bridge/serve.mjs
+++ b/spikes/plugin-bridge/serve.mjs
@@ -1,0 +1,75 @@
+// Two-origin server for the bridge harness. No deps.
+//   host    origin: http://localhost:5320   (the "app")
+//   sandbox origin: http://127.0.0.1:5321    (serves runtime + token-gated bundle)
+import { createServer } from 'node:http';
+import { readFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const DIR = dirname(fileURLToPath(import.meta.url));
+const HOST_PORT = 5320;
+const SANDBOX_PORT = 5321;
+const VALID_TOKEN = 'bridge-token';
+
+async function send(res, status, headers, path) {
+  try {
+    const body = path ? await readFile(join(DIR, path)) : '';
+    res.writeHead(status, headers);
+    res.end(body);
+  } catch (e) {
+    res.writeHead(500);
+    res.end(String(e));
+  }
+}
+
+const jsHeaders = {
+  'Content-Type': 'text/javascript',
+  'Access-Control-Allow-Origin': '*',
+  'Cross-Origin-Resource-Policy': 'cross-origin',
+};
+
+function runtimeHeaders(req) {
+  const sbHost = `http://${req.headers.host}`;
+  return {
+    'Content-Type': 'text/html',
+    'Content-Security-Policy':
+      `default-src 'none'; script-src ${sbHost}; style-src 'unsafe-inline'; connect-src 'none';`,
+    'Cross-Origin-Resource-Policy': 'cross-origin',
+  };
+}
+
+// ---- host ("app") origin -------------------------------------------------
+createServer((req, res) => {
+  const { pathname } = new URL(req.url, `http://localhost:${HOST_PORT}`);
+  if (pathname === '/' || pathname === '/host.html') {
+    return send(res, 200, { 'Content-Type': 'text/html' }, 'public/host.html');
+  }
+  if (pathname === '/host.js') {
+    return send(res, 200, { 'Content-Type': 'text/javascript' }, 'dist/host.js');
+  }
+  res.writeHead(404);
+  res.end('not found');
+}).listen(HOST_PORT, () => console.log(`host    http://localhost:${HOST_PORT}/host.html`));
+
+// ---- sandbox origin ------------------------------------------------------
+createServer((req, res) => {
+  const url = new URL(req.url, `http://127.0.0.1:${SANDBOX_PORT}`);
+  const p = url.pathname;
+  if (p === '/runtime.html') {
+    if (url.searchParams.get('t') !== VALID_TOKEN) {
+      res.writeHead(403);
+      return res.end('bad token');
+    }
+    return send(res, 200, runtimeHeaders(req), 'public/runtime.html');
+  }
+  if (p === '/runtime.js') {
+    return send(res, 200, jsHeaders, 'dist/runtime.js');
+  }
+  // The runtime imports `./bundle?t=<token>`; the real backend verifies the
+  // token here (covered by backend tests) — the harness just serves the plugin.
+  if (p === '/bundle') {
+    return send(res, 200, jsHeaders, 'dist/plugin.js');
+  }
+  res.writeHead(404);
+  res.end('not found');
+}).listen(SANDBOX_PORT, () => console.log(`sandbox http://127.0.0.1:${SANDBOX_PORT}/runtime.html`));

--- a/spikes/plugin-bridge/src/host-entry.ts
+++ b/spikes/plugin-bridge/src/host-entry.ts
@@ -1,0 +1,60 @@
+// The host ("app") side. Embeds the opaque-sandbox iframe, and once it loads,
+// exposes a stub HostApi over a MessageChannel and transfers the port in with
+// the init message (exactly what the app's real PluginSandboxFrame will do).
+// The stub records what the plugin sends back (notify) into the host DOM, so the
+// round-trip is fully observable on this origin.
+import { createRemoteHostApi, postInit } from '@nosdesk/plugin-sdk';
+import type { HostApi, PluginContext, Ticket } from '@nosdesk/plugin-sdk';
+
+const sandboxOrigin = document.body.dataset.sandboxOrigin as string;
+const TOKEN = 'bridge-token';
+
+function set(id: string, text: string): void {
+  const el = document.getElementById(id);
+  if (el) el.textContent = text;
+}
+
+// The stub only fills what the test plugin exercises; the rest satisfy the type.
+const impl: HostApi = {
+  version: '1.0.0',
+  plugin: { uuid: 'test-uuid', name: 'test', displayName: 'Test', version: '1.0.0' },
+  tickets: {
+    async get(id) {
+      set('host-log', `host: tickets.get(${id})`);
+      return { id, title: `ticket ${id} from host` } as unknown as Ticket;
+    },
+    async list() {
+      return [];
+    },
+    async addComment() {
+      return true;
+    },
+  },
+  devices: { async get() { return null; }, async list() { return []; } },
+  attachments: { async list() { return []; }, async getBase64() { return null; } },
+  async fetch() {
+    return null;
+  },
+  storage: { async get() { return null; }, async set() { return true; }, async delete() { return true; } },
+  async collections() {
+    throw new Error('collections not stubbed');
+  },
+  async on() {
+    return async () => {};
+  },
+  async notify(message) {
+    set('result', message);
+  },
+  ui: { async isPrinting() { return false; } },
+};
+
+const context: PluginContext = { ticket: null, device: null };
+
+const iframe = document.createElement('iframe');
+iframe.setAttribute('sandbox', 'allow-scripts');
+iframe.src = `${sandboxOrigin}/runtime.html?t=${TOKEN}`;
+iframe.addEventListener('load', () => {
+  const bridge = createRemoteHostApi(impl);
+  postInit(iframe.contentWindow as Window, bridge, context);
+});
+document.getElementById('frame-slot')?.appendChild(iframe);

--- a/spikes/plugin-bridge/src/plugin.ts
+++ b/spikes/plugin-bridge/src/plugin.ts
@@ -1,0 +1,14 @@
+// A trivial sandboxed plugin. The runtime calls `mount` with a Comlink-proxied
+// HostApi; every call is a round-trip over the transferred port. Proves both
+// directions: reads a value the host returns (tickets.get), then sends a value
+// back to the host (notify) that the host records on its own origin.
+import type { PluginModule } from '@nosdesk/plugin-sdk';
+
+export default {
+  async mount(root, api) {
+    const ticket = await api.tickets.get(42);
+    const title = ticket ? ticket.title : 'null';
+    root.textContent = `plugin got: ${title}`;
+    await api.notify(title);
+  },
+} satisfies PluginModule;


### PR DESCRIPTION
The host end of the plugin bridge, proven end-to-end before it touches the app.

## `@nosdesk/plugin-sdk` (shipped code)
- `src/host.ts`: `createRemoteHostApi(impl)` exposes a `HostApi` over a fresh `MessageChannel` (Comlink) and returns the port to transfer into the iframe; `postInit`/`postContext` post the exact handshake the runtime's `connectToHost` awaits. Both ends of the bridge protocol now live in one package.
- The bridge is **pure transport** — per-call permission enforcement + the workspace pin live in the `impl` the host supplies (next increment).

## `spikes/plugin-bridge/` (validation, not in CI)
Builds the **real** SDK + runtime with esbuild and Playwright-asserts a full Comlink round-trip through an **opaque-origin** `sandbox="allow-scripts"` iframe: the plugin calls `api.tickets.get(42)` (host→plugin return) then `api.notify(title)` (plugin→host arg), and the host-minted value lands on the host origin.

**PASS on Chromium + WebKit** (the Safari/iOS engine). Sibling to `spikes/plugin-sandbox/` (which proved *isolation*); this proves the *bridge*. Kept out of CI like that spike — browsers are heavy and the SDK type-check/lint already gate the shipped code.

## Why this shape
`createRemoteHostApi` is the first real end-to-end Comlink round-trip, exactly the part a type-check can't verify. Proving it in a harness de-risks the remaining 4b: the real host `impl` (adapting `createPluginAPI` with scope enforcement), `PluginSandboxFrame.vue`, and the community-tier flip.