### PR TITLE
Plugin sandbox 4b-3c-3a: consent gate (backend)

### DIFF
--- a/backend/migrations/2026-07-25-000000_plugin_consent/down.sql
+++ b/backend/migrations/2026-07-25-000000_plugin_consent/down.sql
@@ -1,0 +1,8 @@
+ALTER TABLE plugins DROP COLUMN consented_by;
+ALTER TABLE plugins DROP COLUMN consented_at;
+ALTER TABLE plugins DROP COLUMN consented_permissions;
+ALTER TABLE plugins DROP CONSTRAINT plugins_state_check;
+ALTER TABLE plugins ADD CONSTRAINT plugins_state_check
+  CHECK ((state)::text = ANY (ARRAY[
+    'installed'::text, 'disabled'::text, 'quarantined'::text, 'uninstalled'::text
+  ]));

--- a/backend/migrations/2026-07-25-000000_plugin_consent/up.sql
+++ b/backend/migrations/2026-07-25-000000_plugin_consent/up.sql
@@ -1,0 +1,25 @@
+-- Consent gate for the plugin sandbox (4b-3c-3).
+--
+-- A plugin can now land in `awaiting_consent`: the row exists but is NOT served
+-- (the runtime loader serves only `installed`, so this state is inert by
+-- construction). An admin approves the requested permission scope to advance it
+-- to `installed`. Trusted tiers (official / local) auto-advance at install; the
+-- untrusted tiers (verified / community) wait here for consent.
+--
+-- Additive only (new state value + nullable columns, no backfill), so no audit
+-- trigger fires on existing rows.
+
+ALTER TABLE plugins DROP CONSTRAINT plugins_state_check;
+ALTER TABLE plugins ADD CONSTRAINT plugins_state_check
+  CHECK ((state)::text = ANY (ARRAY[
+    'installed'::text, 'disabled'::text, 'quarantined'::text,
+    'uninstalled'::text, 'awaiting_consent'::text
+  ]));
+
+-- The exact permission set the admin consented to (a JSON array of permission
+-- strings). Re-consent is required when a later version's permissions are not a
+-- subset of this. NULL until first consent (and for tiers that never consent via
+-- the UI, it records the auto-consented set at install).
+ALTER TABLE plugins ADD COLUMN consented_permissions jsonb;
+ALTER TABLE plugins ADD COLUMN consented_at timestamptz;
+ALTER TABLE plugins ADD COLUMN consented_by uuid REFERENCES users(uuid) ON DELETE SET NULL;

--- a/backend/src/handlers/plugins.rs
+++ b/backend/src/handlers/plugins.rs
@@ -75,6 +75,10 @@ pub fn config(cfg: &mut web::ServiceConfig) {
         web::delete().to(crate::handlers::plugins::uninstall_plugin),
     )
     .route(
+        "/admin/plugins/{uuid}/consent",
+        web::post().to(crate::handlers::plugins::consent_to_plugin),
+    )
+    .route(
         "/admin/plugins/{uuid}/settings",
         web::get().to(crate::handlers::plugins::get_plugin_settings),
     )
@@ -490,6 +494,70 @@ pub async fn update_plugin(
         Err(e) => {
             error!("Failed to serialize plugin response: {}", e);
             errors::internal("Plugin updated but response failed")
+        }
+    }
+}
+
+enum ConsentResult {
+    Consented(Box<crate::models::Plugin>),
+    NotPending(crate::models::PluginState),
+}
+
+/// Consent to a plugin's requested permission scope (admin only), advancing it
+/// from `AwaitingConsent` to `Installed`. Records the consented scope + who/when
+/// so a later version that widens scope can require re-consent. The consented set
+/// is the plugin's currently-requested manifest permissions (what the admin saw).
+pub async fn consent_to_plugin(
+    req: HttpRequest,
+    pool: web::Data<Pool>,
+    path: web::Path<Uuid>,
+) -> impl Responder {
+    if let Err(e) = require_workspace_role(&req, WorkspaceRole::Admin) {
+        return e;
+    }
+    let claims = match req.extensions().get::<Claims>() {
+        Some(c) => c.clone(),
+        None => return errors::unauthorized("Authentication required"),
+    };
+    let Some(user_uuid) = Uuid::parse_str(&claims.sub).ok() else {
+        return errors::unauthorized("Authentication required");
+    };
+    let plugin_uuid = path.into_inner();
+    let actor = workspace_pinned_actor(&req, "plugins_admin");
+    let mut conn = match helpers::db_conn(&pool) {
+        Ok(c) => c,
+        Err(e) => return e,
+    };
+
+    let result = actor_session::with_actor_context::<_, DieselError>(&mut conn, &actor, |conn| {
+        let plugin = plugin_repo::get_plugin_by_uuid(conn, plugin_uuid)?;
+        if !matches!(plugin.state, crate::models::PluginState::AwaitingConsent) {
+            return Ok(ConsentResult::NotPending(plugin.state));
+        }
+        let perms: Vec<String> = plugin
+            .parse_manifest()
+            .map(|m| m.permissions.iter().map(|p| p.as_string()).collect())
+            .unwrap_or_default();
+        let updated =
+            plugin_repo::consent_plugin(conn, plugin_uuid, serde_json::json!(perms), user_uuid)?;
+        Ok(ConsentResult::Consented(Box::new(updated)))
+    });
+
+    match result {
+        Ok(ConsentResult::Consented(plugin)) => match PluginResponse::try_from(*plugin) {
+            Ok(response) => HttpResponse::Ok().json(response),
+            Err(e) => {
+                error!("Failed to serialize consented plugin: {}", e);
+                errors::internal("Consented but response failed")
+            }
+        },
+        Ok(ConsentResult::NotPending(state)) => {
+            errors::conflict(format!("Plugin is not awaiting consent (state: {state})"))
+        }
+        Err(DieselError::NotFound) => errors::not_found_msg("Plugin not found"),
+        Err(e) => {
+            error!("Failed to consent to plugin: {}", e);
+            errors::internal("Failed to consent to plugin")
         }
     }
 }

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -5876,6 +5876,12 @@ pub struct Plugin {
     /// at `install::MAX_BUNDLE_SIZE` (500 KB).
     pub bundle_js: Option<Vec<u8>>,
     pub workspace_id: i32,
+    /// The exact permission set an admin consented to (JSON array of permission
+    /// strings), or `None` before first consent. A later version whose
+    /// permissions aren't a subset of this requires re-consent.
+    pub consented_permissions: Option<serde_json::Value>,
+    pub consented_at: Option<NaiveDateTime>,
+    pub consented_by: Option<Uuid>,
 }
 
 impl Plugin {
@@ -5884,6 +5890,15 @@ impl Plugin {
     /// only need a yes/no view.
     pub fn is_active(&self) -> bool {
         matches!(self.state, PluginState::Installed)
+    }
+
+    /// The permission set the admin consented to, as a `Vec<String>`. Empty when
+    /// no consent recorded yet (parses the `consented_permissions` JSON array).
+    pub fn consented_permission_set(&self) -> Vec<String> {
+        self.consented_permissions
+            .as_ref()
+            .and_then(|v| serde_json::from_value::<Vec<String>>(v.clone()).ok())
+            .unwrap_or_default()
     }
 }
 
@@ -5925,6 +5940,12 @@ pub enum PluginState {
     /// plugin name reattaches the data automatically. Bundle is
     /// removed from disk.
     Uninstalled,
+    /// Installed but not yet consented to: the row exists and the bundle is
+    /// stored, but it is NOT served (the loader serves only `Installed`), so this
+    /// state is inert until an admin approves the requested permission scope,
+    /// which advances it to `Installed`. Untrusted tiers (verified / community)
+    /// land here at install; trusted tiers (official / local) auto-advance.
+    AwaitingConsent,
 }
 
 impl PluginState {
@@ -5934,6 +5955,7 @@ impl PluginState {
             PluginState::Disabled => "disabled",
             PluginState::Quarantined => "quarantined",
             PluginState::Uninstalled => "uninstalled",
+            PluginState::AwaitingConsent => "awaiting_consent",
         }
     }
 
@@ -5943,6 +5965,7 @@ impl PluginState {
             "disabled" => Ok(PluginState::Disabled),
             "quarantined" => Ok(PluginState::Quarantined),
             "uninstalled" => Ok(PluginState::Uninstalled),
+            "awaiting_consent" => Ok(PluginState::AwaitingConsent),
             other => Err(format!("unknown plugin state {other:?}")),
         }
     }
@@ -5994,7 +6017,8 @@ pub struct NewPlugin {
     pub version: String,
     pub description: Option<String>,
     pub manifest: serde_json::Value,
-    /// Initial lifecycle state, almost always `PluginState::Installed`.
+    /// Initial lifecycle state: `Installed` for auto-consented (official / local)
+    /// tiers, `AwaitingConsent` for the tiers that require admin consent.
     pub state: PluginState,
     pub trust_level: String,
     pub installed_by: Option<Uuid>,
@@ -6003,6 +6027,11 @@ pub struct NewPlugin {
     pub signer_source: Option<String>,
     pub signature_metadata: Option<serde_json::Value>,
     pub icon_svg: Option<Vec<u8>>,
+    /// Consent recorded at install for auto-consented tiers (the manifest's
+    /// permission set); `None` when the plugin lands in `AwaitingConsent`.
+    pub consented_permissions: Option<serde_json::Value>,
+    pub consented_at: Option<NaiveDateTime>,
+    pub consented_by: Option<Uuid>,
 }
 
 /// Plugin update changeset

--- a/backend/src/repository/plugins.rs
+++ b/backend/src/repository/plugins.rs
@@ -161,6 +161,31 @@ pub fn delete_plugin_by_uuid(
 }
 
 /// Update a plugin's bundle metadata
+/// Advance an `AwaitingConsent` plugin to `Installed`, recording the consented
+/// permission set + who/when. The state guard is in the WHERE clause, so a plugin
+/// that isn't awaiting consent matches no rows (`NotFound`). RLS-scoped by the
+/// caller's workspace pin; the `plugins` UPDATE is audited via the row trigger.
+// sync-audit-only: plugin state flip + recorded consent scope — covered by the audit_log trigger on plugins, no sync aggregate
+pub fn consent_plugin(
+    conn: &mut DbConnection,
+    plugin_uuid: Uuid,
+    permissions: serde_json::Value,
+    consented_by: Uuid,
+) -> Result<Plugin, diesel::result::Error> {
+    diesel::update(
+        plugins::table
+            .filter(plugins::uuid.eq(plugin_uuid))
+            .filter(plugins::state.eq(crate::models::PluginState::AwaitingConsent)),
+    )
+    .set((
+        plugins::state.eq(crate::models::PluginState::Installed),
+        plugins::consented_permissions.eq(permissions),
+        plugins::consented_at.eq(chrono::Utc::now().naive_utc()),
+        plugins::consented_by.eq(consented_by),
+    ))
+    .get_result(conn)
+}
+
 pub fn update_plugin_bundle(
     conn: &mut DbConnection,
     plugin_uuid: Uuid,
@@ -610,6 +635,9 @@ mod tests {
             signer_source: None,
             signature_metadata: None,
             icon_svg: None,
+            consented_permissions: None,
+            consented_at: None,
+            consented_by: None,
         }
     }
 

--- a/backend/src/schema.rs
+++ b/backend/src/schema.rs
@@ -1240,6 +1240,9 @@ diesel::table! {
         state -> Varchar,
         bundle_js -> Nullable<Bytea>,
         workspace_id -> Int4,
+        consented_permissions -> Nullable<Jsonb>,
+        consented_at -> Nullable<Timestamptz>,
+        consented_by -> Nullable<Uuid>,
     }
 }
 
@@ -2356,7 +2359,6 @@ diesel::joinable!(plugin_collection_schemas -> plugins (plugin_id));
 diesel::joinable!(plugin_collection_schemas -> workspaces (workspace_id));
 diesel::joinable!(plugin_data -> plugins (plugin_id));
 diesel::joinable!(plugin_data -> workspaces (workspace_id));
-diesel::joinable!(plugins -> users (installed_by));
 diesel::joinable!(plugins -> workspaces (workspace_id));
 diesel::joinable!(project_tickets -> projects (project_id));
 diesel::joinable!(project_tickets -> tickets (ticket_id));

--- a/backend/src/services/plugins/install.rs
+++ b/backend/src/services/plugins/install.rs
@@ -500,6 +500,21 @@ fn update_row(
     )?)
 }
 
+/// Untrusted tiers require a workspace admin to consent to the requested scope
+/// before the plugin serves. Trusted tiers auto-consent: official is
+/// Nosdesk-curated (the vetting is the consent) and local is operator
+/// CLI-installed (they saw the manifest, higher privilege).
+fn tier_requires_consent(trust_level: &str) -> bool {
+    matches!(trust_level, "verified" | "community")
+}
+
+/// The manifest's requested permissions as a JSON array of strings — the shape
+/// stored in `plugins.consented_permissions`.
+fn requested_permission_json(manifest: &PluginManifest) -> serde_json::Value {
+    let perms: Vec<String> = manifest.permissions.iter().map(|p| p.as_string()).collect();
+    serde_json::json!(perms)
+}
+
 fn create_row(
     conn: &mut DbConnection,
     manifest: &PluginManifest,
@@ -508,13 +523,35 @@ fn create_row(
     options: &InstallOptions,
     icon_bytes: Option<Vec<u8>>,
 ) -> Result<Plugin, InstallError> {
+    // Consent landing: untrusted tiers (verified / community) require an admin to
+    // approve the requested scope, so they land in `AwaitingConsent` (created but
+    // not served); trusted tiers (official / local) auto-advance and record the
+    // consent now. A new row has no prior consent, so there's no subset
+    // short-circuit here (that lives in the update path / re-consent, tracked as a
+    // follow-up).
+    let (state, consented_permissions, consented_at, consented_by) =
+        if tier_requires_consent(&signer.trust_level) {
+            (
+                crate::models::PluginState::AwaitingConsent,
+                None,
+                None,
+                None,
+            )
+        } else {
+            (
+                crate::models::PluginState::Installed,
+                Some(requested_permission_json(manifest)),
+                Some(Utc::now().naive_utc()),
+                options.installed_by,
+            )
+        };
     let new_plugin = NewPlugin {
         name: manifest.name.clone(),
         display_name: manifest.display_name.clone(),
         version: manifest.version.clone(),
         description: manifest.description.clone(),
         manifest: manifest_json,
-        state: crate::models::PluginState::Installed,
+        state,
         trust_level: signer.trust_level,
         installed_by: options.installed_by,
         source: options.source.to_string(),
@@ -522,6 +559,9 @@ fn create_row(
         signer_source: signer.signer_source,
         signature_metadata: signer.signature_metadata,
         icon_svg: icon_bytes,
+        consented_permissions,
+        consented_at,
+        consented_by,
     };
     // The install pipeline is the only production constructor of
     // `InstallToken`, so this call is the unique entry point for

--- a/backend/src/services/plugins/lifecycle.rs
+++ b/backend/src/services/plugins/lifecycle.rs
@@ -225,7 +225,9 @@ pub fn apply(
             // ----- Uninstall (preserve) -----
             (PluginState::Installed, PluginAction::UninstallPreserve)
             | (PluginState::Disabled, PluginAction::UninstallPreserve)
-            | (PluginState::Quarantined, PluginAction::UninstallPreserve) => {
+            | (PluginState::Quarantined, PluginAction::UninstallPreserve)
+            // Rejecting a never-consented plugin is an uninstall from AwaitingConsent.
+            | (PluginState::AwaitingConsent, PluginAction::UninstallPreserve) => {
                 let updated = set_state(tx, plugin_uuid, PluginState::Uninstalled)?;
                 log_lifecycle(tx, &updated, &action, prior, actor)?;
                 Ok(ActionOutcome::StateChanged {
@@ -536,6 +538,9 @@ mod integration_tests {
             signer_source: Some("nosdesk-root".to_string()),
             signature_metadata: None,
             icon_svg: None,
+            consented_permissions: None,
+            consented_at: None,
+            consented_by: None,
         };
         plugin_repo::create_plugin(conn, new_plugin, InstallToken::for_test())
             .expect("test plugin insert must succeed")

--- a/backend/tests/common/mod.rs
+++ b/backend/tests/common/mod.rs
@@ -652,6 +652,9 @@ fn seed_one_workspace(conn: &mut TestPooledConn, label: &str) -> WorkspaceSeed {
                 signer_source: None,
                 signature_metadata: None,
                 icon_svg: None,
+                consented_permissions: None,
+                consented_at: None,
+                consented_by: None,
             };
             let plugin: backend::models::Plugin = diesel::insert_into(plugins::table)
                 .values(&new_plugin)


### PR DESCRIPTION
Third piece of 4b-3c, backend half of the consent gate. Untrusted-tier plugins must have their requested permission scope approved by an admin before they serve.

## What lands
- **Migration** (`2026-07-25-000000_plugin_consent`): `awaiting_consent` state value + `consented_permissions`/`consented_at`/`consented_by` columns. Additive (new state value + nullable columns, no backfill), so no audit trigger fires on existing rows.
- **`PluginState::AwaitingConsent`** — inert by construction: the loader serves only `Installed`, so a pending plugin is created + stored but never rendered/served.
- **Install landing:** verified/community land in `AwaitingConsent`; official/local auto-advance to `Installed` and record the consented scope at install (per D4, curation / operator CLI install is the consent).
- **`POST /admin/plugins/{uuid}/consent`** (admin): advance `AwaitingConsent → Installed`, recording the consented permission set + who/when for future re-consent detection. State-guarded; the `plugins` UPDATE is audited + attributed to the admin.
- **Lifecycle:** an admin can uninstall (reject) a plugin from `AwaitingConsent`.

## Scope / deferred
- Re-consent on a scope-widening *update* (noted; the update path currently leaves state to the lifecycle).
- The **consent UI** (permission list + Approve) is 4b-3c-3b.

## Verified
`cargo check` passes; migration applied to the dev DB + `schema.rs` regenerated (the removed `joinable!(plugins -> users)` is harmless, that join is unused, and the second FK on `consented_by` makes it ambiguous). Migration is forward-compatible with a running old backend (Diesel selects named columns).

Follows #140. Next: 4b-3c-3b (consent UI), 4b-3c-4 (flip + delete + combined live verification).