### PR TITLE
plugins(sandbox): governor caps on the host bridge (4b-4)

### DIFF
--- a/frontend/src/plugins/sandboxHostApi.ts
+++ b/frontend/src/plugins/sandboxHostApi.ts
@@ -10,7 +10,7 @@
 //
 // The bridge itself (`createRemoteHostApi`) is pure transport; every permission
 // check still runs here, in-process, exactly as for a first-party plugin.
-import { proxy } from '@nosdesk/plugin-sdk';
+import { proxy, BridgeGovernor, governHostApi } from '@nosdesk/plugin-sdk';
 import type { HostApi, PluginFetchOptions } from '@nosdesk/plugin-sdk';
 import type { Plugin } from '@nosdesk/core/types/plugin';
 import { createPluginAPI, type PluginAPI } from './api';
@@ -104,5 +104,8 @@ export function createHostApiImpl(plugin: Plugin): { hostApi: HostApi; inproc: P
     },
   };
 
-  return { hostApi, inproc };
+  // Meter every bridge call: rate limit + in-flight cap + per-call timeout, per
+  // plugin instance. The plugin sees over-limit calls as thrown errors; the host
+  // stays protected from a buggy or hostile plugin flooding shared capacity.
+  return { hostApi: governHostApi(hostApi, new BridgeGovernor()), inproc };
 }

--- a/packages/plugin-sdk/src/governor.ts
+++ b/packages/plugin-sdk/src/governor.ts
@@ -1,0 +1,95 @@
+// Host-side governor for the plugin bridge.
+//
+// Bounds a buggy or hostile plugin's ability to degrade shared capacity through
+// the bridge: a call-rate limit, a max in-flight cap, and a per-call timeout.
+// Every host API method a plugin invokes goes through `BridgeGovernor.run`, which
+// rejects over-limit calls (the plugin sees a thrown error) rather than letting
+// them pile up on the host. Per plugin instance — each frame gets its own budget.
+
+export interface GovernorOptions {
+  /** Max calls allowed within `windowMs`. */
+  maxCallsPerWindow: number;
+  windowMs: number;
+  /** Max concurrently in-flight host calls. */
+  maxInFlight: number;
+  /** A single call must settle within this; else it rejects (the underlying work
+   * may keep running host-side, but the plugin's call + its slot are freed). */
+  callTimeoutMs: number;
+}
+
+export const DEFAULT_GOVERNOR_OPTIONS: GovernorOptions = {
+  maxCallsPerWindow: 60,
+  windowMs: 1000,
+  maxInFlight: 8,
+  callTimeoutMs: 15_000,
+};
+
+export class BridgeGovernor {
+  private calls: number[] = [];
+  private inFlight = 0;
+
+  constructor(private readonly opts: GovernorOptions = DEFAULT_GOVERNOR_OPTIONS) {}
+
+  async run<T>(fn: () => Promise<T>): Promise<T> {
+    const now = Date.now();
+    const windowStart = now - this.opts.windowMs;
+    this.calls = this.calls.filter((t) => t > windowStart);
+    if (this.calls.length >= this.opts.maxCallsPerWindow) {
+      throw new Error(
+        `plugin bridge rate limit exceeded (${this.opts.maxCallsPerWindow}/${this.opts.windowMs}ms)`,
+      );
+    }
+    if (this.inFlight >= this.opts.maxInFlight) {
+      throw new Error(`plugin bridge in-flight limit exceeded (${this.opts.maxInFlight})`);
+    }
+    this.calls.push(now);
+    this.inFlight += 1;
+    try {
+      return await this.withTimeout(fn());
+    } finally {
+      this.inFlight -= 1;
+    }
+  }
+
+  private withTimeout<T>(p: Promise<T>): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+      const timer = setTimeout(
+        () => reject(new Error(`plugin bridge call timed out after ${this.opts.callTimeoutMs}ms`)),
+        this.opts.callTimeoutMs,
+      );
+      p.then(
+        (v) => {
+          clearTimeout(timer);
+          resolve(v);
+        },
+        (e) => {
+          clearTimeout(timer);
+          reject(e as Error);
+        },
+      );
+    });
+  }
+}
+
+/**
+ * Wrap a host API object so every method call is metered by `governor`. Recurses
+ * into sub-objects (e.g. `tickets`, `devices`) so nested methods are covered too;
+ * a method's *return value* is not re-wrapped, so a Comlink-proxied sub-API
+ * returned from a method (e.g. `collections(name)`) keeps its own transport (its
+ * per-call metering is a follow-up). Non-function properties pass through.
+ */
+export function governHostApi<T extends object>(impl: T, governor: BridgeGovernor): T {
+  return new Proxy(impl, {
+    get(target, prop, receiver) {
+      const value = Reflect.get(target, prop, receiver);
+      if (typeof value === 'function') {
+        return (...args: unknown[]) =>
+          governor.run(() => Promise.resolve((value as (...a: unknown[]) => unknown).apply(target, args)));
+      }
+      if (value && typeof value === 'object') {
+        return governHostApi(value as object, governor);
+      }
+      return value;
+    },
+  });
+}

--- a/packages/plugin-sdk/src/index.ts
+++ b/packages/plugin-sdk/src/index.ts
@@ -18,6 +18,8 @@ export type { PluginRuntime } from './connect';
 // Host-side bridge (used by the app + the bridge harness, not by plugins).
 export { createRemoteHostApi, postInit, postContext, watchPluginHeight } from './host';
 export type { HostBridge } from './host';
+export { BridgeGovernor, governHostApi, DEFAULT_GOVERNOR_OPTIONS } from './governor';
+export type { GovernorOptions } from './governor';
 
 export type {
   HostApi,


### PR DESCRIPTION
## What

Adds a per-instance `BridgeGovernor` that meters every host call a sandboxed plugin makes across the Comlink bridge:

- **Rate limit** — 60 calls / 1000ms (sliding window)
- **In-flight cap** — 8 concurrent host calls
- **Per-call timeout** — 15s; a stuck call rejects and frees its slot

Over-limit calls reject back to the plugin (it sees a thrown error); the host is protected from a buggy or hostile plugin flooding shared capacity. Each frame gets its own budget.

## How

- New `packages/plugin-sdk/src/governor.ts`: `BridgeGovernor` (token-window rate limit + in-flight counter + `withTimeout`) and `governHostApi(impl, governor)`, a recursive Proxy that meters every method call and recurses into sub-objects (`tickets`, `devices`, `ui`). Non-function properties (`version`, `plugin`) pass through.
- `createHostApiImpl` wraps the reshaped `HostApi` in `governHostApi(hostApi, new BridgeGovernor())` before returning it to the frame.

A method's return value is not re-wrapped, so a Comlink-proxied sub-API returned from a call (e.g. `collections(name)`) keeps its own transport; metering that surface is a noted follow-up.

## Verification

- SDK: `type-check` + `lint` clean
- Frontend: `type-check` clean, `eslint` on the changed file clean
- Iframe-side runtime untouched (host-side change only), no `runtime.js` drift