### PR TITLE
plugins(sandbox): fix api.on event subscription across the bridge

### DIFF
--- a/backend/src/handlers/plugin_sandbox/runtime.js
+++ b/backend/src/handlers/plugin_sandbox/runtime.js
@@ -323,6 +323,47 @@ function generateUUID() {
 }
 
 // ../plugin-sdk/src/connect.ts
+function wrapEvents(remote) {
+  const local = /* @__PURE__ */ new Map();
+  const remoteUnsub = /* @__PURE__ */ new Map();
+  const dispatch = (event, data) => {
+    const set = local.get(event);
+    if (!set) return;
+    for (const h of [...set]) {
+      try {
+        void h(data);
+      } catch {
+      }
+    }
+  };
+  const on = async (event, handler) => {
+    let set = local.get(event);
+    if (!set) {
+      set = /* @__PURE__ */ new Set();
+      local.set(event, set);
+      remoteUnsub.set(event, remote.on(event, proxy((d) => dispatch(event, d))));
+    }
+    set.add(handler);
+    return () => {
+      const s = local.get(event);
+      if (!s) return;
+      s.delete(handler);
+      if (s.size === 0) {
+        local.delete(event);
+        const unsubP = remoteUnsub.get(event);
+        remoteUnsub.delete(event);
+        void unsubP?.then((fn) => fn()).catch(() => {
+        });
+      }
+    };
+  };
+  return new Proxy(remote, {
+    get(target, prop, receiver) {
+      if (prop === "on") return on;
+      return Reflect.get(target, prop, receiver);
+    }
+  });
+}
 function connectToHost() {
   return new Promise((resolve) => {
     const listeners = /* @__PURE__ */ new Set();
@@ -334,7 +375,7 @@ function connectToHost() {
       if (!connected && data.type === "nosdesk-plugin-init" && event.ports[0]) {
         connected = true;
         context = data.context;
-        const api = wrap(event.ports[0]);
+        const api = wrapEvents(wrap(event.ports[0]));
         resolve({
           api,
           context,

--- a/packages/plugin-sdk/src/connect.ts
+++ b/packages/plugin-sdk/src/connect.ts
@@ -1,6 +1,6 @@
 import * as Comlink from 'comlink';
 
-import type { HostApi, PluginContext } from './types';
+import type { HostApi, PluginHostApi, PluginContext, PluginEvent, PluginEventHandler } from './types';
 
 /** Protocol messages the host posts to the plugin iframe's `contentWindow`. */
 interface HostInitMessage {
@@ -14,13 +14,73 @@ interface HostContextMessage {
 
 /** The ready plugin runtime handed to a plugin's `mount`. */
 export interface PluginRuntime {
-  /** The host API, proxied over the bridge (every call is a round-trip). */
-  api: Comlink.Remote<HostApi>;
+  /** The host API, proxied over the bridge (every call is a round-trip). `on` is
+   * handled locally, see `wrapEvents`. */
+  api: PluginHostApi;
   /** The context snapshot at connect time. */
   context: PluginContext;
   /** Subscribe to context snapshots the host pushes after connect; returns an
    * unsubscribe. */
   onContextChange(cb: (ctx: PluginContext) => void): () => void;
+}
+
+/**
+ * Wrap the Comlink-remote host API so `api.on(event, handler)` works with a plain
+ * plugin callback. A separately-bundled plugin can't hand a working Comlink-proxy
+ * callback across the bridge — Comlink's `proxyMarker` is a per-module `Symbol`,
+ * so the plugin's proxy marker differs from the marker the runtime's `api`
+ * (`Comlink.wrap`) recognizes, and the handler fails to structured-clone
+ * (`DataCloneError`). So instead: keep the plugin's handlers LOCAL to the iframe,
+ * and register a single dispatcher per event with the host, proxied with THIS
+ * module's Comlink (the same instance that wrapped the port, so the marker
+ * matches). The host calls that one dispatcher; we fan out to local handlers.
+ * Every other member passes straight through to the remote.
+ */
+function wrapEvents(remote: Comlink.Remote<HostApi>): PluginHostApi {
+  const local = new Map<PluginEvent, Set<PluginEventHandler>>();
+  const remoteUnsub = new Map<PluginEvent, Promise<() => Promise<void>>>();
+
+  const dispatch = (event: PluginEvent, data: unknown): void => {
+    const set = local.get(event);
+    if (!set) return;
+    // Copy so a handler that unsubscribes mid-dispatch doesn't skip the next.
+    for (const h of [...set]) {
+      try {
+        void h(data);
+      } catch {
+        // Isolate one handler's failure from the others.
+      }
+    }
+  };
+
+  const on = async (event: PluginEvent, handler: PluginEventHandler): Promise<() => void> => {
+    let set = local.get(event);
+    if (!set) {
+      set = new Set();
+      local.set(event, set);
+      remoteUnsub.set(event, remote.on(event, Comlink.proxy((d: unknown) => dispatch(event, d))));
+    }
+    set.add(handler);
+    return () => {
+      const s = local.get(event);
+      if (!s) return;
+      s.delete(handler);
+      if (s.size === 0) {
+        local.delete(event);
+        const unsubP = remoteUnsub.get(event);
+        remoteUnsub.delete(event);
+        // Fire-and-forget the host-side unsubscribe.
+        void unsubP?.then((fn) => fn()).catch(() => {});
+      }
+    };
+  };
+
+  return new Proxy(remote, {
+    get(target, prop, receiver) {
+      if (prop === 'on') return on;
+      return Reflect.get(target, prop, receiver);
+    },
+  }) as unknown as PluginHostApi;
 }
 
 /**
@@ -49,7 +109,7 @@ export function connectToHost(): Promise<PluginRuntime> {
       if (!connected && data.type === 'nosdesk-plugin-init' && event.ports[0]) {
         connected = true;
         context = data.context;
-        const api = Comlink.wrap<HostApi>(event.ports[0]);
+        const api = wrapEvents(Comlink.wrap<HostApi>(event.ports[0]));
         resolve({
           api,
           context,
@@ -70,8 +130,9 @@ export function connectToHost(): Promise<PluginRuntime> {
   });
 }
 
-/** Re-export so a plugin can wrap its own callbacks (e.g. for `api.on`) when it
- * needs to pass a function across the bridge. */
+/** Re-export of Comlink's `proxy`. Plugins do NOT need this for `api.on` (the
+ * runtime proxies that callback for them); kept for advanced cases where a plugin
+ * itself hands a function across the bridge. */
 export const proxy = Comlink.proxy;
 
 /**

--- a/packages/plugin-sdk/src/index.ts
+++ b/packages/plugin-sdk/src/index.ts
@@ -23,6 +23,7 @@ export type { GovernorOptions } from './governor';
 
 export type {
   HostApi,
+  PluginHostApi,
   PluginContext,
   PluginModule,
   PluginInstance,

--- a/packages/plugin-sdk/src/types.ts
+++ b/packages/plugin-sdk/src/types.ts
@@ -7,7 +7,9 @@
 //   - `fetch` returns a plain object, not a live `Response`.
 //   - `context` is a snapshot passed to `mount` (+ `onContextChange`), not a
 //     live reactive getter.
-//   - `on(...)`'s handler is a callback wrapped by the SDK with Comlink.proxy.
+//   - `on(...)` takes a plain handler; the runtime keeps it local and proxies
+//     the bridge callback itself (see `PluginHostApi`), so plugins never touch
+//     Comlink.proxy.
 //   - the host-internal `_setContext` / `_getEventHandlers` are not exposed.
 //
 // Domain types are re-exported from `@nosdesk/core/types` so plugin authors
@@ -148,6 +150,19 @@ export interface HostApi {
   ui: { isPrinting(): Promise<boolean> };
 }
 
+/**
+ * The host API as a plugin actually receives it in `mount`. Identical to the
+ * Comlink-remote `HostApi` except for `on`: the runtime intercepts it, keeps the
+ * handler local to the iframe, and registers its own Comlink-proxied dispatcher
+ * with the host. That's what makes events work at all — a plugin's own bundled
+ * Comlink has a different `proxyMarker` than the runtime's `api`, so a
+ * plugin-proxied callback can't cross the bridge (it fails to structured-clone).
+ * With this, the plugin just passes a plain function and gets back an
+ * unsubscribe. */
+export type PluginHostApi = Omit<import('comlink').Remote<HostApi>, 'on'> & {
+  on(event: PluginEvent, handler: PluginEventHandler): Promise<() => void>;
+};
+
 /** The host-provided context, snapshotted into the iframe. It is not a live
  * object (it can't cross postMessage reactively); updates arrive via
  * `onContextChange`. */
@@ -177,7 +192,7 @@ export interface PluginInstance {
  * for a simple plugin (re-mounted on context change), or a `PluginInstance` to
  * handle context updates in place. */
 export interface PluginModule {
-  mount(rootEl: HTMLElement, api: import('comlink').Remote<HostApi>, context: PluginContext):
+  mount(rootEl: HTMLElement, api: PluginHostApi, context: PluginContext):
     | void
     | (() => void)
     | PluginInstance;


### PR DESCRIPTION
## Problem

A sandboxed plugin calling `api.on('ticket:updated', handler)` threw:

```
DataCloneError: Failed to execute 'postMessage' on 'MessagePort': () => {…} could not be cloned
```

Comlink's `proxyMarker` is a **per-module** `Symbol("Comlink.proxy")`. A plugin bundles its own Comlink, so its `proxy()` marks the callback with a *different* symbol than the runtime's `api` (`Comlink.wrap`) recognizes — the handler falls through to `structuredClone` and throws. Net: a real sandboxed plugin could not subscribe to events at all. (Surfaced by the combined live reverification of the sandbox arc.)

## Fix

Entirely iframe-side, in the SDK/runtime — no host change, no security-posture change:

`wrapEvents` (in `connect.ts`) wraps the Comlink-remote host API so `api.on` is intercepted:
- the plugin's handlers stay **local** to the iframe;
- one dispatcher per event is registered with the host, proxied with the **runtime's own Comlink** (the same instance that wrapped the port, so the marker matches the serializer);
- the host calls that single dispatcher; the runtime fans out to the local handlers;
- every other `api` member passes straight through to the remote.

Plugins now pass a **plain function** (`api.on(event, fn)`); the exported `proxy` is no longer needed for `on`. New `PluginHostApi` type (`Remote<HostApi>` with a local-handler `on`) is what `mount` receives.

## Verification (local orbstack, driver plugin)

- `api.on('ticket:updated', plainFn)` now resolves cleanly — **no DataCloneError** (was the bug).
- Manually firing the dispatcher shows `liveInstances=1 handlers=1` and the plugin's handler runs across the bridge (counter increments) — the full leg dispatcher → `inproc` → Comlink → plugin handler works.
- SDK type-check + lint clean; frontend type-check clean; `runtime.js` rebuilt and drift-check deterministic.

Note: end-to-end auto-delivery also depends on `onSyncActions` (the sync-stream → dispatcher feed that drives the activity feed / dashboard); that pre-existing leg is unchanged by this fix.