### PR TITLE
plugins: %key% i18n resolver for plugin-authored strings (Phase 3)

### DIFF
--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -6413,6 +6413,15 @@ pub struct PluginManifest {
     /// any non-empty value at install.
     #[serde(default)]
     pub extensions: std::collections::BTreeMap<String, serde_json::Value>,
+
+    /// Per-locale string tables for localizing surface-visible fields. A
+    /// localizable field (`displayName`, `components[].label`/`action.label`,
+    /// `settings[].label`/`description`/`options[].label`) may be `%key%`, which
+    /// the UI resolves against `i18n[<locale>][<key>]`, falling back to
+    /// `i18n["en-US"][<key>]`, then the literal. Every `%key%` used MUST be
+    /// defined for `en-US` (validated at install), so a fallback always exists.
+    #[serde(default)]
+    pub i18n: std::collections::BTreeMap<String, std::collections::BTreeMap<String, String>>,
 }
 
 /// Engine compatibility constraints. Both values are required.

--- a/backend/src/services/plugins/manifest_validate.rs
+++ b/backend/src/services/plugins/manifest_validate.rs
@@ -187,9 +187,17 @@ pub enum ManifestValidationError {
     ReservedFieldNotEmpty {
         field: &'static str,
     },
-    LocalisationKeyReserved {
+    /// A localizable field uses `%key%` but the key isn't defined in
+    /// `i18n["en-US"]`, so it has no fallback and would render as the literal
+    /// `%key%`.
+    UnresolvedI18nKey {
         location: &'static str,
-        value: String,
+        key: String,
+    },
+    /// An `i18n` string table has an empty value.
+    EmptyI18nValue {
+        locale: String,
+        key: String,
     },
     InvalidContactUrl(String),
     InvalidBugsUrl(String),
@@ -256,9 +264,13 @@ impl std::fmt::Display for ManifestValidationError {
                 f,
                 "manifest.{field} is a reserved field and is not yet honoured by this Nosdesk version; remove or set to empty"
             ),
-            Self::LocalisationKeyReserved { location, value } => write!(
+            Self::UnresolvedI18nKey { location, key } => write!(
                 f,
-                "{location} value {value:?} matches the reserved localisation syntax %key%; future Nosdesk versions will resolve these from i18n bundles. Use literal text or wait."
+                "{location} uses %{key}% but i18n[\"en-US\"][\"{key}\"] is not defined; every localisation key must have an en-US fallback"
+            ),
+            Self::EmptyI18nValue { locale, key } => write!(
+                f,
+                "i18n[{locale:?}][{key:?}] is empty"
             ),
             Self::InvalidContactUrl(s) => write!(
                 f,
@@ -432,28 +444,42 @@ pub fn validate(
         }
     }
 
-    // Localisation syntax reservation: any string of the form
-    // `%key%` is reserved for a future i18n resolver. Refuse
-    // surface-visible strings that look like keys today so plugins
-    // can't accidentally claim the syntax.
-    if looks_like_localisation_key(&manifest.display_name) {
-        errors.push(ManifestValidationError::LocalisationKeyReserved {
-            location: "displayName",
-            value: manifest.display_name.clone(),
-        });
-    }
-    for setting in &manifest.settings {
-        if looks_like_localisation_key(&setting.label) {
-            errors.push(ManifestValidationError::LocalisationKeyReserved {
-                location: "settings[].label",
-                value: setting.label.clone(),
-            });
+    // Localisation: a surface-visible field may be `%key%`, resolved by the UI
+    // against `manifest.i18n`. Every key used must have an en-US fallback, so it
+    // always resolves to something.
+    let fallback = manifest.i18n.get(FALLBACK_LOCALE);
+    let mut check_l10n = |location: &'static str, value: &str| {
+        if let Some(e) = check_localizable(fallback, location, value) {
+            errors.push(e);
         }
+    };
+    check_l10n("displayName", &manifest.display_name);
+    for setting in &manifest.settings {
+        check_l10n("settings[].label", &setting.label);
         if let Some(d) = &setting.description {
-            if looks_like_localisation_key(d) {
-                errors.push(ManifestValidationError::LocalisationKeyReserved {
-                    location: "settings[].description",
-                    value: d.clone(),
+            check_l10n("settings[].description", d);
+        }
+        if let Some(opts) = &setting.options {
+            for opt in opts {
+                check_l10n("settings[].options[].label", &opt.label);
+            }
+        }
+    }
+    for comp in manifest.components.values() {
+        if let Some(l) = &comp.label {
+            check_l10n("components[].label", l);
+        }
+        if let Some(a) = &comp.action {
+            check_l10n("components[].action.label", &a.label);
+        }
+    }
+    // Reject empty i18n values (a `%key%` resolving to "" is a silent bug).
+    for (loc, table) in &manifest.i18n {
+        for (k, v) in table {
+            if v.trim().is_empty() {
+                errors.push(ManifestValidationError::EmptyI18nValue {
+                    locale: loc.clone(),
+                    key: k.clone(),
                 });
             }
         }
@@ -470,14 +496,38 @@ pub fn validate(
 /// `%`, identifier characters (letters, digits, underscore, dot),
 /// trailing `%`. Used to refuse manifest strings that would collide
 /// with future i18n bundles.
-fn looks_like_localisation_key(s: &str) -> bool {
-    let inner = match s.strip_prefix('%').and_then(|s| s.strip_suffix('%')) {
-        Some(i) if !i.is_empty() => i,
-        _ => return false,
-    };
-    inner
-        .chars()
-        .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '.')
+/// The locale every `%key%` must be defined for, so a fallback always exists.
+const FALLBACK_LOCALE: &str = "en-US";
+
+/// If `s` is a `%key%` reference, return the inner key. Grammar: leading `%`,
+/// non-empty inner of `[A-Za-z0-9_.]`, trailing `%`. The UI resolver matches this.
+pub(crate) fn i18n_key(s: &str) -> Option<&str> {
+    s.strip_prefix('%')
+        .and_then(|s| s.strip_suffix('%'))
+        .filter(|inner| {
+            !inner.is_empty()
+                && inner
+                    .chars()
+                    .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '.')
+        })
+}
+
+/// Validate a localizable field: if it's a `%key%`, the key must exist in the
+/// en-US fallback table.
+fn check_localizable(
+    fallback: Option<&std::collections::BTreeMap<String, String>>,
+    location: &'static str,
+    value: &str,
+) -> Option<ManifestValidationError> {
+    let key = i18n_key(value)?;
+    if fallback.is_some_and(|m| m.contains_key(key)) {
+        None
+    } else {
+        Some(ManifestValidationError::UnresolvedI18nKey {
+            location,
+            key: key.to_string(),
+        })
+    }
 }
 
 /// Canonical plugin-name rules. 1-100 chars, lowercase ASCII +
@@ -721,6 +771,7 @@ mod tests {
             menus: std::collections::BTreeMap::new(),
             url_handlers: vec![],
             extensions: std::collections::BTreeMap::new(),
+            i18n: std::collections::BTreeMap::new(),
         }
     }
 
@@ -1033,15 +1084,39 @@ mod tests {
     }
 
     #[test]
-    fn rejects_localisation_key_in_display_name() {
+    fn rejects_i18n_key_without_en_us_fallback() {
         let mut m = baseline_manifest();
         m.display_name = "%my.app.name%".into();
         assert_err!(
             validate(&m, &ctx_official()),
-            ManifestValidationError::LocalisationKeyReserved {
+            ManifestValidationError::UnresolvedI18nKey {
                 location: "displayName",
                 ..
             },
+        );
+    }
+
+    #[test]
+    fn accepts_i18n_key_with_en_us_fallback() {
+        let mut m = baseline_manifest();
+        m.display_name = "%my.app.name%".into();
+        m.i18n.insert(
+            "en-US".into(),
+            std::collections::BTreeMap::from([("my.app.name".to_string(), "My App".to_string())]),
+        );
+        assert!(validate(&m, &ctx_official()).is_ok());
+    }
+
+    #[test]
+    fn rejects_empty_i18n_value() {
+        let mut m = baseline_manifest();
+        m.i18n.insert(
+            "en-US".into(),
+            std::collections::BTreeMap::from([("k".to_string(), "  ".to_string())]),
+        );
+        assert_err!(
+            validate(&m, &ctx_official()),
+            ManifestValidationError::EmptyI18nValue { .. },
         );
     }
 

--- a/backend/src/services/plugins/proxy.rs
+++ b/backend/src/services/plugins/proxy.rs
@@ -593,6 +593,7 @@ mod tests {
             menus: std::collections::BTreeMap::new(),
             url_handlers: vec![],
             extensions: std::collections::BTreeMap::new(),
+            i18n: std::collections::BTreeMap::new(),
         }
     }
 

--- a/frontend/src/components/plugins/PluginCard.vue
+++ b/frontend/src/components/plugins/PluginCard.vue
@@ -18,6 +18,8 @@ import { computed, type DeepReadonly } from 'vue';
 import { useFluent } from 'fluent-vue';
 import type { Plugin } from '@nosdesk/core/types/plugin';
 import { formatDate } from '@nosdesk/core/utils/dateUtils';
+import { useDateStore } from '@nosdesk/core/stores/dateStore';
+import { resolvePluginI18n, type PluginI18n } from '@nosdesk/core/utils/pluginI18n';
 import PluginIcon from './PluginIcon.vue';
 import PluginStateBadge from './PluginStateBadge.vue';
 import PluginTrustBadge from './PluginTrustBadge.vue';
@@ -35,6 +37,11 @@ interface Props {
 }
 
 const { plugin, showStateAlways = false } = defineProps<Props>();
+
+const dateStore = useDateStore();
+const displayName = computed(() =>
+  resolvePluginI18n(plugin.display_name, plugin.manifest.i18n as PluginI18n | undefined, dateStore.locale),
+);
 
 const fluent = useFluent();
 const t = (key: string, args?: Record<string, string | number>) => fluent.$t(key, args);
@@ -54,11 +61,11 @@ const srPermissionCount = computed(() => t('plugin-card-sr-permission-count'));
   <article class="overflow-hidden rounded-xl border border-default bg-surface">
     <div class="p-4">
       <div class="flex items-start gap-3">
-        <PluginIcon :uuid="plugin.uuid" :alt="plugin.display_name" />
+        <PluginIcon :uuid="plugin.uuid" :alt="displayName" />
 
         <div class="min-w-0 flex-1">
           <header class="flex flex-wrap items-center gap-1.5 sm:gap-2">
-            <h3 class="font-semibold text-primary">{{ plugin.display_name }}</h3>
+            <h3 class="font-semibold text-primary">{{ displayName }}</h3>
             <code class="rounded bg-surface-alt px-1.5 py-0.5 font-mono text-xs text-secondary">
               v{{ plugin.version }}
             </code>

--- a/frontend/src/plugins/loader.ts
+++ b/frontend/src/plugins/loader.ts
@@ -7,6 +7,8 @@
 
 import { ref, shallowRef, reactive, type ShallowRef } from 'vue';
 import pluginService from '@nosdesk/core/services/pluginService';
+import { useDateStore } from '@nosdesk/core/stores/dateStore';
+import { resolvePluginI18n } from '@nosdesk/core/utils/pluginI18n';
 import { onSyncActions } from '@nosdesk/core/sync/observers';
 import type { SyncAction } from '@nosdesk/core/sync/types';
 import { logger } from '@nosdesk/core/utils/logger';
@@ -143,11 +145,15 @@ async function loadPlugin(plugin: Plugin): Promise<void> {
     }
     const slot = config.slot as PluginSlot;
 
+    // Resolve %key% labels against the manifest's i18n tables at load time.
+    const l10n = (v: string | undefined): string | undefined =>
+      v == null ? v : resolvePluginI18n(v, plugin.manifest.i18n, useDateStore().locale);
+
     const registration: PluginSlotRegistration = {
       pluginUuid: plugin.uuid,
       pluginName: plugin.name,
       componentName,
-      label: config.label,
+      label: l10n(config.label),
       icon: config.icon,
       context: config.context || [],
     };
@@ -162,13 +168,13 @@ async function loadPlugin(plugin: Plugin): Promise<void> {
         pluginName: plugin.name,
         componentName,
         slot,
-        label: config.action.label,
+        label: l10n(config.action.label) ?? config.action.label,
         // Per-component icon comes from the manifest's component
         // config (small inline glyph or override). Plugin-level
         // identity icon is served from /api/plugins/<uuid>/icon and
         // referenced separately by the plugin list views.
         icon: config.icon,
-        componentLabel: config.label,
+        componentLabel: l10n(config.label),
       };
 
       const existingActions = actionRegistrations.get(slot) || [];

--- a/frontend/src/views/admin/plugins/PluginDetailView.vue
+++ b/frontend/src/views/admin/plugins/PluginDetailView.vue
@@ -33,6 +33,8 @@ import PluginTrustBadge from '@/components/plugins/PluginTrustBadge.vue';
 import pluginService from '@nosdesk/core/services/pluginService';
 import { unloadPlugin } from '@/plugins/loader';
 import { logger } from '@nosdesk/core/utils/logger';
+import { useDateStore } from '@nosdesk/core/stores/dateStore';
+import { resolvePluginI18n } from '@nosdesk/core/utils/pluginI18n';
 import type { Plugin, PluginSetting } from '@nosdesk/core/types/plugin';
 import PluginPermissionList from '@/components/plugins/PluginPermissionList.vue';
 
@@ -67,6 +69,11 @@ const pluginQuery = useQuery({
   enabled: () => !!uuid.value,
 });
 const plugin = computed<Plugin | null>(() => pluginQuery.data.value ?? null);
+
+// Resolve a plugin-authored `%key%` string against the manifest's i18n tables.
+const dateStore = useDateStore();
+const l10n = (value: string | null | undefined): string =>
+  resolvePluginI18n(value, plugin.value?.manifest.i18n, dateStore.locale);
 const loadOp = computed(() => ({
   isPending: pluginQuery.asyncStatus.value === 'loading',
   isError: pluginQuery.state.value.status === 'error',
@@ -320,9 +327,9 @@ const saveButtonLabel = computed(() =>
     <template v-if="plugin">
       <!-- Header card -->
       <header class="flex flex-col gap-4 rounded-xl border border-default bg-surface p-5 sm:flex-row sm:items-start">
-        <PluginIcon :uuid="plugin.uuid" :alt="plugin.display_name" size="lg" />
+        <PluginIcon :uuid="plugin.uuid" :alt="l10n(plugin.display_name)" size="lg" />
         <div class="min-w-0 flex-1">
-          <h1 class="text-2xl font-bold text-primary">{{ plugin.display_name }}</h1>
+          <h1 class="text-2xl font-bold text-primary">{{ l10n(plugin.display_name) }}</h1>
           <p class="mt-1 font-mono text-xs text-tertiary">{{ plugin.name }}</p>
           <div class="mt-3 flex flex-wrap items-center gap-2 text-sm">
             <code class="rounded bg-surface-alt px-1.5 py-0.5 font-mono text-xs text-secondary">
@@ -404,11 +411,11 @@ const saveButtonLabel = computed(() =>
           >
             <div>
               <label :for="`setting-${def.key}`" class="block text-sm font-medium text-primary">
-                {{ def.label }}
+                {{ l10n(def.label) }}
                 <span v-if="def.required" class="text-status-error" :aria-label="requiredAriaLabel">*</span>
               </label>
               <p v-if="def.description" class="mt-1 text-xs text-tertiary">
-                {{ def.description }}
+                {{ l10n(def.description) }}
               </p>
             </div>
 

--- a/packages/core/src/types/plugin.ts
+++ b/packages/core/src/types/plugin.ts
@@ -51,6 +51,10 @@ export interface PluginManifest {
   url_handlers?: PluginUrlHandler[];
   /** RESERVED for typed inter-plugin exports. */
   extensions?: unknown;
+  /** Per-locale string tables. A localizable field may be `%key%`, resolved
+   *  against `i18n[locale][key]` (falling back to `i18n['en-US'][key]`, then the
+   *  literal). See `resolvePluginI18n`. */
+  i18n?: Record<string, Record<string, string>>;
 }
 
 export interface PluginCommandDefinition {

--- a/packages/core/src/utils/pluginI18n.ts
+++ b/packages/core/src/utils/pluginI18n.ts
@@ -1,0 +1,29 @@
+// Resolve a plugin's localizable manifest string. A field may be `%key%`, which
+// resolves against the manifest's per-locale `i18n` tables:
+//   i18n[locale][key]  ->  i18n['en-US'][key]  ->  the literal (key unwrapped)
+// Manifest validation guarantees every `%key%` has an en-US fallback, so a
+// `%key%` always resolves to something. A non-`%key%` string is returned as-is.
+
+const FALLBACK_LOCALE = 'en-US';
+
+/** Grammar mirrors the backend `i18n_key`: `%` + `[A-Za-z0-9_.]+` + `%`. */
+const KEY_RE = /^%([A-Za-z0-9_.]+)%$/;
+
+export type PluginI18n = Record<string, Record<string, string>>;
+
+export function resolvePluginI18n(
+  value: string | undefined | null,
+  i18n: PluginI18n | undefined,
+  locale: string,
+): string {
+  if (!value) return value ?? '';
+  const m = KEY_RE.exec(value);
+  if (!m) return value;
+  const key = m[1];
+  const fromLocale = i18n?.[locale]?.[key];
+  if (fromLocale) return fromLocale;
+  const fromFallback = i18n?.[FALLBACK_LOCALE]?.[key];
+  if (fromFallback) return fromFallback;
+  // No table (or a locale-switch gap) — show the bare key, not the raw `%key%`.
+  return key;
+}


### PR DESCRIPTION
Phase 3 — closes the audit's plugin-i18n gap (plugin UI was English-only while host chrome is fully translated).

## Problem
Plugin `display_name` / settings labels / component labels rendered **literally**. The `%key%` syntax was *reserved and refused* at install, with no mechanism to localize plugin UI.

## Change — self-contained per plugin (the VS Code / Chrome `_locales` model)
The manifest gains an optional `i18n: { [locale]: { [key]: value } }`, and a localizable field may be `%key%`, resolved against `i18n[locale][key]` → `i18n['en-US'][key]` → the bare key.

- **Manifest**: new `i18n` map (Rust `PluginManifest` + TS type).
- **Validation**: `%key%` is now **allowed** in `displayName` / `settings[].label`+`description`+`options[].label` / `components[].label`+`action.label`, but every key **must have an en-US fallback** (`UnresolvedI18nKey` error) so it always resolves to something; empty i18n values are rejected. Replaces the old `LocalisationKeyReserved` refusal. 3 new tests (38 manifest tests green).
- **Frontend**: `resolvePluginI18n(value, i18n, locale)` util (locale from the date store), wired at `PluginCard` title, `PluginDetailView` title + settings label/description, and slot/action labels in `loader.ts`.

No `runtime.js` change (host-side rendering + backend validation).

## Verification
38 `manifest_validate` tests green (incl. new i18n cases); core + frontend type-check + eslint clean; no runtime drift.