### PR TITLE
plugin: usePluginActions composable, retire ticketUi activation store

### DIFF
--- a/frontend/src/composables/useTicketDeletionCleanup.ts
+++ b/frontend/src/composables/useTicketDeletionCleanup.ts
@@ -14,8 +14,8 @@
  *     IndexedDB cache, via `useCollabSessionStore.purgeData`.
  *   - In-progress comment draft text/internal flag (localStorage)
  *     via `useTicketDraftsStore.clearDraft`.
- *   - In-memory pending attachments + plugin-activation counters
- *     via `useTicketUiStore.clear*`.
+ *   - In-memory pending attachments via `useTicketUiStore.clearAttachments`
+ *     and plugin-action activation counters via `clearPluginActionScope`.
  *   - Recent-tickets sidebar / dashboard widget cache, so the
  *     deleted entry vanishes without a manual refresh. The
  *     backend's `ON DELETE CASCADE` on `user_ticket_views.ticket_id`
@@ -37,6 +37,7 @@ import { useSyncActions } from '@/composables/useSyncActions'
 import { useCollabSessionStore } from '@/stores/collabSession'
 import { useTicketDraftsStore } from '@nosdesk/core/stores/ticketDrafts'
 import { useTicketUiStore } from '@nosdesk/core/stores/ticketUi'
+import { clearPluginActionScope, pluginActionScope } from '@/plugins/usePluginActions'
 import { useMyWorkspacesStore } from '@/stores/myWorkspaces'
 import { useSyncTicketsStore } from '@/sync/stores/tickets'
 import { RECENT_TICKETS_KEY } from '@/stores/recentTickets'
@@ -66,7 +67,7 @@ export function useTicketDeletionCleanup(): void {
     }
     drafts.clearDraft(id)
     ui.clearAttachments(id)
-    ui.clearPluginActivations(id)
+    clearPluginActionScope(pluginActionScope('ticket', id))
 
     // Recent-tickets sidebar / dashboard widget: drop the cached
     // detail row, then invalidate the list so Pinia Colada

--- a/frontend/src/plugins/components/PluginSlot.vue
+++ b/frontend/src/plugins/components/PluginSlot.vue
@@ -11,6 +11,7 @@ import { slotRegistrations } from '../loader';
 import type { PluginSlotContext } from '../context';
 import { canonicalSlotName } from '@nosdesk/core/types/plugin';
 import type { PluginSlot } from '@nosdesk/core/types/plugin';
+import { pluginActivationKey } from '../usePluginActions';
 import PluginSlotItem from './PluginSlotItem.vue';
 
 const props = defineProps<{
@@ -18,7 +19,8 @@ const props = defineProps<{
   target: string;
   /** Host-provided context; the mount fills the field its slot declares. */
   context?: PluginSlotContext;
-  actionActivatedMap?: Map<string, number>;
+  /** Per-component activation counters from `usePluginActions`. */
+  actionActivatedMap?: ReadonlyMap<string, number>;
 }>();
 
 // Registrations are keyed by canonical name; normalize an alias-passed target.
@@ -35,6 +37,6 @@ provide('pluginSlot', canonical);
     :registration="reg"
     :slot-name="canonical"
     :context="context"
-    :action-activated="actionActivatedMap?.get(`${reg.pluginUuid}:${reg.componentName}`)"
+    :action-activated="actionActivatedMap?.get(pluginActivationKey(reg.pluginUuid, reg.componentName))"
   />
 </template>

--- a/frontend/src/plugins/usePluginActions.ts
+++ b/frontend/src/plugins/usePluginActions.ts
@@ -1,0 +1,101 @@
+/**
+ * Plugin action contributions (mechanism B: host-rendered chrome).
+ *
+ * A plugin panel component may declare an `action` (a host menu trigger). The
+ * host renders it as a native menu item; selecting it bumps a per-entity
+ * activation counter that flows to the plugin's sandbox frame as
+ * `context.actionActivated`, and the plugin reacts (e.g. opens its panel).
+ *
+ * This module is the SINGLE place the action id / activation-key format lives.
+ * Previously the `plugin:<uuid>:<component>` string was built in the ticket
+ * overflow menu, parsed in its select handler, and rebuilt in PluginSlot to
+ * look up the counter, with the counter store living in core's `ticketUi`.
+ * Everything is consolidated here and generalized to any entity scope, so a new
+ * host surface (asset menu, bulk bar) wires actions the same way.
+ */
+import { computed, reactive, unref, type ComputedRef, type MaybeRef } from 'vue';
+import { getActionRegistrations } from './loader';
+import type { PluginSlot } from '@nosdesk/core/types/plugin';
+
+// Namespaces a plugin action id so it coexists with native menu items.
+const MENU_PREFIX = 'plugin:';
+
+/** Menu-item id for a plugin action. Pass the selected id back to `activate()`. */
+export function pluginMenuActionId(pluginUuid: string, componentName: string): string {
+  return `${MENU_PREFIX}${pluginUuid}:${componentName}`;
+}
+
+/**
+ * The key a PluginSlot uses to look up a component's activation counter. Equal
+ * to the menu id with the namespace stripped, so the two always agree.
+ */
+export function pluginActivationKey(pluginUuid: string, componentName: string): string {
+  return `${pluginUuid}:${componentName}`;
+}
+
+function menuIdToActivationKey(menuId: string): string | undefined {
+  return menuId.startsWith(MENU_PREFIX) ? menuId.slice(MENU_PREFIX.length) : undefined;
+}
+
+/** Stable scope string isolating one entity's activation counters. */
+export function pluginActionScope(entity: string, id: string | number): string {
+  return `${entity}:${id}`;
+}
+
+// scope -> (activationKey -> monotonic counter). Module state: survives
+// component unmount (nav-away/back within a tab). Callers clear a scope when the
+// entity is gone (e.g. a deleted ticket) via `clearPluginActionScope`.
+const activations = reactive(new Map<string, Map<string, number>>());
+
+// Shared, stable empty map for scopes with no activations yet — a fresh literal
+// each read would defeat the computed's memoization.
+const EMPTY: ReadonlyMap<string, number> = new Map();
+
+/** Drop every activation counter for a scope. */
+export function clearPluginActionScope(scope: string): void {
+  activations.delete(scope);
+}
+
+export interface PluginActionItem {
+  /** Namespaced menu-item id; pass back to `activate()` on select. */
+  id: string;
+  label: string;
+  icon?: string;
+  trailing?: string;
+}
+
+export function usePluginActions(target: PluginSlot, scope: MaybeRef<string | undefined>) {
+  const items: ComputedRef<PluginActionItem[]> = computed(() =>
+    getActionRegistrations(target).map((a) => ({
+      id: pluginMenuActionId(a.pluginUuid, a.componentName),
+      label: a.label,
+      icon: a.icon,
+      trailing: a.componentLabel || a.pluginName,
+    })),
+  );
+
+  const activatedMap: ComputedRef<ReadonlyMap<string, number>> = computed(() => {
+    const s = unref(scope);
+    return (s !== undefined ? activations.get(s) : undefined) ?? EMPTY;
+  });
+
+  /**
+   * Bump the activation counter for a menu id. A no-op for non-plugin ids and
+   * when the scope is unset, so a shared select handler can call it with any
+   * menu id.
+   */
+  function activate(menuId: string): void {
+    const s = unref(scope);
+    if (s === undefined) return;
+    const key = menuIdToActivationKey(menuId);
+    if (key === undefined) return;
+    let map = activations.get(s);
+    if (!map) {
+      activations.set(s, new Map());
+      map = activations.get(s)!;
+    }
+    map.set(key, (map.get(key) ?? 0) + 1);
+  }
+
+  return { items, activatedMap, activate };
+}

--- a/frontend/src/views/TicketView.vue
+++ b/frontend/src/views/TicketView.vue
@@ -12,7 +12,6 @@ import type { Ticket } from "@nosdesk/core/types/ticket";
 // Composables
 import { useTicketDetail } from "@/sync/stores/ticketDetail";
 import { subscribe } from "@/sync/lifecycle";
-import { useTicketUiStore } from "@nosdesk/core/stores/ticketUi";
 import { useTicketSSE } from "@/composables/useTicketSSE";
 import { useTitleManager } from "@/composables/useTitleManager";
 import { useTicketDrag, shouldSuppressTicketDrop } from "@/composables/useTicketDrag";
@@ -46,7 +45,7 @@ import Modal from "@/components/Modal.vue";
 import NotFoundIllustration from "@/components/common/NotFoundIllustration.vue";
 import SectionCard from "@/components/common/SectionCard.vue";
 import PluginSlot from "@/plugins/components/PluginSlot.vue";
-import { getActionRegistrations } from "@/plugins/loader";
+import { usePluginActions, pluginActionScope } from "@/plugins/usePluginActions";
 import { useCreateTicketAction } from "@/composables/useCreateTicketAction";
 
 
@@ -160,17 +159,19 @@ const showDropAffordance = computed(() => {
            dragState.value.ticket?.id !== ticket.value?.id;
 });
 
-// Unified "+ Add" menu state — plugin activation counters live in
-// `useTicketUiStore` keyed by ticket id so they survive component
-// unmount (Phase 4 will drop KeepAlive on TicketView; the store is
-// the new home for this state). Falls back to an empty map for
-// pre-route or transitional states.
-const ticketUi = useTicketUiStore();
-const pluginActionActivatedMap = computed(() =>
-    ticketId.value !== undefined
-        ? ticketUi.getPluginActivations(ticketId.value)
-        : new Map<string, number>()
+// Plugin action contributions in the ticket overflow menu. `usePluginActions`
+// owns the id format and the per-ticket activation counters (scoped so distinct
+// tickets don't share state, and surviving component unmount). Scope is unset
+// for pre-route / transitional states, which makes `activate` a no-op and the
+// map empty.
+const ticketActionScope = computed(() =>
+    ticketId.value !== undefined ? pluginActionScope('ticket', ticketId.value) : undefined
 );
+const {
+    items: pluginActionItems,
+    activatedMap: pluginActionActivatedMap,
+    activate: activatePluginAction,
+} = usePluginActions('ticket.sidebar.panel', ticketActionScope);
 
 // Plugins consume the canonical `Ticket` shape. The pool-derived
 // view-model is structurally narrower (denormalised workflow_state,
@@ -202,13 +203,12 @@ const overflowMenuItems = computed<MenuItem[]>(() => {
         },
     ];
 
-    const pluginActions = getActionRegistrations('ticket.sidebar.panel');
-    pluginActions.forEach((action, idx) => {
+    pluginActionItems.value.forEach((action, idx) => {
         items.push({
-            id: `plugin:${action.pluginUuid}:${action.componentName}`,
+            id: action.id,
             label: action.label,
             iconUrl: action.icon,
-            trailing: action.componentLabel || action.pluginName,
+            trailing: action.trailing,
             // Divider above the first plugin item so plugin
             // contributions read as a distinct group.
             divider: idx === 0,
@@ -266,9 +266,9 @@ const handleOverflowSelect = (itemId: string) => {
         // Two-step destructive flow: opening the modal is the
         // first click, the modal's confirm button is the second.
         showDeleteConfirm.value = true;
-    } else if (itemId.startsWith('plugin:') && ticketId.value !== undefined) {
-        const key = itemId.replace('plugin:', '');
-        ticketUi.activatePluginAction(ticketId.value, key);
+    } else {
+        // Plugin action ids are namespaced; `activate` no-ops on anything else.
+        activatePluginAction(itemId);
     }
 };
 

--- a/packages/core/src/stores/ticketUi.ts
+++ b/packages/core/src/stores/ticketUi.ts
@@ -3,29 +3,26 @@
  *
  * In-memory only (no localStorage), keyed by ticket id. Holds the
  * bits that should survive nav-away/nav-back within a tab session
- * but don't deserve disk persistence:
- *
- *   - Pending file attachments selected for the comment composer
- *     (`File` objects can't be serialised; the user just picked
- *     them, refreshing to a clean slate is fine).
- *   - Plugin-action activation counters (signal a plugin sidebar
- *     panel to perform a domain action, rendered next-tick).
+ * but don't deserve disk persistence: pending file attachments
+ * selected for the comment composer (`File` objects can't be
+ * serialised; the user just picked them, refreshing to a clean
+ * slate is fine).
  *
  * Cleanup contract: callers that finish working with a ticket
- * (comment submitted, panel torn down) call the matching
- * `clear*` to free memory. Without explicit clears the maps
- * grow until the tab closes; that's acceptable for these data
- * shapes (small, bounded by the number of tickets a user touches
- * in a session).
+ * (comment submitted, ticket deleted) call `clearAttachments` to
+ * free memory. Without explicit clears the map grows until the tab
+ * closes; that's acceptable here (small, bounded by the number of
+ * tickets a user touches in a session).
+ *
+ * Plugin-action activation counters used to live here too; they moved
+ * to the frontend `usePluginActions` composable, which owns the plugin
+ * concern end to end (core stays plugin-agnostic).
  */
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
 
 export const useTicketUiStore = defineStore('ticketUi', () => {
   const attachments = ref<Map<number, File[]>>(new Map())
-  const pluginActivations = ref<Map<number, Map<string, number>>>(new Map())
-
-  // ---- Attachments ------------------------------------------------
 
   function getAttachments(ticketId: number): File[] {
     return attachments.value.get(ticketId) ?? []
@@ -48,40 +45,9 @@ export const useTicketUiStore = defineStore('ticketUi', () => {
     attachments.value = next
   }
 
-  // ---- Plugin activation map -------------------------------------
-  // Each plugin sidebar item that's `activate`d gets its counter
-  // bumped. The PluginSlot watches the counter and re-runs the
-  // action's effect on each tick. Per-ticket so distinct tickets
-  // don't share activation state.
-
-  function getPluginActivations(ticketId: number): Map<string, number> {
-    return pluginActivations.value.get(ticketId) ?? new Map()
-  }
-
-  function activatePluginAction(ticketId: number, key: string): void {
-    const next = new Map(pluginActivations.value)
-    const existing = next.get(ticketId) ?? new Map<string, number>()
-    const updated = new Map(existing)
-    updated.set(key, (updated.get(key) ?? 0) + 1)
-    next.set(ticketId, updated)
-    pluginActivations.value = next
-  }
-
-  function clearPluginActivations(ticketId: number): void {
-    if (!pluginActivations.value.has(ticketId)) return
-    const next = new Map(pluginActivations.value)
-    next.delete(ticketId)
-    pluginActivations.value = next
-  }
-
   return {
-    // Attachments
     getAttachments,
     setAttachments,
     clearAttachments,
-    // Plugin activations
-    getPluginActivations,
-    activatePluginAction,
-    clearPluginActivations,
   }
 })


### PR DESCRIPTION
P-a3, the last foundations increment of the plugin UI-slots redesign. Pure refactor, no behavior change.

## What
The plugin action-contribution path was spread across four places: the `plugin:<uuid>:<component>` id was built in the ticket overflow menu, parsed in its select handler, rebuilt in `PluginSlot` to look up the activation counter, and the counter store lived in core's `ticketUi`.

`usePluginActions` (new frontend composable) now owns all of it: the id format (one helper pair), the activation-counter map (scoped per entity, module state that survives unmount), and `activate` / lookup. `PluginSlot` and the ticket-deletion cleanup route through it. `activate` no-ops on non-plugin ids, so the overflow-menu select handler drops its `startsWith('plugin:')` parsing.

Generalized to any entity scope (`pluginActionScope('ticket', id)`), so a future asset or bulk-action menu wires plugin actions identically.

Also drops the plugin-activation state from core's `ticketUi` store, keeping `@nosdesk/core` plugin-agnostic (plugins are a frontend concern).

## Verification
- `@nosdesk/core` + frontend type-check
- core + frontend lint (boundary guard + view-roots)
- net -31 lines