### PR TITLE
plugins: enforce consented permissions server-side on storage + collections

### DIFF
--- a/backend/src/handlers/plugin_collections.rs
+++ b/backend/src/handlers/plugin_collections.rs
@@ -10,13 +10,13 @@ use uuid::Uuid;
 use crate::extractors::TenantConn;
 use crate::handlers::errors;
 use crate::handlers::helpers;
+use crate::handlers::plugins::{authorize_plugin_data_request, PluginGate};
 use crate::models::{
     Claims, CollectionListResponse, CollectionQueryParams, CollectionRowResponse,
     CollectionSchemaResponse, CreateCollectionRowRequest, NewPluginCollectionRow,
     PluginCollectionRowUpdate, UpdateCollectionRowRequest,
 };
 use crate::repository::plugin_collections as collection_repo;
-use crate::repository::plugins as plugin_repo;
 use crate::services::plugins::validation;
 use crate::utils::i18n;
 use crate::utils::locale::request_locale;
@@ -52,7 +52,7 @@ fn get_claims(req: &HttpRequest) -> Result<Claims, HttpResponse> {
 /// internal error without leaking HttpResponse into the txn closure.
 enum SchemaLookup {
     Ok(crate::models::PluginCollectionSchema, crate::models::Plugin),
-    PluginNotFound,
+    Gate(PluginGate),
     CollectionNotFound,
 }
 
@@ -75,14 +75,18 @@ pub async fn list_collections(
 
     enum ListOutcome {
         Ok(Vec<CollectionSchemaResponse>),
-        PluginNotFound,
+        Gate(PluginGate),
     }
 
     let outcome = tc.run(|conn| {
-        let plugin = match plugin_repo::get_plugin_by_uuid(conn, plugin_uuid) {
+        let plugin = match authorize_plugin_data_request(
+            conn,
+            plugin_uuid,
+            "collection:read",
+            "Plugin has not been granted collection access",
+        )? {
             Ok(p) => p,
-            Err(DieselError::NotFound) => return Ok(ListOutcome::PluginNotFound),
-            Err(e) => return Err(e),
+            Err(gate) => return Ok(ListOutcome::Gate(gate)),
         };
 
         let schemas = collection_repo::get_schemas_by_plugin(conn, plugin.id)?;
@@ -106,7 +110,7 @@ pub async fn list_collections(
 
     match outcome {
         Ok(ListOutcome::Ok(resp)) => HttpResponse::Ok().json(resp),
-        Ok(ListOutcome::PluginNotFound) => errors::not_found_msg("Plugin not found"),
+        Ok(ListOutcome::Gate(gate)) => gate.into_response(),
         Err(e) => {
             error!("Failed to list collections: {}", e);
             errors::internal("Failed to get collections")
@@ -128,10 +132,14 @@ pub async fn get_collection_schema(
     let path = path.into_inner();
 
     let outcome = tc.run(|conn| {
-        let plugin = match plugin_repo::get_plugin_by_uuid(conn, path.uuid) {
+        let plugin = match authorize_plugin_data_request(
+            conn,
+            path.uuid,
+            "collection:read",
+            "Plugin has not been granted collection access",
+        )? {
             Ok(p) => p,
-            Err(DieselError::NotFound) => return Ok(SchemaLookup::PluginNotFound),
-            Err(e) => return Err(e),
+            Err(gate) => return Ok(SchemaLookup::Gate(gate)),
         };
         let schema = match collection_repo::get_schema_by_name(conn, plugin.id, &path.name) {
             Ok(s) => s,
@@ -157,7 +165,7 @@ pub async fn get_collection_schema(
                 row_count,
             })
         }
-        Ok(SchemaLookup::PluginNotFound) => errors::not_found_msg("Plugin not found"),
+        Ok(SchemaLookup::Gate(gate)) => gate.into_response(),
         Ok(SchemaLookup::CollectionNotFound) => errors::not_found_msg("Collection not found"),
         Err(e) => {
             error!("Failed to get collection schema: {}", e);
@@ -196,15 +204,19 @@ pub async fn list_collection_rows(
 
     enum RowsOutcome {
         Ok(Vec<crate::models::PluginCollectionRow>, i64),
-        PluginNotFound,
+        Gate(PluginGate),
         CollectionNotFound,
     }
 
     let outcome = tc.run(|conn| {
-        let plugin = match plugin_repo::get_plugin_by_uuid(conn, path.uuid) {
+        let plugin = match authorize_plugin_data_request(
+            conn,
+            path.uuid,
+            "collection:read",
+            "Plugin has not been granted collection access",
+        )? {
             Ok(p) => p,
-            Err(DieselError::NotFound) => return Ok(RowsOutcome::PluginNotFound),
-            Err(e) => return Err(e),
+            Err(gate) => return Ok(RowsOutcome::Gate(gate)),
         };
         let schema = match collection_repo::get_schema_by_name(conn, plugin.id, &path.name) {
             Ok(s) => s,
@@ -228,7 +240,7 @@ pub async fn list_collection_rows(
             rows: rows.into_iter().map(CollectionRowResponse::from).collect(),
             total,
         }),
-        Ok(RowsOutcome::PluginNotFound) => errors::not_found_msg("Plugin not found"),
+        Ok(RowsOutcome::Gate(gate)) => gate.into_response(),
         Ok(RowsOutcome::CollectionNotFound) => errors::not_found_msg("Collection not found"),
         Err(e) => {
             error!("Failed to list collection rows: {}", e);
@@ -256,16 +268,20 @@ pub async fn create_collection_row(
 
     enum CreateOutcome {
         Ok(crate::models::PluginCollectionRow),
-        PluginNotFound,
+        Gate(PluginGate),
         CollectionNotFound,
         ValidationError(String),
     }
 
     let outcome = tc.run(|conn| {
-        let plugin = match plugin_repo::get_plugin_by_uuid(conn, path.uuid) {
+        let plugin = match authorize_plugin_data_request(
+            conn,
+            path.uuid,
+            "collection:write",
+            "Plugin has not been granted collection write access",
+        )? {
             Ok(p) => p,
-            Err(DieselError::NotFound) => return Ok(CreateOutcome::PluginNotFound),
-            Err(e) => return Err(e),
+            Err(gate) => return Ok(CreateOutcome::Gate(gate)),
         };
         let schema = match collection_repo::get_schema_by_name(conn, plugin.id, &path.name) {
             Ok(s) => s,
@@ -296,7 +312,7 @@ pub async fn create_collection_row(
         Ok(CreateOutcome::Ok(row)) => {
             HttpResponse::Created().json(CollectionRowResponse::from(row))
         }
-        Ok(CreateOutcome::PluginNotFound) => errors::not_found_msg("Plugin not found"),
+        Ok(CreateOutcome::Gate(gate)) => gate.into_response(),
         Ok(CreateOutcome::CollectionNotFound) => errors::not_found_msg("Collection not found"),
         Ok(CreateOutcome::ValidationError(msg)) => {
             HttpResponse::BadRequest().json(serde_json::json!({
@@ -327,15 +343,19 @@ pub async fn get_collection_row(
 
     enum GetOutcome {
         Ok(crate::models::PluginCollectionRow),
-        PluginNotFound,
+        Gate(PluginGate),
         RowNotFound,
     }
 
     let outcome = tc.run(|conn| {
-        match plugin_repo::get_plugin_by_uuid(conn, path.uuid) {
+        match authorize_plugin_data_request(
+            conn,
+            path.uuid,
+            "collection:read",
+            "Plugin has not been granted collection access",
+        )? {
             Ok(_) => {}
-            Err(DieselError::NotFound) => return Ok(GetOutcome::PluginNotFound),
-            Err(e) => return Err(e),
+            Err(gate) => return Ok(GetOutcome::Gate(gate)),
         }
         match collection_repo::get_row_by_uuid(conn, path.row_uuid) {
             Ok(row) => Ok::<_, DieselError>(GetOutcome::Ok(row)),
@@ -346,7 +366,7 @@ pub async fn get_collection_row(
 
     match outcome {
         Ok(GetOutcome::Ok(row)) => HttpResponse::Ok().json(CollectionRowResponse::from(row)),
-        Ok(GetOutcome::PluginNotFound) => errors::not_found_msg("Plugin not found"),
+        Ok(GetOutcome::Gate(gate)) => gate.into_response(),
         Ok(GetOutcome::RowNotFound) => errors::not_found_msg("Row not found"),
         Err(e) => {
             error!("Failed to get collection row: {}", e);
@@ -373,17 +393,21 @@ pub async fn update_collection_row(
 
     enum UpdateOutcome {
         Ok(crate::models::PluginCollectionRow),
-        PluginNotFound,
+        Gate(PluginGate),
         CollectionNotFound,
         RowNotFound,
         ValidationError(String),
     }
 
     let outcome = tc.run(|conn| {
-        let plugin = match plugin_repo::get_plugin_by_uuid(conn, path.uuid) {
+        let plugin = match authorize_plugin_data_request(
+            conn,
+            path.uuid,
+            "collection:write",
+            "Plugin has not been granted collection write access",
+        )? {
             Ok(p) => p,
-            Err(DieselError::NotFound) => return Ok(UpdateOutcome::PluginNotFound),
-            Err(e) => return Err(e),
+            Err(gate) => return Ok(UpdateOutcome::Gate(gate)),
         };
         let schema = match collection_repo::get_schema_by_name(conn, plugin.id, &path.name) {
             Ok(s) => s,
@@ -413,7 +437,7 @@ pub async fn update_collection_row(
 
     match outcome {
         Ok(UpdateOutcome::Ok(row)) => HttpResponse::Ok().json(CollectionRowResponse::from(row)),
-        Ok(UpdateOutcome::PluginNotFound) => errors::not_found_msg("Plugin not found"),
+        Ok(UpdateOutcome::Gate(gate)) => gate.into_response(),
         Ok(UpdateOutcome::CollectionNotFound) => errors::not_found_msg("Collection not found"),
         Ok(UpdateOutcome::RowNotFound) => errors::not_found_msg("Row not found"),
         Ok(UpdateOutcome::ValidationError(msg)) => {
@@ -445,15 +469,19 @@ pub async fn delete_collection_row(
 
     enum DeleteOutcome {
         Deleted,
-        PluginNotFound,
+        Gate(PluginGate),
         RowNotFound,
     }
 
     let outcome = tc.run(|conn| {
-        match plugin_repo::get_plugin_by_uuid(conn, path.uuid) {
+        match authorize_plugin_data_request(
+            conn,
+            path.uuid,
+            "collection:write",
+            "Plugin has not been granted collection write access",
+        )? {
             Ok(_) => {}
-            Err(DieselError::NotFound) => return Ok(DeleteOutcome::PluginNotFound),
-            Err(e) => return Err(e),
+            Err(gate) => return Ok(DeleteOutcome::Gate(gate)),
         }
         match collection_repo::delete_row(conn, path.row_uuid)? {
             n if n > 0 => Ok::<_, DieselError>(DeleteOutcome::Deleted),
@@ -463,7 +491,7 @@ pub async fn delete_collection_row(
 
     match outcome {
         Ok(DeleteOutcome::Deleted) => HttpResponse::NoContent().finish(),
-        Ok(DeleteOutcome::PluginNotFound) => errors::not_found_msg("Plugin not found"),
+        Ok(DeleteOutcome::Gate(gate)) => gate.into_response(),
         Ok(DeleteOutcome::RowNotFound) => errors::not_found_msg("Row not found"),
         Err(e) => {
             error!("Failed to delete collection row: {}", e);

--- a/backend/src/handlers/plugins.rs
+++ b/backend/src/handlers/plugins.rs
@@ -846,6 +846,60 @@ pub async fn delete_plugin_setting(
 }
 
 // =============================================================================
+// Plugin-owned data authorization gate
+// =============================================================================
+
+/// Refusal from [`authorize_plugin_data_request`], each mapping to the right
+/// HTTP status. Keeps the load + Installed + consented-permission gate in one
+/// place for the plugin-owned data endpoints (storage, collections).
+pub enum PluginGate {
+    /// No such plugin in this workspace (RLS-scoped).
+    NotFound,
+    /// The plugin exists but isn't Installed (disabled / quarantined / awaiting
+    /// consent) — its data surface is closed.
+    Inactive,
+    /// The plugin is active but its consented grant doesn't include the needed
+    /// permission.
+    Forbidden(&'static str),
+}
+
+impl PluginGate {
+    pub fn into_response(self) -> HttpResponse {
+        match self {
+            PluginGate::NotFound => errors::not_found_msg("Plugin not found"),
+            PluginGate::Inactive => errors::forbidden("Plugin is not active"),
+            PluginGate::Forbidden(msg) => errors::forbidden(msg),
+        }
+    }
+}
+
+/// Load a plugin and authorize a plugin-owned data request: it must exist (under
+/// workspace RLS), be Installed, and have `needed` in its effective (consented)
+/// grant. The outer `Result` is the DB error channel (propagate with `?`); the
+/// inner is the authorization decision — callers fold `Err(gate)` into their own
+/// outcome enum and render it with `gate.into_response()`. This is the
+/// server-side boundary: `api.ts`'s check is defense-in-depth, not the gate.
+pub fn authorize_plugin_data_request(
+    conn: &mut crate::db::DbConnection,
+    plugin_uuid: Uuid,
+    needed: &str,
+    denied_msg: &'static str,
+) -> Result<Result<crate::models::Plugin, PluginGate>, DieselError> {
+    let plugin = match plugin_repo::get_plugin_by_uuid(conn, plugin_uuid) {
+        Ok(p) => p,
+        Err(DieselError::NotFound) => return Ok(Err(PluginGate::NotFound)),
+        Err(e) => return Err(e),
+    };
+    if !plugin.is_active() {
+        return Ok(Err(PluginGate::Inactive));
+    }
+    if !plugin.has_effective_permission(needed) {
+        return Ok(Err(PluginGate::Forbidden(denied_msg)));
+    }
+    Ok(Ok(plugin))
+}
+
+// =============================================================================
 // Plugin Storage Handlers (for plugin runtime use)
 // =============================================================================
 
@@ -864,20 +918,20 @@ pub async fn get_plugin_storage(
     enum StorageOutcome {
         Ok(crate::models::PluginData),
         Empty,
-        PluginNotFound,
-        PluginDisabled,
+        Gate(PluginGate),
     }
 
     let key_for_closure = key.clone();
     let outcome = tc.run(|conn| {
-        let plugin = match plugin_repo::get_plugin_by_uuid(conn, plugin_uuid) {
+        let plugin = match authorize_plugin_data_request(
+            conn,
+            plugin_uuid,
+            "storage:plugin",
+            "Plugin has not been granted storage access",
+        )? {
             Ok(p) => p,
-            Err(DieselError::NotFound) => return Ok(StorageOutcome::PluginNotFound),
-            Err(e) => return Err(e),
+            Err(gate) => return Ok(StorageOutcome::Gate(gate)),
         };
-        if !plugin.is_active() {
-            return Ok(StorageOutcome::PluginDisabled);
-        }
         match plugin_repo::get_plugin_storage_entry(conn, plugin.id, &key_for_closure) {
             Ok(entry) => Ok::<_, DieselError>(StorageOutcome::Ok(entry)),
             Err(DieselError::NotFound) => Ok(StorageOutcome::Empty),
@@ -893,8 +947,7 @@ pub async fn get_plugin_storage(
             "key": key,
             "value": null
         })),
-        Ok(StorageOutcome::PluginNotFound) => errors::not_found_msg("Plugin not found"),
-        Ok(StorageOutcome::PluginDisabled) => errors::forbidden("Plugin is disabled"),
+        Ok(StorageOutcome::Gate(gate)) => gate.into_response(),
         Err(e) => {
             error!("Failed to get plugin storage: {}", e);
             errors::internal("Failed to get storage")
@@ -918,21 +971,21 @@ pub async fn set_plugin_storage(
 
     enum StorageOutcome {
         Ok(crate::models::PluginData),
-        PluginNotFound,
-        PluginDisabled,
+        Gate(PluginGate),
     }
 
     let key = body.key.clone();
     let value = body.value.clone();
     let outcome = tc.run(|conn| {
-        let plugin = match plugin_repo::get_plugin_by_uuid(conn, plugin_uuid) {
+        let plugin = match authorize_plugin_data_request(
+            conn,
+            plugin_uuid,
+            "storage:plugin",
+            "Plugin has not been granted storage access",
+        )? {
             Ok(p) => p,
-            Err(DieselError::NotFound) => return Ok(StorageOutcome::PluginNotFound),
-            Err(e) => return Err(e),
+            Err(gate) => return Ok(StorageOutcome::Gate(gate)),
         };
-        if !plugin.is_active() {
-            return Ok(StorageOutcome::PluginDisabled);
-        }
         let entry = plugin_repo::set_plugin_storage(conn, plugin.id, key, Some(value))?;
         Ok::<_, DieselError>(StorageOutcome::Ok(entry))
     });
@@ -941,8 +994,7 @@ pub async fn set_plugin_storage(
         Ok(StorageOutcome::Ok(entry)) => {
             HttpResponse::Ok().json(PluginStorageResponse::from(entry))
         }
-        Ok(StorageOutcome::PluginNotFound) => errors::not_found_msg("Plugin not found"),
-        Ok(StorageOutcome::PluginDisabled) => errors::forbidden("Plugin is disabled"),
+        Ok(StorageOutcome::Gate(gate)) => gate.into_response(),
         Err(e) => {
             error!("Failed to set plugin storage: {}", e);
             errors::internal("Failed to set storage")
@@ -964,27 +1016,26 @@ pub async fn delete_plugin_storage(
 
     enum StorageOutcome {
         Deleted,
-        PluginNotFound,
-        PluginDisabled,
+        Gate(PluginGate),
     }
 
     let outcome = tc.run(|conn| {
-        let plugin = match plugin_repo::get_plugin_by_uuid(conn, plugin_uuid) {
+        let plugin = match authorize_plugin_data_request(
+            conn,
+            plugin_uuid,
+            "storage:plugin",
+            "Plugin has not been granted storage access",
+        )? {
             Ok(p) => p,
-            Err(DieselError::NotFound) => return Ok(StorageOutcome::PluginNotFound),
-            Err(e) => return Err(e),
+            Err(gate) => return Ok(StorageOutcome::Gate(gate)),
         };
-        if !plugin.is_active() {
-            return Ok(StorageOutcome::PluginDisabled);
-        }
         plugin_repo::delete_plugin_storage_entry(conn, plugin.id, &key)?;
         Ok::<_, DieselError>(StorageOutcome::Deleted)
     });
 
     match outcome {
         Ok(StorageOutcome::Deleted) => HttpResponse::NoContent().finish(),
-        Ok(StorageOutcome::PluginNotFound) => errors::not_found_msg("Plugin not found"),
-        Ok(StorageOutcome::PluginDisabled) => errors::forbidden("Plugin is disabled"),
+        Ok(StorageOutcome::Gate(gate)) => gate.into_response(),
         Err(e) => {
             error!("Failed to delete plugin storage: {}", e);
             errors::internal("Failed to delete storage")

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -5916,6 +5916,15 @@ impl Plugin {
                 .unwrap_or_default(),
         }
     }
+
+    /// Whether the plugin's effective (consented) grant includes `needed`. The
+    /// server-side authorization gate for plugin-owned data endpoints (storage,
+    /// collections). Exact-string match, so it's for the fixed capability
+    /// permissions (`storage:plugin`, `collection:read`, ...), not `network:*`
+    /// host patterns (the proxy enforces those against the target host).
+    pub fn has_effective_permission(&self, needed: &str) -> bool {
+        self.effective_permission_set().iter().any(|p| p == needed)
+    }
 }
 
 /// Lifecycle state of a plugin row. Stored as a `VARCHAR(32)` in

--- a/backend/tests/plugin_permission_gate.rs
+++ b/backend/tests/plugin_permission_gate.rs
@@ -1,0 +1,132 @@
+//! The plugin-owned data endpoints (storage, collections) authorize server-side
+//! against the plugin's effective (consented) permission set via
+//! `authorize_plugin_data_request` — not merely `is_active()`, and not the
+//! frontend's advisory `hasPermission`. This exercises the gate directly against
+//! seeded plugin rows: a consented permission passes, a non-consented one is
+//! Forbidden, an inactive plugin is refused even for a consented permission, and
+//! an unknown uuid is NotFound.
+
+#![allow(clippy::expect_used)]
+
+use diesel::prelude::*;
+use serde_json::json;
+use uuid::Uuid;
+
+use backend::handlers::plugins::{authorize_plugin_data_request, PluginGate};
+use backend::models::{NewPlugin, Plugin, PluginState};
+use backend::schema::plugins;
+use backend::sync::actor::ActorContext;
+use backend::sync::session::with_actor_context;
+
+mod common;
+
+fn seed_plugin(
+    conn: &mut backend::db::DbConnection,
+    ws_id: i32,
+    admin: Uuid,
+    name: &str,
+    consented: Option<Vec<&str>>,
+    state: PluginState,
+) -> Uuid {
+    let actor = ActorContext::user(admin, None).with_workspace(ws_id);
+    with_actor_context::<_, diesel::result::Error>(conn, &actor, |c| {
+        let new_plugin = NewPlugin {
+            name: name.to_string(),
+            display_name: name.to_string(),
+            version: "1.0.0".to_string(),
+            description: None,
+            manifest: json!({ "name": name, "version": "1.0.0" }),
+            state,
+            trust_level: "verified".to_string(),
+            installed_by: Some(admin),
+            source: "provisioned".to_string(),
+            signer_pubkey: None,
+            signer_source: None,
+            signature_metadata: None,
+            icon_svg: None,
+            consented_permissions: consented.map(|v| json!(v)),
+            consented_at: None,
+            consented_by: None,
+        };
+        let p: Plugin = diesel::insert_into(plugins::table)
+            .values(&new_plugin)
+            .get_result(c)?;
+        Ok(p.uuid)
+    })
+    .expect("seed plugin")
+}
+
+/// Run the gate as a handler would: pinned to the workspace (RLS), returning the
+/// authorization decision.
+fn gate(
+    conn: &mut backend::db::DbConnection,
+    ws_id: i32,
+    uuid: Uuid,
+    needed: &str,
+) -> Result<Plugin, PluginGate> {
+    let actor = ActorContext::system("test:plugin_gate").with_workspace(ws_id);
+    with_actor_context::<_, diesel::result::Error>(conn, &actor, |c| {
+        authorize_plugin_data_request(c, uuid, needed, "denied")
+    })
+    .expect("pinned gate")
+}
+
+#[test]
+fn gate_enforces_consented_scope() {
+    common::ensure_test_keyring();
+    let db = common::TestDb::new();
+    let mut conn = db.conn();
+    let ws = common::mint_workspace(&mut conn, "gate-ws", "Gate WS");
+    let admin = common::insert_user(&mut conn, "Gate Admin").uuid;
+
+    // Consented to storage:plugin + collection:read, NOT collection:write.
+    let p = seed_plugin(
+        &mut conn,
+        ws,
+        admin,
+        "gate-granted",
+        Some(vec!["storage:plugin", "collection:read"]),
+        PluginState::Installed,
+    );
+    assert!(
+        gate(&mut conn, ws, p, "storage:plugin").is_ok(),
+        "a consented permission must pass the gate"
+    );
+    assert!(
+        gate(&mut conn, ws, p, "collection:read").is_ok(),
+        "a consented permission must pass the gate"
+    );
+    assert!(
+        matches!(
+            gate(&mut conn, ws, p, "collection:write"),
+            Err(PluginGate::Forbidden(_))
+        ),
+        "a permission not in the consented set must be Forbidden"
+    );
+
+    // Disabled plugin: refused even for a consented permission.
+    let disabled = seed_plugin(
+        &mut conn,
+        ws,
+        admin,
+        "gate-disabled",
+        Some(vec!["storage:plugin"]),
+        PluginState::Disabled,
+    );
+    assert!(
+        matches!(
+            gate(&mut conn, ws, disabled, "storage:plugin"),
+            Err(PluginGate::Inactive)
+        ),
+        "a non-Installed plugin must be Inactive regardless of consent"
+    );
+
+    // Unknown uuid: NotFound (RLS-scoped).
+    assert!(
+        matches!(
+            gate(&mut conn, ws, Uuid::now_v7(), "storage:plugin"),
+            Err(PluginGate::NotFound)
+        ),
+        "an unknown plugin uuid must be NotFound"
+    );
+}


### PR DESCRIPTION
Phase 1 of the plugin hardening — the keystone's server-side half (design: `docs/plugin-enforcement-design.md`). Closes the S2 HIGH finding.

## Problem
The plugin-owned data endpoints (`/plugins/{uuid}/storage`, `/plugins/{uuid}/collections/*`) authorized on **auth + `is_active()` only**, taking a caller-supplied `{uuid}`. A workspace member could bypass the iframe and read/write **any** installed plugin's storage and collection rows, regardless of consent — the permission check lived only in `api.ts` (client side, advisory). Collections checked **neither** state nor permission.

## Change
One server-side gate, `authorize_plugin_data_request(conn, uuid, needed, denied_msg)`: the plugin must exist (under workspace RLS), be `Installed`, and have `needed` in its **effective (consented)** permission set. Returns the plugin or a `PluginGate` (`NotFound`/`Inactive`/`Forbidden`) that maps to the right HTTP status.

Wired into:
- **Storage** (get/set/delete) → `storage:plugin`
- **Collections** — reads (list/schema/list-rows/get-row) → `collection:read`; writes (create/update/delete) → `collection:write`

replacing the duplicated load + `is_active` blocks with the shared gate. This makes `consented_permissions` (authoritative since #146) the actual authorization boundary server-side, from trusted DB state rather than the forgeable client path.

Out of scope (already covered or next increment):
- **Events** already gate on `Installed` + the manifest event allowlist + a per-(workspace,plugin) rate limiter.
- **Proxy** enforces its network allowlist (== the consented set under the lockstep invariant); its confused-deputy hardening (rate-limit + audit) is the next increment (Decision 4).

## Verification
- New `Plugin::has_effective_permission()`.
- DB-backed gate test (`tests/plugin_permission_gate.rs`): consented permission passes, non-consented → `Forbidden`, disabled → `Inactive`, unknown uuid → `NotFound` — green against the real DB.
- `cargo check --all-targets`, clippy (no new warnings in changed files) clean.

Note: `api.ts` already required `collection:read/write` to use collections, so this enforces the same requirement where it counts (server-side) rather than adding a new one.