### PR TITLE
plugin: mount settings.integrations.page on the plugin detail view

### DIFF
--- a/backend/src/services/plugins/plugin_slots.generated.json
+++ b/backend/src/services/plugins/plugin_slots.generated.json
@@ -29,11 +29,11 @@
     "context": "none",
     "cardinality": "many",
     "order": 100,
-    "status": "reserved",
+    "status": "stable",
     "aliases": [
       "settings-integrations"
     ],
-    "description": "Pages under Settings > Integrations"
+    "description": "A plugin's configuration page, shown on its admin detail view"
   },
   {
     "name": "dashboard.widget",

--- a/frontend/src/plugins/components/PluginSlot.vue
+++ b/frontend/src/plugins/components/PluginSlot.vue
@@ -21,11 +21,17 @@ const props = defineProps<{
   context?: PluginSlotContext;
   /** Per-component activation counters from `usePluginActions`. */
   actionActivatedMap?: ReadonlyMap<string, number>;
+  /** Render only the given plugin's contributions (e.g. a plugin's own config
+   *  page on its detail view). Omit to render every plugin's contribution. */
+  pluginUuid?: string;
 }>();
 
 // Registrations are keyed by canonical name; normalize an alias-passed target.
 const canonical = computed(() => canonicalSlotName(props.target) ?? props.target);
-const registrations = computed(() => slotRegistrations.get(canonical.value as PluginSlot) ?? []);
+const registrations = computed(() => {
+  const all = slotRegistrations.get(canonical.value as PluginSlot) ?? [];
+  return props.pluginUuid ? all.filter((r) => r.pluginUuid === props.pluginUuid) : all;
+});
 
 provide('pluginSlot', canonical);
 </script>

--- a/frontend/src/views/admin/plugins/PluginDetailView.vue
+++ b/frontend/src/views/admin/plugins/PluginDetailView.vue
@@ -31,12 +31,14 @@ import PluginIcon from '@/components/plugins/PluginIcon.vue';
 import PluginStateBadge from '@/components/plugins/PluginStateBadge.vue';
 import PluginTrustBadge from '@/components/plugins/PluginTrustBadge.vue';
 import pluginService from '@nosdesk/core/services/pluginService';
-import { unloadPlugin } from '@/plugins/loader';
+import { unloadPlugin, getLoadedPlugin } from '@/plugins/loader';
 import { logger } from '@nosdesk/core/utils/logger';
 import { useDateStore } from '@nosdesk/core/stores/dateStore';
 import { resolvePluginI18n } from '@nosdesk/core/utils/pluginI18n';
 import type { Plugin, PluginSetting } from '@nosdesk/core/types/plugin';
+import { canonicalSlotName } from '@nosdesk/core/types/plugin';
 import PluginPermissionList from '@/components/plugins/PluginPermissionList.vue';
+import PluginSlot from '@/plugins/components/PluginSlot.vue';
 
 const route = useRoute();
 const router = useRouter();
@@ -74,6 +76,17 @@ const plugin = computed<Plugin | null>(() => pluginQuery.data.value ?? null);
 const dateStore = useDateStore();
 const l10n = (value: string | null | undefined): string =>
   resolvePluginI18n(value, plugin.value?.manifest.i18n, dateStore.locale);
+
+// Show the plugin's own config panel (`settings.integrations.page`) when it both
+// declares that component AND is loaded into the slot registry (i.e. enabled) —
+// so a disabled plugin that declares one doesn't render an empty heading.
+const showIntegrationPanel = computed(() => {
+  const p = plugin.value;
+  if (!p || !getLoadedPlugin(p.uuid)) return false;
+  return Object.values(p.manifest.components).some(
+    (c) => canonicalSlotName(c.slot) === 'settings.integrations.page',
+  );
+});
 const loadOp = computed(() => ({
   isPending: pluginQuery.asyncStatus.value === 'loading',
   isError: pluginQuery.state.value.status === 'error',
@@ -542,6 +555,19 @@ const saveButtonLabel = computed(() =>
             </div>
           </footer>
         </form>
+      </section>
+
+      <!-- Plugin-rendered configuration page (settings.integrations.page). A
+           sandboxed panel the plugin fills; scoped to this plugin only. -->
+      <section
+        v-if="showIntegrationPanel"
+        aria-labelledby="integration-page-heading"
+        class="rounded-xl border border-default bg-surface p-5"
+      >
+        <h2 id="integration-page-heading" class="mb-4 font-semibold text-primary">
+          {{ t('plugin-detail-integration-page-heading') }}
+        </h2>
+        <PluginSlot target="settings.integrations.page" :plugin-uuid="plugin.uuid" />
       </section>
 
       <!-- Metadata -->

--- a/i18n/locales/en-US/main.ftl
+++ b/i18n/locales/en-US/main.ftl
@@ -4939,6 +4939,7 @@ plugin-detail-loading = Loading plugin...
 plugin-detail-loading-settings = Loading settings...
 plugin-detail-lifecycle-heading = Lifecycle
 plugin-detail-settings-heading = Settings
+plugin-detail-integration-page-heading = Configuration
 plugin-detail-metadata-heading = Metadata
 plugin-detail-metadata-source = Source
 plugin-detail-metadata-permissions = Permissions

--- a/i18n/locales/fr-FR/main.ftl
+++ b/i18n/locales/fr-FR/main.ftl
@@ -4778,6 +4778,8 @@ plugin-detail-loading = Chargement du plugin...
 plugin-detail-loading-settings = Chargement des paramètres...
 plugin-detail-lifecycle-heading = Cycle de vie
 plugin-detail-settings-heading = Paramètres
+# machine, à relire par un locuteur natif
+plugin-detail-integration-page-heading = Configuration
 plugin-detail-metadata-heading = Métadonnées
 plugin-detail-metadata-source = Source
 plugin-detail-metadata-permissions = Permissions

--- a/i18n/locales/nl-NL/main.ftl
+++ b/i18n/locales/nl-NL/main.ftl
@@ -4769,6 +4769,8 @@ plugin-detail-loading = Plugin laden...
 plugin-detail-loading-settings = Instellingen laden...
 plugin-detail-lifecycle-heading = Levenscyclus
 plugin-detail-settings-heading = Instellingen
+# machine, door een moedertaalspreker te controleren
+plugin-detail-integration-page-heading = Configuratie
 plugin-detail-metadata-heading = Metadata
 plugin-detail-metadata-source = Bron
 plugin-detail-metadata-permissions = Machtigingen

--- a/packages/core/src/types/pluginSlots.ts
+++ b/packages/core/src/types/pluginSlots.ts
@@ -83,9 +83,9 @@ export const SLOT_REGISTRY = [
     context: 'none',
     cardinality: 'many',
     order: 100,
-    status: 'reserved',
+    status: 'stable',
     aliases: ['settings-integrations'],
-    description: 'Pages under Settings > Integrations',
+    description: "A plugin's configuration page, shown on its admin detail view",
   },
   {
     name: 'dashboard.widget',


### PR DESCRIPTION
First panel of P-b (plugin UI-slots redesign): the first slot promoted from reserved to a live mount.

## What
`settings.integrations.page` is now `stable` and rendered. A plugin's own rich config / OAuth panel shows on its admin detail page (`/admin/plugins/:uuid`), below the declarative settings form, scoped to that plugin.

- `PluginSlot` gains an optional `pluginUuid` prop that filters to one plugin's contributions (reusable for any per-plugin mount).
- The detail-view section shows only when the plugin declares a `settings.integrations.page` component AND is loaded (enabled), so a disabled plugin doesn't render an empty heading.
- Rationale for mounting here (vs a new shared Settings > Integrations index): a plugin's config UI lives with the plugin, needs no new IA, and the detail page already sits under the Integrations nav group. This refines the design-of-record's "Settings > Integrations" note; happy to move to a dedicated index later if preferred.

## Verification
- core + frontend type-check, frontend lint
- slot registry regenerated + drift-clean
- new i18n key added (en-US + machine fr/nl, per the i18n workflow)