### PR TITLE
plugins(lifecycle): allow Quarantine from AwaitingConsent (Phase 3, C9)

### DIFF
--- a/backend/src/services/plugins/lifecycle.rs
+++ b/backend/src/services/plugins/lifecycle.rs
@@ -212,8 +212,12 @@ pub fn apply(
             }
 
             // ----- Quarantine -----
+            // Also from AwaitingConsent: a signer-revocation sweep can hit a
+            // not-yet-consented plugin, and it must be quarantinable (not error
+            // out) even though it isn't serving.
             (PluginState::Installed, PluginAction::Quarantine { .. })
-            | (PluginState::Disabled, PluginAction::Quarantine { .. }) => {
+            | (PluginState::Disabled, PluginAction::Quarantine { .. })
+            | (PluginState::AwaitingConsent, PluginAction::Quarantine { .. }) => {
                 let updated = set_state(tx, plugin_uuid, PluginState::Quarantined)?;
                 log_lifecycle(tx, &updated, &action, prior, actor)?;
                 Ok(ActionOutcome::StateChanged {
@@ -421,6 +425,9 @@ mod tests {
             (PluginState::Uninstalled, "Reinstall"),
             (PluginState::Installed, "RequireReconsent"),
             (PluginState::Disabled, "RequireReconsent"),
+            (PluginState::AwaitingConsent, "Quarantine"),
+            (PluginState::AwaitingConsent, "UninstallPreserve"),
+            (PluginState::AwaitingConsent, "UninstallCascade"),
         ]
     }
 
@@ -441,12 +448,13 @@ mod tests {
         ]
     }
 
-    fn all_states() -> [PluginState; 4] {
+    fn all_states() -> [PluginState; 5] {
         [
             PluginState::Installed,
             PluginState::Disabled,
             PluginState::Quarantined,
             PluginState::Uninstalled,
+            PluginState::AwaitingConsent,
         ]
     }
 


### PR DESCRIPTION
Phase 3 — audit C9.

## Problem
A background signer-revocation sweep that hit a plugin sitting in `AwaitingConsent` got `InvalidTransition` — `Quarantine` was legal only from `Installed`/`Disabled` — and errored instead of quarantining it. An awaiting-consent plugin whose signer was revoked should still be flagged.

## Change
- Allow `Quarantine` from `AwaitingConsent` (it isn't serving, but must be markable).
- Close the pre-existing test-table drift the audit flagged: add `AwaitingConsent` to `all_states()` and its match-accepted transitions (`Quarantine` / `UninstallPreserve` / `UninstallCascade`) to `legal_transitions()`, so the consistency test actually covers the state.

## Verification
8 lifecycle unit tests green (incl. `legal_transitions_table_is_consistent`).