### PR TITLE
Plugin sandbox step 4b-2: render community-tier plugins in the sandbox

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,6 +22,7 @@
     "@date-fns/tz": "^1.4.1",
     "@fluent/bundle": "^0.19.1",
     "@nosdesk/core": "workspace:*",
+    "@nosdesk/plugin-sdk": "workspace:*",
     "@nosdesk/mobile": "workspace:*",
     "@pinia/colada": "^1.2.0",
     "@simplewebauthn/browser": "^13.2.2",

--- a/frontend/src/plugins/api.ts
+++ b/frontend/src/plugins/api.ts
@@ -588,12 +588,14 @@ export function getHostApiForPlugin(plugin: Plugin): PluginAPI {
     case 'local':
       return createPluginAPI(plugin);
     case 'community':
-      // The sandboxed transport for community-tier plugins is not
-      // wired yet; until it ships, community plugins fall back to
-      // the in-process impl. The architectural review's stricter
-      // posture (run community in a null-origin iframe) is a
-      // committed follow-up, not a regression in security from
-      // today's behaviour.
+      // Community plugins RENDER in the opaque-origin iframe sandbox
+      // (`PluginSlotItem` -> `PluginSandboxFrame`, host API bridged via
+      // `createHostApiImpl`), never through this in-process instance.
+      // This arm is reached only by the event dispatcher's per-plugin
+      // cache; the in-process impl there is inert for community plugins
+      // (component rendering is gated off, and event delivery to
+      // sandboxed plugins is a committed follow-up), so returning it is
+      // harmless and keeps the dispatcher's loop uniform.
       return createPluginAPI(plugin);
     default:
       // Unknown tier (forward-compat for future tiers we haven't

--- a/frontend/src/plugins/components/PluginSandboxFrame.vue
+++ b/frontend/src/plugins/components/PluginSandboxFrame.vue
@@ -1,0 +1,114 @@
+<script setup lang="ts">
+/**
+ * Plugin Sandbox Frame
+ *
+ * Renders a sandboxed (community-tier) plugin in an opaque-origin iframe. Mints
+ * a bundle token, points the iframe at the runtime, and once it loads, exposes
+ * the host API over a MessageChannel (transferred in with the init message).
+ * Context snapshots are pushed on ticket/device change. The iframe carries only
+ * `sandbox="allow-scripts"` (no `allow-same-origin`), so it is a null origin:
+ * no cookies, no first-party DOM, all host access flows through the bridge.
+ */
+import { onBeforeUnmount, onMounted, ref, watch } from 'vue';
+import { createRemoteHostApi, postContext, postInit } from '@nosdesk/plugin-sdk';
+import type { HostBridge, PluginContext } from '@nosdesk/plugin-sdk';
+import pluginService from '@nosdesk/core/services/pluginService';
+import { logger } from '@nosdesk/core/utils/logger';
+import type { Plugin } from '@nosdesk/core/types/plugin';
+import type { Ticket } from '@nosdesk/core/types/ticket';
+import type { Asset } from '@nosdesk/core/types/asset';
+import { createHostApiImpl } from '../sandboxHostApi';
+
+const props = defineProps<{
+  plugin: Plugin;
+  ticket?: Ticket;
+  device?: Asset;
+}>();
+
+const frameRef = ref<HTMLIFrameElement | null>(null);
+const runtimeUrl = ref<string | null>(null);
+const error = ref<string | null>(null);
+
+let bridge: HostBridge | null = null;
+let connected = false;
+
+function snapshot(): PluginContext {
+  return { ticket: props.ticket ?? null, device: props.device ?? null };
+}
+
+function onFrameLoad(): void {
+  const win = frameRef.value?.contentWindow;
+  if (!win) return;
+  // A fresh bridge per load (the runtime reloads on token refresh / remount).
+  bridge?.dispose();
+  bridge = createRemoteHostApi(createHostApiImpl(props.plugin));
+  postInit(win, bridge, snapshot());
+  connected = true;
+}
+
+onMounted(async () => {
+  try {
+    const { runtime_url } = await pluginService.getBundleToken(props.plugin.uuid);
+    runtimeUrl.value = runtime_url;
+  } catch (e) {
+    logger.error('Failed to mint plugin bundle token', { plugin: props.plugin.name, error: e });
+    error.value = 'Failed to load plugin';
+  }
+});
+
+// Push a fresh context snapshot whenever the slot's ticket/device changes.
+watch(
+  [() => props.ticket, () => props.device],
+  () => {
+    const win = frameRef.value?.contentWindow;
+    if (connected && win) postContext(win, snapshot());
+  },
+);
+
+onBeforeUnmount(() => {
+  bridge?.dispose();
+  bridge = null;
+  connected = false;
+});
+</script>
+
+<template>
+  <div class="plugin-sandbox-frame" :data-plugin="plugin.name">
+    <!-- Error state (hidden on print) -->
+    <div
+      v-if="error"
+      class="print:hidden p-3 bg-red-500/10 border border-red-500/30 rounded text-sm text-red-400"
+    >
+      <div class="font-medium">Plugin Error</div>
+      <div class="text-xs mt-1">{{ error }}</div>
+    </div>
+
+    <iframe
+      v-else-if="runtimeUrl"
+      ref="frameRef"
+      :src="runtimeUrl"
+      sandbox="allow-scripts"
+      referrerpolicy="no-referrer"
+      class="plugin-sandbox-iframe"
+      @load="onFrameLoad"
+    />
+  </div>
+</template>
+
+<style scoped>
+.plugin-sandbox-iframe {
+  display: block;
+  width: 100%;
+  border: 0;
+  background: transparent;
+  /* v1: a fixed min-height. Auto-resize to content (a plugin-reported height
+     over the bridge) is a follow-up; a cross-origin iframe can't self-size. */
+  min-height: 8rem;
+}
+
+@media print {
+  .plugin-sandbox-frame {
+    display: none;
+  }
+}
+</style>

--- a/frontend/src/plugins/components/PluginSlotItem.vue
+++ b/frontend/src/plugins/components/PluginSlotItem.vue
@@ -10,6 +10,8 @@ import { onErrorCaptured, ref, watchEffect } from 'vue';
 import { getLoadedPlugin, type PluginSlotRegistration } from '../loader';
 import { getHostApiForPlugin } from '../api';
 import { createPluginComponent, canRenderComponent } from '../componentLoader';
+import { isSandboxed } from '../sandboxHostApi';
+import PluginSandboxFrame from './PluginSandboxFrame.vue';
 import { logger } from '@nosdesk/core/utils/logger';
 import type { Ticket } from '@nosdesk/core/types/ticket';
 import type { Asset } from '@nosdesk/core/types/asset';
@@ -30,17 +32,23 @@ onErrorCaptured((err) => {
   return false;
 });
 
-// Check if this plugin can render a component (has bundle, trusted, etc.)
-const canRender = canRenderComponent(props.registration.pluginUuid);
+// Sandboxed (community-tier) plugins render in an iframe via PluginSandboxFrame,
+// not the in-process Vue-component path. Resolve the tier first so we don't build
+// an in-process API/component for them.
+const loaded = getLoadedPlugin(props.registration.pluginUuid);
+const sandboxed = loaded ? isSandboxed(loaded.plugin) : false;
+
+// Check if this plugin can render a component in-process (has bundle, trusted).
+const canRender = !sandboxed && canRenderComponent(props.registration.pluginUuid);
 
 // Create async component once at setup (stable reference prevents re-fetching)
 const asyncComponent = canRender
   ? createPluginComponent(props.registration.pluginUuid, props.registration.componentName)
   : null;
 
-// Create plugin API once at setup
-const loaded = getLoadedPlugin(props.registration.pluginUuid);
-const api = loaded ? getHostApiForPlugin(loaded.plugin) : null;
+// Create the in-process plugin API once at setup (sandboxed plugins get theirs
+// inside the frame, over the bridge).
+const api = !sandboxed && loaded ? getHostApiForPlugin(loaded.plugin) : null;
 
 // Keep API context in sync with props
 watchEffect(() => {
@@ -64,6 +72,14 @@ watchEffect(() => {
       <div class="font-medium">Plugin Error</div>
       <div class="text-xs mt-1">{{ error }}</div>
     </div>
+
+    <!-- Sandboxed (community-tier) plugin: opaque-origin iframe over the bridge -->
+    <PluginSandboxFrame
+      v-else-if="sandboxed && loaded"
+      :plugin="loaded.plugin"
+      :ticket="ticket"
+      :device="device"
+    />
 
     <!-- Render component (bundle is preloaded so this resolves instantly) -->
     <component

--- a/frontend/src/plugins/sandboxHostApi.ts
+++ b/frontend/src/plugins/sandboxHostApi.ts
@@ -1,0 +1,105 @@
+// Host-side adapter for sandboxed plugins.
+//
+// `createHostApiImpl` reshapes the in-process `PluginAPI` (from `createPluginAPI`,
+// with all its permission gating + service calls intact) into the boundary-safe
+// `HostApi` the SDK bridge exposes over Comlink. Only the four surfaces the
+// process boundary forces change: `fetch` returns a plain object (not a live
+// `Response`), `collections`/`on` hand back Comlink proxies, and the sync
+// `notify`/`isPrinting` become async. Context is delivered by the frame (via
+// `postInit`/`postContext`), not through this object.
+//
+// The bridge itself (`createRemoteHostApi`) is pure transport; every permission
+// check still runs here, in-process, exactly as for a first-party plugin.
+import { proxy } from '@nosdesk/plugin-sdk';
+import type { HostApi, PluginFetchOptions } from '@nosdesk/plugin-sdk';
+import type { Plugin } from '@nosdesk/core/types/plugin';
+import { createPluginAPI } from './api';
+
+/**
+ * Which tiers render in the iframe sandbox. Community (and any future untrusted
+ * tier) run sandboxed; official/verified/local stay on the in-process Vue-
+ * component path until they migrate to the `{ mount }` contract. Keeping this in
+ * one place mirrors `getHostApiForPlugin`'s single-dispatch DRY guarantee.
+ */
+export function isSandboxed(plugin: Plugin): boolean {
+  return plugin.trust_level === 'community';
+}
+
+/** Build the `HostApi` a sandboxed plugin sees, backed by the in-process impl. */
+export function createHostApiImpl(plugin: Plugin): HostApi {
+  const inproc = createPluginAPI(plugin);
+
+  return {
+    version: inproc.version,
+    plugin: inproc.plugin,
+
+    tickets: {
+      get: (id) => inproc.tickets.get(id),
+      list: () => inproc.tickets.list(),
+      addComment: (id, comment) => inproc.tickets.addComment(id, comment),
+    },
+    devices: {
+      get: (id) => inproc.devices.get(id),
+      list: () => inproc.devices.list(),
+    },
+    attachments: {
+      async list(ticketId) {
+        // The in-process shape carries nullable/extra fields; narrow to the
+        // boundary shape with sane defaults.
+        const atts = await inproc.attachments.list(ticketId);
+        return atts.map((a) => ({
+          id: a.id,
+          name: a.name,
+          url: a.url,
+          mimeType: a.mimeType ?? 'application/octet-stream',
+          size: a.size ?? 0,
+        }));
+      },
+      getBase64: (attachmentId, ticketId) => inproc.attachments.getBase64(attachmentId, ticketId),
+    },
+
+    async fetch(url, options) {
+      const res = await inproc.fetch(url, options as PluginFetchOptions);
+      if (!res) return null;
+      const headers: Record<string, string> = {};
+      res.headers.forEach((value, key) => {
+        headers[key] = value;
+      });
+      return { status: res.status, headers, body: await res.text() };
+    },
+
+    storage: {
+      get: (key) => inproc.storage.get(key),
+      set: (key, value) => inproc.storage.set(key, value),
+      delete: (key) => inproc.storage.delete(key),
+    },
+
+    // A collection sub-API is stateful (bound to `name`); proxy it so the
+    // plugin's calls on it round-trip too.
+    async collections(name) {
+      return proxy(inproc.collections.get(name));
+    },
+
+    // The plugin passes a Comlink-proxied handler; forward it into the
+    // in-process registry and proxy the unsubscribe back. (Dispatch of events to
+    // sandboxed plugins is wired in a follow-up; registration is inert until
+    // then, but never throws.)
+    async on(event, handler) {
+      const unsubscribe = inproc.on(event, (data) => {
+        void handler(data);
+      });
+      return proxy(async () => {
+        unsubscribe();
+      });
+    },
+
+    async notify(message, type) {
+      inproc.notify(message, type);
+    },
+    ui: {
+      async isPrinting() {
+        return inproc.ui.isPrinting();
+      },
+    },
+  };
+}

--- a/packages/core/src/services/pluginService.ts
+++ b/packages/core/src/services/pluginService.ts
@@ -349,6 +349,16 @@ const pluginService = {
       throw error;
     }
   },
+
+  // Mint a short-lived, workspace + plugin + bundle-hash scoped token the
+  // sandbox iframe uses to fetch this plugin's bundle cross-origin (it can't
+  // send the session cookie). `runtime_url` is the ready-to-embed iframe src.
+  async getBundleToken(
+    pluginUuid: string,
+  ): Promise<{ token: string; runtime_url: string; expires_in: number }> {
+    const response = await apiClient.get(`/plugins/${pluginUuid}/bundle-token`);
+    return response.data;
+  },
 };
 
 export default pluginService;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,6 +22,9 @@ importers:
       '@nosdesk/mobile':
         specifier: workspace:*
         version: link:../mobile
+      '@nosdesk/plugin-sdk':
+        specifier: workspace:*
+        version: link:../packages/plugin-sdk
       '@pinia/colada':
         specifier: ^1.2.0
         version: 1.3.1(pinia@3.0.4(typescript@6.0.3)(vue@3.5.39(typescript@6.0.3)))(vue@3.5.39(typescript@6.0.3))


### PR DESCRIPTION
Wires the sandbox bridge into the app. Community-tier plugins now **render** (in an opaque-origin iframe); official/verified/local are untouched and stay in-process.

## What lands
- **`pluginService.getBundleToken`** (core) — mints the short-lived bundle token, returns the ready-to-embed `runtime_url`.
- **`sandboxHostApi.ts`** — `createHostApiImpl(plugin)` adapts the in-process `createPluginAPI` to the SDK's boundary-safe `HostApi`, reusing **every permission check** and reshaping only the four surfaces the process boundary forces (plain `fetch` response, Comlink-proxied `collections`/`on`, async `notify`/`isPrinting`). `isSandboxed()` picks the tier.
- **`PluginSandboxFrame.vue`** — mints the token, embeds `sandbox="allow-scripts"` iframe at `runtime_url`, exposes the host API over a transferred `MessageChannel` (`createRemoteHostApi` + `postInit`), pushes `postContext` on ticket/device change, disposes on unmount.
- **`PluginSlotItem`** — renders the frame for sandboxed plugins instead of the in-process Vue-component path (which already gated community off).

## Safety / scope
- Backend **unchanged**; frame-src already defaults to `'self'` (+ optional sandbox origin), so no CSP change.
- The 4b-1 harness already proved the Comlink round-trip transport on Chromium + WebKit; this wires the real host impl behind it.
- **Deferred (follow-ups):** event *delivery* to sandboxed plugins (registration is inert-but-safe today), iframe auto-resize (fixed min-height v1), and the full north-star (migrate official/local + delete in-process path + consent UI).

## Verified
core type-check + lint · frontend type-check + lint + full vite build, all green. First live render of a sandboxed plugin is best validated in-app (and on iOS).