### PR TITLE
fix(dev): mount packages/plugin-sdk into frontend-watch

### DIFF
--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -250,6 +250,8 @@ services:
       - core_node_modules:/repo/packages/core/node_modules
       - ./mobile:/repo/mobile
       - mobile_node_modules:/repo/mobile/node_modules
+      - ./packages/plugin-sdk:/repo/packages/plugin-sdk
+      - plugin_sdk_node_modules:/repo/packages/plugin-sdk/node_modules
       # pnpm workspace node_modules live in volumes (not on the host bind
       # mount) so the symlinked store resolves and host artifacts don't collide.
       - frontend_node_modules:/repo/node_modules
@@ -272,6 +274,8 @@ volumes:
   core_node_modules:
     driver: local
   mobile_node_modules:
+    driver: local
+  plugin_sdk_node_modules:
     driver: local
   backend_cargo_cache:
     driver: local


### PR DESCRIPTION
Follow-up dev-infra fix for the sandbox community flip (#132).

The frontend now imports `@nosdesk/plugin-sdk`, but `compose.dev.yaml`'s `frontend-watch` only mounted the `core` + `mobile` workspace packages, so its in-container `pnpm install` couldn't resolve `@nosdesk/plugin-sdk` and vite failed:

```
[vite]: Rolldown failed to resolve import "@nosdesk/plugin-sdk" from "frontend/src/plugins/sandboxHostApi.ts"
```

Mount `packages/plugin-sdk` + a shadow `node_modules` volume, matching how core/mobile are wired. Verified: after this, frontend-watch builds cleanly (`built in 11s`) with the sandbox code. CI didn't catch it because CI builds on the host with the full workspace resolved.