### PR TITLE
plugins(api): fetch body-encoding fix + type cleanups (Phase 2)

### DIFF
--- a/frontend/src/plugins/api.ts
+++ b/frontend/src/plugins/api.ts
@@ -39,7 +39,6 @@ export interface PluginComment {
   content: string;
   /** Post as an internal note (hidden from the requester, not relayed). */
   is_internal?: boolean;
-  metadata?: Record<string, unknown>;
 }
 
 export interface PluginAttachment {
@@ -77,10 +76,6 @@ export interface PluginUser {
   role: string;
 }
 
-export interface PluginContext {
-  ticket: Ticket | null;
-  asset: Asset | null;
-}
 
 export interface PluginUIHelpers {
   /** Check if the page is currently being printed (via matchMedia) */
@@ -405,7 +400,11 @@ export function createPluginAPI(plugin: Plugin): PluginAPI {
           url,
           method: (options?.method as PluginProxyRequest['method']) || 'GET',
           headers: options?.headers as Record<string, string>,
-          body: options?.body ? (typeof options.body === 'string' ? JSON.parse(options.body) : options.body) : undefined,
+          // Pass the body through as-is; the backend encodes per `content_type`
+          // ('json' default, or 'form'). Never JSON.parse a string body — a
+          // pre-encoded form/text/XML string is not JSON and would throw. Only
+          // null/undefined mean "no body" (so '' and 0 are preserved).
+          body: options?.body ?? undefined,
           content_type: options?.content_type,
         };
 


### PR DESCRIPTION
Phase 2 — final cleanups (audit API5 + duplicate-type residue).

## Changes
- **`fetch` body-encoding bug**: `fetch` did `typeof body === 'string' ? JSON.parse(body) : body`. A pre-encoded form/text/XML string isn't JSON, so `JSON.parse` threw, was swallowed, and the call failed — directly contradicting `content_type: 'form'`. Falsy bodies (`''`, `0`) were also dropped. Now the body passes through as-is and the backend encodes per `content_type`; only `null`/`undefined` mean "no body".
- **Type cleanup**: drop the unused `metadata` field from `PluginComment` (the impl only reads `content` + `is_internal`), aligning with the SDK's author-facing type; delete the dead, unused `api.ts` `PluginContext` (the live one is the SDK's — nothing imported this).

## Deferred (not cleanups, tracked for later)
- `api.settings.get` needs a new **non-admin** runtime endpoint (settings currently have only an admin-gated read) — a capability, not a cleanup.
- The `engines.plugin_api` v2/negotiation story is a docs item (the `"1"` pin is already enforced).

## Verification
frontend type-check + eslint clean.