### PR TITLE
plugins: tear down disabled/quarantined plugins in every session via sync

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -37,7 +37,7 @@ const usePageTransition = !isTauriRuntime()
 import { setMentionNavigationHandler } from '@/plugins/prosemirror-mention-view'
 import authService from '@nosdesk/core/services/authService'
 import { useBrandingStore } from '@/stores/branding'
-import { loadPlugins, initializeEventDispatcher } from '@/plugins'
+import { loadPlugins, initializeEventDispatcher, startPluginLifecycleSync } from '@/plugins'
 import { useAuthStore } from '@/stores/auth'
 import { usePageActionsStore } from '@nosdesk/core/stores/pageActions'
 import { useMyWorkspacesStore } from '@/stores/myWorkspaces'
@@ -304,6 +304,7 @@ const handleCreateClick = () => {
 // Initialize plugins after authentication
 const authStore = useAuthStore();
 let eventDispatcherCleanup: (() => void) | null = null;
+let pluginLifecycleCleanup: (() => void) | null = null;
 
 // Watch auth state and load plugins when authenticated
 // immediate: true handles initial state, watch handles subsequent changes
@@ -314,6 +315,10 @@ watch(
       try {
         await loadPlugins();
         eventDispatcherCleanup = initializeEventDispatcher();
+        // Tear down / load plugins in this session as their state changes
+        // server-side (disable / quarantine / uninstall / re-enable), not just
+        // in the admin tab that flipped the state.
+        pluginLifecycleCleanup = startPluginLifecycleSync();
       } catch (error) {
         console.error('Failed to initialize plugins:', error);
       }
@@ -321,6 +326,8 @@ watch(
       // Cleanup on logout
       eventDispatcherCleanup?.();
       eventDispatcherCleanup = null;
+      pluginLifecycleCleanup?.();
+      pluginLifecycleCleanup = null;
     }
   },
   { immediate: true }

--- a/frontend/src/plugins/index.ts
+++ b/frontend/src/plugins/index.ts
@@ -8,6 +8,8 @@
 // Plugin Loader
 export {
   loadPlugins,
+  reconcileEnabledPlugins,
+  startPluginLifecycleSync,
   getSlotRegistrations,
   getLoadedPlugin,
   getLoadedPlugins,

--- a/frontend/src/plugins/loader.ts
+++ b/frontend/src/plugins/loader.ts
@@ -7,6 +7,8 @@
 
 import { ref, shallowRef, reactive, type ShallowRef } from 'vue';
 import pluginService from '@nosdesk/core/services/pluginService';
+import { onSyncActions } from '@nosdesk/core/sync/observers';
+import type { SyncAction } from '@nosdesk/core/sync/types';
 import { logger } from '@nosdesk/core/utils/logger';
 import { translate } from '@/i18n';
 import type { Plugin, PluginSlot, PluginManifest } from '@nosdesk/core/types/plugin';
@@ -222,6 +224,72 @@ export function unloadPlugin(uuid: string): void {
   }
 
   logger.info(`Unloaded plugin: ${uuid}`);
+}
+
+/**
+ * Reconcile the loaded set against the server's enabled list: unload plugins that
+ * are no longer enabled (disabled / quarantined / uninstalled) and load any newly
+ * enabled ones. `/plugins/enabled` returns only `installed` plugins, so a single
+ * refetch + diff covers every lifecycle transition. Idempotent; safe to call
+ * repeatedly.
+ */
+export async function reconcileEnabledPlugins(): Promise<void> {
+  let enabled: Plugin[];
+  try {
+    enabled = await pluginService.listEnabledPlugins();
+  } catch (error) {
+    logger.warn('Plugin reconcile: failed to fetch enabled list', { error });
+    return;
+  }
+  const enabledByUuid = new Set(enabled.map(p => p.uuid));
+
+  // Unload anything no longer enabled — this tears down its sandbox frame in
+  // EVERY open session, not just the admin tab that flipped the state, so a
+  // disabled or signer-revoked (quarantined) plugin actually stops running.
+  for (const uuid of [...loadedPlugins.value.keys()]) {
+    if (!enabledByUuid.has(uuid)) {
+      unloadPlugin(uuid);
+    }
+  }
+  // Load anything newly enabled (re-enabled or freshly installed).
+  for (const plugin of enabled) {
+    if (!loadedPlugins.value.has(plugin.uuid)) {
+      await loadPlugin(plugin);
+    }
+  }
+}
+
+const PLUGIN_LIFECYCLE_EVENTS = new Set([
+  'plugin.installed',
+  'plugin.updated',
+  'plugin.uninstalled',
+]);
+
+let lifecycleUnsub: (() => void) | null = null;
+let reconcileTimer: ReturnType<typeof setTimeout> | null = null;
+
+/**
+ * Subscribe to plugin lifecycle sync actions so every session reconciles its
+ * loaded plugins as their state changes server-side — not only the acting admin's
+ * tab. Debounced to coalesce bursts. Returns a cleanup fn; idempotent.
+ */
+export function startPluginLifecycleSync(): () => void {
+  if (lifecycleUnsub) return lifecycleUnsub;
+  const unsub = onSyncActions((actions: SyncAction[]) => {
+    if (!actions.some(a => PLUGIN_LIFECYCLE_EVENTS.has(a.event_type))) return;
+    if (reconcileTimer) clearTimeout(reconcileTimer);
+    reconcileTimer = setTimeout(() => {
+      reconcileTimer = null;
+      void reconcileEnabledPlugins();
+    }, 400);
+  });
+  lifecycleUnsub = () => {
+    unsub();
+    if (reconcileTimer) clearTimeout(reconcileTimer);
+    reconcileTimer = null;
+    lifecycleUnsub = null;
+  };
+  return lifecycleUnsub;
 }
 
 /**


### PR DESCRIPTION
Phase 1 — the disable/quarantine live-session teardown (audit C2).

## Problem
A plugin disabled or signer-revoked (quarantined) server-side kept **running in every open tab except the admin's** that flipped it: only `usePlugins`' toggle/uninstall called `unloadPlugin`. The `is_active()` gate covers only plugin-specific endpoints; the core-data surface (`api.tickets/devices/users/attachments`) runs as the user, so a live sandbox frame retained ticket/device access until a manual reload. For a quarantine (signer revoked / signature mismatch) this defeats the state's purpose.

## Change (frontend-only)
Subscribe the loader to plugin lifecycle sync actions (`plugin.installed` / `plugin.updated` / `plugin.uninstalled`, emitted to the workspace group) and **reconcile** on any of them: refetch `/plugins/enabled` (which returns only `Installed` plugins) and diff — `unloadPlugin` anything no longer enabled (disposing its sandbox frame) and `loadPlugin` anything newly enabled. One path uniformly covers disable / quarantine / uninstall / re-enable. Debounced (400ms); started on auth, cleaned up on logout in `App.vue`.

No backend change needed: `/plugins/enabled` already reflects state, and the plugin sync actions already emit to the workspace group (same stream that drives the activity feed).

## Verification
Deterministic teardown test on the dev stack (via a temporary reconcile hook, since driving it through `onSyncActions` in headless Playwright is the same flaky leg noted in the events work): a rendered plugin's sandbox frame count goes **1 → disable+reconcile → 0 (torn down, no page reload) → re-enable+reconcile → 1 (reloaded)**. `unloadPlugin`/`loadPlugin` are existing tested primitives; the new logic is the diff. Type-check + eslint clean.

Note: the `onSyncActions` trigger rides the same production-working stream as the activity feed / dashboard invalidation; the harness limitation is only in headless SSE, not the code.