### PR TITLE
plugin: ticket.bulk.action on a ticket selection

### DIFF
--- a/backend/src/services/plugins/plugin_slots.generated.json
+++ b/backend/src/services/plugins/plugin_slots.generated.json
@@ -82,6 +82,16 @@
     "description": "Actions in the ticket header menu (open the component in a modal)"
   },
   {
+    "name": "ticket.bulk.action",
+    "mechanism": "action",
+    "context": "ticket",
+    "cardinality": "many",
+    "order": 100,
+    "status": "stable",
+    "aliases": [],
+    "description": "Actions on a ticket selection (open the component in a modal)"
+  },
+  {
     "name": "asset.header.action",
     "mechanism": "action",
     "context": "asset",

--- a/frontend/src/components/views/TicketsBulkBar.vue
+++ b/frontend/src/components/views/TicketsBulkBar.vue
@@ -33,6 +33,8 @@ import { PRIORITY_OPTIONS } from '@nosdesk/core/constants/ticketOptions'
 import type { TicketPriority } from '@nosdesk/core/constants/ticketOptions'
 import { WORKFLOW_CATEGORIES, getCategoryLabel, type WorkflowStateCategory } from '@nosdesk/core/types/workflow'
 import { useSyncTicketsStore } from '@/sync/stores/tickets'
+import { getSlotRegistrations } from '@/plugins/loader'
+import { openPluginModal } from '@/plugins/usePluginModal'
 
 const props = defineProps<{
   /** Selected ticket ids (strings, since useBulkSelection's set
@@ -179,6 +181,20 @@ const canMerge = computed(() => selectedTickets.value.length >= 2)
 function onMerged(): void {
   showMergeDialog.value = false
   emit('clear')
+}
+
+// ---- Plugin bulk actions --------------------------------------
+// Plugins contributing a `ticket.bulk.action` render as buttons here; clicking
+// one opens the plugin's component in the on-demand modal, handing it the
+// current ticket-id selection. Labels are already i18n-resolved at load time.
+const pluginBulkActions = computed(() => getSlotRegistrations('ticket.bulk.action'))
+function runPluginBulkAction(reg: { pluginUuid: string; componentName: string }): void {
+  openPluginModal({
+    pluginUuid: reg.pluginUuid,
+    componentName: reg.componentName,
+    slot: 'ticket.bulk.action',
+    context: { ticketIds: ids.value },
+  })
 }
 </script>
 
@@ -342,6 +358,23 @@ function onMerged(): void {
         >
           <Icon name="link" class="w-3.5 h-3.5" />
           <span>{{ $t('ticket-list-bulk-merge') }}</span>
+        </button>
+      </template>
+
+      <!-- Plugin bulk actions — each opens the plugin's component in a modal
+           with the current selection. -->
+      <template v-if="pluginBulkActions.length > 0">
+        <span class="h-4 w-px bg-default mx-1" aria-hidden="true" />
+        <button
+          v-for="action in pluginBulkActions"
+          :key="`${action.pluginUuid}:${action.componentName}`"
+          type="button"
+          class="inline-flex items-center gap-1 px-2 py-1 rounded text-xs text-secondary hover:text-primary hover:bg-surface-hover transition-colors"
+          @click="runPluginBulkAction(action)"
+        >
+          <img v-if="action.icon" :src="action.icon" class="w-3.5 h-3.5" alt="" />
+          <Icon v-else name="puzzle" class="w-3.5 h-3.5" />
+          <span>{{ action.label ?? action.pluginName }}</span>
         </button>
       </template>
 

--- a/frontend/src/plugins/components/PluginSandboxFrame.vue
+++ b/frontend/src/plugins/components/PluginSandboxFrame.vue
@@ -56,6 +56,7 @@ function snapshot(): PluginContext {
   return {
     ticket: plain(props.context?.ticket),
     asset: plain(props.context?.asset),
+    ticketIds: plain(props.context?.ticketIds),
     component: { name: props.component.name, slot: props.component.slot },
     actionActivated: props.actionActivated,
   };

--- a/frontend/src/plugins/context.ts
+++ b/frontend/src/plugins/context.ts
@@ -13,6 +13,8 @@ import type { Asset } from '@nosdesk/core/types/asset';
 export interface PluginSlotContext {
   ticket?: Ticket;
   asset?: Asset;
+  /** Selected ticket ids for a bulk action (`ticket.bulk.action`). */
+  ticketIds?: number[];
   // Future context types (e.g. `documentationPage`) land here alongside a
   // matching line in PluginSandboxFrame's snapshot() and the SDK wire type.
 }

--- a/packages/core/src/types/pluginSlots.ts
+++ b/packages/core/src/types/pluginSlots.ts
@@ -128,6 +128,16 @@ export const SLOT_REGISTRY = [
     description: 'Actions in the ticket header menu (open the component in a modal)',
   },
   {
+    name: 'ticket.bulk.action',
+    mechanism: 'action',
+    context: 'ticket',
+    cardinality: 'many',
+    order: 100,
+    status: 'stable',
+    aliases: [],
+    description: 'Actions on a ticket selection (open the component in a modal)',
+  },
+  {
     name: 'asset.header.action',
     mechanism: 'action',
     context: 'asset',

--- a/packages/plugin-sdk/src/types.ts
+++ b/packages/plugin-sdk/src/types.ts
@@ -235,6 +235,9 @@ export type PluginHostApi = Omit<import('comlink').Remote<HostApi>, 'on'> & {
 export interface PluginContext {
   ticket: Ticket | null;
   asset: Asset | null;
+  /** Selected ticket ids for a bulk action (`ticket.bulk.action`). The plugin
+   * operates on the whole selection. Null / absent outside a bulk context. */
+  ticketIds?: number[] | null;
   /** Which of the plugin's manifest components this mount is rendering. A bundle
    * may declare several (different slots); the plugin switches its UI on `name`
    * (the manifest `components` map key) / `slot`. */


### PR DESCRIPTION
First of the P-d action slots. Plugins can now act on a ticket selection.

## What
`ticket.bulk.action` is now `stable` and rendered. A plugin contributing one appears as a button in the tickets bulk bar (next to Status/Priority/Assignee/Merge); clicking it opens the plugin's component in the on-demand modal, handing it the current ticket-id selection as context.

- Extends the plugin context wire with `ticketIds` (SDK `PluginContext` + frontend `PluginSlotContext` + the sandbox `snapshot()`), so the plugin knows which tickets to act on. Type-only change — `runtime.js` rebuilt and unchanged (drift-clean).
- Uses the modal surface from #169; no new dispatch machinery.

## Verification
- SDK + core + frontend type-check, frontend lint (mount-parity now sees 6 stable slots)
- slot registry regenerated + drift-clean; runtime.js drift-clean