### PR TITLE
plugin: slot-registry foundations (single source + generic PluginSlot)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,6 +205,14 @@ jobs:
           pnpm --filter @nosdesk/plugin-runtime run build
           git diff --exit-code backend/src/handlers/plugin_sandbox/runtime.js
 
+      # Regenerate the backend's slot allowlist from the single-source TS
+      # registry and assert the committed JSON is in sync — catches a
+      # pluginSlots.ts edit that wasn't regenerated + committed.
+      - name: Plugin slot registry gen + drift check
+        run: |
+          pnpm --filter @nosdesk/core run build:slots
+          git diff --exit-code backend/src/services/plugins/plugin_slots.generated.json
+
       - name: Audit
         # Advisory only — must not hard-block merges. npm retired the legacy
         # audit endpoint (returns HTTP 410), which older `pnpm audit` still

--- a/backend/src/services/plugins/manifest_validate.rs
+++ b/backend/src/services/plugins/manifest_validate.rs
@@ -39,35 +39,13 @@ pub const SUPPORTED_PLUGIN_API_VERSION: &str = "1";
 // adding a new permission means extending that enum plus the
 // matching handler enforcement, not editing a list here.
 
-/// Slot identifiers from the canonical taxonomy declared in
-/// `frontend/src/types/plugin.ts::PLUGIN_SLOTS`. Plugins may
-/// declare any slot in this list at install time; if the runtime
-/// hasn't yet added a `<PluginSlot slot-name="x">` mount point
-/// for the slot, the plugin's contribution is a silent no-op
-/// (matches the VS Code contribution-point model).
-///
-/// Adding a slot is a two-step coordinated change: extend the
-/// frontend `PluginSlot` union + `PLUGIN_SLOTS` registry, and
-/// add the literal here. Mounting the slot in a Vue template is
-/// independent: plugins can author against the slot before
-/// the template lands, the contribution just doesn't render
-/// until the mount point exists.
-pub(crate) const KNOWN_SLOTS: &[&str] = &[
-    // Global
-    "navbar-items",
-    "settings-integrations",
-    // Ticket context
-    "ticket-header-actions",
-    "ticket-sidebar",
-    "ticket-tabs",
-    "ticket-footer-actions",
-    // Document context
-    "document-toolbar",
-    "document-sidebar",
-    // Asset context
-    "asset-header-actions",
-    "asset-info-panels",
-];
+// Slot identifiers come from the single source of truth in
+// `packages/core/src/types/pluginSlots.ts`, generated into
+// `plugin_slots.generated.json` and read via `slot_registry`. A plugin may
+// target any canonical name or legacy alias in the registry; a slot with no
+// live mount point yet (`status: "reserved"`) is a silent no-op until one
+// lands (the VS Code contribution-point model). Adding a slot is a one-place
+// edit in the TS registry followed by `build:slots`.
 
 /// Context types a component can request. The runtime passes the
 /// matching object on the `context` prop.
@@ -631,7 +609,7 @@ fn validate_component(component: &PluginComponentConfig) -> Result<(), ManifestV
         ));
     }
 
-    if !KNOWN_SLOTS.contains(&component.slot.as_str()) {
+    if !crate::services::plugins::slot_registry::is_known_slot(&component.slot) {
         return Err(ManifestValidationError::InvalidSlot(component.slot.clone()));
     }
     for ctx in &component.context {

--- a/backend/src/services/plugins/mod.rs
+++ b/backend/src/services/plugins/mod.rs
@@ -12,6 +12,7 @@ pub mod provisioning;
 pub mod proxy;
 pub mod registry;
 pub mod signing;
+pub mod slot_registry;
 pub mod svg_validate;
 pub mod trust;
 pub mod types;

--- a/backend/src/services/plugins/plugin_slots.generated.json
+++ b/backend/src/services/plugins/plugin_slots.generated.json
@@ -1,0 +1,120 @@
+[
+  {
+    "name": "ticket.sidebar.panel",
+    "mechanism": "panel",
+    "context": "ticket",
+    "cardinality": "many",
+    "order": 100,
+    "status": "stable",
+    "aliases": [
+      "ticket-sidebar"
+    ],
+    "description": "Panels in the ticket sidebar"
+  },
+  {
+    "name": "asset.info.panel",
+    "mechanism": "panel",
+    "context": "asset",
+    "cardinality": "many",
+    "order": 100,
+    "status": "stable",
+    "aliases": [
+      "asset-info-panels"
+    ],
+    "description": "Info panels on the asset view"
+  },
+  {
+    "name": "settings.integrations.page",
+    "mechanism": "panel",
+    "context": "none",
+    "cardinality": "many",
+    "order": 100,
+    "status": "reserved",
+    "aliases": [
+      "settings-integrations"
+    ],
+    "description": "Pages under Settings > Integrations"
+  },
+  {
+    "name": "dashboard.widget",
+    "mechanism": "panel",
+    "context": "none",
+    "cardinality": "many",
+    "order": 100,
+    "status": "reserved",
+    "aliases": [],
+    "description": "Widgets on the dashboard"
+  },
+  {
+    "name": "ticket.tab.panel",
+    "mechanism": "panel",
+    "context": "ticket",
+    "cardinality": "many",
+    "order": 100,
+    "status": "reserved",
+    "aliases": [
+      "ticket-tabs"
+    ],
+    "description": "Tabs on the ticket view"
+  },
+  {
+    "name": "document.sidebar.panel",
+    "mechanism": "panel",
+    "context": "documentationPage",
+    "cardinality": "many",
+    "order": 100,
+    "status": "reserved",
+    "aliases": [
+      "document-sidebar"
+    ],
+    "description": "Panels in the document sidebar"
+  },
+  {
+    "name": "ticket.header.action",
+    "mechanism": "action",
+    "context": "ticket",
+    "cardinality": "many",
+    "order": 100,
+    "status": "reserved",
+    "aliases": [
+      "ticket-header-actions"
+    ],
+    "description": "Actions in the ticket header menu"
+  },
+  {
+    "name": "asset.header.action",
+    "mechanism": "action",
+    "context": "asset",
+    "cardinality": "many",
+    "order": 100,
+    "status": "reserved",
+    "aliases": [
+      "asset-header-actions"
+    ],
+    "description": "Actions in the asset header menu"
+  },
+  {
+    "name": "document.toolbar.action",
+    "mechanism": "action",
+    "context": "documentationPage",
+    "cardinality": "many",
+    "order": 100,
+    "status": "reserved",
+    "aliases": [
+      "document-toolbar"
+    ],
+    "description": "Actions in the document toolbar menu"
+  },
+  {
+    "name": "nav.item",
+    "mechanism": "action",
+    "context": "none",
+    "cardinality": "many",
+    "order": 100,
+    "status": "reserved",
+    "aliases": [
+      "navbar-items"
+    ],
+    "description": "Links in the navigation sidebar"
+  }
+]

--- a/backend/src/services/plugins/slot_registry.rs
+++ b/backend/src/services/plugins/slot_registry.rs
@@ -1,0 +1,96 @@
+//! Plugin UI slot allowlist.
+//!
+//! Read from `plugin_slots.generated.json`, which is generated from the single
+//! source of truth in `packages/core/src/types/pluginSlots.ts` by
+//! `pnpm --filter @nosdesk/core build:slots` and drift-checked in CI. There is
+//! no hand-maintained slot list here — a manifest edit on the TS side flows
+//! through the generated JSON, so the frontend taxonomy and this validator can
+//! never silently disagree.
+
+use std::sync::LazyLock;
+
+use serde::Deserialize;
+
+/// One slot definition, mirroring the TS `SlotDef`. Only the fields the backend
+/// needs to enforce are read; the rest (order, description, mechanism) are
+/// deserialized for completeness / future use.
+#[derive(Debug, Clone, Deserialize)]
+pub struct SlotDef {
+    /// Canonical dotted identifier.
+    pub name: String,
+    pub mechanism: String,
+    pub context: String,
+    pub cardinality: String,
+    pub order: i64,
+    pub status: String,
+    /// Legacy flat names still accepted at validation time.
+    #[serde(default)]
+    pub aliases: Vec<String>,
+    pub description: String,
+}
+
+static RAW: &str = include_str!("plugin_slots.generated.json");
+
+/// The parsed registry. Panics at first access if the generated JSON is
+/// malformed, which only happens if the committed artifact was hand-edited or
+/// the generator regressed — both caught in CI before merge.
+pub static SLOT_REGISTRY: LazyLock<Vec<SlotDef>> = LazyLock::new(|| {
+    serde_json::from_str(RAW).expect("plugin_slots.generated.json must be valid SlotDef JSON")
+});
+
+/// True if `name` matches a canonical slot name or any of its aliases.
+pub fn is_known_slot(name: &str) -> bool {
+    SLOT_REGISTRY
+        .iter()
+        .any(|s| s.name == name || s.aliases.iter().any(|a| a == name))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn generated_json_parses_and_is_nonempty() {
+        assert!(!SLOT_REGISTRY.is_empty());
+    }
+
+    #[test]
+    fn known_mechanisms_and_statuses() {
+        for s in SLOT_REGISTRY.iter() {
+            assert!(
+                matches!(s.mechanism.as_str(), "panel" | "action"),
+                "unknown mechanism {} on {}",
+                s.mechanism,
+                s.name
+            );
+            assert!(
+                matches!(s.status.as_str(), "stable" | "reserved" | "experimental"),
+                "unknown status {} on {}",
+                s.status,
+                s.name
+            );
+            assert!(
+                matches!(
+                    s.context.as_str(),
+                    "ticket" | "asset" | "documentationPage" | "none"
+                ),
+                "unknown context {} on {}",
+                s.context,
+                s.name
+            );
+            assert!(matches!(s.cardinality.as_str(), "one" | "many"));
+            assert!(s.order >= 0);
+            assert!(!s.description.is_empty());
+        }
+    }
+
+    #[test]
+    fn live_slots_and_aliases_resolve() {
+        // The two mounted slots plus their legacy aliases must validate.
+        assert!(is_known_slot("ticket.sidebar.panel"));
+        assert!(is_known_slot("ticket-sidebar"));
+        assert!(is_known_slot("asset.info.panel"));
+        assert!(is_known_slot("asset-info-panels"));
+        assert!(!is_known_slot("nope.not.a.slot"));
+    }
+}

--- a/frontend/src/plugins/components/PluginSandboxFrame.vue
+++ b/frontend/src/plugins/components/PluginSandboxFrame.vue
@@ -15,8 +15,7 @@ import type { HostBridge, PluginContext } from '@nosdesk/plugin-sdk';
 import pluginService from '@nosdesk/core/services/pluginService';
 import { logger } from '@nosdesk/core/utils/logger';
 import type { Plugin } from '@nosdesk/core/types/plugin';
-import type { Ticket } from '@nosdesk/core/types/ticket';
-import type { Asset } from '@nosdesk/core/types/asset';
+import type { PluginSlotContext } from '../context';
 import { createHostApiImpl } from '../sandboxHostApi';
 import { registerPluginInstance } from '../pluginInstances';
 
@@ -24,8 +23,8 @@ const props = defineProps<{
   plugin: Plugin;
   /** Which manifest component this frame renders (a bundle may declare several). */
   component: { name: string; slot: string };
-  ticket?: Ticket;
-  device?: Asset;
+  /** Host-provided context bag; the snapshot projects its fields onto the wire. */
+  context?: PluginSlotContext;
   /** Monotonic counter from the host action menu; forwarded to the plugin. */
   actionActivated?: number;
 }>();
@@ -55,8 +54,8 @@ function plain<T>(value: T | undefined): T | null {
 }
 function snapshot(): PluginContext {
   return {
-    ticket: plain(props.ticket),
-    asset: plain(props.device),
+    ticket: plain(props.context?.ticket),
+    asset: plain(props.context?.asset),
     component: { name: props.component.name, slot: props.component.slot },
     actionActivated: props.actionActivated,
   };
@@ -119,12 +118,12 @@ onMounted(() => {
   void mintToken();
 });
 
-// Push a fresh context snapshot whenever ticket/asset, the component, or the
+// Push a fresh context snapshot whenever the context bag, the component, or the
 // action counter changes. `deep` is required: the sync pool patches ticket/asset
 // rows IN PLACE (same object identity), so a shallow, reference-keyed watch would
 // miss field updates and leave the plugin on stale context.
 watch(
-  [() => props.ticket, () => props.device, () => props.component, () => props.actionActivated],
+  [() => props.context, () => props.component, () => props.actionActivated],
   () => {
     const win = frameRef.value?.contentWindow;
     if (connected && win) postContext(win, snapshot());

--- a/frontend/src/plugins/components/PluginSlot.vue
+++ b/frontend/src/plugins/components/PluginSlot.vue
@@ -2,30 +2,30 @@
 /**
  * Plugin Slot Component
  *
- * Renders plugin components registered for a specific slot.
- * Provides context (ticket, device, etc.) to plugin components.
+ * Renders every plugin component registered for a slot `target`. Takes the
+ * canonical dotted target name (a legacy alias is accepted and normalized) plus
+ * a typed `context` bag, and provides the resolved slot name to descendants.
  */
 import { computed, provide } from 'vue';
 import { slotRegistrations } from '../loader';
-import type { PluginSlot as SlotType } from '@nosdesk/core/types/plugin';
-import type { Ticket } from '@nosdesk/core/types/ticket';
-import type { Asset } from '@nosdesk/core/types/asset';
+import type { PluginSlotContext } from '../context';
+import { canonicalSlotName } from '@nosdesk/core/types/plugin';
+import type { PluginSlot } from '@nosdesk/core/types/plugin';
 import PluginSlotItem from './PluginSlotItem.vue';
 
 const props = defineProps<{
-  slotName: SlotType;
-  ticket?: Ticket;
-  device?: Asset;
+  /** Canonical dotted slot name (e.g. `ticket.sidebar.panel`); an alias works too. */
+  target: string;
+  /** Host-provided context; the mount fills the field its slot declares. */
+  context?: PluginSlotContext;
   actionActivatedMap?: Map<string, number>;
 }>();
 
-// Get registrations for this slot
-const registrations = computed(() => {
-  return slotRegistrations.get(props.slotName) || [];
-});
+// Registrations are keyed by canonical name; normalize an alias-passed target.
+const canonical = computed(() => canonicalSlotName(props.target) ?? props.target);
+const registrations = computed(() => slotRegistrations.get(canonical.value as PluginSlot) ?? []);
 
-// Provide slot name for nested components
-provide('pluginSlot', props.slotName);
+provide('pluginSlot', canonical);
 </script>
 
 <template>
@@ -33,9 +33,8 @@ provide('pluginSlot', props.slotName);
     v-for="reg in registrations"
     :key="`${reg.pluginUuid}-${reg.componentName}`"
     :registration="reg"
-    :slot-name="slotName"
-    :ticket="ticket"
-    :device="device"
-    :actionActivated="actionActivatedMap?.get(`${reg.pluginUuid}:${reg.componentName}`)"
+    :slot-name="canonical"
+    :context="context"
+    :action-activated="actionActivatedMap?.get(`${reg.pluginUuid}:${reg.componentName}`)"
   />
 </template>

--- a/frontend/src/plugins/components/PluginSlotItem.vue
+++ b/frontend/src/plugins/components/PluginSlotItem.vue
@@ -8,16 +8,14 @@
  */
 import { onErrorCaptured, ref } from 'vue';
 import { getLoadedPlugin, type PluginSlotRegistration } from '../loader';
+import type { PluginSlotContext } from '../context';
 import PluginSandboxFrame from './PluginSandboxFrame.vue';
 import { logger } from '@nosdesk/core/utils/logger';
-import type { Ticket } from '@nosdesk/core/types/ticket';
-import type { Asset } from '@nosdesk/core/types/asset';
 
 const props = defineProps<{
   registration: PluginSlotRegistration;
   slotName: string;
-  ticket?: Ticket;
-  device?: Asset;
+  context?: PluginSlotContext;
   actionActivated?: number;
 }>();
 
@@ -48,8 +46,7 @@ const loaded = getLoadedPlugin(props.registration.pluginUuid);
       v-else-if="loaded"
       :plugin="loaded.plugin"
       :component="{ name: registration.componentName, slot: slotName }"
-      :ticket="ticket"
-      :device="device"
+      :context="context"
       :actionActivated="actionActivated"
     />
   </div>

--- a/frontend/src/plugins/context.ts
+++ b/frontend/src/plugins/context.ts
@@ -1,0 +1,18 @@
+import type { Ticket } from '@nosdesk/core/types/ticket';
+import type { Asset } from '@nosdesk/core/types/asset';
+
+/**
+ * The host-provided context bag handed to a plugin slot.
+ *
+ * Every field is optional; a mount fills the one matching its slot's declared
+ * context type (see `SlotDef.context`). This replaces the old per-entity prop
+ * drilling (`ticket` + `device` threaded through PluginSlot -> PluginSlotItem
+ * -> PluginSandboxFrame): adding a new context type is now a field here plus one
+ * line in the sandbox snapshot, not an edit across every layer.
+ */
+export interface PluginSlotContext {
+  ticket?: Ticket;
+  asset?: Asset;
+  // Future context types (e.g. `documentationPage`) land here alongside a
+  // matching line in PluginSandboxFrame's snapshot() and the SDK wire type.
+}

--- a/frontend/src/plugins/loader.ts
+++ b/frontend/src/plugins/loader.ts
@@ -14,7 +14,7 @@ import type { SyncAction } from '@nosdesk/core/sync/types';
 import { logger } from '@nosdesk/core/utils/logger';
 import { translate } from '@/i18n';
 import type { Plugin, PluginSlot, PluginManifest } from '@nosdesk/core/types/plugin';
-import { isKnownSlot } from '@nosdesk/core/types/plugin';
+import { canonicalSlotName } from '@nosdesk/core/types/plugin';
 
 // =============================================================================
 // Types
@@ -136,14 +136,17 @@ async function loadPlugin(plugin: Plugin): Promise<void> {
     // server-side, but we don't want a typoed slot to register a
     // garbage entry that no host template will ever mount. Skip
     // and log instead.
-    if (!isKnownSlot(config.slot)) {
+    // Normalize the manifest's slot (canonical dotted name or legacy alias) to
+    // its canonical name so registrations key consistently and mounts query by
+    // the dotted target regardless of which form the manifest declared.
+    const slot = canonicalSlotName(config.slot);
+    if (!slot) {
       logger.warn(
         `Skipping plugin component with unknown slot: ${config.slot}`,
         { plugin: plugin.name, componentName }
       );
       continue;
     }
-    const slot = config.slot as PluginSlot;
 
     // Resolve %key% labels against the manifest's i18n tables at load time.
     const l10n = (v: string | undefined): string | undefined =>

--- a/frontend/src/plugins/loader.ts
+++ b/frontend/src/plugins/loader.ts
@@ -14,7 +14,7 @@ import type { SyncAction } from '@nosdesk/core/sync/types';
 import { logger } from '@nosdesk/core/utils/logger';
 import { translate } from '@/i18n';
 import type { Plugin, PluginSlot, PluginManifest } from '@nosdesk/core/types/plugin';
-import { PLUGIN_SLOTS } from '@nosdesk/core/types/plugin';
+import { isKnownSlot } from '@nosdesk/core/types/plugin';
 
 // =============================================================================
 // Types
@@ -136,7 +136,7 @@ async function loadPlugin(plugin: Plugin): Promise<void> {
     // server-side, but we don't want a typoed slot to register a
     // garbage entry that no host template will ever mount. Skip
     // and log instead.
-    if (!(config.slot in PLUGIN_SLOTS)) {
+    if (!isKnownSlot(config.slot)) {
       logger.warn(
         `Skipping plugin component with unknown slot: ${config.slot}`,
         { plugin: plugin.name, componentName }

--- a/frontend/src/views/AssetView.vue
+++ b/frontend/src/views/AssetView.vue
@@ -1028,7 +1028,7 @@ useSyncActions(
               />
             </SectionCard>
 
-            <PluginSlot slot-name="asset-info-panels" :device="device" />
+            <PluginSlot target="asset.info.panel" :context="{ asset: device }" />
           </div>
 
           <!-- Rail: groups + record metadata (small, secondary facts). -->

--- a/frontend/src/views/TicketView.vue
+++ b/frontend/src/views/TicketView.vue
@@ -202,7 +202,7 @@ const overflowMenuItems = computed<MenuItem[]>(() => {
         },
     ];
 
-    const pluginActions = getActionRegistrations('ticket-sidebar');
+    const pluginActions = getActionRegistrations('ticket.sidebar.panel');
     pluginActions.forEach((action, idx) => {
         items.push({
             id: `plugin:${action.pluginUuid}:${action.componentName}`,
@@ -673,7 +673,7 @@ const rootEl = ref<HTMLElement | null>(null);
 
                             <TicketLoansCard :ticket-id="ticket.id" :requester-uuid="ticket.requester" :has-devices="devices.length > 0" />
 
-                            <PluginSlot slot-name="ticket-sidebar" :ticket="pluginTicket" :actionActivatedMap="pluginActionActivatedMap" />
+                            <PluginSlot target="ticket.sidebar.panel" :context="{ ticket: pluginTicket }" :action-activated-map="pluginActionActivatedMap" />
                         </template>
 
                         </div>

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -10,7 +10,8 @@
   },
   "scripts": {
     "type-check": "vue-tsc --noEmit",
-    "lint": "eslint src"
+    "lint": "eslint src",
+    "build:slots": "node scripts/gen-plugin-slots.mjs"
   },
   "dependencies": {
     "@pinia/colada": "^1.2.0",

--- a/packages/core/scripts/gen-plugin-slots.mjs
+++ b/packages/core/scripts/gen-plugin-slots.mjs
@@ -1,0 +1,18 @@
+// Generate the backend's machine-readable slot allowlist from the single source
+// of truth in src/types/pluginSlots.ts. Run via `pnpm --filter @nosdesk/core
+// build:slots`; CI regenerates and `git diff --exit-code`s the output, so a
+// registry edit that wasn't regenerated fails the build (mirrors runtime.js).
+//
+// Node (>=24) strips the TypeScript types from the imported registry natively,
+// so no bundler is needed — the registry is pure data with no runtime imports.
+
+import { writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { SLOT_REGISTRY } from '../src/types/pluginSlots.ts';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const out = resolve(here, '../../../backend/src/services/plugins/plugin_slots.generated.json');
+
+writeFileSync(out, JSON.stringify(SLOT_REGISTRY, null, 2) + '\n');
+console.log(`Wrote ${SLOT_REGISTRY.length} slot definitions to ${out}`);

--- a/packages/core/src/types/plugin.ts
+++ b/packages/core/src/types/plugin.ts
@@ -384,39 +384,24 @@ export interface PluginProxyResponse {
 // =============================================================================
 // Plugin UI Slots
 // =============================================================================
+//
+// The slot taxonomy now lives in its own single-source module (also read by the
+// Rust validator via a generated JSON). Re-exported here so existing importers
+// of `PluginSlot` / `PLUGIN_SLOTS` keep working. `PluginSlot` accepts both the
+// canonical dotted names and the legacy flat aliases during the migration.
+// New code should import from `./pluginSlots` directly.
+export type { AnySlotName, CanonicalSlotName, LegacySlotName, SlotDef } from './pluginSlots';
+export {
+  SLOT_REGISTRY,
+  SLOT_NAMES,
+  PLUGIN_SLOTS,
+  getSlot,
+  isKnownSlot,
+  canonicalSlotName,
+} from './pluginSlots';
+import type { AnySlotName } from './pluginSlots';
 
-export type PluginSlot =
-  // Global slots
-  | 'navbar-items'
-  | 'settings-integrations'
-  // Ticket context
-  | 'ticket-header-actions'
-  | 'ticket-sidebar'
-  | 'ticket-tabs'
-  | 'ticket-footer-actions'
-  // Document context
-  | 'document-toolbar'
-  | 'document-sidebar'
-  // Asset context
-  | 'asset-header-actions'
-  | 'asset-info-panels';
-
-export const PLUGIN_SLOTS: Record<PluginSlot, { multiple: boolean; description: string }> = {
-  // Global slots
-  'navbar-items': { multiple: true, description: 'Add items to the navigation bar' },
-  'settings-integrations': { multiple: true, description: 'Add pages to Settings > Integrations' },
-  // Ticket context
-  'ticket-header-actions': { multiple: true, description: 'Add buttons to ticket header' },
-  'ticket-sidebar': { multiple: true, description: 'Add panels to ticket sidebar' },
-  'ticket-tabs': { multiple: true, description: 'Add tabs to ticket view' },
-  'ticket-footer-actions': { multiple: true, description: 'Add buttons to ticket footer' },
-  // Document context
-  'document-toolbar': { multiple: true, description: 'Add actions to document toolbar' },
-  'document-sidebar': { multiple: true, description: 'Add panels to document sidebar' },
-  // Asset context
-  'asset-header-actions': { multiple: true, description: 'Add buttons to device header' },
-  'asset-info-panels': { multiple: true, description: 'Add info panels to device view' },
-};
+export type PluginSlot = AnySlotName;
 
 // =============================================================================
 // Plugin Permissions

--- a/packages/core/src/types/pluginSlots.ts
+++ b/packages/core/src/types/pluginSlots.ts
@@ -1,0 +1,197 @@
+// =============================================================================
+// Plugin UI extension points — single source of truth
+// =============================================================================
+//
+// This module is the ONE canonical declaration of every plugin UI extension
+// point. Both toolchains read from here:
+//
+//   * Frontend/TS: imports `SLOT_REGISTRY` + the helpers/types below directly.
+//   * Backend/Rust: reads `backend/src/services/plugins/plugin_slots.generated.json`,
+//     which is generated from this file by `pnpm --filter @nosdesk/core build:slots`
+//     and drift-checked in CI (mirrors the runtime.js pattern).
+//
+// Adding or changing a slot is a one-place edit here, then `build:slots` to
+// regenerate the JSON. There is no hand-synced Rust allowlist any more.
+//
+// Two mechanisms (see docs/plugin-ui-slots-design.md):
+//   * `panel`  — an iframe surface the plugin fills, wrapped in host chrome.
+//   * `action` — declarative metadata the host renders as native chrome
+//                (menu item, button, nav link) which then activates the plugin.
+//
+// Taxonomy is dotted `<entity>.<region>.<kind>` so the name self-documents its
+// placement and the host can pattern-match a family. Old flat kebab-case names
+// live on as `aliases` for graceful back-compat; a manifest may target either.
+
+/** How the host renders a contribution to this slot. */
+export type SlotMechanism = 'panel' | 'action';
+
+/** The single host-provided context object a mount hands to the plugin. */
+export type SlotContextType = 'ticket' | 'asset' | 'documentationPage' | 'none';
+
+/** Whether one plugin may contribute once or many times to a slot. */
+export type SlotCardinality = 'one' | 'many';
+
+/**
+ * Lifecycle of a slot in the taxonomy.
+ *   * `stable`       — has a live mount point; renders today.
+ *   * `reserved`     — declared for authors to target, no mount yet (silent
+ *                      no-op until one lands, like a VS Code contribution point).
+ *   * `experimental` — mounted but the contract may still change.
+ */
+export type SlotStatus = 'stable' | 'reserved' | 'experimental';
+
+export interface SlotDef {
+  /** Canonical dotted identifier. */
+  readonly name: string;
+  readonly mechanism: SlotMechanism;
+  readonly context: SlotContextType;
+  readonly cardinality: SlotCardinality;
+  /** Default sort order within the slot; host tiebreaks by install order. */
+  readonly order: number;
+  readonly status: SlotStatus;
+  /** Legacy flat names still accepted at validation/registration time. */
+  readonly aliases: readonly string[];
+  readonly description: string;
+}
+
+// The registry. `as const satisfies` keeps literal `name`/`aliases` types (so
+// the derived unions below are precise) while checking each row's shape.
+export const SLOT_REGISTRY = [
+  {
+    name: 'ticket.sidebar.panel',
+    mechanism: 'panel',
+    context: 'ticket',
+    cardinality: 'many',
+    order: 100,
+    status: 'stable',
+    aliases: ['ticket-sidebar'],
+    description: 'Panels in the ticket sidebar',
+  },
+  {
+    name: 'asset.info.panel',
+    mechanism: 'panel',
+    context: 'asset',
+    cardinality: 'many',
+    order: 100,
+    status: 'stable',
+    aliases: ['asset-info-panels'],
+    description: 'Info panels on the asset view',
+  },
+  {
+    name: 'settings.integrations.page',
+    mechanism: 'panel',
+    context: 'none',
+    cardinality: 'many',
+    order: 100,
+    status: 'reserved',
+    aliases: ['settings-integrations'],
+    description: 'Pages under Settings > Integrations',
+  },
+  {
+    name: 'dashboard.widget',
+    mechanism: 'panel',
+    context: 'none',
+    cardinality: 'many',
+    order: 100,
+    status: 'reserved',
+    aliases: [],
+    description: 'Widgets on the dashboard',
+  },
+  {
+    name: 'ticket.tab.panel',
+    mechanism: 'panel',
+    context: 'ticket',
+    cardinality: 'many',
+    order: 100,
+    status: 'reserved',
+    aliases: ['ticket-tabs'],
+    description: 'Tabs on the ticket view',
+  },
+  {
+    name: 'document.sidebar.panel',
+    mechanism: 'panel',
+    context: 'documentationPage',
+    cardinality: 'many',
+    order: 100,
+    status: 'reserved',
+    aliases: ['document-sidebar'],
+    description: 'Panels in the document sidebar',
+  },
+  {
+    name: 'ticket.header.action',
+    mechanism: 'action',
+    context: 'ticket',
+    cardinality: 'many',
+    order: 100,
+    status: 'reserved',
+    aliases: ['ticket-header-actions'],
+    description: 'Actions in the ticket header menu',
+  },
+  {
+    name: 'asset.header.action',
+    mechanism: 'action',
+    context: 'asset',
+    cardinality: 'many',
+    order: 100,
+    status: 'reserved',
+    aliases: ['asset-header-actions'],
+    description: 'Actions in the asset header menu',
+  },
+  {
+    name: 'document.toolbar.action',
+    mechanism: 'action',
+    context: 'documentationPage',
+    cardinality: 'many',
+    order: 100,
+    status: 'reserved',
+    aliases: ['document-toolbar'],
+    description: 'Actions in the document toolbar menu',
+  },
+  {
+    name: 'nav.item',
+    mechanism: 'action',
+    context: 'none',
+    cardinality: 'many',
+    order: 100,
+    status: 'reserved',
+    aliases: ['navbar-items'],
+    description: 'Links in the navigation sidebar',
+  },
+] as const satisfies readonly SlotDef[];
+
+/** A canonical dotted slot name. */
+export type CanonicalSlotName = (typeof SLOT_REGISTRY)[number]['name'];
+/** Any legacy flat alias still accepted. */
+export type LegacySlotName = (typeof SLOT_REGISTRY)[number]['aliases'][number];
+/** Either form — what a manifest or call site may reference. */
+export type AnySlotName = CanonicalSlotName | LegacySlotName;
+
+const BY_NAME = new Map<string, SlotDef>();
+for (const def of SLOT_REGISTRY) {
+  BY_NAME.set(def.name, def);
+  for (const alias of def.aliases) BY_NAME.set(alias, def);
+}
+
+/** Resolve a canonical or alias name to its definition, else undefined. */
+export function getSlot(name: string): SlotDef | undefined {
+  return BY_NAME.get(name);
+}
+
+/** True if `name` is a known canonical name or alias. */
+export function isKnownSlot(name: string): boolean {
+  return BY_NAME.has(name);
+}
+
+/** Canonical name for a canonical-or-alias input, else undefined. */
+export function canonicalSlotName(name: string): CanonicalSlotName | undefined {
+  return BY_NAME.get(name)?.name as CanonicalSlotName | undefined;
+}
+
+/** All canonical names, in registry order. */
+export const SLOT_NAMES = SLOT_REGISTRY.map((s) => s.name) as readonly CanonicalSlotName[];
+
+// Back-compat shim for the old `PLUGIN_SLOTS` shape (`{ multiple, description }`),
+// keyed by canonical name. Prefer `getSlot()` / `SLOT_REGISTRY` in new code.
+export const PLUGIN_SLOTS = Object.fromEntries(
+  SLOT_REGISTRY.map((s) => [s.name, { multiple: s.cardinality === 'many', description: s.description }]),
+) as Record<CanonicalSlotName, { multiple: boolean; description: string }>;


### PR DESCRIPTION
Foundations (P-a1 + P-a2) of the plugin UI-slots redesign (design of record agreed 2026-07-27). Pure refactor, no behavior change; the maintainability keystone before any new slot lands.

## P-a1 — single source of truth
Collapses the three hand-synced slot lists (TS `PluginSlot` union + `PLUGIN_SLOTS` + Rust `KNOWN_SLOTS`) into one: `packages/core/src/types/pluginSlots.ts`. A generator (`gen-plugin-slots.mjs`, Node 24 native TS-strip, no bundler) emits `plugin_slots.generated.json` into the backend tree; `slot_registry.rs` reads it via `include_str!` and manifest validation calls `is_known_slot()`. `plugin.ts` re-exports for back-compat. A CI drift-check step regenerates and `git diff --exit-code`s the JSON, mirroring runtime.js.

Slots gain dotted canonical names (`ticket.sidebar.panel`, `asset.info.panel`, ...) with the old flat names kept as `aliases`, plus `mechanism` / `context` / `cardinality` / `order` / `status` metadata.

## P-a2 — generic PluginSlot + typed context bag
Replaces the per-entity prop drilling (`ticket` + `device` threaded through PluginSlot -> PluginSlotItem -> PluginSandboxFrame) with a single `PluginSlotContext` bag. `<PluginSlot>` now takes a canonical `target` + a `context` object; the loader canonicalizes registration keys so a manifest may declare the dotted name or a legacy alias interchangeably. The two live mounts move to dotted targets. Adding a context type is now one field + one snapshot line.

## Behavior
Unchanged. The two live slots validate and mount exactly as before (via their aliases on the wire).

## Verification
- `@nosdesk/core` + frontend type-check
- backend `cargo check --lib --tests`
- 3 new `slot_registry` tests
- drift-clean