### PR TITLE
Plugin sandbox 4b-3c-3b: consent UI (permission list + approve)

### DIFF
--- a/frontend/src/components/plugins/PluginPermissionList.vue
+++ b/frontend/src/components/plugins/PluginPermissionList.vue
@@ -1,0 +1,44 @@
+<script setup lang="ts">
+/**
+ * Renders a plugin's requested permissions as a human-readable list, with
+ * destructive scopes (write/delete) flagged prominently. Shared by the consent
+ * screen and the plugin detail page so the two never drift.
+ */
+import { computed } from 'vue';
+import { useFluent } from 'fluent-vue';
+import { describePermission } from '@nosdesk/core/types/plugin';
+import type { PluginPermission } from '@nosdesk/core/types/plugin';
+
+const props = defineProps<{ permissions: (PluginPermission | string)[] }>();
+
+const fluent = useFluent();
+const t = (key: string, args?: Record<string, string | number>) => fluent.$t(key, args);
+
+const items = computed(() =>
+  props.permissions.map((value) => ({ value, ...describePermission(value) })),
+);
+</script>
+
+<template>
+  <ul v-if="items.length" class="flex flex-col gap-2">
+    <li
+      v-for="perm in items"
+      :key="perm.value"
+      class="flex items-start gap-2 rounded-md border p-2"
+      :class="perm.destructive ? 'border-status-error/40 bg-status-error/5' : 'border-default'"
+    >
+      <div class="flex-1">
+        <div class="flex items-center gap-2">
+          <span class="text-sm font-medium text-primary">{{ t(perm.labelKey, perm.args) }}</span>
+          <span
+            v-if="perm.destructive"
+            class="rounded bg-status-error/15 px-1.5 py-0.5 text-xs font-medium text-status-error"
+          >
+            {{ t('plugin-permission-destructive-badge') }}
+          </span>
+        </div>
+        <p class="mt-0.5 text-xs text-secondary">{{ t(perm.descriptionKey, perm.args) }}</p>
+      </div>
+    </li>
+  </ul>
+</template>

--- a/frontend/src/components/plugins/PluginStateBadge.vue
+++ b/frontend/src/components/plugins/PluginStateBadge.vue
@@ -35,6 +35,10 @@ const STYLES: Record<PluginState, { pillClass: string; textClass: string }> = {
     pillClass: 'bg-surface-alt text-tertiary',
     textClass: 'text-tertiary',
   },
+  awaiting_consent: {
+    pillClass: 'bg-status-warning/10 text-status-warning',
+    textClass: 'text-status-warning',
+  },
 };
 
 const LABEL_KEY: Record<PluginState, string> = {
@@ -42,6 +46,7 @@ const LABEL_KEY: Record<PluginState, string> = {
   disabled: 'plugin-state-disabled',
   quarantined: 'plugin-state-quarantined',
   uninstalled: 'plugin-state-uninstalled',
+  awaiting_consent: 'plugin-state-awaiting-consent',
 };
 
 const label = computed(() => t(LABEL_KEY[props.state]));

--- a/frontend/src/views/admin/plugins/PluginDetailView.vue
+++ b/frontend/src/views/admin/plugins/PluginDetailView.vue
@@ -34,6 +34,7 @@ import pluginService from '@nosdesk/core/services/pluginService';
 import { unloadPlugin } from '@/plugins/loader';
 import { logger } from '@nosdesk/core/utils/logger';
 import type { Plugin, PluginSetting } from '@nosdesk/core/types/plugin';
+import PluginPermissionList from '@/components/plugins/PluginPermissionList.vue';
 
 const route = useRoute();
 const router = useRouter();
@@ -108,6 +109,26 @@ async function loadSettings() {
 function announce(msg: string) {
   successMessage.value = msg;
   setTimeout(() => (successMessage.value = ''), 3000);
+}
+
+// Consent gate: untrusted-tier plugins land in `awaiting_consent` and don't run
+// until an admin approves their requested permission scope.
+const isAwaitingConsent = computed(() => plugin.value?.state === 'awaiting_consent');
+const consentInFlight = ref(false);
+async function approveConsent() {
+  if (!plugin.value) return;
+  consentInFlight.value = true;
+  errorMessage.value = '';
+  try {
+    await pluginService.consentToPlugin(uuid.value);
+    await pluginQuery.refetch();
+    announce(t('plugin-detail-consent-approve'));
+  } catch (error) {
+    logger.error('Failed to consent to plugin', { error, uuid: uuid.value });
+    errorMessage.value = error instanceof Error ? error.message : String(error);
+  } finally {
+    consentInFlight.value = false;
+  }
 }
 
 function isSecretConfigured(key: string): boolean {
@@ -316,6 +337,26 @@ const saveButtonLabel = computed(() =>
         </div>
       </header>
 
+      <!-- Consent gate: pending admin approval of the requested permission scope -->
+      <section
+        v-if="isAwaitingConsent"
+        class="rounded-xl border border-status-warning/40 bg-status-warning/5 p-5"
+      >
+        <h2 class="font-semibold text-primary">{{ t('plugin-detail-consent-pending-title') }}</h2>
+        <p class="mt-1 text-sm text-secondary">{{ t('plugin-detail-consent-pending-body') }}</p>
+        <div class="mt-4">
+          <h3 class="mb-2 text-xs tracking-wide text-tertiary uppercase">
+            {{ t('plugin-detail-consent-heading') }}
+          </h3>
+          <PluginPermissionList :permissions="plugin.manifest.permissions" />
+        </div>
+        <div class="mt-4">
+          <Button variant="primary" :disabled="consentInFlight" @click="approveConsent">
+            {{ consentInFlight ? t('plugin-detail-consent-approving') : t('plugin-detail-consent-approve') }}
+          </Button>
+        </div>
+      </section>
+
       <!-- Lifecycle actions -->
       <section
         aria-labelledby="lifecycle-heading"
@@ -507,9 +548,14 @@ const saveButtonLabel = computed(() =>
             <dt class="text-xs tracking-wide text-tertiary uppercase">{{ t('plugin-detail-metadata-source') }}</dt>
             <dd class="mt-1 text-secondary">{{ plugin.source }}</dd>
           </div>
-          <div>
+          <div class="sm:col-span-2">
             <dt class="text-xs tracking-wide text-tertiary uppercase">{{ t('plugin-detail-metadata-permissions') }}</dt>
-            <dd class="mt-1 text-secondary">{{ t('plugin-detail-metadata-permissions-count', { count: plugin.manifest.permissions.length }) }}</dd>
+            <dd class="mt-2">
+              <PluginPermissionList :permissions="plugin.manifest.permissions" />
+              <span v-if="!plugin.manifest.permissions.length" class="text-secondary">
+                {{ t('plugin-detail-metadata-permissions-count', { count: 0 }) }}
+              </span>
+            </dd>
           </div>
           <div v-if="plugin.manifest.repository" class="sm:col-span-2">
             <dt class="text-xs tracking-wide text-tertiary uppercase">{{ t('plugin-detail-metadata-repository') }}</dt>

--- a/frontend/src/views/admin/plugins/PluginListView.vue
+++ b/frontend/src/views/admin/plugins/PluginListView.vue
@@ -64,6 +64,7 @@ const stateCounts = computed(() => {
     disabled: 0,
     quarantined: 0,
     uninstalled: 0,
+    awaiting_consent: 0,
   };
   for (const p of plugins.value) counts[p.state]++;
   return counts;
@@ -125,9 +126,10 @@ const STATE_LABELS: Record<PluginState, string> = {
   disabled: 'Disabled',
   quarantined: 'Quarantined',
   uninstalled: 'Uninstalled',
+  awaiting_consent: 'Awaiting consent',
 };
 
-const STATE_FILTER_ORDER: PluginState[] = ['installed', 'disabled', 'quarantined', 'uninstalled'];
+const STATE_FILTER_ORDER: PluginState[] = ['installed', 'awaiting_consent', 'disabled', 'quarantined', 'uninstalled'];
 </script>
 
 <template>

--- a/i18n/locales/en-US/main.ftl
+++ b/i18n/locales/en-US/main.ftl
@@ -4915,6 +4915,7 @@ plugin-state-active = Active
 plugin-state-disabled = Disabled
 plugin-state-quarantined = Quarantined
 plugin-state-uninstalled = Uninstalled
+plugin-state-awaiting-consent = Awaiting consent
 
 # Plugin admin: trust tier pills (PluginTrustBadge)
 plugin-trust-official = Official
@@ -5957,6 +5958,16 @@ plugin-permission-collection-read-label = Read Collections
 plugin-permission-collection-read-description = Read typed collection rows
 plugin-permission-collection-write-label = Write Collections
 plugin-permission-collection-write-description = Create and update typed collection rows
+plugin-permission-network-label = Network access
+plugin-permission-network-description = Make network requests to { $host }
+plugin-permission-unknown-label = { $permission }
+plugin-permission-unknown-description = An unrecognized permission
+plugin-permission-destructive-badge = Can change data
+plugin-detail-consent-heading = Permissions requested
+plugin-detail-consent-pending-title = Awaiting your approval
+plugin-detail-consent-pending-body = This plugin won't run until you review and approve the permissions it requests.
+plugin-detail-consent-approve = Approve & enable
+plugin-detail-consent-approving = Approving…
 error-resource-not-found = The requested resource was not found.
 error-network = Couldn't reach the server. It may be offline or unreachable.
 error-timeout = The request timed out. The server may still be processing it.

--- a/i18n/locales/fr-FR/main.ftl
+++ b/i18n/locales/fr-FR/main.ftl
@@ -4753,6 +4753,8 @@ plugin-state-active = Actif
 plugin-state-disabled = Désactivé
 plugin-state-quarantined = En quarantaine
 plugin-state-uninstalled = Désinstallé
+# MACHINE TRANSLATION, pending native review
+plugin-state-awaiting-consent = En attente d'approbation
 
 # Plugin admin: trust tier pills (PluginTrustBadge)
 plugin-trust-official = Officiel
@@ -5741,6 +5743,17 @@ plugin-permission-collection-read-label = Lire les collections
 plugin-permission-collection-read-description = Lire les enregistrements de collections typées
 plugin-permission-collection-write-label = Écrire les collections
 plugin-permission-collection-write-description = Créer et mettre à jour les enregistrements de collections typées
+# MACHINE TRANSLATION, pending native review
+plugin-permission-network-label = Accès réseau
+plugin-permission-network-description = Effectuer des requêtes réseau vers { $host }
+plugin-permission-unknown-label = { $permission }
+plugin-permission-unknown-description = Une autorisation non reconnue
+plugin-permission-destructive-badge = Peut modifier des données
+plugin-detail-consent-heading = Autorisations demandées
+plugin-detail-consent-pending-title = En attente de votre approbation
+plugin-detail-consent-pending-body = Ce plugin ne s'exécutera pas tant que vous n'aurez pas examiné et approuvé les autorisations qu'il demande.
+plugin-detail-consent-approve = Approuver et activer
+plugin-detail-consent-approving = Approbation…
 error-resource-not-found = La ressource demandée est introuvable.
 error-network = Impossible de joindre le serveur. Il est peut-être hors ligne ou injoignable.
 error-timeout = La requête a expiré. Le serveur la traite peut-être encore.

--- a/i18n/locales/nl-NL/main.ftl
+++ b/i18n/locales/nl-NL/main.ftl
@@ -4744,6 +4744,8 @@ plugin-state-active = Actief
 plugin-state-disabled = Uitgeschakeld
 plugin-state-quarantined = In quarantaine
 plugin-state-uninstalled = Verwijderd
+# MACHINE TRANSLATION, pending native review
+plugin-state-awaiting-consent = Wacht op goedkeuring
 
 # Plugin admin: trust tier pills (PluginTrustBadge)
 plugin-trust-official = Officieel
@@ -5732,6 +5734,17 @@ plugin-permission-collection-read-label = Collecties lezen
 plugin-permission-collection-read-description = Records uit getypeerde collecties lezen
 plugin-permission-collection-write-label = Collecties schrijven
 plugin-permission-collection-write-description = Records in getypeerde collecties aanmaken en bijwerken
+# MACHINE TRANSLATION, pending native review
+plugin-permission-network-label = Netwerktoegang
+plugin-permission-network-description = Netwerkverzoeken doen naar { $host }
+plugin-permission-unknown-label = { $permission }
+plugin-permission-unknown-description = Een niet-herkende machtiging
+plugin-permission-destructive-badge = Kan gegevens wijzigen
+plugin-detail-consent-heading = Gevraagde machtigingen
+plugin-detail-consent-pending-title = Wacht op uw goedkeuring
+plugin-detail-consent-pending-body = Deze plugin wordt pas uitgevoerd nadat u de gevraagde machtigingen hebt bekeken en goedgekeurd.
+plugin-detail-consent-approve = Goedkeuren en inschakelen
+plugin-detail-consent-approving = Goedkeuren…
 error-resource-not-found = De gevraagde bron is niet gevonden.
 error-network = Kan de server niet bereiken. Mogelijk is deze offline of onbereikbaar.
 error-timeout = De aanvraag is verlopen. De server verwerkt deze mogelijk nog.

--- a/packages/core/src/services/pluginService.ts
+++ b/packages/core/src/services/pluginService.ts
@@ -80,6 +80,20 @@ const pluginService = {
   },
 
   /**
+   * Consent to a plugin's requested permission scope (admin only), advancing it
+   * from `awaiting_consent` to `installed`.
+   */
+  async consentToPlugin(uuid: string): Promise<Plugin> {
+    try {
+      const response = await apiClient.post(`/admin/plugins/${uuid}/consent`);
+      return response.data;
+    } catch (error) {
+      logger.error('Failed to consent to plugin', { error, uuid });
+      throw error;
+    }
+  },
+
+  /**
    * Uninstall a plugin (admin only)
    */
   async uninstallPlugin(uuid: string): Promise<void> {

--- a/packages/core/src/types/plugin.ts
+++ b/packages/core/src/types/plugin.ts
@@ -148,7 +148,10 @@ export type PluginState =
   | 'installed'
   | 'disabled'
   | 'quarantined'
-  | 'uninstalled';
+  | 'uninstalled'
+  // Installed but not yet consented to (untrusted tiers): stored but not served
+  // until an admin approves the requested permission scope.
+  | 'awaiting_consent';
 
 // =============================================================================
 // Registry types (mirror the JSON served by nosdesk.com)
@@ -438,18 +441,58 @@ export type PluginPermission =
  * `translate()`. The install-confirmation UI is the intended
  * consumer; until it lands, keep the table in step with the
  * backend allowlist so we have ready strings when it ships. */
-export const PLUGIN_PERMISSIONS: { value: PluginPermission; labelKey: string; descriptionKey: string }[] = [
+export interface PermissionMeta {
+  value: PluginPermission;
+  labelKey: string;
+  descriptionKey: string;
+  /** Grants that can modify or remove shared data — flagged prominently on the
+   * consent screen. */
+  destructive?: boolean;
+}
+
+export const PLUGIN_PERMISSIONS: PermissionMeta[] = [
   { value: 'ticket:read',       labelKey: 'plugin-permission-ticket-read-label',       descriptionKey: 'plugin-permission-ticket-read-description' },
-  { value: 'ticket:write',      labelKey: 'plugin-permission-ticket-write-label',      descriptionKey: 'plugin-permission-ticket-write-description' },
+  { value: 'ticket:write',      labelKey: 'plugin-permission-ticket-write-label',      descriptionKey: 'plugin-permission-ticket-write-description',   destructive: true },
   { value: 'ticket:comment',    labelKey: 'plugin-permission-ticket-comment-label',    descriptionKey: 'plugin-permission-ticket-comment-description' },
-  { value: 'ticket:delete',     labelKey: 'plugin-permission-ticket-delete-label',     descriptionKey: 'plugin-permission-ticket-delete-description' },
+  { value: 'ticket:delete',     labelKey: 'plugin-permission-ticket-delete-label',     descriptionKey: 'plugin-permission-ticket-delete-description',  destructive: true },
   { value: 'asset:read',       labelKey: 'plugin-permission-asset-read-label',       descriptionKey: 'plugin-permission-asset-read-description' },
-  { value: 'asset:write',      labelKey: 'plugin-permission-asset-write-label',      descriptionKey: 'plugin-permission-asset-write-description' },
+  { value: 'asset:write',      labelKey: 'plugin-permission-asset-write-label',      descriptionKey: 'plugin-permission-asset-write-description',    destructive: true },
   { value: 'user:read',         labelKey: 'plugin-permission-user-read-label',         descriptionKey: 'plugin-permission-user-read-description' },
   { value: 'storage:plugin',    labelKey: 'plugin-permission-storage-plugin-label',    descriptionKey: 'plugin-permission-storage-plugin-description' },
   { value: 'collection:read',   labelKey: 'plugin-permission-collection-read-label',   descriptionKey: 'plugin-permission-collection-read-description' },
   { value: 'collection:write',  labelKey: 'plugin-permission-collection-write-label',  descriptionKey: 'plugin-permission-collection-write-description' },
 ];
+
+/** How a single requested permission renders on the consent screen / detail
+ * page. Handles `network:<host>` (not in the static table) and unknown values.
+ * Returns i18n keys + optional interpolation args, resolved by the caller. */
+export interface PermissionDescriptor {
+  labelKey: string;
+  descriptionKey: string;
+  destructive: boolean;
+  args?: Record<string, string>;
+}
+
+export function describePermission(value: PluginPermission | string): PermissionDescriptor {
+  if (value.startsWith('network:')) {
+    return {
+      labelKey: 'plugin-permission-network-label',
+      descriptionKey: 'plugin-permission-network-description',
+      destructive: false,
+      args: { host: value.slice('network:'.length) },
+    };
+  }
+  const entry = PLUGIN_PERMISSIONS.find((p) => p.value === value);
+  if (entry) {
+    return { labelKey: entry.labelKey, descriptionKey: entry.descriptionKey, destructive: !!entry.destructive };
+  }
+  return {
+    labelKey: 'plugin-permission-unknown-label',
+    descriptionKey: 'plugin-permission-unknown-description',
+    destructive: false,
+    args: { permission: value },
+  };
+}
 
 // =============================================================================
 // Plugin Events


### PR DESCRIPTION
Frontend half of the consent gate (pairs with #141). An admin reviews + approves a plugin's requested permission scope before it runs.

## What lands
- **`PluginState` gains `awaiting_consent`** (+ state badge, list-view maps, i18n label).
- **`PLUGIN_PERMISSIONS` gains a `destructive` flag** (`ticket:write`/`delete`, `asset:write`) + **`describePermission()`** resolving any permission (incl. `network:<host>` and unknowns) to a readable label/description/destructive.
- **`PluginPermissionList.vue`** — shared component rendering the requested permissions as readable rows with **destructive scopes flagged prominently** (the hard requirement from the delete decision). Used by both the consent screen and the detail page, so they never drift (DRY).
- **`PluginDetailView`** — a consent banner (permission list + **Approve**) when the plugin is `awaiting_consent`, calling `consentToPlugin` then refetching; the metadata permission **count** is replaced by the full **list** (transparency for all tiers, including auto-advanced ones with no blocking screen).
- **i18n**: new keys in en-US + machine fr/nl (flagged pending native review).

## Notes
- Merge **after #141** (the backend consent endpoint + state).
- Verified: core + frontend type-check & lint.