### PR TITLE
Plugin sandbox 4b-3b: auto-size the iframe to plugin content

### DIFF
--- a/backend/src/handlers/plugin_sandbox/runtime.js
+++ b/backend/src/handlers/plugin_sandbox/runtime.js
@@ -353,10 +353,25 @@ function connectToHost() {
     window.addEventListener("message", onMessage);
   });
 }
+function reportHeight(height) {
+  window.parent.postMessage({ type: "nosdesk-plugin-height", height }, "*");
+}
 
 // src/runtime.ts
 var token = new URLSearchParams(location.search).get("t");
 var root = document.getElementById("root");
+function observeHeight(el) {
+  let last = -1;
+  const report = () => {
+    const h = Math.ceil(el.getBoundingClientRect().height);
+    if (h > 0 && h !== last) {
+      last = h;
+      reportHeight(h);
+    }
+  };
+  new ResizeObserver(report).observe(el);
+  report();
+}
 async function boot() {
   if (!root) throw new Error("sandbox runtime: no #root element");
   if (!token) throw new Error("sandbox runtime: missing bundle token");
@@ -371,6 +386,7 @@ async function boot() {
   }
   const plugin = mod.default;
   let cleanup = plugin.mount(root, runtime.api, runtime.context) ?? void 0;
+  observeHeight(root);
   runtime.onContextChange((ctx) => {
     if (cleanup) cleanup();
     root.replaceChildren();

--- a/frontend/src/plugins/components/PluginSandboxFrame.vue
+++ b/frontend/src/plugins/components/PluginSandboxFrame.vue
@@ -10,7 +10,7 @@
  * no cookies, no first-party DOM, all host access flows through the bridge.
  */
 import { onBeforeUnmount, onMounted, ref, watch } from 'vue';
-import { createRemoteHostApi, postContext, postInit } from '@nosdesk/plugin-sdk';
+import { createRemoteHostApi, postContext, postInit, watchPluginHeight } from '@nosdesk/plugin-sdk';
 import type { HostBridge, PluginContext } from '@nosdesk/plugin-sdk';
 import pluginService from '@nosdesk/core/services/pluginService';
 import { logger } from '@nosdesk/core/utils/logger';
@@ -29,9 +29,11 @@ const props = defineProps<{
 const frameRef = ref<HTMLIFrameElement | null>(null);
 const runtimeUrl = ref<string | null>(null);
 const error = ref<string | null>(null);
+const iframeHeight = ref<number | null>(null);
 
 let bridge: HostBridge | null = null;
 let unregisterInstance: (() => void) | null = null;
+let stopHeight: (() => void) | null = null;
 let connected = false;
 
 // The context is posted over postMessage (structured clone), so it must be a
@@ -58,6 +60,15 @@ function onFrameLoad(): void {
   bridge = createRemoteHostApi(hostApi);
   postInit(win, bridge, snapshot());
   connected = true;
+
+  // Size the iframe to the plugin's reported content height.
+  stopHeight?.();
+  const iframe = frameRef.value;
+  stopHeight = iframe
+    ? watchPluginHeight(iframe, (px) => {
+        iframeHeight.value = px;
+      })
+    : null;
 }
 
 onMounted(async () => {
@@ -84,6 +95,8 @@ onBeforeUnmount(() => {
   bridge = null;
   unregisterInstance?.();
   unregisterInstance = null;
+  stopHeight?.();
+  stopHeight = null;
   connected = false;
 });
 </script>
@@ -106,6 +119,7 @@ onBeforeUnmount(() => {
       sandbox="allow-scripts"
       referrerpolicy="no-referrer"
       class="plugin-sandbox-iframe"
+      :style="iframeHeight ? { height: `${iframeHeight}px` } : undefined"
       @load="onFrameLoad"
     />
   </div>
@@ -117,9 +131,10 @@ onBeforeUnmount(() => {
   width: 100%;
   border: 0;
   background: transparent;
-  /* v1: a fixed min-height. Auto-resize to content (a plugin-reported height
-     over the bridge) is a follow-up; a cross-origin iframe can't self-size. */
-  min-height: 8rem;
+  /* Height tracks the plugin's reported content height (inline style, set from
+     the runtime's ResizeObserver over the bridge). min-height is the floor until
+     the first report arrives. */
+  min-height: 4rem;
 }
 
 @media print {

--- a/packages/plugin-runtime/src/runtime.ts
+++ b/packages/plugin-runtime/src/runtime.ts
@@ -9,11 +9,27 @@
 // and served by the backend at /__plugin-sandbox/runtime.js. It is NOT loadable
 // standalone: connectToHost() resolves only once the host posts the init message
 // with the transferred MessageChannel port (the host bridge, sandbox step 4).
-import { connectToHost } from '@nosdesk/plugin-sdk';
+import { connectToHost, reportHeight } from '@nosdesk/plugin-sdk';
 import type { PluginModule } from '@nosdesk/plugin-sdk';
 
 const token = new URLSearchParams(location.search).get('t');
 const root = document.getElementById('root');
+
+// Report content height to the host on every change so it can size the iframe
+// (a cross-origin sandboxed iframe can't self-size). Deduped to avoid a resize
+// feedback loop.
+function observeHeight(el: HTMLElement): void {
+  let last = -1;
+  const report = (): void => {
+    const h = Math.ceil(el.getBoundingClientRect().height);
+    if (h > 0 && h !== last) {
+      last = h;
+      reportHeight(h);
+    }
+  };
+  new ResizeObserver(report).observe(el);
+  report();
+}
 
 async function boot(): Promise<void> {
   if (!root) throw new Error('sandbox runtime: no #root element');
@@ -33,6 +49,7 @@ async function boot(): Promise<void> {
   const plugin = mod.default;
 
   let cleanup = plugin.mount(root, runtime.api, runtime.context) ?? undefined;
+  observeHeight(root);
 
   // v1 context updates are coarse: re-mount on change. A plugin that wants
   // fine-grained updates can hold its own state and diff; a richer update

--- a/packages/plugin-sdk/src/connect.ts
+++ b/packages/plugin-sdk/src/connect.ts
@@ -71,3 +71,14 @@ export function connectToHost(): Promise<PluginRuntime> {
 /** Re-export so a plugin can wrap its own callbacks (e.g. for `api.on`) when it
  * needs to pass a function across the bridge. */
 export const proxy = Comlink.proxy;
+
+/**
+ * Report the plugin's current content height (px) to the host so it can size the
+ * iframe to the content (a cross-origin sandboxed iframe can't self-size). Posted
+ * as a plain window message to the parent, not over the Comlink port; the host
+ * matches it by `event.source` (the port is the API capability, this is display
+ * only). The runtime calls this automatically via a ResizeObserver.
+ */
+export function reportHeight(height: number): void {
+  window.parent.postMessage({ type: 'nosdesk-plugin-height', height }, '*');
+}

--- a/packages/plugin-sdk/src/host.ts
+++ b/packages/plugin-sdk/src/host.ts
@@ -46,3 +46,29 @@ export function postInit(target: Window, bridge: HostBridge, context: PluginCont
 export function postContext(target: Window, context: PluginContext): void {
   target.postMessage({ type: 'nosdesk-plugin-context', context }, '*');
 }
+
+interface PluginHeightMessage {
+  type: 'nosdesk-plugin-height';
+  height: number;
+}
+
+/**
+ * Listen for content-height reports from a specific plugin iframe so the host can
+ * size it to its content. Matches by `event.source === iframe.contentWindow` (an
+ * opaque sandboxed frame has origin `"null"`, so source identity is the check, not
+ * the origin). Returns a cleanup fn. Pairs with the runtime's `reportHeight`.
+ */
+export function watchPluginHeight(
+  iframe: HTMLIFrameElement,
+  onHeight: (px: number) => void,
+): () => void {
+  function onMessage(event: MessageEvent): void {
+    if (event.source !== iframe.contentWindow) return;
+    const data = event.data as PluginHeightMessage | undefined;
+    if (data?.type === 'nosdesk-plugin-height' && typeof data.height === 'number') {
+      onHeight(data.height);
+    }
+  }
+  window.addEventListener('message', onMessage);
+  return () => window.removeEventListener('message', onMessage);
+}

--- a/packages/plugin-sdk/src/index.ts
+++ b/packages/plugin-sdk/src/index.ts
@@ -12,11 +12,11 @@
 //       root.textContent = t ? t.title : 'no ticket';
 //     },
 //   } satisfies PluginModule;
-export { connectToHost, proxy } from './connect';
+export { connectToHost, proxy, reportHeight } from './connect';
 export type { PluginRuntime } from './connect';
 
 // Host-side bridge (used by the app + the bridge harness, not by plugins).
-export { createRemoteHostApi, postInit, postContext } from './host';
+export { createRemoteHostApi, postInit, postContext, watchPluginHeight } from './host';
 export type { HostBridge } from './host';
 
 export type {


### PR DESCRIPTION
Second piece of 4b-3. A cross-origin sandboxed iframe can't self-size, so the frame used a fixed `min-height` that clipped taller plugins.

## Mechanism
- **Runtime** (`@nosdesk/plugin-runtime`): a `ResizeObserver` on the plugin root reports content height via `reportHeight(px)` — a plain window message to the parent (`nosdesk-plugin-height`), deduped to avoid a resize loop.
- **SDK**: `reportHeight` (plugin side) + `watchPluginHeight(iframe, cb)` (host side), matched by `event.source === iframe.contentWindow` (the opaque frame's origin is `"null"`; the Comlink port stays the API capability, this channel is display-only).
- **`PluginSandboxFrame`**: sets the iframe height from the report; `min-height` is now just the floor until the first report.

## Notes
- Height payload is a single number (trivially clone-safe, no context-style clone risk).
- Runtime rebuilt; `backend/.../runtime.js` drift-committed (CI drift check covers it).
- Verified: SDK + runtime + frontend type-check & lint; runtime build. A live resize check needs a backend rebuild to embed the new runtime.js.

Follows #136 (4b-3a).