### PR TITLE
plugins: bound plugin storage + collections growth (Phase 3)

### DIFF
--- a/backend/src/handlers/plugin_collections.rs
+++ b/backend/src/handlers/plugin_collections.rs
@@ -36,6 +36,10 @@ pub struct CollectionRowPath {
     row_uuid: Uuid,
 }
 
+/// Cap on rows per collection so an untrusted plugin can't grow
+/// `plugin_collection_rows` unbounded.
+const MAX_ROWS_PER_COLLECTION: i64 = 50_000;
+
 // =============================================================================
 // Helpers
 // =============================================================================
@@ -270,6 +274,7 @@ pub async fn create_collection_row(
         Ok(crate::models::PluginCollectionRow),
         Gate(PluginGate),
         CollectionNotFound,
+        RowLimitExceeded,
         ValidationError(String),
     }
 
@@ -288,6 +293,12 @@ pub async fn create_collection_row(
             Err(DieselError::NotFound) => return Ok(CreateOutcome::CollectionNotFound),
             Err(e) => return Err(e),
         };
+
+        // Bound growth: an untrusted plugin must not be able to grow a collection
+        // unbounded.
+        if collection_repo::count_rows_by_schema(conn, schema.id)? >= MAX_ROWS_PER_COLLECTION {
+            return Ok(CreateOutcome::RowLimitExceeded);
+        }
 
         // Parse the collection definition from the schema for validation
         if let Ok(definition) =
@@ -314,6 +325,9 @@ pub async fn create_collection_row(
         }
         Ok(CreateOutcome::Gate(gate)) => gate.into_response(),
         Ok(CreateOutcome::CollectionNotFound) => errors::not_found_msg("Collection not found"),
+        Ok(CreateOutcome::RowLimitExceeded) => errors::bad_request(format!(
+            "collection row limit exceeded (max {MAX_ROWS_PER_COLLECTION} rows)"
+        )),
         Ok(CreateOutcome::ValidationError(msg)) => {
             HttpResponse::BadRequest().json(serde_json::json!({
                 "error": i18n::tr(&locale, "backend-error-validation"),

--- a/backend/src/handlers/plugins.rs
+++ b/backend/src/handlers/plugins.rs
@@ -903,6 +903,13 @@ pub fn authorize_plugin_data_request(
 // Plugin Storage Handlers (for plugin runtime use)
 // =============================================================================
 
+/// Bounds on the plugin key/value store so an untrusted plugin can't exhaust the
+/// row's workspace. Overwrites of an existing key don't count against the entry
+/// quota; only new keys do.
+const MAX_STORAGE_KEY_LEN: usize = 256;
+const MAX_STORAGE_VALUE_BYTES: usize = 64 * 1024;
+const MAX_STORAGE_ENTRIES_PER_PLUGIN: i64 = 1000;
+
 /// Get storage value for a plugin (authenticated users - for plugin use)
 pub async fn get_plugin_storage(
     req: HttpRequest,
@@ -969,9 +976,24 @@ pub async fn set_plugin_storage(
     let plugin_uuid = path.into_inner();
     let body = body.into_inner();
 
+    if body.key.is_empty() || body.key.len() > MAX_STORAGE_KEY_LEN {
+        return errors::bad_request(format!(
+            "storage key must be 1..={MAX_STORAGE_KEY_LEN} characters"
+        ));
+    }
+    let value_size = serde_json::to_vec(&body.value)
+        .map(|v| v.len())
+        .unwrap_or(usize::MAX);
+    if value_size > MAX_STORAGE_VALUE_BYTES {
+        return errors::bad_request(format!(
+            "storage value is {value_size} bytes, exceeds {MAX_STORAGE_VALUE_BYTES}"
+        ));
+    }
+
     enum StorageOutcome {
         Ok(crate::models::PluginData),
         Gate(PluginGate),
+        QuotaExceeded,
     }
 
     let key = body.key.clone();
@@ -986,6 +1008,17 @@ pub async fn set_plugin_storage(
             Ok(p) => p,
             Err(gate) => return Ok(StorageOutcome::Gate(gate)),
         };
+        // Per-plugin key quota — new keys only (an overwrite of an existing key
+        // is always allowed, even at the cap).
+        let is_new = matches!(
+            plugin_repo::get_plugin_storage_entry(conn, plugin.id, &key),
+            Err(DieselError::NotFound)
+        );
+        if is_new
+            && plugin_repo::count_plugin_storage(conn, plugin.id)? >= MAX_STORAGE_ENTRIES_PER_PLUGIN
+        {
+            return Ok(StorageOutcome::QuotaExceeded);
+        }
         let entry = plugin_repo::set_plugin_storage(conn, plugin.id, key, Some(value))?;
         Ok::<_, DieselError>(StorageOutcome::Ok(entry))
     });
@@ -995,6 +1028,9 @@ pub async fn set_plugin_storage(
             HttpResponse::Ok().json(PluginStorageResponse::from(entry))
         }
         Ok(StorageOutcome::Gate(gate)) => gate.into_response(),
+        Ok(StorageOutcome::QuotaExceeded) => errors::bad_request(format!(
+            "storage entry quota exceeded (max {MAX_STORAGE_ENTRIES_PER_PLUGIN} keys)"
+        )),
         Err(e) => {
             error!("Failed to set plugin storage: {}", e);
             errors::internal("Failed to set storage")

--- a/backend/src/repository/plugins.rs
+++ b/backend/src/repository/plugins.rs
@@ -536,6 +536,18 @@ pub fn get_plugin_storage_entry(
     get_plugin_data_entry(conn, plugin_id, "storage", key)
 }
 
+/// Count a plugin's storage entries (for the per-plugin key quota).
+pub fn count_plugin_storage(
+    conn: &mut DbConnection,
+    plugin_id: i32,
+) -> Result<i64, diesel::result::Error> {
+    plugin_data::table
+        .filter(plugin_data::plugin_id.eq(plugin_id))
+        .filter(plugin_data::data_type.eq("storage"))
+        .count()
+        .get_result(conn)
+}
+
 // sync-audit-only: Plugin local storage / activity log — covered by the audit_log trigger on plugin_data and plugin_collection_rows
 /// Set a plugin storage entry (upsert)
 pub fn set_plugin_storage(


### PR DESCRIPTION
Phase 3 — the ungoverned-growth DoS gap from the audit (storage had no caps; collections could grow unbounded).

## Storage (`set_plugin_storage`)
- **key length** ≤ 256 chars, **value** ≤ 64 KB (serialized) — reject otherwise (400).
- **per-plugin entry quota** of 1000 keys; only *new* keys count against it (an overwrite of an existing key is always allowed, even at the cap). Adds a `count_plugin_storage` repo fn.

## Collections (`create_collection_row`)
- **per-collection row cap** of 50,000; `create` rejects at the cap (400). Reuses the existing `count_rows_by_schema`.

All limits return 400 with a clear message. The count queries are read-only (no sync markers needed).

## Verification
`cargo check` clean.