### PR TITLE
plugins: sandbox correctness cleanup (Phase 3)

### DIFF
--- a/backend/src/handlers/plugin_sandbox/runtime.js
+++ b/backend/src/handlers/plugin_sandbox/runtime.js
@@ -323,6 +323,7 @@ function generateUUID() {
 }
 
 // ../plugin-sdk/src/connect.ts
+var CONNECT_TIMEOUT_MS = 1e4;
 function wrapEvents(remote) {
   const local = /* @__PURE__ */ new Map();
   const remoteUnsub = /* @__PURE__ */ new Map();
@@ -360,25 +361,41 @@ function wrapEvents(remote) {
       }
     };
   };
-  return new Proxy(remote, {
+  const reset = () => {
+    for (const unsubP of remoteUnsub.values()) {
+      void unsubP.then((fn) => fn()).catch(() => {
+      });
+    }
+    remoteUnsub.clear();
+    local.clear();
+  };
+  const api = new Proxy(remote, {
     get(target, prop, receiver) {
       if (prop === "on") return on;
       return Reflect.get(target, prop, receiver);
     }
   });
+  return { api, reset };
 }
 function connectToHost() {
-  return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
     const listeners = /* @__PURE__ */ new Set();
     let context = { ticket: null, asset: null, component: { name: "", slot: "" } };
     let connected = false;
+    const timer = setTimeout(() => {
+      if (!connected) {
+        window.removeEventListener("message", onMessage);
+        reject(new Error("sandbox runtime: host did not connect in time"));
+      }
+    }, CONNECT_TIMEOUT_MS);
     function onMessage(event) {
       const data = event.data;
       if (!data || typeof data !== "object") return;
       if (!connected && data.type === "nosdesk-plugin-init" && event.ports[0]) {
         connected = true;
+        clearTimeout(timer);
         context = data.context;
-        const api = wrapEvents(wrap(event.ports[0]));
+        const { api, reset } = wrapEvents(wrap(event.ports[0]));
         resolve({
           api,
           context,
@@ -387,7 +404,8 @@ function connectToHost() {
             return () => {
               listeners.delete(cb);
             };
-          }
+          },
+          resetEvents: reset
         });
       } else if (data.type === "nosdesk-plugin-context") {
         context = data.context;
@@ -448,6 +466,7 @@ async function boot() {
       return;
     }
     instance.unmount?.();
+    runtime.resetEvents();
     root.replaceChildren();
     instance = toInstance(plugin.mount(root, runtime.api, ctx));
   });

--- a/frontend/src/plugins/components/PluginSandboxFrame.vue
+++ b/frontend/src/plugins/components/PluginSandboxFrame.vue
@@ -119,14 +119,17 @@ onMounted(() => {
   void mintToken();
 });
 
-// Push a fresh context snapshot whenever ticket/device or the action counter
-// changes (the action counter is how a host menu trigger reaches the plugin).
+// Push a fresh context snapshot whenever ticket/asset, the component, or the
+// action counter changes. `deep` is required: the sync pool patches ticket/asset
+// rows IN PLACE (same object identity), so a shallow, reference-keyed watch would
+// miss field updates and leave the plugin on stale context.
 watch(
-  [() => props.ticket, () => props.device, () => props.actionActivated],
+  [() => props.ticket, () => props.device, () => props.component, () => props.actionActivated],
   () => {
     const win = frameRef.value?.contentWindow;
     if (connected && win) postContext(win, snapshot());
   },
+  { deep: true },
 );
 
 onBeforeUnmount(() => {

--- a/frontend/src/plugins/eventDispatcher.ts
+++ b/frontend/src/plugins/eventDispatcher.ts
@@ -108,12 +108,10 @@ export function initializeEventDispatcher(): () => void {
 /**
  * Dispatch an event to every live plugin instance's handlers.
  *
- * Iterates the live-instance registry (populated by the render paths:
- * `PluginSlotItem` for in-process plugins, `PluginSandboxFrame` /
- * `createHostApiImpl` for sandboxed ones), so handlers land wherever the plugin
- * actually registered them — including across the bridge for a sandboxed plugin,
- * whose `_getEventHandlers` returns the wrappers that forward to the Comlink
- * proxy.
+ * Iterates the live-instance registry (populated by `PluginSandboxFrame` via
+ * `createHostApiImpl`), so handlers land on the in-process instance the plugin's
+ * `api.on` registered on — its `_getEventHandlers` returns the wrappers that
+ * forward each event across the bridge to the sandboxed plugin.
  */
 /**
  * The read permission an event requires — event payloads carry the entity's

--- a/frontend/src/plugins/pluginInstances.ts
+++ b/frontend/src/plugins/pluginInstances.ts
@@ -1,11 +1,12 @@
 // Registry of the LIVE plugin API instances a plugin's event handlers actually
 // land on, so the event dispatcher can reach them.
 //
-// `getHostApiForPlugin` / `createPluginAPI` return a fresh instance per call, and
-// context is per-instance (a plugin in two slots has two independent contexts).
-// So `api.on(...)` handlers register on the specific instance the render path
-// created — the in-process one held by a `PluginSlotItem`, or the in-process one
-// wrapped behind a sandboxed plugin's `createHostApiImpl`. The dispatcher must
+// `createPluginAPI` returns a fresh instance per call, and context is
+// per-instance (a plugin in two slots has two independent contexts). So
+// `api.on(...)` handlers register on the specific instance the render path
+// created — the in-process `PluginAPI` a sandboxed plugin's `createHostApiImpl`
+// wraps behind the bridge (there is no in-process render path any more). The
+// dispatcher must
 // iterate exactly those live instances (not a throwaway of its own), which is
 // what this registry provides. Each mounted instance registers on setup and
 // unregisters on unmount; a plugin rendered in N places has N live instances and

--- a/packages/plugin-runtime/src/runtime.ts
+++ b/packages/plugin-runtime/src/runtime.ts
@@ -76,6 +76,10 @@ async function boot(): Promise<void> {
       return;
     }
     instance.unmount?.();
+    // Drop the prior mount's api.on subscriptions so a simple plugin that
+    // subscribes in mount doesn't accumulate handlers (and duplicate deliveries)
+    // across re-mounts.
+    runtime.resetEvents();
     root.replaceChildren();
     instance = toInstance(plugin.mount(root, runtime.api, ctx));
   });

--- a/packages/plugin-sdk/src/connect.ts
+++ b/packages/plugin-sdk/src/connect.ts
@@ -29,7 +29,13 @@ export interface PluginRuntime {
   /** Subscribe to context snapshots the host pushes after connect; returns an
    * unsubscribe. */
   onContextChange(cb: (ctx: PluginContext) => void): () => void;
+  /** Drop all `api.on` subscriptions. The runtime calls this before re-mounting a
+   * simple plugin so event handlers don't accumulate across re-mounts. */
+  resetEvents(): void;
 }
+
+/** How long to wait for the host's init message before giving up. */
+const CONNECT_TIMEOUT_MS = 10_000;
 
 /**
  * Wrap the Comlink-remote host API so `api.on(event, handler)` works with a plain
@@ -43,7 +49,10 @@ export interface PluginRuntime {
  * matches). The host calls that one dispatcher; we fan out to local handlers.
  * Every other member passes straight through to the remote.
  */
-function wrapEvents(remote: Comlink.Remote<HostApi>): PluginHostApi {
+function wrapEvents(remote: Comlink.Remote<HostApi>): {
+  api: PluginHostApi;
+  reset: () => void;
+} {
   const local = new Map<PluginEvent, Set<PluginEventHandler>>();
   const remoteUnsub = new Map<PluginEvent, Promise<() => Promise<void>>>();
 
@@ -85,12 +94,28 @@ function wrapEvents(remote: Comlink.Remote<HostApi>): PluginHostApi {
     };
   };
 
-  return new Proxy(remote, {
+  // Drop every local subscription + its single host-side dispatcher. The runtime
+  // calls this before re-mounting a simple plugin (one that returned void, so the
+  // runtime unmount+re-mounts on context change) — otherwise a plugin that
+  // subscribes in `mount` would accumulate a handler per re-mount and receive
+  // each event N times. A plugin returning `{ update }` is never re-mounted, so
+  // its subscriptions persist.
+  const reset = (): void => {
+    for (const unsubP of remoteUnsub.values()) {
+      void unsubP.then((fn) => fn()).catch(() => {});
+    }
+    remoteUnsub.clear();
+    local.clear();
+  };
+
+  const api = new Proxy(remote, {
     get(target, prop, receiver) {
       if (prop === 'on') return on;
       return Reflect.get(target, prop, receiver);
     },
   }) as unknown as PluginHostApi;
+
+  return { api, reset };
 }
 
 /**
@@ -105,12 +130,22 @@ function wrapEvents(remote: Comlink.Remote<HostApi>): PluginHostApi {
  * and communicate only over that port afterwards.
  */
 export function connectToHost(): Promise<PluginRuntime> {
-  return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
     const listeners = new Set<(ctx: PluginContext) => void>();
     // Placeholder until the host's init message delivers the real context; the
     // runtime resolves with `data.context`, so this is never handed to a plugin.
     let context: PluginContext = { ticket: null, asset: null, component: { name: '', slot: '' } };
     let connected = false;
+
+    // Fail loudly if the host never connects (dropped port / host disposed before
+    // postInit) so `boot()` can render an error instead of hanging on a blank
+    // frame. The listener stays after connect — context updates reuse it.
+    const timer = setTimeout(() => {
+      if (!connected) {
+        window.removeEventListener('message', onMessage);
+        reject(new Error('sandbox runtime: host did not connect in time'));
+      }
+    }, CONNECT_TIMEOUT_MS);
 
     function onMessage(event: MessageEvent) {
       const data = event.data as HostInitMessage | HostContextMessage | undefined;
@@ -118,8 +153,9 @@ export function connectToHost(): Promise<PluginRuntime> {
 
       if (!connected && data.type === 'nosdesk-plugin-init' && event.ports[0]) {
         connected = true;
+        clearTimeout(timer);
         context = data.context;
-        const api = wrapEvents(Comlink.wrap<HostApi>(event.ports[0]));
+        const { api, reset } = wrapEvents(Comlink.wrap<HostApi>(event.ports[0]));
         resolve({
           api,
           context,
@@ -129,6 +165,7 @@ export function connectToHost(): Promise<PluginRuntime> {
               listeners.delete(cb);
             };
           },
+          resetEvents: reset,
         });
       } else if (data.type === 'nosdesk-plugin-context') {
         context = data.context;


### PR DESCRIPTION
Phase 3 (completeness) — the correctness batch from the audit.

- **C1 — event-handler leak on re-mount**: a "simple" plugin (mount returns void, so the runtime unmount+re-mounts on context change) that subscribes in `mount` accumulated a handler in `wrapEvents`' local set on every re-mount and received each event N times. `wrapEvents` now exposes `reset()`; `connectToHost` surfaces it as `runtime.resetEvents()`; the runtime clears subscriptions before a re-mount. A plugin returning `{ update }` is never re-mounted, so its subscriptions persist.
- **C4 — stale context from in-place pool mutations**: the frame's context watcher was shallow + reference-keyed, but the sync pool patches ticket/asset rows **in place** (same object identity), so field updates were missed and the plugin saw stale context. Now `{ deep: true }` and includes `component`.
- **C6 — `connectToHost` never timed out**: a dropped port / host disposed before `postInit` hung `boot()` on a blank frame forever. Added a 10s timeout that rejects (so `boot().catch` renders an error) and removes its listener on that path. The listener **stays after connect** — context updates reuse it (the audit's "remove listener after connect" would have broken context delivery).
- **C10 — stale comments** referencing the removed in-process render path.

`runtime.js` rebuilt (drift-checked). Out of scope: C8 fail-open (already fixed in #154 by the `if (!loaded) return` guard); C9 lifecycle quarantine-from-awaiting-consent and C3/C7 `releaseProxy` (LOW) are follow-ups.

## Verification
SDK + runtime + frontend type-check + eslint clean.