### PR TITLE
plugins: gate api.on by read permission + type the event payload (Phase 2)

### DIFF
--- a/backend/src/handlers/plugin_sandbox/runtime.js
+++ b/backend/src/handlers/plugin_sandbox/runtime.js
@@ -326,12 +326,12 @@ function generateUUID() {
 function wrapEvents(remote) {
   const local = /* @__PURE__ */ new Map();
   const remoteUnsub = /* @__PURE__ */ new Map();
-  const dispatch = (event, data) => {
+  const dispatch = (event, payload) => {
     const set = local.get(event);
     if (!set) return;
     for (const h of [...set]) {
       try {
-        void h(data);
+        void h(payload);
       } catch {
       }
     }
@@ -341,7 +341,10 @@ function wrapEvents(remote) {
     if (!set) {
       set = /* @__PURE__ */ new Set();
       local.set(event, set);
-      remoteUnsub.set(event, remote.on(event, proxy((d) => dispatch(event, d))));
+      remoteUnsub.set(
+        event,
+        remote.on(event, proxy((d) => dispatch(event, d)))
+      );
     }
     set.add(handler);
     return () => {

--- a/frontend/src/plugins/eventDispatcher.ts
+++ b/frontend/src/plugins/eventDispatcher.ts
@@ -115,12 +115,32 @@ export function initializeEventDispatcher(): () => void {
  * whose `_getEventHandlers` returns the wrappers that forward to the Comlink
  * proxy.
  */
+/**
+ * The read permission an event requires — event payloads carry the entity's
+ * projection in `data`, so subscribing must be gated on the matching read grant
+ * (else a zero-permission plugin could observe ticket/asset data). `document:*`
+ * has no read permission yet, so it fails closed (returns null -> denied).
+ */
+function requiredReadPermission(event: PluginEvent): string | null {
+  if (event.startsWith('ticket:')) return 'ticket:read';
+  if (event.startsWith('asset:')) return 'asset:read';
+  return null;
+}
+
 function dispatchToPlugins(event: PluginEvent, data: unknown): void {
   const isRestricted = RESTRICTED_EVENTS.includes(event);
+  const needed = requiredReadPermission(event);
 
   forEachLiveInstance((uuid, api) => {
+    const loaded = getLoadedPlugin(uuid);
+    if (!loaded) return;
     // Skip restricted events for community plugins.
-    if (isRestricted && getLoadedPlugin(uuid)?.plugin.trust_level === 'community') {
+    if (isRestricted && loaded.plugin.trust_level === 'community') {
+      return;
+    }
+    // Gate on the matching read permission from the CONSENTED set (fail closed).
+    const granted = loaded.plugin.consented_permissions ?? loaded.plugin.manifest.permissions;
+    if (!needed || !granted.includes(needed)) {
       return;
     }
 

--- a/frontend/src/plugins/sandboxHostApi.ts
+++ b/frontend/src/plugins/sandboxHostApi.ts
@@ -11,7 +11,7 @@
 // The bridge itself (`createRemoteHostApi`) is pure transport; every permission
 // check still runs here, in-process, exactly as for a first-party plugin.
 import { proxy, BridgeGovernor, governHostApi } from '@nosdesk/plugin-sdk';
-import type { HostApi, PluginFetchOptions } from '@nosdesk/plugin-sdk';
+import type { HostApi, PluginFetchOptions, PluginEventPayload } from '@nosdesk/plugin-sdk';
 import type { Plugin } from '@nosdesk/core/types/plugin';
 import { createPluginAPI, type PluginAPI } from './api';
 
@@ -83,12 +83,12 @@ export function createHostApiImpl(plugin: Plugin): { hostApi: HostApi; inproc: P
     },
 
     // The plugin passes a Comlink-proxied handler; forward it into the
-    // in-process registry and proxy the unsubscribe back. (Dispatch of events to
-    // sandboxed plugins is wired in a follow-up; registration is inert until
-    // then, but never throws.)
+    // in-process registry (the event dispatcher fans workspace sync actions to it
+    // over the bridge) and proxy the unsubscribe back. The dispatcher passes the
+    // sync action, which is `PluginEventPayload`-shaped.
     async on(event, handler) {
       const unsubscribe = inproc.on(event, (data) => {
-        void handler(data);
+        void handler(data as PluginEventPayload);
       });
       return proxy(async () => {
         unsubscribe();

--- a/packages/plugin-sdk/src/connect.ts
+++ b/packages/plugin-sdk/src/connect.ts
@@ -1,6 +1,13 @@
 import * as Comlink from 'comlink';
 
-import type { HostApi, PluginHostApi, PluginContext, PluginEvent, PluginEventHandler } from './types';
+import type {
+  HostApi,
+  PluginHostApi,
+  PluginContext,
+  PluginEvent,
+  PluginEventHandler,
+  PluginEventPayload,
+} from './types';
 
 /** Protocol messages the host posts to the plugin iframe's `contentWindow`. */
 interface HostInitMessage {
@@ -40,13 +47,13 @@ function wrapEvents(remote: Comlink.Remote<HostApi>): PluginHostApi {
   const local = new Map<PluginEvent, Set<PluginEventHandler>>();
   const remoteUnsub = new Map<PluginEvent, Promise<() => Promise<void>>>();
 
-  const dispatch = (event: PluginEvent, data: unknown): void => {
+  const dispatch = (event: PluginEvent, payload: PluginEventPayload): void => {
     const set = local.get(event);
     if (!set) return;
     // Copy so a handler that unsubscribes mid-dispatch doesn't skip the next.
     for (const h of [...set]) {
       try {
-        void h(data);
+        void h(payload);
       } catch {
         // Isolate one handler's failure from the others.
       }
@@ -58,7 +65,10 @@ function wrapEvents(remote: Comlink.Remote<HostApi>): PluginHostApi {
     if (!set) {
       set = new Set();
       local.set(event, set);
-      remoteUnsub.set(event, remote.on(event, Comlink.proxy((d: unknown) => dispatch(event, d))));
+      remoteUnsub.set(
+        event,
+        remote.on(event, Comlink.proxy((d: PluginEventPayload) => dispatch(event, d))),
+      );
     }
     set.add(handler);
     return () => {

--- a/packages/plugin-sdk/src/index.ts
+++ b/packages/plugin-sdk/src/index.ts
@@ -38,6 +38,7 @@ export type {
   PluginFetchOptions,
   PluginFetchResponse,
   PluginEventHandler,
+  PluginEventPayload,
   // Domain types, re-exported so authors import only from this package.
   Ticket,
   Asset,

--- a/packages/plugin-sdk/src/types.ts
+++ b/packages/plugin-sdk/src/types.ts
@@ -82,7 +82,16 @@ export interface PluginFetchResponse {
 
 /** A host-event handler. The SDK wraps it with `Comlink.proxy` so it can cross
  * the bridge. */
-export type PluginEventHandler = (data: unknown) => void | Promise<void>;
+/** The payload an event handler receives: the sync action's type, the affected
+ * aggregate's id, and its entity projection in `data`. A subset of the host's
+ * internal sync action — the fields a plugin can rely on. */
+export interface PluginEventPayload {
+  event_type: string;
+  aggregate_id: string;
+  data: unknown;
+}
+
+export type PluginEventHandler = (payload: PluginEventPayload) => void | Promise<void>;
 
 /** CRUD over one plugin collection. */
 export interface PluginCollection {


### PR DESCRIPTION
Phase 2 — closes audit A1 (HIGH).

## Problem
`api.on(event, handler)` had **no permission gate**. A plugin declaring zero permissions could subscribe to `ticket:updated` / `ticket:comment_added` and receive the affected entity's projection in the payload — so event data leaked around `ticket:read` / `asset:read`. The only filter was a community-tier block on `asset:*`, not the plugin's declared read grant.

## Change
- **eventDispatcher** now gates every delivery on the matching read permission from the plugin's **consented** set: `ticket:*` → `ticket:read`, `asset:*` → `asset:read`. `document:*` has no read permission yet, so it **fails closed**. Events are dispatched entirely client-side (the dispatcher reads the sync stream and calls plugin handlers over the bridge), so this is the real enforcement point for events.
- **Typed payload**: new `PluginEventPayload { event_type, aggregate_id, data }`; `PluginEventHandler` now takes it (was `unknown`), threaded through the bridge (`connect.wrapEvents`, `sandboxHostApi` on-adapter).
- Fixed the stale `sandboxHostApi` comment claiming event dispatch is "inert until a follow-up" (it's live). `runtime.js` rebuilt (parameter rename only).

## Verification
SDK + frontend type-check + eslint clean; `runtime.js` drift-checked.