### PR TITLE
plugins(api): unified typed error model — throw PluginApiError (Phase 2)

### DIFF
--- a/frontend/src/plugins/api.ts
+++ b/frontend/src/plugins/api.ts
@@ -16,6 +16,7 @@ import { getAssetById, getAssets, updateAsset } from '@/services/assetService';
 import userService from '@/services/userService';
 import { logger } from '@nosdesk/core/utils/logger';
 import { useToastStore } from '@nosdesk/core/stores/toast';
+import { PluginApiError } from '@nosdesk/plugin-sdk';
 import type { Plugin, PluginPermission, PluginProxyRequest, PluginEvent, CollectionRow, CollectionListResponse } from '@nosdesk/core/types/plugin';
 import type { Ticket } from '@nosdesk/core/types/ticket';
 import type { Asset } from '@nosdesk/core/types/asset';
@@ -137,6 +138,18 @@ export function createPluginAPI(plugin: Plugin): PluginAPI {
   // are traceable (the actor stays the user — the plugin acts as them).
   const pluginAttribution = { headers: { 'X-Nosdesk-Plugin': plugin.uuid } };
 
+  // Unified failure reporting: denial and upstream failure THROW a typed
+  // PluginApiError (the plugin catches + inspects `code`); `null` is reserved for
+  // a genuine not-found. Both are `never` so callers don't need a trailing return.
+  const denied = (perm: string): never => {
+    logger.warn(`Plugin ${plugin.name} denied ${perm}`);
+    throw new PluginApiError('denied', `${perm} not granted`);
+  };
+  const upstream = (what: string, error: unknown): never => {
+    logger.error(`Plugin ${plugin.name} ${what}`, { error });
+    throw new PluginApiError('upstream', what);
+  };
+
   const api: PluginAPI = {
     version: '1.0.0',
 
@@ -151,107 +164,75 @@ export function createPluginAPI(plugin: Plugin): PluginAPI {
     // === READ: Access core data ===
     tickets: {
       async get(id: number): Promise<Ticket | null> {
-        if (!hasPermission('ticket:read')) {
-          logger.warn(`Plugin ${plugin.name} denied ticket:read permission`);
-          return null;
-        }
+        if (!hasPermission('ticket:read')) denied('ticket:read');
         try {
           return await getTicketById(id);
         } catch (error) {
-          logger.error(`Plugin ${plugin.name} failed to get ticket`, { id, error });
-          return null;
+          throw upstream('failed to get ticket', error);
         }
       },
       async list(): Promise<Ticket[]> {
-        if (!hasPermission('ticket:read')) {
-          logger.warn(`Plugin ${plugin.name} denied ticket:read permission`);
-          return [];
-        }
+        if (!hasPermission('ticket:read')) denied('ticket:read');
         try {
           return await getTickets();
         } catch (error) {
-          logger.error(`Plugin ${plugin.name} failed to list tickets`, { error });
-          return [];
+          throw upstream('failed to list tickets', error);
         }
       },
       async addComment(ticketId: number, comment: PluginComment): Promise<boolean> {
-        if (!hasPermission('ticket:comment')) {
-          logger.warn(`Plugin ${plugin.name} denied ticket:comment permission`);
-          return false;
-        }
+        if (!hasPermission('ticket:comment')) denied('ticket:comment');
         try {
           await addCommentToTicket(ticketId, comment.content, []);
           return true;
         } catch (error) {
-          logger.error(`Plugin ${plugin.name} failed to add comment`, { ticketId, error });
-          return false;
+          throw upstream('failed to add comment', error);
         }
       },
       // Acts as the current user: the write hits the same endpoint the app uses,
       // bounded by the user's own perms + RLS. Restrict to the patch's safe field
       // subset (never a full ticket).
       async update(id: number, patch: PluginTicketPatch): Promise<Ticket | null> {
-        if (!hasPermission('ticket:write')) {
-          logger.warn(`Plugin ${plugin.name} denied ticket:write permission`);
-          return null;
-        }
+        if (!hasPermission('ticket:write')) denied('ticket:write');
         try {
           return await updateTicket(id, patch as Partial<Ticket>, pluginAttribution);
         } catch (error) {
-          logger.error(`Plugin ${plugin.name} failed to update ticket`, { id, error });
-          return null;
+          throw upstream('failed to update ticket', error);
         }
       },
       async delete(id: number): Promise<boolean> {
-        if (!hasPermission('ticket:delete')) {
-          logger.warn(`Plugin ${plugin.name} denied ticket:delete permission`);
-          return false;
-        }
+        if (!hasPermission('ticket:delete')) denied('ticket:delete');
         try {
           await deleteTicket(id, pluginAttribution);
           return true;
         } catch (error) {
-          logger.error(`Plugin ${plugin.name} failed to delete ticket`, { id, error });
-          return false;
+          throw upstream('failed to delete ticket', error);
         }
       },
     },
 
     assets: {
       async get(id: number): Promise<Asset | null> {
-        if (!hasPermission('asset:read')) {
-          logger.warn(`Plugin ${plugin.name} denied asset:read permission`);
-          return null;
-        }
+        if (!hasPermission('asset:read')) denied('asset:read');
         try {
           return await getAssetById(id);
         } catch (error) {
-          logger.error(`Plugin ${plugin.name} failed to get asset`, { id, error });
-          return null;
+          throw upstream('failed to get asset', error);
         }
       },
       async list(): Promise<Asset[]> {
-        if (!hasPermission('asset:read')) {
-          logger.warn(`Plugin ${plugin.name} denied asset:read permission`);
-          return [];
-        }
+        if (!hasPermission('asset:read')) denied('asset:read');
         try {
           return await getAssets();
         } catch (error) {
-          logger.error(`Plugin ${plugin.name} failed to list assets`, { error });
-          return [];
+          throw upstream('failed to list assets', error);
         }
       },
       async update(id: number, patch: PluginAssetPatch): Promise<Asset | null> {
-        if (!hasPermission('asset:write')) {
-          logger.warn(`Plugin ${plugin.name} denied asset:write permission`);
-          return null;
-        }
+        if (!hasPermission('asset:write')) denied('asset:write');
         try {
           return await updateAsset(id, patch as Partial<Asset>, pluginAttribution);
         } catch (error) {
-          logger.error(`Plugin ${plugin.name} failed to update asset`, { id, error });
-          return null;
+          throw upstream('failed to update asset', error);
         }
       },
     },
@@ -259,10 +240,7 @@ export function createPluginAPI(plugin: Plugin): PluginAPI {
     // === READ: Users (identity projection) ===
     users: {
       async get(uuid: string): Promise<PluginUser | null> {
-        if (!hasPermission('user:read')) {
-          logger.warn(`Plugin ${plugin.name} denied user:read permission`);
-          return null;
-        }
+        if (!hasPermission('user:read')) denied('user:read');
         try {
           const u = await userService.getUserByUuid(uuid);
           if (!u) return null;
@@ -274,8 +252,7 @@ export function createPluginAPI(plugin: Plugin): PluginAPI {
             role: (u.workspace_role ?? u.platform_role) as string,
           };
         } catch (error) {
-          logger.error(`Plugin ${plugin.name} failed to get user`, { uuid, error });
-          return null;
+          throw upstream('failed to get user', error);
         }
       },
     },
@@ -283,10 +260,7 @@ export function createPluginAPI(plugin: Plugin): PluginAPI {
     // === ATTACHMENTS: Access ticket attachments ===
     attachments: {
       async list(ticketId: number): Promise<PluginAttachment[]> {
-        if (!hasPermission('ticket:read')) {
-          logger.warn(`Plugin ${plugin.name} denied ticket:read permission`);
-          return [];
-        }
+        if (!hasPermission('ticket:read')) denied('ticket:read');
         try {
           const ticket = await getTicketById(ticketId);
           if (!ticket) return [];
@@ -307,15 +281,11 @@ export function createPluginAPI(plugin: Plugin): PluginAPI {
           }
           return result;
         } catch (error) {
-          logger.error(`Plugin ${plugin.name} failed to list attachments`, { ticketId, error });
-          return [];
+          throw upstream('failed to list attachments', error);
         }
       },
       async getContent(attachmentId: number, ticketId: number): Promise<{ blob: Blob; name: string; mimeType: string } | null> {
-        if (!hasPermission('ticket:read')) {
-          logger.warn(`Plugin ${plugin.name} denied ticket:read permission`);
-          return null;
-        }
+        if (!hasPermission('ticket:read')) denied('ticket:read');
         try {
           const attachments = await api.attachments.list(ticketId);
           const att = attachments.find(a => a.id === attachmentId);
@@ -325,15 +295,11 @@ export function createPluginAPI(plugin: Plugin): PluginAPI {
           const blob = await response.blob();
           return { blob, name: att.name, mimeType: att.mimeType || 'application/octet-stream' };
         } catch (error) {
-          logger.error(`Plugin ${plugin.name} failed to get attachment content`, { attachmentId, ticketId, error });
-          return null;
+          throw upstream('failed to get attachment content', error);
         }
       },
       async getBase64(attachmentId: number, ticketId: number): Promise<{ data: string; name: string; mimeType: string } | null> {
-        if (!hasPermission('ticket:read')) {
-          logger.warn(`Plugin ${plugin.name} denied ticket:read permission`);
-          return null;
-        }
+        if (!hasPermission('ticket:read')) denied('ticket:read');
         try {
           const content = await api.attachments.getContent(attachmentId, ticketId);
           if (!content) return null;
@@ -346,8 +312,7 @@ export function createPluginAPI(plugin: Plugin): PluginAPI {
           const data = btoa(binary);
           return { data, name: content.name, mimeType: content.mimeType };
         } catch (error) {
-          logger.error(`Plugin ${plugin.name} failed to get attachment base64`, { attachmentId, ticketId, error });
-          return null;
+          throw upstream('failed to get attachment base64', error);
         }
       },
     },
@@ -357,20 +322,16 @@ export function createPluginAPI(plugin: Plugin): PluginAPI {
     // permission enforcement, but we also fail closed here so a
     // denied plugin doesn't burn round-trips and the rejection
     // pattern is consistent with every other gated method.
-    async fetch(url: string, options?: PluginFetchOptions): Promise<Response | null> {
+    async fetch(url: string, options?: PluginFetchOptions): Promise<Response> {
       let parsed: URL;
       try {
         parsed = new URL(url);
       } catch {
         logger.warn(`Plugin ${plugin.name} fetch refused: invalid URL`, { url });
-        return null;
+        throw new PluginApiError('invalid', `invalid fetch URL: ${url}`);
       }
       if (!hasNetworkPermission(parsed.host)) {
-        logger.warn(
-          `Plugin ${plugin.name} fetch refused: no matching network:<host> permission`,
-          { host: parsed.host }
-        );
-        return null;
+        denied(`network:${parsed.host}`);
       }
 
       try {
@@ -390,50 +351,37 @@ export function createPluginAPI(plugin: Plugin): PluginAPI {
           headers: response.headers,
         });
       } catch (error) {
-        logger.error(`Plugin ${plugin.name} fetch failed`, { url, error });
-        return null;
-      }
+          throw upstream('fetch failed', error);
+        }
     },
 
     // === STORE: Plugin data ===
     storage: {
       async get<T>(key: string): Promise<T | null> {
-        if (!hasPermission('storage:plugin')) {
-          logger.warn(`Plugin ${plugin.name} denied storage:plugin permission`);
-          return null;
-        }
+        if (!hasPermission('storage:plugin')) denied('storage:plugin');
         try {
           const result = await pluginService.getStorage(plugin.uuid, key);
           return result.value as T;
         } catch (error) {
-          logger.error(`Plugin ${plugin.name} failed to get storage`, { key, error });
-          return null;
+          throw upstream('failed to get storage', error);
         }
       },
       async set<T>(key: string, value: T): Promise<boolean> {
-        if (!hasPermission('storage:plugin')) {
-          logger.warn(`Plugin ${plugin.name} denied storage:plugin permission`);
-          return false;
-        }
+        if (!hasPermission('storage:plugin')) denied('storage:plugin');
         try {
           await pluginService.setStorage(plugin.uuid, { key, value });
           return true;
         } catch (error) {
-          logger.error(`Plugin ${plugin.name} failed to set storage`, { key, error });
-          return false;
+          throw upstream('failed to set storage', error);
         }
       },
       async delete(key: string): Promise<boolean> {
-        if (!hasPermission('storage:plugin')) {
-          logger.warn(`Plugin ${plugin.name} denied storage:plugin permission`);
-          return false;
-        }
+        if (!hasPermission('storage:plugin')) denied('storage:plugin');
         try {
           await pluginService.deleteStorage(plugin.uuid, key);
           return true;
         } catch (error) {
-          logger.error(`Plugin ${plugin.name} failed to delete storage`, { key, error });
-          return false;
+          throw upstream('failed to delete storage', error);
         }
       },
     },
@@ -446,65 +394,45 @@ export function createPluginAPI(plugin: Plugin): PluginAPI {
 
         return {
           async create(data: Record<string, unknown>): Promise<CollectionRow | null> {
-            if (!hasCollectionWrite) {
-              logger.warn(`Plugin ${plugin.name} denied collection:write permission`);
-              return null;
-            }
+            if (!hasCollectionWrite) denied('collection:write');
             try {
               return await pluginService.createCollectionRow(plugin.uuid, collectionName, data);
             } catch (error) {
-              logger.error(`Plugin ${plugin.name} failed to create collection row`, { collectionName, error });
-              return null;
-            }
+          throw upstream('failed to create collection row', error);
+        }
           },
           async get(uuid: string): Promise<CollectionRow | null> {
-            if (!hasCollectionRead) {
-              logger.warn(`Plugin ${plugin.name} denied collection:read permission`);
-              return null;
-            }
+            if (!hasCollectionRead) denied('collection:read');
             try {
               return await pluginService.getCollectionRow(plugin.uuid, collectionName, uuid);
             } catch (error) {
-              logger.error(`Plugin ${plugin.name} failed to get collection row`, { collectionName, uuid, error });
-              return null;
-            }
+          throw upstream('failed to get collection row', error);
+        }
           },
           async update(uuid: string, data: Record<string, unknown>): Promise<CollectionRow | null> {
-            if (!hasCollectionWrite) {
-              logger.warn(`Plugin ${plugin.name} denied collection:write permission`);
-              return null;
-            }
+            if (!hasCollectionWrite) denied('collection:write');
             try {
               return await pluginService.updateCollectionRow(plugin.uuid, collectionName, uuid, data);
             } catch (error) {
-              logger.error(`Plugin ${plugin.name} failed to update collection row`, { collectionName, uuid, error });
-              return null;
-            }
+          throw upstream('failed to update collection row', error);
+        }
           },
           async delete(uuid: string): Promise<boolean> {
-            if (!hasCollectionWrite) {
-              logger.warn(`Plugin ${plugin.name} denied collection:write permission`);
-              return false;
-            }
+            if (!hasCollectionWrite) denied('collection:write');
             try {
               await pluginService.deleteCollectionRow(plugin.uuid, collectionName, uuid);
               return true;
             } catch (error) {
-              logger.error(`Plugin ${plugin.name} failed to delete collection row`, { collectionName, uuid, error });
-              return false;
-            }
+          throw upstream('failed to delete collection row', error);
+        }
           },
           async list(params?: { limit?: number; offset?: number; filter?: string; sort_by?: string; sort_order?: string }): Promise<CollectionListResponse> {
-            if (!hasCollectionRead) {
-              logger.warn(`Plugin ${plugin.name} denied collection:read permission`);
-              return { rows: [], total: 0 };
-            }
+            if (!hasCollectionRead) denied('collection:read');
             try {
               return await pluginService.listCollectionRows(plugin.uuid, collectionName, params);
             } catch (error) {
-              logger.error(`Plugin ${plugin.name} failed to list collection rows`, { collectionName, error });
-              return { rows: [], total: 0 };
-            }
+          throw upstream('failed to list collection rows', error);
+        }
           },
         };
       },
@@ -609,7 +537,7 @@ export interface PluginAPI {
   };
 
   // External requests
-  fetch(url: string, options?: PluginFetchOptions): Promise<Response | null>;
+  fetch(url: string, options?: PluginFetchOptions): Promise<Response>;
 
   // Plugin storage
   storage: {

--- a/frontend/src/plugins/sandboxHostApi.ts
+++ b/frontend/src/plugins/sandboxHostApi.ts
@@ -60,8 +60,9 @@ export function createHostApiImpl(plugin: Plugin): { hostApi: HostApi; inproc: P
     },
 
     async fetch(url, options) {
+      // inproc.fetch throws a PluginApiError on denial / invalid URL / failure;
+      // a returned Response is always a real response.
       const res = await inproc.fetch(url, options as PluginFetchOptions);
-      if (!res) return null;
       const headers: Record<string, string> = {};
       res.headers.forEach((value, key) => {
         headers[key] = value;

--- a/packages/plugin-sdk/src/errors.ts
+++ b/packages/plugin-sdk/src/errors.ts
@@ -1,0 +1,71 @@
+// The typed error a host API call throws when it can't return a value. Unifies
+// the surface: denial, rate-limit, timeout, bad input, and upstream failure all
+// throw a `PluginApiError` (distinguishable by `code`); `null` is reserved for a
+// genuine not-found (a `get` of a resource that doesn't exist).
+//
+// Bridge note: Comlink's built-in error serialization preserves an Error's
+// `name`, `message`, and `stack` but NOT custom fields, so the `code` is carried
+// in the `name` (`PluginApiError:<code>`) and recovered on the plugin side with
+// `asPluginApiError`.
+
+export type PluginApiErrorCode =
+  | 'denied' // the plugin's consented scope doesn't grant this
+  | 'not_found' // the addressed resource doesn't exist
+  | 'rate_limited' // the bridge governor's call-rate / in-flight cap
+  | 'timeout' // the call didn't settle within the governor's budget
+  | 'invalid' // bad input (e.g. an unparseable fetch URL)
+  | 'upstream'; // the host-side call failed for another reason
+
+const NAME_PREFIX = 'PluginApiError';
+
+export class PluginApiError extends Error {
+  readonly code: PluginApiErrorCode;
+  constructor(code: PluginApiErrorCode, detail?: string) {
+    super(detail ? `${code}: ${detail}` : code);
+    // `name` carries the code so it survives Comlink's error serialization.
+    this.name = `${NAME_PREFIX}:${code}`;
+    this.code = code;
+  }
+}
+
+const CODES = new Set<PluginApiErrorCode>([
+  'denied',
+  'not_found',
+  'rate_limited',
+  'timeout',
+  'invalid',
+  'upstream',
+]);
+
+/**
+ * Recover a `PluginApiError` from a value caught across the bridge. Comlink
+ * re-throws host errors as plain `Error`s (name + message preserved), so match on
+ * the `PluginApiError:<code>` name and rebuild a typed error. Returns `null` for
+ * anything that isn't a plugin API error, so a plugin can:
+ *
+ *   catch (e) { const pe = asPluginApiError(e); if (pe?.code === 'denied') … }
+ */
+export function asPluginApiError(err: unknown): PluginApiError | null {
+  if (err instanceof PluginApiError) return err;
+  if (
+    typeof err === 'object' &&
+    err !== null &&
+    'name' in err &&
+    typeof (err as { name: unknown }).name === 'string'
+  ) {
+    const name = (err as { name: string }).name;
+    if (name.startsWith(`${NAME_PREFIX}:`)) {
+      const code = name.slice(NAME_PREFIX.length + 1) as PluginApiErrorCode;
+      if (CODES.has(code)) {
+        const message =
+          'message' in err && typeof (err as { message: unknown }).message === 'string'
+            ? (err as { message: string }).message
+            : code;
+        // Strip the `code: ` prefix the constructor added, if present.
+        const detail = message.startsWith(`${code}: `) ? message.slice(code.length + 2) : undefined;
+        return new PluginApiError(code, detail);
+      }
+    }
+  }
+  return null;
+}

--- a/packages/plugin-sdk/src/governor.ts
+++ b/packages/plugin-sdk/src/governor.ts
@@ -5,6 +5,7 @@
 // Every host API method a plugin invokes goes through `BridgeGovernor.run`, which
 // rejects over-limit calls (the plugin sees a thrown error) rather than letting
 // them pile up on the host. Per plugin instance — each frame gets its own budget.
+import { PluginApiError } from './errors';
 
 export interface GovernorOptions {
   /** Max calls allowed within `windowMs`. */
@@ -35,12 +36,13 @@ export class BridgeGovernor {
     const windowStart = now - this.opts.windowMs;
     this.calls = this.calls.filter((t) => t > windowStart);
     if (this.calls.length >= this.opts.maxCallsPerWindow) {
-      throw new Error(
-        `plugin bridge rate limit exceeded (${this.opts.maxCallsPerWindow}/${this.opts.windowMs}ms)`,
+      throw new PluginApiError(
+        'rate_limited',
+        `bridge rate limit exceeded (${this.opts.maxCallsPerWindow}/${this.opts.windowMs}ms)`,
       );
     }
     if (this.inFlight >= this.opts.maxInFlight) {
-      throw new Error(`plugin bridge in-flight limit exceeded (${this.opts.maxInFlight})`);
+      throw new PluginApiError('rate_limited', `bridge in-flight limit exceeded (${this.opts.maxInFlight})`);
     }
     this.calls.push(now);
     this.inFlight += 1;
@@ -54,7 +56,10 @@ export class BridgeGovernor {
   private withTimeout<T>(p: Promise<T>): Promise<T> {
     return new Promise<T>((resolve, reject) => {
       const timer = setTimeout(
-        () => reject(new Error(`plugin bridge call timed out after ${this.opts.callTimeoutMs}ms`)),
+        () =>
+          reject(
+            new PluginApiError('timeout', `bridge call timed out after ${this.opts.callTimeoutMs}ms`),
+          ),
         this.opts.callTimeoutMs,
       );
       p.then(

--- a/packages/plugin-sdk/src/index.ts
+++ b/packages/plugin-sdk/src/index.ts
@@ -20,6 +20,8 @@ export { createRemoteHostApi, postInit, postContext, watchPluginHeight } from '.
 export type { HostBridge } from './host';
 export { BridgeGovernor, governHostApi, DEFAULT_GOVERNOR_OPTIONS } from './governor';
 export type { GovernorOptions } from './governor';
+export { PluginApiError, asPluginApiError } from './errors';
+export type { PluginApiErrorCode } from './errors';
 
 export type {
   HostApi,

--- a/packages/plugin-sdk/src/types.ts
+++ b/packages/plugin-sdk/src/types.ts
@@ -101,8 +101,13 @@ export interface PluginCollection {
 
 /**
  * The host API a sandboxed plugin calls over the Comlink bridge. Each call is a
- * round-trip; the host enforces the plugin's manifest permissions per call. A
- * method rejects (or the sub-API is absent) when a permission isn't granted.
+ * round-trip; the host enforces the plugin's consented permissions per call.
+ *
+ * Failure contract: a call THROWS a `PluginApiError` (recover with
+ * `asPluginApiError`, branch on `.code`: `denied` | `invalid` | `rate_limited` |
+ * `timeout` | `upstream`). `null` is returned only for a genuine not-found — a
+ * `get` of a resource that doesn't exist. So `null` means "not there"; a throw
+ * means "couldn't".
  */
 export interface HostApi {
   /** Runtime API version (semver); the major is the breaking-change signal. */
@@ -135,8 +140,9 @@ export interface HostApi {
       ticketId: number,
     ): Promise<{ data: string; name: string; mimeType: string } | null>;
   };
-  /** Outbound HTTP via the host's SSRF-guarded, manifest-allowlisted proxy. */
-  fetch(url: string, options?: PluginFetchOptions): Promise<PluginFetchResponse | null>;
+  /** Outbound HTTP via the host's SSRF-guarded, manifest-allowlisted proxy.
+   * Throws a `PluginApiError` on denial / invalid URL / upstream failure. */
+  fetch(url: string, options?: PluginFetchOptions): Promise<PluginFetchResponse>;
   storage: {
     get<T>(key: string): Promise<T | null>;
     set<T>(key: string, value: T): Promise<boolean>;


### PR DESCRIPTION
Phase 2 — the error model. The audit called this "the single most doc-shaping decision." Chosen: **throw typed errors**.

## Problem
Denial, invalid input, rate-limit, timeout, and upstream failure all collapsed to `null`/`false`/`[]`, while the governor threw plain `Error`s. A plugin author couldn't distinguish "you lack permission" from "it doesn't exist" from "the host errored," and had to both null-check and try/catch.

## Change
Unify on throwing a typed `PluginApiError{code}`; reserve `null` for a genuine not-found (a `get` of a missing resource). **`null` = "not there", throw = "couldn't".**

- New `@nosdesk/plugin-sdk` `PluginApiError` — `code`: `denied` | `not_found` | `rate_limited` | `timeout` | `invalid` | `upstream` — plus `asPluginApiError(e)`. Comlink's error serialization drops custom fields, so the `code` rides the error **name** (`PluginApiError:<code>`) and is recovered on the plugin side:
  ```ts
  catch (e) { const pe = asPluginApiError(e); if (pe?.code === 'denied') … }
  ```
- Governor throws `PluginApiError` (`rate_limited` / `timeout`) instead of `Error`.
- `api.ts`: `denied(perm)` and `upstream(what, error)` helpers (both `: never`) replace every gated method's warn+return-null / error+return-null block (~15 methods); `fetch` throws `invalid` / `denied` / `upstream`. **Net −113 lines** of boilerplate.
- `fetch` tightened to `Promise<Response>` (throws, never null); `HostApi.fetch` → `Promise<PluginFetchResponse>`; boundary adapter updated.

## Verification
SDK + frontend type-check + eslint clean. No `runtime.js` change (host-side only — verified no drift). Zero external plugins, so this is a free breaking change.