### PR TITLE
Plugin sandbox 4b-3c-1: component identity + action signal + update contract

### DIFF
--- a/backend/src/handlers/plugin_sandbox/runtime.js
+++ b/backend/src/handlers/plugin_sandbox/runtime.js
@@ -326,7 +326,7 @@ function generateUUID() {
 function connectToHost() {
   return new Promise((resolve) => {
     const listeners = /* @__PURE__ */ new Set();
-    let context = { ticket: null, device: null };
+    let context = { ticket: null, device: null, component: { name: "", slot: "" } };
     let connected = false;
     function onMessage(event) {
       const data = event.data;
@@ -358,6 +358,11 @@ function reportHeight(height) {
 }
 
 // src/runtime.ts
+function toInstance(result) {
+  if (typeof result === "function") return { unmount: result };
+  if (result && typeof result === "object") return result;
+  return {};
+}
 var token = new URLSearchParams(location.search).get("t");
 var root = document.getElementById("root");
 function observeHeight(el) {
@@ -385,12 +390,16 @@ async function boot() {
     throw new Error("sandbox runtime: bundle has no default { mount } export");
   }
   const plugin = mod.default;
-  let cleanup = plugin.mount(root, runtime.api, runtime.context) ?? void 0;
+  let instance = toInstance(plugin.mount(root, runtime.api, runtime.context));
   observeHeight(root);
   runtime.onContextChange((ctx) => {
-    if (cleanup) cleanup();
+    if (instance.update) {
+      instance.update(ctx);
+      return;
+    }
+    instance.unmount?.();
     root.replaceChildren();
-    cleanup = plugin.mount(root, runtime.api, ctx) ?? void 0;
+    instance = toInstance(plugin.mount(root, runtime.api, ctx));
   });
 }
 boot().catch((e) => {

--- a/frontend/src/plugins/components/PluginSandboxFrame.vue
+++ b/frontend/src/plugins/components/PluginSandboxFrame.vue
@@ -22,8 +22,12 @@ import { registerPluginInstance } from '../pluginInstances';
 
 const props = defineProps<{
   plugin: Plugin;
+  /** Which manifest component this frame renders (a bundle may declare several). */
+  component: { name: string; slot: string };
   ticket?: Ticket;
   device?: Asset;
+  /** Monotonic counter from the host action menu; forwarded to the plugin. */
+  actionActivated?: number;
 }>();
 
 const frameRef = ref<HTMLIFrameElement | null>(null);
@@ -44,7 +48,12 @@ function plain<T>(value: T | undefined): T | null {
   return value == null ? null : (JSON.parse(JSON.stringify(value)) as T);
 }
 function snapshot(): PluginContext {
-  return { ticket: plain(props.ticket), device: plain(props.device) };
+  return {
+    ticket: plain(props.ticket),
+    device: plain(props.device),
+    component: { name: props.component.name, slot: props.component.slot },
+    actionActivated: props.actionActivated,
+  };
 }
 
 function onFrameLoad(): void {
@@ -81,9 +90,10 @@ onMounted(async () => {
   }
 });
 
-// Push a fresh context snapshot whenever the slot's ticket/device changes.
+// Push a fresh context snapshot whenever ticket/device or the action counter
+// changes (the action counter is how a host menu trigger reaches the plugin).
 watch(
-  [() => props.ticket, () => props.device],
+  [() => props.ticket, () => props.device, () => props.actionActivated],
   () => {
     const win = frameRef.value?.contentWindow;
     if (connected && win) postContext(win, snapshot());

--- a/frontend/src/plugins/components/PluginSlot.vue
+++ b/frontend/src/plugins/components/PluginSlot.vue
@@ -33,6 +33,7 @@ provide('pluginSlot', props.slotName);
     v-for="reg in registrations"
     :key="`${reg.pluginUuid}-${reg.componentName}`"
     :registration="reg"
+    :slot-name="slotName"
     :ticket="ticket"
     :device="device"
     :actionActivated="actionActivatedMap?.get(`${reg.pluginUuid}:${reg.componentName}`)"

--- a/frontend/src/plugins/components/PluginSlotItem.vue
+++ b/frontend/src/plugins/components/PluginSlotItem.vue
@@ -19,6 +19,7 @@ import type { Asset } from '@nosdesk/core/types/asset';
 
 const props = defineProps<{
   registration: PluginSlotRegistration;
+  slotName: string;
   ticket?: Ticket;
   device?: Asset;
   actionActivated?: number;
@@ -85,8 +86,10 @@ watchEffect(() => {
     <PluginSandboxFrame
       v-else-if="sandboxed && loaded"
       :plugin="loaded.plugin"
+      :component="{ name: registration.componentName, slot: slotName }"
       :ticket="ticket"
       :device="device"
+      :actionActivated="actionActivated"
     />
 
     <!-- Render component (bundle is preloaded so this resolves instantly) -->

--- a/packages/plugin-runtime/src/runtime.ts
+++ b/packages/plugin-runtime/src/runtime.ts
@@ -10,7 +10,14 @@
 // standalone: connectToHost() resolves only once the host posts the init message
 // with the transferred MessageChannel port (the host bridge, sandbox step 4).
 import { connectToHost, reportHeight } from '@nosdesk/plugin-sdk';
-import type { PluginModule } from '@nosdesk/plugin-sdk';
+import type { PluginInstance, PluginModule } from '@nosdesk/plugin-sdk';
+
+/** Normalize the value a plugin's `mount` returns into a `PluginInstance`. */
+function toInstance(result: void | (() => void) | PluginInstance): PluginInstance {
+  if (typeof result === 'function') return { unmount: result };
+  if (result && typeof result === 'object') return result;
+  return {};
+}
 
 const token = new URLSearchParams(location.search).get('t');
 const root = document.getElementById('root');
@@ -48,16 +55,20 @@ async function boot(): Promise<void> {
   }
   const plugin = mod.default;
 
-  let cleanup = plugin.mount(root, runtime.api, runtime.context) ?? undefined;
+  let instance = toInstance(plugin.mount(root, runtime.api, runtime.context));
   observeHeight(root);
 
-  // v1 context updates are coarse: re-mount on change. A plugin that wants
-  // fine-grained updates can hold its own state and diff; a richer update
-  // channel can come later without changing the mount contract.
+  // On context change (ticket/device/action), prefer the plugin's in-place
+  // `update` (no re-mount, keeps state — needed for action signals); fall back to
+  // unmount + re-mount for simple plugins that returned void / a cleanup fn.
   runtime.onContextChange((ctx) => {
-    if (cleanup) cleanup();
+    if (instance.update) {
+      instance.update(ctx);
+      return;
+    }
+    instance.unmount?.();
     root.replaceChildren();
-    cleanup = plugin.mount(root, runtime.api, ctx) ?? undefined;
+    instance = toInstance(plugin.mount(root, runtime.api, ctx));
   });
 }
 

--- a/packages/plugin-sdk/src/connect.ts
+++ b/packages/plugin-sdk/src/connect.ts
@@ -37,7 +37,9 @@ export interface PluginRuntime {
 export function connectToHost(): Promise<PluginRuntime> {
   return new Promise((resolve) => {
     const listeners = new Set<(ctx: PluginContext) => void>();
-    let context: PluginContext = { ticket: null, device: null };
+    // Placeholder until the host's init message delivers the real context; the
+    // runtime resolves with `data.context`, so this is never handed to a plugin.
+    let context: PluginContext = { ticket: null, device: null, component: { name: '', slot: '' } };
     let connected = false;
 
     function onMessage(event: MessageEvent) {

--- a/packages/plugin-sdk/src/index.ts
+++ b/packages/plugin-sdk/src/index.ts
@@ -23,6 +23,7 @@ export type {
   HostApi,
   PluginContext,
   PluginModule,
+  PluginInstance,
   PluginComment,
   PluginAttachment,
   PluginCollection,

--- a/packages/plugin-sdk/src/types.ts
+++ b/packages/plugin-sdk/src/types.ts
@@ -119,12 +119,31 @@ export interface HostApi {
 export interface PluginContext {
   ticket: Ticket | null;
   device: Asset | null;
+  /** Which of the plugin's manifest components this mount is rendering. A bundle
+   * may declare several (different slots); the plugin switches its UI on `name`
+   * (the manifest `components` map key) / `slot`. */
+  component: { name: string; slot: string };
+  /** Monotonic counter for this component's declared `action` (a host menu
+   * trigger). Increments on each activation; absent if the component declares no
+   * action. The plugin reacts (e.g. opens a panel) when it changes. */
+  actionActivated?: number;
+}
+
+/** What a plugin's `mount` may return to get granular updates instead of a
+ * re-mount: `update` is called with each new context, `unmount` on teardown.
+ * Both optional — omitting `update` falls back to unmount + re-mount. */
+export interface PluginInstance {
+  update?(context: PluginContext): void;
+  unmount?(): void;
 }
 
 /** A plugin bundle's default export: the framework-agnostic entry. The runtime
- * calls `mount` once the bridge is ready; a returned function is the teardown. */
+ * calls `mount` once the bridge is ready. Return nothing or a teardown function
+ * for a simple plugin (re-mounted on context change), or a `PluginInstance` to
+ * handle context updates in place. */
 export interface PluginModule {
   mount(rootEl: HTMLElement, api: import('comlink').Remote<HostApi>, context: PluginContext):
     | void
-    | (() => void);
+    | (() => void)
+    | PluginInstance;
 }


### PR DESCRIPTION
First piece of 4b-3c (the north-star finish). Closes the two gaps between the sandbox and the in-process model so the sandbox can become the **universal** render path, the prerequisite for flipping all tiers + deleting the in-process code (4b-3c-4).

## Gap 1 — component identity
In-process bundles are a map `{ [name]: VueComponent }`; the sandbox calls a single `mount`. A multi-component bundle couldn't tell which slot it was rendering. `PluginContext` now carries `component: { name, slot }` (the manifest component map key + slot); the plugin switches its UI on it. `PluginSlot → PluginSlotItem` thread `slotName` through to the frame.

## Gap 2 — action signal + granular updates
In-process, a host menu-trigger increments a reactive `actionActivated` counter the component watches. The sandbox had no such channel and *re-mounted* on every context change (state-destroying).
- `PluginContext` gains `actionActivated?: number` (posted on change) — reuses the context channel, no new bridge surface.
- `mount` may now return a `PluginInstance { update?, unmount? }`; the runtime calls `update(ctx)` on context change instead of unmount + re-mount, so action/ticket changes keep plugin state. Simple plugins (return `void`/cleanup fn) keep re-mounting (fallback).

## Notes
- New context fields are clone-safe primitives (string/number) — no repeat of the reactive-ticket clone bug (#134).
- Runtime rebuilt; `backend/.../runtime.js` drift-committed.
- Verified: SDK + runtime + frontend type-check & lint; runtime build.
- **Live action-flow verification** (multi-component render + menu-trigger updating a panel without re-mount) needs a backend rebuild to embed the new runtime.js; doing it as a dedicated pass. New-field risk is low (clone-safe primitives + type-checked).

Follows #136/#137. Next: 4b-3c-2 (back the 4 permissions), 4b-3c-3 (consent), 4b-3c-4 (flip + delete).