### PR TITLE
Plugin sandbox 4b-3a: deliver events via a live-instance registry

### DIFF
--- a/frontend/src/plugins/components/PluginSandboxFrame.vue
+++ b/frontend/src/plugins/components/PluginSandboxFrame.vue
@@ -18,6 +18,7 @@ import type { Plugin } from '@nosdesk/core/types/plugin';
 import type { Ticket } from '@nosdesk/core/types/ticket';
 import type { Asset } from '@nosdesk/core/types/asset';
 import { createHostApiImpl } from '../sandboxHostApi';
+import { registerPluginInstance } from '../pluginInstances';
 
 const props = defineProps<{
   plugin: Plugin;
@@ -30,6 +31,7 @@ const runtimeUrl = ref<string | null>(null);
 const error = ref<string | null>(null);
 
 let bridge: HostBridge | null = null;
+let unregisterInstance: (() => void) | null = null;
 let connected = false;
 
 // The context is posted over postMessage (structured clone), so it must be a
@@ -48,7 +50,12 @@ function onFrameLoad(): void {
   if (!win) return;
   // A fresh bridge per load (the runtime reloads on token refresh / remount).
   bridge?.dispose();
-  bridge = createRemoteHostApi(createHostApiImpl(props.plugin));
+  unregisterInstance?.();
+  const { hostApi, inproc } = createHostApiImpl(props.plugin);
+  // Register the backing instance so the event dispatcher can reach this
+  // sandboxed plugin's `on` handlers (they land on `inproc`, over the bridge).
+  unregisterInstance = registerPluginInstance(props.plugin.uuid, inproc);
+  bridge = createRemoteHostApi(hostApi);
   postInit(win, bridge, snapshot());
   connected = true;
 }
@@ -75,6 +82,8 @@ watch(
 onBeforeUnmount(() => {
   bridge?.dispose();
   bridge = null;
+  unregisterInstance?.();
+  unregisterInstance = null;
   connected = false;
 });
 </script>

--- a/frontend/src/plugins/components/PluginSlotItem.vue
+++ b/frontend/src/plugins/components/PluginSlotItem.vue
@@ -6,11 +6,12 @@
  * Handles its own API creation and component loading.
  * Bundles are preloaded during plugin init so components render instantly.
  */
-import { onErrorCaptured, ref, watchEffect } from 'vue';
+import { onErrorCaptured, onUnmounted, ref, watchEffect } from 'vue';
 import { getLoadedPlugin, type PluginSlotRegistration } from '../loader';
 import { getHostApiForPlugin } from '../api';
 import { createPluginComponent, canRenderComponent } from '../componentLoader';
 import { isSandboxed } from '../sandboxHostApi';
+import { registerPluginInstance } from '../pluginInstances';
 import PluginSandboxFrame from './PluginSandboxFrame.vue';
 import { logger } from '@nosdesk/core/utils/logger';
 import type { Ticket } from '@nosdesk/core/types/ticket';
@@ -49,6 +50,13 @@ const asyncComponent = canRender
 // Create the in-process plugin API once at setup (sandboxed plugins get theirs
 // inside the frame, over the bridge).
 const api = !sandboxed && loaded ? getHostApiForPlugin(loaded.plugin) : null;
+
+// Register this instance so the event dispatcher reaches its `on` handlers; drop
+// it on unmount. (Sandboxed plugins register their own backing instance in the
+// frame.)
+if (api && loaded) {
+  onUnmounted(registerPluginInstance(loaded.plugin.uuid, api));
+}
 
 // Keep API context in sync with props
 watchEffect(() => {

--- a/frontend/src/plugins/eventDispatcher.ts
+++ b/frontend/src/plugins/eventDispatcher.ts
@@ -10,8 +10,8 @@
 
 import { onSyncActions } from '@nosdesk/core/sync/observers';
 import type { SyncAction } from '@nosdesk/core/sync/types';
-import { getLoadedPlugins } from './loader';
-import { getHostApiForPlugin } from './api';
+import { getLoadedPlugin } from './loader';
+import { forEachLiveInstance } from './pluginInstances';
 import { logger } from '@nosdesk/core/utils/logger';
 import type { PluginEvent } from '@nosdesk/core/types/plugin';
 
@@ -67,9 +67,6 @@ const RESTRICTED_EVENTS: PluginEvent[] = [
 // Event Dispatcher
 // =============================================================================
 
-// Cached plugin APIs for event dispatch
-const pluginApis = new Map<string, ReturnType<typeof getHostApiForPlugin>>();
-
 // Cleanup function reference
 let cleanupFn: (() => void) | null = null;
 
@@ -86,16 +83,7 @@ export function initializeEventDispatcher(): () => void {
     return cleanupFn;
   }
 
-  // Build plugin API cache
-  pluginApis.clear();
-  for (const { plugin } of getLoadedPlugins()) {
-    pluginApis.set(plugin.uuid, getHostApiForPlugin(plugin));
-  }
-
-  logger.info('Event dispatcher initialized', {
-    pluginCount: pluginApis.size,
-    plugins: Array.from(pluginApis.keys()),
-  });
+  logger.info('Event dispatcher initialized');
 
   // Subscribe to the sync change-stream. Each action maps to zero or
   // more plugin events; the action itself is the payload so handlers
@@ -110,7 +98,6 @@ export function initializeEventDispatcher(): () => void {
 
   cleanupFn = () => {
     unsubscribe();
-    pluginApis.clear();
     cleanupFn = null;
     logger.debug('Event dispatcher cleaned up');
   };
@@ -119,28 +106,27 @@ export function initializeEventDispatcher(): () => void {
 }
 
 /**
- * Dispatch an event to all plugin handlers
+ * Dispatch an event to every live plugin instance's handlers.
+ *
+ * Iterates the live-instance registry (populated by the render paths:
+ * `PluginSlotItem` for in-process plugins, `PluginSandboxFrame` /
+ * `createHostApiImpl` for sandboxed ones), so handlers land wherever the plugin
+ * actually registered them — including across the bridge for a sandboxed plugin,
+ * whose `_getEventHandlers` returns the wrappers that forward to the Comlink
+ * proxy.
  */
 function dispatchToPlugins(event: PluginEvent, data: unknown): void {
   const isRestricted = RESTRICTED_EVENTS.includes(event);
 
-  for (const [uuid, api] of pluginApis) {
-    // Skip restricted events for community plugins
-    if (isRestricted) {
-      const loadedPlugins = getLoadedPlugins();
-      const loadedPlugin = loadedPlugins.find(p => p.plugin.uuid === uuid);
-      if (loadedPlugin?.plugin.trust_level === 'community') {
-        continue;
-      }
+  forEachLiveInstance((uuid, api) => {
+    // Skip restricted events for community plugins.
+    if (isRestricted && getLoadedPlugin(uuid)?.plugin.trust_level === 'community') {
+      return;
     }
 
-    // Get and call all handlers for this event
-    const handlers = api._getEventHandlers(event);
-
-    for (const handler of handlers) {
+    for (const handler of api._getEventHandlers(event)) {
       try {
         const result = handler(data);
-        // Handle async handlers
         if (result instanceof Promise) {
           result.catch((error) => {
             logger.error(`Plugin ${uuid} async handler error for ${event}`, { error });
@@ -150,18 +136,7 @@ function dispatchToPlugins(event: PluginEvent, data: unknown): void {
         logger.error(`Plugin ${uuid} handler error for ${event}`, { error });
       }
     }
-  }
-}
-
-/**
- * Refresh the plugin API cache (call after plugins are reloaded)
- */
-export function refreshPluginApis(): void {
-  pluginApis.clear();
-  for (const { plugin } of getLoadedPlugins()) {
-    pluginApis.set(plugin.uuid, getHostApiForPlugin(plugin));
-  }
-  logger.debug('Plugin APIs refreshed', { count: pluginApis.size });
+  });
 }
 
 /**

--- a/frontend/src/plugins/index.ts
+++ b/frontend/src/plugins/index.ts
@@ -33,7 +33,6 @@ export {
 // Event Dispatcher
 export {
   initializeEventDispatcher,
-  refreshPluginApis,
   isEventDispatcherInitialized,
   stopEventDispatcher,
 } from './eventDispatcher';

--- a/frontend/src/plugins/pluginInstances.ts
+++ b/frontend/src/plugins/pluginInstances.ts
@@ -1,0 +1,38 @@
+// Registry of the LIVE plugin API instances a plugin's event handlers actually
+// land on, so the event dispatcher can reach them.
+//
+// `getHostApiForPlugin` / `createPluginAPI` return a fresh instance per call, and
+// context is per-instance (a plugin in two slots has two independent contexts).
+// So `api.on(...)` handlers register on the specific instance the render path
+// created — the in-process one held by a `PluginSlotItem`, or the in-process one
+// wrapped behind a sandboxed plugin's `createHostApiImpl`. The dispatcher must
+// iterate exactly those live instances (not a throwaway of its own), which is
+// what this registry provides. Each mounted instance registers on setup and
+// unregisters on unmount; a plugin rendered in N places has N live instances and
+// receives each event N times (once per instance), which is correct.
+import type { PluginAPI } from './api';
+
+const live = new Map<string, Set<PluginAPI>>();
+
+/** Register a live instance; returns an unregister fn to call on unmount. */
+export function registerPluginInstance(uuid: string, api: PluginAPI): () => void {
+  let set = live.get(uuid);
+  if (!set) {
+    set = new Set();
+    live.set(uuid, set);
+  }
+  set.add(api);
+  return () => {
+    const s = live.get(uuid);
+    if (!s) return;
+    s.delete(api);
+    if (s.size === 0) live.delete(uuid);
+  };
+}
+
+/** Visit every live instance across all plugins (uuid + its API instance). */
+export function forEachLiveInstance(cb: (uuid: string, api: PluginAPI) => void): void {
+  for (const [uuid, set] of live) {
+    for (const api of set) cb(uuid, api);
+  }
+}

--- a/frontend/src/plugins/sandboxHostApi.ts
+++ b/frontend/src/plugins/sandboxHostApi.ts
@@ -13,7 +13,7 @@
 import { proxy } from '@nosdesk/plugin-sdk';
 import type { HostApi, PluginFetchOptions } from '@nosdesk/plugin-sdk';
 import type { Plugin } from '@nosdesk/core/types/plugin';
-import { createPluginAPI } from './api';
+import { createPluginAPI, type PluginAPI } from './api';
 
 /**
  * Which tiers render in the iframe sandbox. Community (and any future untrusted
@@ -25,11 +25,16 @@ export function isSandboxed(plugin: Plugin): boolean {
   return plugin.trust_level === 'community';
 }
 
-/** Build the `HostApi` a sandboxed plugin sees, backed by the in-process impl. */
-export function createHostApiImpl(plugin: Plugin): HostApi {
+/**
+ * Build the `HostApi` a sandboxed plugin sees, backed by the in-process impl.
+ * Returns the `inproc` instance too: the frame registers it in the live-instance
+ * registry so the event dispatcher reaches the plugin's `on` handlers (which land
+ * on `inproc` and forward across the bridge).
+ */
+export function createHostApiImpl(plugin: Plugin): { hostApi: HostApi; inproc: PluginAPI } {
   const inproc = createPluginAPI(plugin);
 
-  return {
+  const hostApi: HostApi = {
     version: inproc.version,
     plugin: inproc.plugin,
 
@@ -102,4 +107,6 @@ export function createHostApiImpl(plugin: Plugin): HostApi {
       },
     },
   };
+
+  return { hostApi, inproc };
 }


### PR DESCRIPTION
First piece of 4b-3. Makes plugin **event delivery** actually work, for sandboxed *and* in-process plugins.

## The bug
The event dispatcher built its own throwaway `PluginAPI` instances via `getHostApiForPlugin`, which returns a **fresh instance per call**. But plugins register `on()` handlers on the instance the *render path* created (a `PluginSlotItem`'s, or the `inproc` behind a sandboxed plugin's `createHostApiImpl`). So the dispatcher's separate instances never saw those handlers, events reached **nothing** (in-process plugins too, not just sandboxed).

## The fix
`pluginInstances.ts`: a live-instance registry. Each mounted render path registers the `PluginAPI` its handlers land on and unregisters on unmount; the dispatcher iterates those live instances instead of building its own. For a sandboxed plugin the handler forwards across the Comlink bridge, so events now reach sandboxed plugins. `createHostApiImpl` returns `{ hostApi, inproc }` so the frame can register the backing instance. A plugin in N slots has N live instances and gets each event N times (correct, one per instance).

## Notes
- Dropped the now-unused `refreshPluginApis`.
- Event payloads are plain sync-action data (JSON, structured-clone-safe), so unlike the context path (#134) they cross the bridge without sanitization.
- Verified: frontend type-check + lint. A full live event round-trip needs an SDK-bundled plugin using `proxy()` for its handler (bigger than the render harness); the render path itself was already live-verified.