### PR TITLE
chore(deny): stop gating transitive unmaintained advisories

### DIFF
--- a/backend/deny.toml
+++ b/backend/deny.toml
@@ -18,6 +18,11 @@
 # crates that are stable-enough-not-to-need-releases.
 version = 2
 yanked = "deny"
+# Only gate "unmaintained" advisories for direct workspace deps, not transitive
+# ones (matches the policy above). Without this, a fresh unmaintained advisory on
+# a crate deep in the tree (e.g. smallstr via yrs) fails CI repo-wide with nothing
+# actionable. Vulnerability advisories are still gated for the whole tree.
+unmaintained = "workspace"
 ignore = [
     # RUSTSEC-2023-0071 — rsa 0.9.10 "Marvin Attack" timing sidechannel
     # on RSA decryption. 5.9 medium. No upstream fix.


### PR DESCRIPTION
`cargo deny` started failing CI repo-wide on **RUSTSEC-2026-0215** (`smallstr` unmaintained), pulled transitively via `yrs` (the Yjs CRDT core), nothing actionable and not a vulnerability.

`deny.toml` already documents the intended policy:

> Unmaintained advisories on transitive-only deps are tracked but not gated.

But that wasn't enforced in config, so a default change re-gated them. This sets `advisories.unmaintained = "workspace"` so cargo-deny only fails unmaintained advisories for **direct workspace deps**, not transitive ones. **Vulnerability advisories stay gated across the whole tree** (yanked = deny, the vuln ignores are unchanged).

Unblocks #133 and #134.