### PR TITLE
plugins: consented_permissions authoritative + re-consent on scope widening

### DIFF
--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -5900,6 +5900,22 @@ impl Plugin {
             .and_then(|v| serde_json::from_value::<Vec<String>>(v.clone()).ok())
             .unwrap_or_default()
     }
+
+    /// The effective granted permission set for runtime enforcement: the recorded
+    /// consented set when consent exists, else (legacy rows installed before the
+    /// consent gate) the manifest's requested set. Empty on a manifest parse
+    /// failure — fail closed. `consented_permissions == Some([])` is an explicit
+    /// grant of nothing, distinct from `None` (no consent recorded), so the
+    /// fallback keys off `is_none()`, not emptiness.
+    pub fn effective_permission_set(&self) -> Vec<String> {
+        match &self.consented_permissions {
+            Some(v) => serde_json::from_value::<Vec<String>>(v.clone()).unwrap_or_default(),
+            None => self
+                .parse_manifest()
+                .map(|m| m.permissions.iter().map(|p| p.as_string()).collect())
+                .unwrap_or_default(),
+        }
+    }
 }
 
 /// Lifecycle state of a plugin row. Stored as a `VARCHAR(32)` in
@@ -6052,6 +6068,12 @@ pub struct PluginUpdate {
     /// fields' `Option<T>` because clearing-to-NULL on update is
     /// realistic here (a new plugin version might drop its icon).
     pub icon_svg: Option<Option<Vec<u8>>>,
+    /// Consent bookkeeping, kept in lockstep with the served manifest by the
+    /// update path. `None` leaves the column alone (used when an update requires
+    /// re-consent — the admin's approval re-records it against the new manifest).
+    pub consented_permissions: Option<serde_json::Value>,
+    pub consented_at: Option<NaiveDateTime>,
+    pub consented_by: Option<Uuid>,
 }
 
 /// Plugin bundle update changeset. `bundle_js` carries the raw
@@ -6629,6 +6651,11 @@ pub struct PluginResponse {
     pub bundle_size: Option<i32>,
     pub bundle_uploaded_at: Option<NaiveDateTime>,
     pub source: String,
+    /// The permission set the admin consented to, as a string array. `None` for
+    /// legacy rows installed before the consent gate (the frontend then falls
+    /// back to the manifest's requested set). This is the AUTHORITATIVE grant the
+    /// UI + runtime gate against, not `manifest.permissions`.
+    pub consented_permissions: Option<Vec<String>>,
     /// When non-null, the publisher that signed this plugin has been
     /// revoked from `plugin_trusted_publishers`. The plugin keeps
     /// running (we don't tear down installed rows on revocation),
@@ -6668,6 +6695,9 @@ impl TryFrom<Plugin> for PluginResponse {
             bundle_size: p.bundle_size,
             bundle_uploaded_at: p.bundle_uploaded_at,
             source: p.source,
+            consented_permissions: p
+                .consented_permissions
+                .and_then(|v| serde_json::from_value::<Vec<String>>(v).ok()),
             // Default to None; handlers enrich via a separate
             // revocation map lookup so the conversion stays
             // dependency-free and the bulk list endpoint can resolve

--- a/backend/src/services/plugins/install.rs
+++ b/backend/src/services/plugins/install.rs
@@ -479,12 +479,21 @@ fn update_row(
         Some(icon_bytes.clone())
     };
 
+    // Re-consent gate: an update that widens the requested permission scope
+    // beyond what was consented must be re-approved by an admin before it serves
+    // again (untrusted tiers). Trusted tiers (official / local) auto-consent to
+    // the new scope, matching install-time behaviour. Computed against the
+    // pre-update effective grant.
+    let old_effective = existing.effective_permission_set();
+    let new_perms: Vec<String> = manifest.permissions.iter().map(|p| p.as_string()).collect();
+    let needs_reconsent = reconsent_required(&old_effective, &new_perms, &signer.trust_level);
+
     let update = PluginUpdate {
         display_name: Some(manifest.display_name.clone()),
         version: Some(manifest.version.clone()),
         description: manifest.description.clone(),
         manifest: Some(manifest_json),
-        // State changes flow through `lifecycle::apply` (above);
+        // State changes flow through `lifecycle::apply` (above / below);
         // never write `state` directly from the install path.
         state: None,
         trust_level: Some(signer.trust_level.clone()),
@@ -492,12 +501,37 @@ fn update_row(
         signer_source: signer.signer_source.clone(),
         signature_metadata: signer.signature_metadata.clone(),
         icon_svg: icon_update,
+        // Keep the consented set authoritative + in lockstep with the served
+        // manifest on an auto-consented or non-widening update. When re-consent
+        // is required, leave it at the prior scope (the admin's approval
+        // re-records it) and transition to AwaitingConsent below.
+        consented_permissions: (!needs_reconsent).then(|| serde_json::json!(new_perms)),
+        consented_at: (!needs_reconsent).then(|| Utc::now().naive_utc()),
+        consented_by: if needs_reconsent { None } else { installed_by },
     };
-    Ok(plugin_repo::update_plugin_by_uuid(
-        conn,
-        existing.uuid,
-        update,
-    )?)
+    let updated = plugin_repo::update_plugin_by_uuid(conn, existing.uuid, update)?;
+
+    if needs_reconsent {
+        use crate::services::plugins::lifecycle::{apply, ActionError, PluginAction};
+        // Installed / Disabled -> AwaitingConsent: stop serving the widened scope
+        // until an admin re-approves. Atomic within the outer install txn.
+        match apply(
+            conn,
+            existing.uuid,
+            PluginAction::RequireReconsent,
+            installed_by,
+        ) {
+            Ok(_) => {}
+            Err(ActionError::Db(e)) => return Err(InstallError::Db(e)),
+            Err(e) => {
+                return Err(InstallError::InvalidManifest(format!(
+                    "re-consent transition failed: {e}"
+                )))
+            }
+        }
+        return Ok(plugin_repo::get_plugin_by_uuid(conn, existing.uuid)?);
+    }
+    Ok(updated)
 }
 
 /// Untrusted tiers require a workspace admin to consent to the requested scope
@@ -506,6 +540,16 @@ fn update_row(
 /// CLI-installed (they saw the manifest, higher privilege).
 fn tier_requires_consent(trust_level: &str) -> bool {
     matches!(trust_level, "verified" | "community")
+}
+
+/// Whether an update from the `old_effective` grant to the `new_perms` requested
+/// scope on a `trust_level` plugin must be re-approved by an admin before serving
+/// again. Trusted tiers (official / local) auto-consent to the new scope;
+/// untrusted tiers (verified / community) re-consent only when the scope actually
+/// widens — i.e. the update requests a permission not already granted. A same-or-
+/// narrower update keeps serving.
+fn reconsent_required(old_effective: &[String], new_perms: &[String], trust_level: &str) -> bool {
+    tier_requires_consent(trust_level) && new_perms.iter().any(|p| !old_effective.contains(p))
 }
 
 /// The manifest's requested permissions as a JSON array of strings — the shape
@@ -694,5 +738,84 @@ fn provision_settings_from_env(
             settings_count,
             plugin.name
         );
+    }
+}
+
+#[cfg(test)]
+mod reconsent_tests {
+    use super::reconsent_required;
+
+    fn v(perms: &[&str]) -> Vec<String> {
+        perms.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn untrusted_tier_widening_requires_reconsent() {
+        // community/verified: a new permission not already granted re-gates.
+        assert!(reconsent_required(
+            &v(&["ticket:read"]),
+            &v(&["ticket:read", "ticket:write"]),
+            "community"
+        ));
+        assert!(reconsent_required(
+            &v(&["ticket:read"]),
+            &v(&["ticket:read", "asset:write"]),
+            "verified"
+        ));
+        // A brand-new scope on an empty prior grant widens.
+        assert!(reconsent_required(
+            &v(&[]),
+            &v(&["ticket:read"]),
+            "community"
+        ));
+    }
+
+    #[test]
+    fn untrusted_tier_same_or_narrower_keeps_serving() {
+        assert!(!reconsent_required(
+            &v(&["ticket:read", "ticket:write"]),
+            &v(&["ticket:read", "ticket:write"]),
+            "community"
+        ));
+        assert!(!reconsent_required(
+            &v(&["ticket:read", "ticket:write"]),
+            &v(&["ticket:read"]),
+            "community"
+        ));
+        assert!(!reconsent_required(
+            &v(&["ticket:read"]),
+            &v(&[]),
+            "verified"
+        ));
+    }
+
+    #[test]
+    fn trusted_tiers_auto_consent_even_when_widening() {
+        // official/local never re-gate — they auto-consent to the new scope.
+        assert!(!reconsent_required(
+            &v(&["ticket:read"]),
+            &v(&["ticket:read", "ticket:delete"]),
+            "official"
+        ));
+        assert!(!reconsent_required(
+            &v(&[]),
+            &v(&["ticket:write", "network:example.com"]),
+            "local"
+        ));
+    }
+
+    #[test]
+    fn network_permissions_compared_verbatim() {
+        // A different host is a distinct permission string, so it widens.
+        assert!(reconsent_required(
+            &v(&["network:a.com"]),
+            &v(&["network:a.com", "network:b.com"]),
+            "community"
+        ));
+        assert!(!reconsent_required(
+            &v(&["network:a.com"]),
+            &v(&["network:a.com"]),
+            "community"
+        ));
     }
 }

--- a/backend/src/services/plugins/lifecycle.rs
+++ b/backend/src/services/plugins/lifecycle.rs
@@ -76,6 +76,13 @@ pub enum PluginAction {
     /// the action is refused with `SignerMismatch` to prevent
     /// cross-publisher data inheritance.
     Reinstall { signer_pubkey: Option<String> },
+    /// An update widened the plugin's requested permission scope
+    /// beyond what was consented, so it must be re-approved by an
+    /// admin before serving again. From `Installed` or `Disabled`.
+    /// Set by the install/update path (not user-initiated); the
+    /// widened manifest is already written, `consented_permissions`
+    /// stays at the prior scope until the admin re-consents.
+    RequireReconsent,
 }
 
 impl PluginAction {
@@ -88,6 +95,7 @@ impl PluginAction {
             Self::UninstallPreserve => "UninstallPreserve",
             Self::UninstallCascade => "UninstallCascade",
             Self::Reinstall { .. } => "Reinstall",
+            Self::RequireReconsent => "RequireReconsent",
         }
     }
 }
@@ -293,6 +301,17 @@ pub fn apply(
                 })
             }
 
+            // ----- Re-consent required (scope-widening update) -----
+            (PluginState::Installed, PluginAction::RequireReconsent)
+            | (PluginState::Disabled, PluginAction::RequireReconsent) => {
+                let updated = set_state(tx, plugin_uuid, PluginState::AwaitingConsent)?;
+                log_lifecycle(tx, &updated, &action, prior, actor)?;
+                Ok(ActionOutcome::StateChanged {
+                    plugin: updated,
+                    prior_state: prior,
+                })
+            }
+
             // ----- Everything else is a refused transition -----
             (from, action) => Err(ActionError::InvalidTransition {
                 from,
@@ -400,6 +419,8 @@ mod tests {
             (PluginState::Quarantined, "UninstallCascade"),
             (PluginState::Uninstalled, "UninstallCascade"),
             (PluginState::Uninstalled, "Reinstall"),
+            (PluginState::Installed, "RequireReconsent"),
+            (PluginState::Disabled, "RequireReconsent"),
         ]
     }
 
@@ -416,6 +437,7 @@ mod tests {
             PluginAction::Reinstall {
                 signer_pubkey: Some("pk".into()),
             },
+            PluginAction::RequireReconsent,
         ]
     }
 

--- a/frontend/src/plugins/api.ts
+++ b/frontend/src/plugins/api.ts
@@ -92,7 +92,14 @@ export interface PluginFetchOptions extends Omit<RequestInit, 'body'> {
  * The API is sandboxed - each plugin gets its own instance with access only to what it's permitted.
  */
 export function createPluginAPI(plugin: Plugin): PluginAPI {
-  const permissions = new Set<string>(plugin.manifest.permissions);
+  // The effective grant is the CONSENTED set, not the raw manifest — an admin
+  // may have approved a narrower scope, and the manifest can widen on update
+  // ahead of re-consent. Fall back to the manifest only for legacy rows with no
+  // consent recorded (`consented_permissions === null`). This mirrors the
+  // backend's `Plugin::effective_permission_set`.
+  const permissions = new Set<string>(
+    plugin.consented_permissions ?? plugin.manifest.permissions,
+  );
   const eventHandlers = new Map<PluginEvent, EventHandler[]>();
 
   // Typed permission check. Accepts non-network permissions

--- a/packages/core/src/types/plugin.ts
+++ b/packages/core/src/types/plugin.ts
@@ -266,6 +266,10 @@ export interface Plugin {
    * loader treats only `installed` as a serving-eligible state. */
   state: PluginState;
   trust_level: PluginTrustLevel;
+  /** The permission set the admin consented to — the AUTHORITATIVE grant the
+   *  runtime gates against, not `manifest.permissions`. `null` for legacy rows
+   *  installed before the consent gate (callers fall back to the manifest set). */
+  consented_permissions: string[] | null;
   source: PluginSource;
   installed_by: string | null;
   installed_at: string;


### PR DESCRIPTION
Phase 1 of the plugin-system hardening (design: keystone in the audit). Closes two of the convergent HIGH findings.

## Problem
The consent record was decorative. Runtime permission checks read the **live manifest** (`consented_permission_set()` had zero callers), and `install.rs update_row` rewrote the manifest with `state: None` — so a same-signer update could **widen a plugin's scope with no admin re-approval**, and the consented set was never the effective grant.

## Change
- **`Plugin::effective_permission_set()`** — the recorded consented set when present, else (legacy rows installed before the consent gate) the manifest set; empty on parse failure (fail closed). Frontend `api.ts` now gates on `consented_permissions ?? manifest`, mirroring it. `consented_permissions` is exposed on `PluginResponse` + the frontend `Plugin` type.
- **Re-consent on widening** (`update_row`): `reconsent_required(old_effective, new_perms, trust_level)` — an update that requests a permission not already granted, on an untrusted tier (verified/community), transitions the plugin to `AwaitingConsent` (new `PluginAction::RequireReconsent`) until an admin re-approves. Trusted tiers (official/local) auto-consent to the new scope. Every non-re-consent update keeps `consented_permissions` in lockstep with the served manifest, so the consented set is authoritative at runtime.
- The re-consent UI is free: an `AwaitingConsent` plugin already renders the consent banner + permission list + Approve (from the consent-UI increment), now showing the widened scope.

## Verification
- `reconsent_required` unit tests: widen/narrow/same × community/verified/official/local, plus verbatim `network:<host>` comparison — 4 tests, green.
- Lifecycle transition-table consistency test updated for `RequireReconsent` — green.
- `cargo check --all-targets`, `cargo clippy --lib` (0 warnings), frontend + core type-check + eslint clean.

Next increment: server-side enforcement of the consented set on plugin-owned endpoints (storage/collections/proxy/events).