### PR TITLE
plugins: harden the bundle token (dedicated key, tight leeway, refresh)

### DIFF
--- a/backend/src/handlers/plugin_sandbox/runtime.js
+++ b/backend/src/handlers/plugin_sandbox/runtime.js
@@ -423,10 +423,16 @@ async function boot() {
   if (!token) throw new Error("sandbox runtime: missing bundle token");
   const runtime = await connectToHost();
   const bundleUrl = `./bundle?t=${encodeURIComponent(token)}`;
-  const mod = await import(
-    /* @vite-ignore */
-    bundleUrl
-  );
+  let mod;
+  try {
+    mod = await import(
+      /* @vite-ignore */
+      bundleUrl
+    );
+  } catch (e) {
+    window.parent.postMessage({ type: "nosdesk-plugin-bundle-error" }, "*");
+    throw e;
+  }
   if (!mod.default || typeof mod.default.mount !== "function") {
     throw new Error("sandbox runtime: bundle has no default { mount } export");
   }

--- a/backend/src/services/plugins/bundle_token.rs
+++ b/backend/src/services/plugins/bundle_token.rs
@@ -10,15 +10,37 @@
 
 use jsonwebtoken::{decode, encode, Algorithm, DecodingKey, EncodingKey, Header, Validation};
 use serde::{Deserialize, Serialize};
+use std::sync::OnceLock;
 use std::time::{SystemTime, UNIX_EPOCH};
 use uuid::Uuid;
 
 use crate::utils::jwt::JWT_SECRET;
 
-/// Fixed discriminator: a session token can't be replayed as a bundle token and
-/// vice-versa (the claim shapes already differ; this is belt-and-suspenders).
+/// Fixed discriminator: kept as belt-and-suspenders, but no longer the only thing
+/// separating a bundle token from a session token — see `bundle_key`.
 const TYP: &str = "plugin_bundle";
 const TTL_SECS: u64 = 60;
+/// Clock-skew tolerance on `exp`. Small: mint + verify run on the same backend
+/// (or a clock-synced cluster), and the whole point of the ~60s TTL is a tight
+/// replay window, so the previous 30s (half the lifetime) is dropped to 5s.
+const LEEWAY_SECS: u64 = 5;
+
+/// Domain-separation label for the bundle-token signing key. Bumping the suffix
+/// rotates every outstanding token.
+const BUNDLE_KEY_LABEL: &[u8] = b"nosdesk-plugin-bundle-token-v1";
+
+/// A dedicated HS256 key for bundle tokens, DERIVED from `JWT_SECRET` via
+/// `HMAC-SHA256(JWT_SECRET, label)`. So a session token (signed with the raw
+/// `JWT_SECRET`) can't be verified as a bundle token and vice-versa, and leaking
+/// the bundle key doesn't reveal `JWT_SECRET`. No new operator config: the key is
+/// derived, not a separate env var.
+fn bundle_key() -> &'static [u8] {
+    static KEY: OnceLock<Vec<u8>> = OnceLock::new();
+    KEY.get_or_init(|| {
+        let k = ring::hmac::Key::new(ring::hmac::HMAC_SHA256, JWT_SECRET.as_bytes());
+        ring::hmac::sign(&k, BUNDLE_KEY_LABEL).as_ref().to_vec()
+    })
+}
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct PluginBundleClaims {
@@ -70,7 +92,7 @@ pub fn mint(
     encode(
         &Header::default(),
         &claims,
-        &EncodingKey::from_secret(JWT_SECRET.as_bytes()),
+        &EncodingKey::from_secret(bundle_key()),
     )
     .map_err(BundleTokenError::Encode)
 }
@@ -79,10 +101,9 @@ pub fn verify(token: &str) -> Result<PluginBundleClaims, BundleTokenError> {
     let mut v = Validation::new(Algorithm::HS256);
     v.validate_exp = true;
     v.validate_aud = false; // our tokens carry no audience
-    v.leeway = 30;
-    let data =
-        decode::<PluginBundleClaims>(token, &DecodingKey::from_secret(JWT_SECRET.as_bytes()), &v)
-            .map_err(BundleTokenError::Decode)?;
+    v.leeway = LEEWAY_SECS;
+    let data = decode::<PluginBundleClaims>(token, &DecodingKey::from_secret(bundle_key()), &v)
+        .map_err(BundleTokenError::Decode)?;
     if data.claims.typ != TYP {
         return Err(BundleTokenError::WrongType);
     }
@@ -134,13 +155,41 @@ mod tests {
             exp: now + 60,
             iat: now,
         };
+        // Sign with the bundle key so the signature passes and the `typ` guard is
+        // what rejects it.
         let t = encode(
             &Header::default(),
             &forged,
-            &EncodingKey::from_secret(JWT_SECRET.as_bytes()),
+            &EncodingKey::from_secret(bundle_key()),
         )
         .unwrap();
         assert!(matches!(verify(&t), Err(BundleTokenError::WrongType)));
+    }
+
+    #[test]
+    fn rejects_token_signed_with_session_key() {
+        // Key separation: a token signed with the raw JWT_SECRET (a session token)
+        // must not verify as a bundle token, even with a valid `typ`.
+        set_secret();
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        let claims = PluginBundleClaims {
+            typ: TYP.to_string(),
+            workspace_id: 1,
+            plugin_uuid: Uuid::now_v7(),
+            bundle_hash: "x".to_string(),
+            exp: now + 60,
+            iat: now,
+        };
+        let t = encode(
+            &Header::default(),
+            &claims,
+            &EncodingKey::from_secret(JWT_SECRET.as_bytes()),
+        )
+        .unwrap();
+        assert!(matches!(verify(&t), Err(BundleTokenError::Decode(_))));
     }
 
     #[test]

--- a/frontend/src/plugins/components/PluginSandboxFrame.vue
+++ b/frontend/src/plugins/components/PluginSandboxFrame.vue
@@ -40,6 +40,12 @@ let unregisterInstance: (() => void) | null = null;
 let stopHeight: (() => void) | null = null;
 let connected = false;
 
+// The bundle token lives ~60s; an iframe reload after expiry (bfcache / crash)
+// re-fetches the bundle with a stale token and 403s. The runtime signals us, and
+// we re-mint + reload — bounded so a genuinely broken bundle can't loop forever.
+const MAX_BUNDLE_RETRIES = 3;
+let bundleRetries = 0;
+
 // The context is posted over postMessage (structured clone), so it must be a
 // plain, clone-safe projection. The props are Vue reactive proxies and may carry
 // non-cloneable fields; a JSON round-trip strips both the reactivity and anything
@@ -76,11 +82,16 @@ function onFrameLoad(): void {
   stopHeight = iframe
     ? watchPluginHeight(iframe, (px) => {
         iframeHeight.value = px;
+        // A height report means the bundle loaded + mounted + rendered: the
+        // token was fresh, so reset the refresh budget for the next expiry.
+        bundleRetries = 0;
       })
     : null;
 }
 
-onMounted(async () => {
+// Mint a fresh bundle token and (re)point the iframe at the runtime. Changing
+// `runtimeUrl` swaps the `:src`, which reloads the frame with the new token.
+async function mintToken(): Promise<void> {
   try {
     const { runtime_url } = await pluginService.getBundleToken(props.plugin.uuid);
     runtimeUrl.value = runtime_url;
@@ -88,6 +99,24 @@ onMounted(async () => {
     logger.error('Failed to mint plugin bundle token', { plugin: props.plugin.name, error: e });
     error.value = 'Failed to load plugin';
   }
+}
+
+// The runtime posts this when its bundle fetch failed (usually an expired token
+// on a reload). Re-mint + reload, bounded by the retry budget.
+function onWindowMessage(event: MessageEvent): void {
+  if (event.source !== frameRef.value?.contentWindow) return;
+  if ((event.data as { type?: string } | undefined)?.type !== 'nosdesk-plugin-bundle-error') return;
+  if (bundleRetries >= MAX_BUNDLE_RETRIES) {
+    error.value = 'Failed to load plugin';
+    return;
+  }
+  bundleRetries += 1;
+  void mintToken();
+}
+
+onMounted(() => {
+  window.addEventListener('message', onWindowMessage);
+  void mintToken();
 });
 
 // Push a fresh context snapshot whenever ticket/device or the action counter
@@ -101,6 +130,7 @@ watch(
 );
 
 onBeforeUnmount(() => {
+  window.removeEventListener('message', onWindowMessage);
   bridge?.dispose();
   bridge = null;
   unregisterInstance?.();

--- a/packages/plugin-runtime/src/runtime.ts
+++ b/packages/plugin-runtime/src/runtime.ts
@@ -49,7 +49,16 @@ async function boot(): Promise<void> {
   // external runtime import: the bundle is fetched from the sandbox origin at
   // load time, never bundled here.
   const bundleUrl = `./bundle?t=${encodeURIComponent(token)}`;
-  const mod = (await import(/* @vite-ignore */ bundleUrl)) as { default?: PluginModule };
+  let mod: { default?: PluginModule };
+  try {
+    mod = (await import(/* @vite-ignore */ bundleUrl)) as { default?: PluginModule };
+  } catch (e) {
+    // The bundle fetch failed — most often the ~60s bundle token expired before
+    // an iframe reload (bfcache eviction / renderer crash). Ask the host to
+    // re-mint a fresh token and reload us, rather than dead-ending on a 403.
+    window.parent.postMessage({ type: 'nosdesk-plugin-bundle-error' }, '*');
+    throw e;
+  }
   if (!mod.default || typeof mod.default.mount !== 'function') {
     throw new Error('sandbox runtime: bundle has no default { mount } export');
   }


### PR DESCRIPTION
Closes the last Phase-1 security item (audit S5 + C5).

## S5 — key separation + replay window
- **Dedicated signing key**: bundle tokens are signed/verified with a key **derived** from `JWT_SECRET` via `HMAC-SHA256(JWT_SECRET, "nosdesk-plugin-bundle-token-v1")`, not the raw secret. A session token can no longer be verified as a bundle token (or vice-versa), and leaking the bundle key doesn't reveal `JWT_SECRET`. No new operator config — the key is derived, not a separate env var. (Previously separation rested only on the `typ` string check, kept as belt-and-suspenders.)
- **Leeway 30s → 5s**: mint + verify run on the same clock-synced backend, and the ~60s TTL exists precisely to keep the replay window tight; 30s was half the token's lifetime.
- Tests: roundtrip; wrong-`typ` (now signed with the bundle key so the signature passes and the `typ` guard is what rejects); and a **new key-separation test** — a token signed with the raw `JWT_SECRET` is rejected.

## C5 — refresh path
The ~60s token was baked into the iframe URL once. An iframe reload after expiry (bfcache eviction / renderer crash) re-fetched `./bundle?t=<stale>` and 403'd into a dead "plugin failed to load". Now:
- the **runtime** posts `nosdesk-plugin-bundle-error` when its bundle fetch fails, then rethrows;
- the **frame** listens (matched to its own iframe), re-mints a fresh token, and reloads — bounded by a retry budget that resets on a successful render (height report).

`runtime.js` rebuilt (drift-checked).

## Verification
- `bundle_token` unit tests green — the `roundtrips` test exercises mint→verify with the derived key, which is exactly the `/bundle-token` → `/bundle` path, so the key change is validated end-to-end. Key-separation test proves a session-key token is rejected.
- Runtime + SDK + frontend type-check + eslint clean; clippy clean on the changed file.

No migration concern: outstanding old-key tokens expire within ~60s of deploy.