### PR TITLE
plugins(api): settings.get — plugins can read their own config (Phase 3)

### DIFF
--- a/backend/src/handlers/plugins.rs
+++ b/backend/src/handlers/plugins.rs
@@ -130,6 +130,10 @@ pub fn config(cfg: &mut web::ServiceConfig) {
         "/plugins/{uuid}/proxy",
         web::post().to(crate::handlers::plugins::proxy_plugin_request),
     )
+    .route(
+        "/plugins/{uuid}/settings",
+        web::get().to(crate::handlers::plugins::get_plugin_runtime_settings),
+    )
     // ===== PLUGIN EVENT EMISSION =====
     // Authenticated user iframes can call this to record a
     // plugin-emitted event in sync_actions with
@@ -1287,6 +1291,54 @@ pub async fn proxy_plugin_request(
             // method, 504 timeout, 502 other network faults (was a flat 400).
             error!("Proxy request failed: {}", e);
             HttpResponse::build(e.status_code()).json(serde_json::json!({ "error": e.to_string() }))
+        }
+    }
+}
+
+/// Read a plugin's own settings at runtime (non-admin, for plugin use). Secret
+/// values are redacted by `PluginSettingResponse` (`value: None` when
+/// `is_secret`) — a plugin never sees its admin-configured secrets, which are
+/// injected server-side by the egress proxy. Requires the plugin to be Installed.
+pub async fn get_plugin_runtime_settings(
+    req: HttpRequest,
+    mut tc: TenantConn,
+    path: web::Path<Uuid>,
+) -> impl Responder {
+    if req.extensions().get::<Claims>().is_none() {
+        return errors::unauthorized("Authentication required");
+    }
+    let plugin_uuid = path.into_inner();
+
+    enum Outcome {
+        Ok(Vec<crate::models::PluginData>),
+        NotFound,
+        Inactive,
+    }
+
+    let outcome = tc.run(|conn| {
+        let plugin = match plugin_repo::get_plugin_by_uuid(conn, plugin_uuid) {
+            Ok(p) => p,
+            Err(DieselError::NotFound) => return Ok(Outcome::NotFound),
+            Err(e) => return Err(e),
+        };
+        if !plugin.is_active() {
+            return Ok(Outcome::Inactive);
+        }
+        let settings = plugin_repo::get_plugin_settings(conn, plugin.id)?;
+        Ok::<_, DieselError>(Outcome::Ok(settings))
+    });
+
+    match outcome {
+        Ok(Outcome::Ok(settings)) => {
+            let response: Vec<PluginSettingResponse> =
+                settings.into_iter().map(Into::into).collect();
+            HttpResponse::Ok().json(response)
+        }
+        Ok(Outcome::NotFound) => errors::not_found_msg("Plugin not found"),
+        Ok(Outcome::Inactive) => errors::forbidden("Plugin is not active"),
+        Err(e) => {
+            error!("Failed to get plugin runtime settings: {}", e);
+            errors::internal("Failed to get settings")
         }
     }
 }

--- a/frontend/src/plugins/api.ts
+++ b/frontend/src/plugins/api.ts
@@ -520,6 +520,21 @@ export function createPluginAPI(plugin: Plugin): PluginAPI {
       };
     },
 
+    // === SETTINGS: The plugin's own admin-configured config ===
+    settings: {
+      async get(key: string): Promise<unknown | null> {
+        try {
+          const settings = await pluginService.getRuntimeSettings(plugin.uuid);
+          const s = settings.find((x) => x.key === key);
+          // A secret's value is redacted to null server-side; unset keys are
+          // absent. Either way the plugin gets null, never the secret.
+          return s ? (s.value ?? null) : null;
+        } catch (error) {
+          throw upstream('failed to get setting', error);
+        }
+      },
+    },
+
     // === NOTIFY: User feedback ===
     // Surface plugin notifications through the same toast store
     // the rest of the app uses. Plugin name is the toast title so
@@ -624,6 +639,11 @@ export interface PluginAPI {
       delete(uuid: string): Promise<boolean>;
       list(params?: { limit?: number; offset?: number; filter?: string; sort_by?: string; sort_order?: string }): Promise<CollectionListResponse>;
     };
+  };
+
+  // The plugin's own admin-configured settings (secrets redacted)
+  settings: {
+    get(key: string): Promise<unknown | null>;
   };
 
   // Event subscription

--- a/frontend/src/plugins/sandboxHostApi.ts
+++ b/frontend/src/plugins/sandboxHostApi.ts
@@ -80,6 +80,10 @@ export function createHostApiImpl(plugin: Plugin): { hostApi: HostApi; inproc: P
       delete: (key) => inproc.storage.delete(key),
     },
 
+    settings: {
+      get: (key) => inproc.settings.get(key),
+    },
+
     // A collection sub-API is stateful (bound to `name`); proxy it so the
     // plugin's calls on it round-trip too.
     async collections(name) {

--- a/packages/core/src/services/pluginService.ts
+++ b/packages/core/src/services/pluginService.ts
@@ -189,6 +189,20 @@ const pluginService = {
   },
 
   /**
+   * Read a plugin's own settings at runtime (non-admin, for the plugin bridge).
+   * Secret values are redacted server-side (`value: null` when `is_secret`).
+   */
+  async getRuntimeSettings(uuid: string): Promise<PluginSetting[]> {
+    try {
+      const response = await apiClient.get(`/plugins/${uuid}/settings`);
+      return response.data || [];
+    } catch (error) {
+      logger.error('Failed to get plugin runtime settings', { error, uuid });
+      throw error;
+    }
+  },
+
+  /**
    * Set a plugin setting (admin only)
    */
   async setPluginSetting(uuid: string, request: SetPluginSettingRequest): Promise<PluginSetting> {

--- a/packages/plugin-sdk/src/types.ts
+++ b/packages/plugin-sdk/src/types.ts
@@ -206,6 +206,12 @@ export interface HostApi {
   collections(name: string): Promise<PluginCollection>;
   /** Subscribe to a host event; resolves to an async unsubscribe. */
   on(event: PluginEvent, handler: PluginEventHandler): Promise<() => Promise<void>>;
+  settings: {
+    /** Read one of the plugin's admin-configured settings. Secrets are redacted
+     * (a `secret`-type setting's value is always `null` — the egress proxy
+     * injects them server-side); `null` also for an unset key. */
+    get(key: string): Promise<unknown | null>;
+  };
   notify(message: string, type?: 'info' | 'success' | 'warning' | 'error'): Promise<void>;
   ui: { isPrinting(): Promise<boolean> };
 }


### PR DESCRIPTION
Phase 3 — closes the audit's "settings declarable but unreadable" gap (API3).

## Problem
A plugin could **declare** settings (an admin configures them in `PluginDetailView`), but had **no way to read them at runtime** — the only settings-read endpoint was admin-gated. Settings were write-by-admin, read-by-nobody.

## Change
- **Backend**: `GET /plugins/{uuid}/settings` (non-admin, auth + `Installed`) → `PluginSettingResponse[]`, which **already redacts secret values** (`value: null` when `is_secret`). A plugin never sees its admin-configured secrets — those stay server-side for egress-proxy auth injection.
- `pluginService.getRuntimeSettings(uuid)` hits it.
- **`api.settings.get(key)`**: returns the value, or `null` for a secret / unset key. Wired through the SDK `HostApi.settings` + the boundary adapter. No permission gate (a plugin reading its own non-secret config is ambient, like `api.plugin`).

No `runtime.js` change (host-side).

## Verification
SDK + frontend + core type-check + eslint clean; backend `cargo check` clean.