### PR TITLE
plugins(api): rename devices -> assets for one vocabulary (Phase 2)

### DIFF
--- a/backend/src/handlers/plugin_sandbox/runtime.js
+++ b/backend/src/handlers/plugin_sandbox/runtime.js
@@ -367,7 +367,7 @@ function wrapEvents(remote) {
 function connectToHost() {
   return new Promise((resolve) => {
     const listeners = /* @__PURE__ */ new Set();
-    let context = { ticket: null, device: null, component: { name: "", slot: "" } };
+    let context = { ticket: null, asset: null, component: { name: "", slot: "" } };
     let connected = false;
     function onMessage(event) {
       const data = event.data;

--- a/backend/src/services/plugins/manifest_validate.rs
+++ b/backend/src/services/plugins/manifest_validate.rs
@@ -73,8 +73,9 @@ pub(crate) const KNOWN_SLOTS: &[&str] = &[
 /// matching object on the `context` prop.
 pub(crate) const KNOWN_CONTEXTS: &[&str] = &[
     "ticket",
+    // Delivered to `asset-*` slots as `context.asset`.
+    "asset",
     // Reserved:
-    "device",
     "user",
     "comment",
     "documentation_page",

--- a/frontend/src/plugins/api.ts
+++ b/frontend/src/plugins/api.ts
@@ -66,7 +66,7 @@ export interface PluginUser {
 
 export interface PluginContext {
   ticket: Ticket | null;
-  device: Asset | null;
+  asset: Asset | null;
 }
 
 export interface PluginUIHelpers {
@@ -217,28 +217,28 @@ export function createPluginAPI(plugin: Plugin): PluginAPI {
       },
     },
 
-    devices: {
+    assets: {
       async get(id: number): Promise<Asset | null> {
         if (!hasPermission('asset:read')) {
-          logger.warn(`Plugin ${plugin.name} denied device:read permission`);
+          logger.warn(`Plugin ${plugin.name} denied asset:read permission`);
           return null;
         }
         try {
           return await getAssetById(id);
         } catch (error) {
-          logger.error(`Plugin ${plugin.name} failed to get device`, { id, error });
+          logger.error(`Plugin ${plugin.name} failed to get asset`, { id, error });
           return null;
         }
       },
       async list(): Promise<Asset[]> {
         if (!hasPermission('asset:read')) {
-          logger.warn(`Plugin ${plugin.name} denied device:read permission`);
+          logger.warn(`Plugin ${plugin.name} denied asset:read permission`);
           return [];
         }
         try {
           return await getAssets();
         } catch (error) {
-          logger.error(`Plugin ${plugin.name} failed to list devices`, { error });
+          logger.error(`Plugin ${plugin.name} failed to list assets`, { error });
           return [];
         }
       },
@@ -250,7 +250,7 @@ export function createPluginAPI(plugin: Plugin): PluginAPI {
         try {
           return await updateAsset(id, patch as Partial<Asset>, pluginAttribution);
         } catch (error) {
-          logger.error(`Plugin ${plugin.name} failed to update device`, { id, error });
+          logger.error(`Plugin ${plugin.name} failed to update asset`, { id, error });
           return null;
         }
       },
@@ -591,7 +591,7 @@ export interface PluginAPI {
     delete(id: number): Promise<boolean>;
   };
 
-  devices: {
+  assets: {
     get(id: number): Promise<Asset | null>;
     list(): Promise<Asset[]>;
     update(id: number, patch: PluginAssetPatch): Promise<Asset | null>;

--- a/frontend/src/plugins/components/PluginSandboxFrame.vue
+++ b/frontend/src/plugins/components/PluginSandboxFrame.vue
@@ -56,7 +56,7 @@ function plain<T>(value: T | undefined): T | null {
 function snapshot(): PluginContext {
   return {
     ticket: plain(props.ticket),
-    device: plain(props.device),
+    asset: plain(props.device),
     component: { name: props.component.name, slot: props.component.slot },
     actionActivated: props.actionActivated,
   };

--- a/frontend/src/plugins/sandboxHostApi.ts
+++ b/frontend/src/plugins/sandboxHostApi.ts
@@ -35,10 +35,10 @@ export function createHostApiImpl(plugin: Plugin): { hostApi: HostApi; inproc: P
       update: (id, patch) => inproc.tickets.update(id, patch),
       delete: (id) => inproc.tickets.delete(id),
     },
-    devices: {
-      get: (id) => inproc.devices.get(id),
-      list: () => inproc.devices.list(),
-      update: (id, patch) => inproc.devices.update(id, patch),
+    assets: {
+      get: (id) => inproc.assets.get(id),
+      list: () => inproc.assets.list(),
+      update: (id, patch) => inproc.assets.update(id, patch),
     },
     users: {
       get: (uuid) => inproc.users.get(uuid),

--- a/packages/plugin-sdk/src/connect.ts
+++ b/packages/plugin-sdk/src/connect.ts
@@ -99,7 +99,7 @@ export function connectToHost(): Promise<PluginRuntime> {
     const listeners = new Set<(ctx: PluginContext) => void>();
     // Placeholder until the host's init message delivers the real context; the
     // runtime resolves with `data.context`, so this is never handed to a plugin.
-    let context: PluginContext = { ticket: null, device: null, component: { name: '', slot: '' } };
+    let context: PluginContext = { ticket: null, asset: null, component: { name: '', slot: '' } };
     let connected = false;
 
     function onMessage(event: MessageEvent) {

--- a/packages/plugin-sdk/src/governor.ts
+++ b/packages/plugin-sdk/src/governor.ts
@@ -73,7 +73,7 @@ export class BridgeGovernor {
 
 /**
  * Wrap a host API object so every method call is metered by `governor`. Recurses
- * into sub-objects (e.g. `tickets`, `devices`) so nested methods are covered too;
+ * into sub-objects (e.g. `tickets`, `assets`) so nested methods are covered too;
  * a method's *return value* is not re-wrapped, so a Comlink-proxied sub-API
  * returned from a method (e.g. `collections(name)`) keeps its own transport (its
  * per-call metering is a follow-up). Non-function properties pass through.

--- a/packages/plugin-sdk/src/types.ts
+++ b/packages/plugin-sdk/src/types.ts
@@ -118,7 +118,7 @@ export interface HostApi {
     /** Delete a ticket (`ticket:delete`). Acts as the current user. */
     delete(id: number): Promise<boolean>;
   };
-  devices: {
+  assets: {
     get(id: number): Promise<Asset | null>;
     list(): Promise<Asset[]>;
     /** Patch an asset (`asset:write`). Acts as the current user. */
@@ -168,7 +168,7 @@ export type PluginHostApi = Omit<import('comlink').Remote<HostApi>, 'on'> & {
  * `onContextChange`. */
 export interface PluginContext {
   ticket: Ticket | null;
-  device: Asset | null;
+  asset: Asset | null;
   /** Which of the plugin's manifest components this mount is rendering. A bundle
    * may declare several (different slots); the plugin switches its UI on `name`
    * (the manifest `components` map key) / `slot`. */


### PR DESCRIPTION
Phase 2 (API coherence) — first increment. Cheap breaking change while there are zero external plugins.

## Problem
The same entity was named **three ways** across the plugin surface: the API namespace `api.devices`, the context key `context.device` / manifest context token `"device"` — but the permissions `asset:read`/`asset:write`, the type `Asset`, the patch `PluginAssetPatch`, and the slots `asset-header-actions` / `asset-info-panels`. Authors had to map device↔asset constantly, and the deny-log strings even said `"device:read"` while checking `asset:read`.

## Change — one noun (asset)
- SDK: `HostApi.devices` → `assets`; `PluginContext.device` → `asset`.
- `api.ts`: impl object + `PluginAPI` interface `devices` → `assets`; fix the `device:read`/get/list/update log strings.
- `sandboxHostApi`: boundary key `assets` over `inproc.assets`; frame `snapshot()` builds `context.asset` (still sourced from the internal `device` Vue prop plumbing — internal, never plugin-facing).
- Backend `KNOWN_CONTEXTS`: `"device"` → `"asset"` (moved out of "reserved" — it's actively delivered to `asset-*` slots as `context.asset`).
- `runtime.js` rebuilt (the `connect.ts` context placeholder is bundled in).

## Verification
SDK + frontend + core type-check + eslint clean; backend `cargo check` clean; no remaining `context.device` / `PluginContext.device` references (only the internal `props.device` Vue plumbing). `runtime.js` drift-checked.