### PR TITLE
plugins(api): addComment carries plugin attribution + is_internal (Phase 2)

### DIFF
--- a/frontend/src/plugins/api.ts
+++ b/frontend/src/plugins/api.ts
@@ -27,6 +27,8 @@ import type { Asset } from '@nosdesk/core/types/asset';
 
 export interface PluginComment {
   content: string;
+  /** Post as an internal note (hidden from the requester, not relayed). */
+  is_internal?: boolean;
   metadata?: Record<string, unknown>;
 }
 
@@ -182,7 +184,14 @@ export function createPluginAPI(plugin: Plugin): PluginAPI {
       async addComment(ticketId: number, comment: PluginComment): Promise<boolean> {
         if (!hasPermission('ticket:comment')) denied('ticket:comment');
         try {
-          await addCommentToTicket(ticketId, comment.content, []);
+          await addCommentToTicket(
+            ticketId,
+            comment.content,
+            [],
+            comment.is_internal ?? false,
+            undefined,
+            pluginAttribution,
+          );
           return true;
         } catch (error) {
           throw upstream('failed to add comment', error);

--- a/packages/core/src/services/ticketService.ts
+++ b/packages/core/src/services/ticketService.ts
@@ -234,7 +234,8 @@ export const addCommentToTicket = async (
   content: string,
   attachments: { url: string; name: string }[] = [],
   isInternal: boolean = false,
-  clientId?: string
+  clientId?: string,
+  config?: AxiosRequestConfig
 ): Promise<Comment> => {
   try {
     const response = await apiClient.post(`/tickets/${ticketId}/comments`, {
@@ -257,7 +258,7 @@ export const addCommentToTicket = async (
       // optimistic create reconciles structurally (see sync/optimisticCreates).
       // Omitted (undefined) by callers that don't opt in; backend defaults None.
       client_id: clientId,
-    });
+    }, config);
     return response.data;
   } catch (error) {
     logger.error('Failed to add comment to ticket', { error, ticketId });


### PR DESCRIPTION
Phase 2 — `addComment` attribution + `is_internal`.

## Problem
`api.tickets.addComment` called `addCommentToTicket(id, content, [])`:
- **no attribution header** — plugin-authored comments were untraceable, unlike `tickets.update`/`delete` which pass `X-Nosdesk-Plugin`;
- **dropped `is_internal`** — advertised on the SDK `PluginComment` type but ignored, so a plugin couldn't post an internal note (hidden from the requester, not relayed).

## Change
- `addCommentToTicket` gains an optional `AxiosRequestConfig` (mirroring `updateTicket`/`deleteTicket` from the audit-attribution work), passed to the POST.
- `api.ts` threads `comment.is_internal` + `pluginAttribution` through, and adds `is_internal` to the `api.ts` `PluginComment` type (already present on the SDK type).

Backend attribution flows via the existing `X-Nosdesk-Plugin` header + `request_context` middleware — no backend change.

## Verification
core + frontend type-check + eslint clean.