### PR TITLE
fix(plugins): clone-safe context snapshot for the sandbox iframe

### DIFF
--- a/frontend/src/plugins/components/PluginSandboxFrame.vue
+++ b/frontend/src/plugins/components/PluginSandboxFrame.vue
@@ -32,8 +32,15 @@ const error = ref<string | null>(null);
 let bridge: HostBridge | null = null;
 let connected = false;
 
+// The context is posted over postMessage (structured clone), so it must be a
+// plain, clone-safe projection. The props are Vue reactive proxies and may carry
+// non-cloneable fields; a JSON round-trip strips both the reactivity and anything
+// structured clone would reject.
+function plain<T>(value: T | undefined): T | null {
+  return value == null ? null : (JSON.parse(JSON.stringify(value)) as T);
+}
 function snapshot(): PluginContext {
-  return { ticket: props.ticket ?? null, device: props.device ?? null };
+  return { ticket: plain(props.ticket), device: plain(props.device) };
 }
 
 function onFrameLoad(): void {


### PR DESCRIPTION
A real runtime bug in the sandbox community flip (#132), caught by **live in-app validation** on the dev stack.

## Bug
`PluginSandboxFrame` posted the raw `ticket`/`device` props into `postMessage`. Those are Vue reactive proxies and may carry non-cloneable fields, so structured clone threw:

```
Failed to execute 'postMessage' on 'Window': #<Object> could not be cloned
```

The sandboxed plugin mounted but never received its context (the whole frame errored).

## Fix
Project the props to a plain, structured-clone-safe object (JSON round-trip) before posting via `postInit`/`postContext`.

## Why the harness missed it
The bridge harness (#131) passed `context: null`, so it never exercised a real context payload. This is exactly the class of bug a type-check + null-context harness can't catch, hence the live render check.

## Verified live
With this fix, a community plugin renders in the ticket sidebar inside the opaque-origin iframe and receives the ticket context across the bridge (`context.ticket = #1 "..."`), and a scoped `api.tickets.list()` round-trips to the host. Playwright: `RENDERED_BOX=true`, `ROUNDTRIP_OK=true`.