### PR TITLE
Plugin sandbox 4b-3c-2b: attribute plugin-initiated writes in the audit trail

### DIFF
--- a/backend/src/middleware/request_context.rs
+++ b/backend/src/middleware/request_context.rs
@@ -415,6 +415,20 @@ pub fn populate(req: &ServiceRequest, claims: &Claims) {
         // reports it from the actor).
         Span::current().record("workspace_id", ws.workspace_id);
     }
+    // Plugin-initiated writes (from the sandbox host API) carry
+    // `X-Nosdesk-Plugin: <uuid>`. Record it as the actor reference so the audit /
+    // sync trail attributes the write to the plugin. The actor stays
+    // `kind = user` (authz is unchanged — the plugin acts as the user, bounded by
+    // the user's own perms + RLS); this only annotates *who initiated* it.
+    // Best-effort: a malformed or absent header simply leaves the reference unset.
+    if let Some(plugin_uuid) = req
+        .headers()
+        .get("X-Nosdesk-Plugin")
+        .and_then(|h| h.to_str().ok())
+        .and_then(|s| Uuid::parse_str(s).ok())
+    {
+        actor.reference = Some(format!("plugin:{plugin_uuid}"));
+    }
     record_user_on_span(&claims.sub, ActorKind::User.as_str());
     req.extensions_mut()
         .insert(RequestContext::new(correlation_id, actor));

--- a/backend/src/startup.rs
+++ b/backend/src/startup.rs
@@ -1620,6 +1620,10 @@ pub async fn build_server(
                 // does not, so the preflight must allow them.
                 "X-Auth-Mode",
                 "X-Nosdesk-Workspace",
+                // Plugin-initiated writes carry this so the backend attributes
+                // them in the audit trail; must survive the cross-origin (native
+                // app) preflight like the selection header above.
+                "X-Nosdesk-Plugin",
             ])
             .expose_headers(vec!["content-disposition"])
             .supports_credentials()

--- a/frontend/src/plugins/api.ts
+++ b/frontend/src/plugins/api.ts
@@ -138,6 +138,11 @@ export function createPluginAPI(plugin: Plugin): PluginAPI {
     device: null,
   };
 
+  // Attribution header on plugin-initiated writes: the backend records
+  // `actor_ref = plugin:<uuid>` in the audit / sync trail so a plugin's writes
+  // are traceable (the actor stays the user — the plugin acts as them).
+  const pluginAttribution = { headers: { 'X-Nosdesk-Plugin': plugin.uuid } };
+
   const api: PluginAPI = {
     version: '1.0.0',
 
@@ -197,7 +202,7 @@ export function createPluginAPI(plugin: Plugin): PluginAPI {
           return null;
         }
         try {
-          return await updateTicket(id, patch as Partial<Ticket>);
+          return await updateTicket(id, patch as Partial<Ticket>, pluginAttribution);
         } catch (error) {
           logger.error(`Plugin ${plugin.name} failed to update ticket`, { id, error });
           return null;
@@ -209,7 +214,7 @@ export function createPluginAPI(plugin: Plugin): PluginAPI {
           return false;
         }
         try {
-          await deleteTicket(id);
+          await deleteTicket(id, pluginAttribution);
           return true;
         } catch (error) {
           logger.error(`Plugin ${plugin.name} failed to delete ticket`, { id, error });
@@ -249,7 +254,7 @@ export function createPluginAPI(plugin: Plugin): PluginAPI {
           return null;
         }
         try {
-          return await updateAsset(id, patch as Partial<Asset>);
+          return await updateAsset(id, patch as Partial<Asset>, pluginAttribution);
         } catch (error) {
           logger.error(`Plugin ${plugin.name} failed to update device`, { id, error });
           return null;

--- a/frontend/src/services/assetService.ts
+++ b/frontend/src/services/assetService.ts
@@ -1,4 +1,5 @@
 import apiClient from '@nosdesk/core/apiClient';
+import type { AxiosRequestConfig } from 'axios';
 import type { Asset, AssetFormData } from '@nosdesk/core/types/asset';
 import type { PaginationParams, PaginatedResponse } from '@nosdesk/core/types/pagination';
 import { logger } from '@nosdesk/core/utils/logger';
@@ -345,13 +346,13 @@ export const clearAssetModel = async (assetId: number): Promise<Asset> => {
  * @param device - The updated device data
  * @returns Promise<Asset> - A promise that resolves to the updated device
  */
-export const updateAsset = async (id: number, device: Partial<Asset>): Promise<Asset> => {
+export const updateAsset = async (id: number, device: Partial<Asset>, config?: AxiosRequestConfig): Promise<Asset> => {
   try {
     // Forward the partial directly. Pass B removed the
     // hand-mapped column projection; the backend DeviceUpdate
     // accepts only the universal columns plus kind/attributes,
     // which is exactly the shape `Partial<Asset>` carries.
-    const response = await apiClient.put(`/assets/${id}`, device);
+    const response = await apiClient.put(`/assets/${id}`, device, config);
     return transformDeviceResponse(response.data);
   } catch (error) {
     logger.error('Failed to update device', { error, deviceId: id });

--- a/packages/core/src/services/ticketService.ts
+++ b/packages/core/src/services/ticketService.ts
@@ -1,4 +1,5 @@
 import apiClient from '../apiClient';
+import type { AxiosRequestConfig } from 'axios';
 import { logger } from '../utils/logger';
 import { RequestManager } from '../utils/requestManager';
 import type {
@@ -126,9 +127,9 @@ export const createTicket = async (ticket: Omit<Ticket, 'id' | 'created' | 'modi
   }
 };
 
-export const updateTicket = async (id: number, ticket: Partial<Ticket>): Promise<Ticket> => {
+export const updateTicket = async (id: number, ticket: Partial<Ticket>, config?: AxiosRequestConfig): Promise<Ticket> => {
   try {
-    const response = await apiClient.patch(`/tickets/${id}`, ticket);
+    const response = await apiClient.patch(`/tickets/${id}`, ticket, config);
     return response.data;
   } catch (error) {
     logger.error('Failed to update ticket', { error, ticketId: id });
@@ -155,9 +156,9 @@ export const previewTicketField = async (
   await apiClient.post(`/tickets/${id}/field-preview`, { field, value });
 };
 
-export const deleteTicket = async (id: number): Promise<void> => {
+export const deleteTicket = async (id: number, config?: AxiosRequestConfig): Promise<void> => {
   try {
-    await apiClient.delete(`/tickets/${id}`);
+    await apiClient.delete(`/tickets/${id}`, config);
   } catch (error) {
     logger.error('Failed to delete ticket', { error, ticketId: id });
     throw error;


### PR DESCRIPTION
Closes the deferral from #139. Plugin writes act as the current user, so without a marker they're indistinguishable from the user's own actions in the audit trail. Tag them.

## How
- **Frontend:** the plugin API's write methods (`tickets.update`/`delete`, `devices.update`) send `X-Nosdesk-Plugin: <uuid>` (one attribution config, reused). The write services (`updateTicket`/`deleteTicket`/`updateAsset`) take an optional axios config; existing callers unaffected.
- **Backend:** `request_context::populate` (the single actor-construction point) reads the header and sets `actor.reference = "plugin:<uuid>"`. The actor **stays `kind=user`** — authz is unchanged, the plugin acts as the user; this only annotates the initiator, recorded via the existing `app.actor_ref` GUC → audit/sync trail (`ActorKind::Plugin` machinery already existed). CORS allow-list gains `X-Nosdesk-Plugin` so it survives the native-app cross-origin preflight (like `X-Nosdesk-Workspace`).

## Scope
- Best-effort: a malformed/absent header just leaves the ref unset.
- Deferred (noted): attributing `addComment` (low-risk); validating the uuid is an installed plugin (spoofing only *misattributes*, never escalates authz).

## Verified
core + frontend type-check & lint. Backend change is small (header read + one CORS entry); relying on CI clippy/test.

Follows #139. Next: 4b-3c-3 (consent gate), 4b-3c-4 (flip + delete + combined live verification).