### PR TITLE
plugin: bind collection-row ops to the owning plugin and collection

### DIFF
--- a/backend/src/handlers/plugin_collections.rs
+++ b/backend/src/handlers/plugin_collections.rs
@@ -358,20 +358,28 @@ pub async fn get_collection_row(
     enum GetOutcome {
         Ok(crate::models::PluginCollectionRow),
         Gate(PluginGate),
+        CollectionNotFound,
         RowNotFound,
     }
 
     let outcome = tc.run(|conn| {
-        match authorize_plugin_data_request(
+        let plugin = match authorize_plugin_data_request(
             conn,
             path.uuid,
             "collection:read",
             "Plugin has not been granted collection access",
         )? {
-            Ok(_) => {}
+            Ok(p) => p,
             Err(gate) => return Ok(GetOutcome::Gate(gate)),
-        }
-        match collection_repo::get_row_by_uuid(conn, path.row_uuid) {
+        };
+        // Resolve the collection named in the path so the row lookup is scoped
+        // to it (and thus to the authorized plugin), not just to the row UUID.
+        let schema = match collection_repo::get_schema_by_name(conn, plugin.id, &path.name) {
+            Ok(s) => s,
+            Err(DieselError::NotFound) => return Ok(GetOutcome::CollectionNotFound),
+            Err(e) => return Err(e),
+        };
+        match collection_repo::get_row_by_uuid(conn, schema.id, path.row_uuid) {
             Ok(row) => Ok::<_, DieselError>(GetOutcome::Ok(row)),
             Err(DieselError::NotFound) => Ok(GetOutcome::RowNotFound),
             Err(e) => Err(e),
@@ -381,6 +389,7 @@ pub async fn get_collection_row(
     match outcome {
         Ok(GetOutcome::Ok(row)) => HttpResponse::Ok().json(CollectionRowResponse::from(row)),
         Ok(GetOutcome::Gate(gate)) => gate.into_response(),
+        Ok(GetOutcome::CollectionNotFound) => errors::not_found_msg("Collection not found"),
         Ok(GetOutcome::RowNotFound) => errors::not_found_msg("Row not found"),
         Err(e) => {
             error!("Failed to get collection row: {}", e);
@@ -442,7 +451,7 @@ pub async fn update_collection_row(
             data: Some(body_data.clone()),
         };
 
-        match collection_repo::update_row(conn, path.row_uuid, update) {
+        match collection_repo::update_row(conn, schema.id, path.row_uuid, update) {
             Ok(row) => Ok::<_, DieselError>(UpdateOutcome::Ok(row)),
             Err(DieselError::NotFound) => Ok(UpdateOutcome::RowNotFound),
             Err(e) => Err(e),
@@ -484,20 +493,28 @@ pub async fn delete_collection_row(
     enum DeleteOutcome {
         Deleted,
         Gate(PluginGate),
+        CollectionNotFound,
         RowNotFound,
     }
 
     let outcome = tc.run(|conn| {
-        match authorize_plugin_data_request(
+        let plugin = match authorize_plugin_data_request(
             conn,
             path.uuid,
             "collection:write",
             "Plugin has not been granted collection write access",
         )? {
-            Ok(_) => {}
+            Ok(p) => p,
             Err(gate) => return Ok(DeleteOutcome::Gate(gate)),
-        }
-        match collection_repo::delete_row(conn, path.row_uuid)? {
+        };
+        // Scope the delete to the named collection (and thus the authorized
+        // plugin), not just the row UUID.
+        let schema = match collection_repo::get_schema_by_name(conn, plugin.id, &path.name) {
+            Ok(s) => s,
+            Err(DieselError::NotFound) => return Ok(DeleteOutcome::CollectionNotFound),
+            Err(e) => return Err(e),
+        };
+        match collection_repo::delete_row(conn, schema.id, path.row_uuid)? {
             n if n > 0 => Ok::<_, DieselError>(DeleteOutcome::Deleted),
             _ => Ok(DeleteOutcome::RowNotFound),
         }
@@ -506,6 +523,7 @@ pub async fn delete_collection_row(
     match outcome {
         Ok(DeleteOutcome::Deleted) => HttpResponse::NoContent().finish(),
         Ok(DeleteOutcome::Gate(gate)) => gate.into_response(),
+        Ok(DeleteOutcome::CollectionNotFound) => errors::not_found_msg("Collection not found"),
         Ok(DeleteOutcome::RowNotFound) => errors::not_found_msg("Row not found"),
         Err(e) => {
             error!("Failed to delete collection row: {}", e);

--- a/backend/src/handlers/plugins.rs
+++ b/backend/src/handlers/plugins.rs
@@ -1280,9 +1280,18 @@ pub async fn proxy_plugin_request(
         }
     }
 
-    // Execute the proxied request with secrets for auth injection
+    // Execute the proxied request with secrets for auth injection. Egress is
+    // gated on the effective (consented) permission set, not the raw manifest,
+    // consistent with every other plugin authorization check.
+    let network_perms = plugin.effective_permission_set();
     match proxy_service
-        .proxy_request(&plugin.name, &manifest, body.into_inner(), &secrets)
+        .proxy_request(
+            &plugin.name,
+            &manifest,
+            &network_perms,
+            body.into_inner(),
+            &secrets,
+        )
         .await
     {
         Ok(response) => HttpResponse::Ok().json(response),

--- a/backend/src/repository/plugin_collections.rs
+++ b/backend/src/repository/plugin_collections.rs
@@ -87,33 +87,55 @@ pub fn create_row(
         .get_result(conn)
 }
 
-/// Get a row by UUID
+/// Get a row by UUID, scoped to its owning collection schema.
+///
+/// The `sid` filter is the object-level authorization boundary: schemas are
+/// resolved per `(plugin_id, collection_name)`, so requiring the row to belong
+/// to `sid` scopes the lookup to the plugin AND the named collection in the
+/// request path. Without it, any workspace member with a plugin holding
+/// `collection:read` could read another plugin's row by its UUID (RLS only
+/// scopes to the tenant, not to the plugin).
 pub fn get_row_by_uuid(
     conn: &mut DbConnection,
+    sid: i32,
     row_uuid: Uuid,
 ) -> Result<PluginCollectionRow, diesel::result::Error> {
     plugin_collection_rows::table
+        .filter(plugin_collection_rows::schema_id.eq(sid))
         .filter(plugin_collection_rows::uuid.eq(row_uuid))
         .first::<PluginCollectionRow>(conn)
 }
 
 // sync-audit-only: Plugin local storage / activity log — covered by the audit_log trigger on plugin_data and plugin_collection_rows
-/// Update a row
+/// Update a row, scoped to its owning collection schema (see `get_row_by_uuid`).
 pub fn update_row(
     conn: &mut DbConnection,
+    sid: i32,
     row_uuid: Uuid,
     update: PluginCollectionRowUpdate,
 ) -> Result<PluginCollectionRow, diesel::result::Error> {
-    diesel::update(plugin_collection_rows::table.filter(plugin_collection_rows::uuid.eq(row_uuid)))
-        .set(&update)
-        .get_result(conn)
+    diesel::update(
+        plugin_collection_rows::table
+            .filter(plugin_collection_rows::schema_id.eq(sid))
+            .filter(plugin_collection_rows::uuid.eq(row_uuid)),
+    )
+    .set(&update)
+    .get_result(conn)
 }
 
 // sync-audit-only: Plugin local storage / activity log — covered by the audit_log trigger on plugin_data and plugin_collection_rows
-/// Delete a row
-pub fn delete_row(conn: &mut DbConnection, row_uuid: Uuid) -> Result<usize, diesel::result::Error> {
-    diesel::delete(plugin_collection_rows::table.filter(plugin_collection_rows::uuid.eq(row_uuid)))
-        .execute(conn)
+/// Delete a row, scoped to its owning collection schema (see `get_row_by_uuid`).
+pub fn delete_row(
+    conn: &mut DbConnection,
+    sid: i32,
+    row_uuid: Uuid,
+) -> Result<usize, diesel::result::Error> {
+    diesel::delete(
+        plugin_collection_rows::table
+            .filter(plugin_collection_rows::schema_id.eq(sid))
+            .filter(plugin_collection_rows::uuid.eq(row_uuid)),
+    )
+    .execute(conn)
 }
 
 // sync-audit-only: Plugin local storage / activity log — covered by the audit_log trigger on plugin_data and plugin_collection_rows

--- a/backend/src/services/plugins/proxy.rs
+++ b/backend/src/services/plugins/proxy.rs
@@ -109,13 +109,15 @@ impl PluginProxyService {
 
     /// Check if a plugin has permission to access a URL.
     ///
-    /// Both the URL host and the manifest's `network:<pattern>`
-    /// permissions go through the same `Host` / `HostPattern`
-    /// parsers, so case, normalisation, and wildcard semantics are
-    /// shared with the validator. Any URL that doesn't normalise
-    /// to a valid named host (IP literals, malformed URLs) is
-    /// refused outright.
-    fn has_permission(&self, manifest: &PluginManifest, url: &str) -> bool {
+    /// `network_perms` is the plugin's EFFECTIVE (consented) permission set, not
+    /// the raw manifest, so egress is authorized from the same trusted grant the
+    /// rest of the plugin surface enforces on (a scope the admin actually
+    /// consented to, reflecting mid-session revoke). Both the URL host and each
+    /// `network:<pattern>` permission go through the same `Host` / `HostPattern`
+    /// parsers, so case, normalisation, and wildcard semantics are shared with
+    /// the validator. Any URL that doesn't normalise to a valid named host (IP
+    /// literals, malformed URLs) is refused outright.
+    fn has_permission(&self, network_perms: &[String], url: &str) -> bool {
         let parsed = match url::Url::parse(url) {
             Ok(u) => u,
             Err(_) => return false,
@@ -127,11 +129,12 @@ impl PluginProxyService {
             return false;
         };
 
-        manifest
-            .permissions
-            .iter()
-            .filter_map(crate::services::plugins::types::Permission::network_pattern)
-            .any(|pattern| pattern.matches(&host))
+        network_perms.iter().any(|perm| {
+            crate::services::plugins::types::Permission::parse(perm)
+                .ok()
+                .and_then(|p| p.network_pattern().map(|pattern| pattern.matches(&host)))
+                .unwrap_or(false)
+        })
     }
 
     /// Get the auth header name that the manifest's auth config would inject for a given URL.
@@ -158,6 +161,7 @@ impl PluginProxyService {
         plugin_name: &str,
         url: &str,
         manifest: &PluginManifest,
+        network_perms: &[String],
         secrets: &HashMap<String, String>,
     ) -> Result<Option<(String, String)>, PluginProxyError> {
         // A URL that reached here already passed `has_permission` (which parses
@@ -225,7 +229,7 @@ impl PluginProxyService {
                 // to any host) and the IP-literal SSRF guard (a literal
                 // token_url host bypasses the resolver). See
                 // security-audit-2026-06.
-                if !self.has_permission(manifest, token_url) {
+                if !self.has_permission(network_perms, token_url) {
                     warn!(
                         plugin = plugin_name,
                         token_url = token_url,
@@ -362,11 +366,12 @@ impl PluginProxyService {
         &self,
         plugin_name: &str,
         manifest: &PluginManifest,
+        network_perms: &[String],
         request: PluginProxyRequest,
         secrets: &HashMap<String, String>,
     ) -> Result<PluginProxyResponse, PluginProxyError> {
         // Check permission
-        if !self.has_permission(manifest, &request.url) {
+        if !self.has_permission(network_perms, &request.url) {
             warn!(
                 plugin = plugin_name,
                 url = request.url,
@@ -427,7 +432,7 @@ impl PluginProxyService {
         // closed rather than sending the request without the intended
         // credentials.
         if let Some((header_name, header_value)) = self
-            .get_auth_for_url(plugin_name, &request.url, manifest, secrets)
+            .get_auth_for_url(plugin_name, &request.url, manifest, network_perms, secrets)
             .await?
         {
             debug!(
@@ -601,14 +606,21 @@ mod tests {
         Host::parse(s).expect("test host must be valid")
     }
 
+    /// Effective permission strings for a test manifest. In these unit tests the
+    /// consented set equals the manifest (no reconsent state), so deriving it
+    /// from the manifest mirrors what the handler passes at runtime.
+    fn net_perms(manifest: &PluginManifest) -> Vec<String> {
+        manifest.permissions.iter().map(|p| p.as_string()).collect()
+    }
+
     #[test]
     fn test_exact_domain_permission() {
         let service = PluginProxyService::new();
         let manifest = create_test_manifest(vec!["network:api.example.com"]);
 
-        assert!(service.has_permission(&manifest, "https://api.example.com/v1/data"));
-        assert!(!service.has_permission(&manifest, "https://other.example.com/data"));
-        assert!(!service.has_permission(&manifest, "https://api.other.com/data"));
+        assert!(service.has_permission(&net_perms(&manifest), "https://api.example.com/v1/data"));
+        assert!(!service.has_permission(&net_perms(&manifest), "https://other.example.com/data"));
+        assert!(!service.has_permission(&net_perms(&manifest), "https://api.other.com/data"));
     }
 
     #[test]
@@ -616,10 +628,10 @@ mod tests {
         let service = PluginProxyService::new();
         let manifest = create_test_manifest(vec!["network:*.example.com"]);
 
-        assert!(service.has_permission(&manifest, "https://api.example.com/v1/data"));
-        assert!(service.has_permission(&manifest, "https://www.example.com/data"));
-        assert!(service.has_permission(&manifest, "https://example.com/data"));
-        assert!(!service.has_permission(&manifest, "https://api.other.com/data"));
+        assert!(service.has_permission(&net_perms(&manifest), "https://api.example.com/v1/data"));
+        assert!(service.has_permission(&net_perms(&manifest), "https://www.example.com/data"));
+        assert!(service.has_permission(&net_perms(&manifest), "https://example.com/data"));
+        assert!(!service.has_permission(&net_perms(&manifest), "https://api.other.com/data"));
     }
 
     #[test]
@@ -629,7 +641,7 @@ mod tests {
         // outcome for the spec we documented; record it.
         let service = PluginProxyService::new();
         let manifest = create_test_manifest(vec!["network:*.example.com"]);
-        assert!(!service.has_permission(&manifest, "https://v1.api.example.com/data"));
+        assert!(!service.has_permission(&net_perms(&manifest), "https://v1.api.example.com/data"));
     }
 
     #[test]
@@ -640,7 +652,7 @@ mod tests {
         // both sides so the match is consistent.
         let service = PluginProxyService::new();
         let manifest = create_test_manifest(vec!["network:api.example.com"]);
-        assert!(service.has_permission(&manifest, "https://API.EXAMPLE.COM/data"));
+        assert!(service.has_permission(&net_perms(&manifest), "https://API.EXAMPLE.COM/data"));
     }
 
     #[test]
@@ -649,7 +661,7 @@ mod tests {
         // named host. `Host::parse` rejects IP literals.
         let service = PluginProxyService::new();
         let manifest = create_test_manifest(vec!["network:*.example.com"]);
-        assert!(!service.has_permission(&manifest, "https://127.0.0.1/data"));
+        assert!(!service.has_permission(&net_perms(&manifest), "https://127.0.0.1/data"));
     }
 
     #[test]
@@ -657,7 +669,7 @@ mod tests {
         let service = PluginProxyService::new();
         let manifest = create_test_manifest(vec!["ticket:read"]);
 
-        assert!(!service.has_permission(&manifest, "https://api.example.com/data"));
+        assert!(!service.has_permission(&net_perms(&manifest), "https://api.example.com/data"));
     }
 
     #[test]
@@ -723,7 +735,13 @@ mod tests {
         secrets.insert("github_token".to_string(), "ghp_test123".to_string());
 
         let result = service
-            .get_auth_for_url("test", "https://api.github.com/repos", &manifest, &secrets)
+            .get_auth_for_url(
+                "test",
+                "https://api.github.com/repos",
+                &manifest,
+                &net_perms(&manifest),
+                &secrets,
+            )
             .await
             .expect("auth resolution should not error");
 
@@ -755,7 +773,13 @@ mod tests {
         secrets.insert("pass".to_string(), "secret".to_string());
 
         let result = service
-            .get_auth_for_url("test", "https://api.example.com/data", &manifest, &secrets)
+            .get_auth_for_url(
+                "test",
+                "https://api.example.com/data",
+                &manifest,
+                &net_perms(&manifest),
+                &secrets,
+            )
             .await
             .expect("auth resolution should not error");
 
@@ -787,7 +811,13 @@ mod tests {
         secrets.insert("api_key".to_string(), "key123".to_string());
 
         let result = service
-            .get_auth_for_url("test", "https://api.example.com/data", &manifest, &secrets)
+            .get_auth_for_url(
+                "test",
+                "https://api.example.com/data",
+                &manifest,
+                &net_perms(&manifest),
+                &secrets,
+            )
             .await
             .expect("auth resolution should not error");
 
@@ -804,7 +834,13 @@ mod tests {
 
         let secrets = HashMap::new();
         let result = service
-            .get_auth_for_url("test", "https://api.example.com/data", &manifest, &secrets)
+            .get_auth_for_url(
+                "test",
+                "https://api.example.com/data",
+                &manifest,
+                &net_perms(&manifest),
+                &secrets,
+            )
             .await
             .expect("auth resolution should not error");
 
@@ -830,7 +866,13 @@ mod tests {
         // Empty secrets map: the declared secret can't be resolved.
         let secrets = HashMap::new();
         let result = service
-            .get_auth_for_url("test", "https://api.example.com/data", &manifest, &secrets)
+            .get_auth_for_url(
+                "test",
+                "https://api.example.com/data",
+                &manifest,
+                &net_perms(&manifest),
+                &secrets,
+            )
             .await;
 
         assert!(

--- a/backend/tests/plugin_collection_row_scoping.rs
+++ b/backend/tests/plugin_collection_row_scoping.rs
@@ -1,0 +1,171 @@
+//! Cross-plugin isolation for collection rows.
+//!
+//! Row get/update/delete scope by the owning collection schema, so a plugin
+//! cannot reach ANOTHER plugin's row by its UUID even within the same workspace.
+//! RLS on `plugin_collection_rows` scopes only to the tenant (`workspace_id`),
+//! not to the plugin, so without the `schema_id` filter a workspace member with
+//! any `collection:read`/`write` plugin could read/overwrite/delete a sibling
+//! plugin's row given its UUID. This exercises the repository scoping directly.
+
+#![allow(clippy::expect_used)]
+
+use diesel::prelude::*;
+use serde_json::json;
+use uuid::Uuid;
+
+use backend::models::{
+    NewPlugin, NewPluginCollectionRow, NewPluginCollectionSchema, Plugin, PluginCollectionRow,
+    PluginCollectionRowUpdate, PluginState,
+};
+use backend::repository::plugin_collections as repo;
+use backend::schema::plugins;
+use backend::sync::actor::ActorContext;
+use backend::sync::session::with_actor_context;
+
+mod common;
+
+fn seed_plugin(
+    conn: &mut backend::db::DbConnection,
+    ws_id: i32,
+    admin: Uuid,
+    name: &str,
+) -> Plugin {
+    let actor = ActorContext::user(admin, None).with_workspace(ws_id);
+    with_actor_context::<_, diesel::result::Error>(conn, &actor, |c| {
+        let new_plugin = NewPlugin {
+            name: name.to_string(),
+            display_name: name.to_string(),
+            version: "1.0.0".to_string(),
+            description: None,
+            manifest: json!({ "name": name, "version": "1.0.0" }),
+            state: PluginState::Installed,
+            trust_level: "verified".to_string(),
+            installed_by: Some(admin),
+            source: "provisioned".to_string(),
+            signer_pubkey: None,
+            signer_source: None,
+            signature_metadata: None,
+            icon_svg: None,
+            consented_permissions: Some(json!(["collection:read", "collection:write"])),
+            consented_at: None,
+            consented_by: None,
+        };
+        diesel::insert_into(plugins::table)
+            .values(&new_plugin)
+            .get_result::<Plugin>(c)
+    })
+    .expect("seed plugin")
+}
+
+#[test]
+fn collection_rows_are_scoped_to_their_plugin_schema() {
+    common::ensure_test_keyring();
+    let db = common::TestDb::new();
+    let mut conn = db.conn();
+    let ws = common::mint_workspace(&mut conn, "row-scope-ws", "Row Scope WS");
+    let admin = common::insert_user(&mut conn, "Row Admin").uuid;
+
+    let plugin_a = seed_plugin(&mut conn, ws, admin, "plugin-a");
+    let plugin_b = seed_plugin(&mut conn, ws, admin, "plugin-b");
+
+    let actor = ActorContext::user(admin, None).with_workspace(ws);
+
+    // Each plugin owns a collection named "notes"; only B has a row.
+    let (schema_a_id, schema_b_id, row_b) =
+        with_actor_context::<_, diesel::result::Error>(&mut conn, &actor, |c| {
+            let schema_a = repo::create_schema(
+                c,
+                NewPluginCollectionSchema {
+                    plugin_id: plugin_a.id,
+                    collection_name: "notes".into(),
+                    schema: json!({ "fields": [] }),
+                    version: 1,
+                },
+            )?;
+            let schema_b = repo::create_schema(
+                c,
+                NewPluginCollectionSchema {
+                    plugin_id: plugin_b.id,
+                    collection_name: "notes".into(),
+                    schema: json!({ "fields": [] }),
+                    version: 1,
+                },
+            )?;
+            let row_b = repo::create_row(
+                c,
+                NewPluginCollectionRow {
+                    plugin_id: plugin_b.id,
+                    schema_id: schema_b.id,
+                    data: json!({ "secret": "b" }),
+                    created_by: Some(admin),
+                },
+            )?;
+            Ok((schema_a.id, schema_b.id, row_b))
+        })
+        .expect("seed collections");
+
+    // Owner (schema B) reads its own row.
+    let owner_read =
+        with_actor_context::<PluginCollectionRow, diesel::result::Error>(&mut conn, &actor, |c| {
+            repo::get_row_by_uuid(c, schema_b_id, row_b.uuid)
+        });
+    assert!(owner_read.is_ok(), "owner must read its own row");
+
+    // Cross-plugin READ via schema A is NotFound.
+    let cross_read =
+        with_actor_context::<PluginCollectionRow, diesel::result::Error>(&mut conn, &actor, |c| {
+            repo::get_row_by_uuid(c, schema_a_id, row_b.uuid)
+        });
+    assert!(
+        matches!(cross_read, Err(diesel::result::Error::NotFound)),
+        "a plugin must not read another plugin's row by uuid"
+    );
+
+    // Cross-plugin UPDATE via schema A touches nothing.
+    let cross_update =
+        with_actor_context::<PluginCollectionRow, diesel::result::Error>(&mut conn, &actor, |c| {
+            repo::update_row(
+                c,
+                schema_a_id,
+                row_b.uuid,
+                PluginCollectionRowUpdate {
+                    data: Some(json!({ "secret": "pwned" })),
+                },
+            )
+        });
+    assert!(
+        matches!(cross_update, Err(diesel::result::Error::NotFound)),
+        "a plugin must not update another plugin's row"
+    );
+
+    // Cross-plugin DELETE via schema A removes nothing.
+    let cross_delete = with_actor_context::<usize, diesel::result::Error>(&mut conn, &actor, |c| {
+        repo::delete_row(c, schema_a_id, row_b.uuid)
+    })
+    .expect("delete runs");
+    assert_eq!(
+        cross_delete, 0,
+        "a plugin must not delete another plugin's row"
+    );
+
+    // B's row is intact and its owner can delete it.
+    let still_there =
+        with_actor_context::<PluginCollectionRow, diesel::result::Error>(&mut conn, &actor, |c| {
+            repo::get_row_by_uuid(c, schema_b_id, row_b.uuid)
+        });
+    assert!(
+        still_there.is_ok(),
+        "the row must survive cross-plugin tampering attempts"
+    );
+    assert_eq!(
+        still_there.expect("row").data,
+        json!({ "secret": "b" }),
+        "the row data must be unchanged"
+    );
+
+    let owner_delete = with_actor_context::<usize, diesel::result::Error>(&mut conn, &actor, |c| {
+        repo::delete_row(c, schema_b_id, row_b.uuid)
+    })
+    .expect("owner delete runs");
+    assert_eq!(owner_delete, 1, "the owner must delete its own row");
+}


### PR DESCRIPTION
Hardening from a fresh review pass over the plugin system. Backend only.

## Row scoping
`get`/`update`/`delete` on `/plugins/{uuid}/collections/{name}/rows/{row_uuid}` matched rows only by `{row_uuid}`. `get`/`delete` ignored `{name}` entirely, and no handler bound the row to the plugin in the path. RLS scopes `plugin_collection_rows` to the tenant (`workspace_id`), not to the plugin, so a row op needs its own object-level scoping to keep one plugin's rows isolated from a sibling plugin's within the same workspace.

Fix: resolve the schema by `(plugin.id, name)` in all three handlers (as create/update/list already do) and filter rows by `schema_id` in the repository. Every row op is now bound to the named collection of the authorized plugin; a missing collection returns "Collection not found" on get/delete, consistent with update. Every sibling endpoint (storage, schema listing, row create/list) already scoped this way; this brings the by-uuid row ops in line.

New DB-backed test `plugin_collection_row_scoping.rs`: a plugin cannot read/update/delete another plugin's row by uuid, the row survives the attempts, and the owner can still operate on it.

## Proxy consistency
The egress proxy checked the target host against the raw manifest permissions; every other plugin authorization check uses the effective (consented) permission set. Switched the proxy (request URL + OAuth token_url gates) to the effective set so egress authorization is uniform. Safe today (consented stays in lockstep with the manifest via the reconsent flow); this removes the latent divergence.

## Verification
- backend `cargo check --lib --tests`
- new row-scoping test passes; existing 14 proxy tests + gate test pass