### PR TITLE
plugin: on-demand modal surface + ticket.header.action

### DIFF
--- a/backend/src/services/plugins/plugin_slots.generated.json
+++ b/backend/src/services/plugins/plugin_slots.generated.json
@@ -75,11 +75,11 @@
     "context": "ticket",
     "cardinality": "many",
     "order": 100,
-    "status": "reserved",
+    "status": "stable",
     "aliases": [
       "ticket-header-actions"
     ],
-    "description": "Actions in the ticket header menu"
+    "description": "Actions in the ticket header menu (open the component in a modal)"
   },
   {
     "name": "asset.header.action",

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -15,6 +15,7 @@ import RouteProgress from './components/common/RouteProgress.vue'
 import LoadingSpinner from './components/common/LoadingSpinner.vue'
 import { useWorkspaceSwitch } from '@/composables/useWorkspaceSwitch'
 import { GlobalSearchModal } from './components/GlobalSearch'
+import PluginModalHost from '@/plugins/components/PluginModalHost.vue'
 import { useTitleManager } from '@/composables/useTitleManager'
 import { useMobileSearch } from '@/composables/useMobileSearch'
 import { useCursorScanlines } from '@/composables/useCursorScanlines'
@@ -489,6 +490,9 @@ onMounted(async () => {
 
   <!-- Global Search Modal -->
   <GlobalSearchModal />
+
+  <!-- On-demand plugin modal surface (opened by plugin action contributions) -->
+  <PluginModalHost />
 </template>
 
 <style>

--- a/frontend/src/plugins/components/PluginModalHost.vue
+++ b/frontend/src/plugins/components/PluginModalHost.vue
@@ -1,0 +1,43 @@
+<!--
+PluginModalHost — the single host for the on-demand plugin modal surface.
+
+Mounted once at app root. Watches the shared `pluginModal` request (opened by
+action handlers via `openPluginModal`) and renders the requested plugin
+component in a sandbox frame inside a Modal. One plugin modal at a time; the
+user closes it (X / backdrop / Esc). If the plugin is no longer loaded, the
+modal simply doesn't open.
+-->
+<script setup lang="ts">
+import { computed } from 'vue';
+import { useFluent } from 'fluent-vue';
+import Modal from '@/components/Modal.vue';
+import PluginSandboxFrame from './PluginSandboxFrame.vue';
+import { pluginModal, closePluginModal } from '../usePluginModal';
+import { getLoadedPlugin } from '../loader';
+
+const fluent = useFluent();
+const t = (k: string, args?: Record<string, string | number>) => fluent.$t(k, args);
+
+// Only open for a plugin that's actually loaded (enabled).
+const loaded = computed(() => {
+  const req = pluginModal.value;
+  return req ? getLoadedPlugin(req.pluginUuid) : undefined;
+});
+const open = computed(() => !!pluginModal.value && !!loaded.value);
+
+const title = computed(
+  () => pluginModal.value?.title ?? loaded.value?.plugin.name ?? t('plugin-modal-title'),
+);
+</script>
+
+<template>
+  <Modal :show="open" :title="title" size="lg" @close="closePluginModal">
+    <PluginSandboxFrame
+      v-if="open && pluginModal && loaded"
+      :key="`${pluginModal.pluginUuid}:${pluginModal.componentName}`"
+      :plugin="loaded.plugin"
+      :component="{ name: pluginModal.componentName, slot: pluginModal.slot }"
+      :context="pluginModal.context"
+    />
+  </Modal>
+</template>

--- a/frontend/src/plugins/usePluginActions.ts
+++ b/frontend/src/plugins/usePluginActions.ts
@@ -37,6 +37,17 @@ function menuIdToActivationKey(menuId: string): string | undefined {
   return menuId.startsWith(MENU_PREFIX) ? menuId.slice(MENU_PREFIX.length) : undefined;
 }
 
+/** Parse a plugin menu-action id back into its plugin + component parts. */
+export function parsePluginMenuActionId(
+  menuId: string,
+): { pluginUuid: string; componentName: string } | undefined {
+  const key = menuIdToActivationKey(menuId);
+  if (key === undefined) return undefined;
+  const sep = key.indexOf(':');
+  if (sep <= 0 || sep === key.length - 1) return undefined;
+  return { pluginUuid: key.slice(0, sep), componentName: key.slice(sep + 1) };
+}
+
 /** Stable scope string isolating one entity's activation counters. */
 export function pluginActionScope(entity: string, id: string | number): string {
   return `${entity}:${id}`;

--- a/frontend/src/plugins/usePluginModal.ts
+++ b/frontend/src/plugins/usePluginModal.ts
@@ -1,0 +1,43 @@
+/**
+ * On-demand plugin modal surface.
+ *
+ * A host-invoked, transient surface: an action contribution (e.g. a
+ * `ticket.header.action` menu item) opens a plugin's component in a modal that
+ * floats over the page, rather than poking an already-mounted panel. This is
+ * the "modal" reserved surface from the UI-slots design (the Zendesk/Slack
+ * pattern) and is what makes the action mechanism usable without the plugin
+ * also owning a persistent panel.
+ *
+ * Module state, so any action handler can open the single shared modal that
+ * `PluginModalHost` (mounted once at app root) renders. Opening a second one
+ * replaces the first — one plugin modal at a time.
+ */
+import { shallowRef, computed, type ComputedRef } from 'vue';
+import type { PluginSlotContext } from './context';
+
+export interface PluginModalRequest {
+  pluginUuid: string;
+  /** Manifest component key to render (its `slot` is the invoking action slot). */
+  componentName: string;
+  /** Slot the component was contributed to (passed through to the frame). */
+  slot: string;
+  /** Host context handed to the component (e.g. the ticket the action fired on). */
+  context?: PluginSlotContext;
+  /** Optional explicit title; falls back to the component label / plugin name. */
+  title?: string;
+}
+
+const current = shallowRef<PluginModalRequest | null>(null);
+
+/** The open modal request, or null when closed. Mutate only via open/close. */
+export const pluginModal: ComputedRef<PluginModalRequest | null> = computed(() => current.value);
+
+/** Open (or replace) the plugin modal. */
+export function openPluginModal(request: PluginModalRequest): void {
+  current.value = request;
+}
+
+/** Close the plugin modal if open. */
+export function closePluginModal(): void {
+  current.value = null;
+}

--- a/frontend/src/views/TicketView.vue
+++ b/frontend/src/views/TicketView.vue
@@ -45,7 +45,8 @@ import Modal from "@/components/Modal.vue";
 import NotFoundIllustration from "@/components/common/NotFoundIllustration.vue";
 import SectionCard from "@/components/common/SectionCard.vue";
 import PluginSlot from "@/plugins/components/PluginSlot.vue";
-import { usePluginActions, pluginActionScope } from "@/plugins/usePluginActions";
+import { usePluginActions, pluginActionScope, parsePluginMenuActionId } from "@/plugins/usePluginActions";
+import { openPluginModal } from "@/plugins/usePluginModal";
 import { useCreateTicketAction } from "@/composables/useCreateTicketAction";
 
 
@@ -159,11 +160,15 @@ const showDropAffordance = computed(() => {
            dragState.value.ticket?.id !== ticket.value?.id;
 });
 
-// Plugin action contributions in the ticket overflow menu. `usePluginActions`
-// owns the id format and the per-ticket activation counters (scoped so distinct
-// tickets don't share state, and surviving component unmount). Scope is unset
-// for pre-route / transitional states, which makes `activate` a no-op and the
-// map empty.
+// Plugin action contributions in the ticket overflow menu. Two kinds:
+//   * Sidebar-panel actions (a panel that self-declares an action): selecting
+//     one pokes the already-mounted sidebar iframe via an activation counter.
+//   * Header actions (`ticket.header.action`): selecting one opens the plugin's
+//     component in the on-demand modal surface (no persistent panel needed).
+// `usePluginActions` owns the id format and the per-ticket activation counters
+// (scoped so distinct tickets don't share state, and surviving component
+// unmount). Scope is unset for pre-route / transitional states, which makes
+// `activate` a no-op and the map empty.
 const ticketActionScope = computed(() =>
     ticketId.value !== undefined ? pluginActionScope('ticket', ticketId.value) : undefined
 );
@@ -172,6 +177,7 @@ const {
     activatedMap: pluginActionActivatedMap,
     activate: activatePluginAction,
 } = usePluginActions('ticket.sidebar.panel', ticketActionScope);
+const { items: pluginHeaderActionItems } = usePluginActions('ticket.header.action', ticketActionScope);
 
 // Plugins consume the canonical `Ticket` shape. The pool-derived
 // view-model is structurally narrower (denormalised workflow_state,
@@ -203,7 +209,8 @@ const overflowMenuItems = computed<MenuItem[]>(() => {
         },
     ];
 
-    pluginActionItems.value.forEach((action, idx) => {
+    // Both action kinds share the plugin group; divider above the first one.
+    [...pluginActionItems.value, ...pluginHeaderActionItems.value].forEach((action, idx) => {
         items.push({
             id: action.id,
             label: action.label,
@@ -266,8 +273,21 @@ const handleOverflowSelect = (itemId: string) => {
         // Two-step destructive flow: opening the modal is the
         // first click, the modal's confirm button is the second.
         showDeleteConfirm.value = true;
+    } else if (pluginHeaderActionItems.value.some((a) => a.id === itemId)) {
+        // Header action: open the plugin's component in the on-demand modal,
+        // handing it the current ticket as context.
+        const parsed = parsePluginMenuActionId(itemId);
+        if (parsed) {
+            openPluginModal({
+                pluginUuid: parsed.pluginUuid,
+                componentName: parsed.componentName,
+                slot: 'ticket.header.action',
+                context: { ticket: pluginTicket.value },
+            });
+        }
     } else {
-        // Plugin action ids are namespaced; `activate` no-ops on anything else.
+        // Sidebar-panel action: `activate` pokes the mounted iframe (no-ops on
+        // any non-plugin id).
         activatePluginAction(itemId);
     }
 };

--- a/i18n/locales/en-US/main.ftl
+++ b/i18n/locales/en-US/main.ftl
@@ -4940,6 +4940,7 @@ plugin-detail-loading-settings = Loading settings...
 plugin-detail-lifecycle-heading = Lifecycle
 plugin-detail-settings-heading = Settings
 plugin-detail-integration-page-heading = Configuration
+plugin-modal-title = Plugin
 plugin-detail-metadata-heading = Metadata
 plugin-detail-metadata-source = Source
 plugin-detail-metadata-permissions = Permissions

--- a/i18n/locales/fr-FR/main.ftl
+++ b/i18n/locales/fr-FR/main.ftl
@@ -4780,6 +4780,8 @@ plugin-detail-lifecycle-heading = Cycle de vie
 plugin-detail-settings-heading = Paramètres
 # machine, à relire par un locuteur natif
 plugin-detail-integration-page-heading = Configuration
+# machine, à relire par un locuteur natif
+plugin-modal-title = Extension
 plugin-detail-metadata-heading = Métadonnées
 plugin-detail-metadata-source = Source
 plugin-detail-metadata-permissions = Permissions

--- a/i18n/locales/nl-NL/main.ftl
+++ b/i18n/locales/nl-NL/main.ftl
@@ -4771,6 +4771,8 @@ plugin-detail-lifecycle-heading = Levenscyclus
 plugin-detail-settings-heading = Instellingen
 # machine, door een moedertaalspreker te controleren
 plugin-detail-integration-page-heading = Configuratie
+# machine, door een moedertaalspreker te controleren
+plugin-modal-title = Plug-in
 plugin-detail-metadata-heading = Metadata
 plugin-detail-metadata-source = Bron
 plugin-detail-metadata-permissions = Machtigingen

--- a/packages/core/src/types/pluginSlots.ts
+++ b/packages/core/src/types/pluginSlots.ts
@@ -123,9 +123,9 @@ export const SLOT_REGISTRY = [
     context: 'ticket',
     cardinality: 'many',
     order: 100,
-    status: 'reserved',
+    status: 'stable',
     aliases: ['ticket-header-actions'],
-    description: 'Actions in the ticket header menu',
+    description: 'Actions in the ticket header menu (open the component in a modal)',
   },
   {
     name: 'asset.header.action',


### PR DESCRIPTION
Formalizes `ticket.header.action` (the D3 third item) by building the on-demand modal surface it needs.

## The problem
A header menu action has nowhere to dispatch: unlike a sidebar-panel action (which pokes an already-mounted iframe), a header action has no persistent panel. The signed-off design reserved a **modal** surface (Zendesk/Slack pattern) for exactly this.

## What
- **On-demand modal surface.** `openPluginModal(request)` renders a plugin's component in a sandbox frame inside a `Modal` (`PluginModalHost`, mounted once at app root). Transient, host-invoked, one at a time; the user closes it. Built from existing primitives (`Modal` + `PluginSandboxFrame`).
- **`ticket.header.action` → stable + wired.** Header actions join the ticket overflow menu alongside sidebar-panel actions, but selecting one **opens the plugin's component in the modal** (handing it the ticket as context) instead of poking a mounted iframe. So a plugin can offer a "Create linked issue", "Escalate", etc. action without also owning a sidebar panel.
- `parsePluginMenuActionId` recovers the plugin + component from a namespaced menu id (in `usePluginActions`, which owns the id format).

Two dispatch behaviours, one menu, each honest to its slot: panel-actions poke, header-actions open a modal.

## Verification
- core + frontend type-check, frontend + core lint
- slot registry regenerated + drift-clean
- new i18n key (en-US + machine fr/nl)