### PR TITLE
plugin: nav.item full-page surface + sidebar link

### DIFF
--- a/backend/src/services/plugins/plugin_slots.generated.json
+++ b/backend/src/services/plugins/plugin_slots.generated.json
@@ -121,10 +121,10 @@
     "context": "none",
     "cardinality": "many",
     "order": 100,
-    "status": "reserved",
+    "status": "stable",
     "aliases": [
       "navbar-items"
     ],
-    "description": "Links in the navigation sidebar"
+    "description": "A nav-sidebar link to a full-page plugin surface"
   }
 ]

--- a/frontend/src/components/NavLinkIcon.vue
+++ b/frontend/src/components/NavLinkIcon.vue
@@ -1,0 +1,20 @@
+<!--
+NavLinkIcon — renders a nav link's icon. Core links carry an SVG path (`icon`);
+plugin nav items carry an icon URL (`iconUrl`, rendered as an <img>). Keeps the
+img-vs-svg branch in one place across the sidebar's render variants.
+-->
+<script setup lang="ts">
+defineProps<{
+  /** SVG path data for a core nav link. */
+  icon: string;
+  /** Icon URL for a plugin nav item; when set, wins over `icon`. */
+  iconUrl?: string;
+}>();
+</script>
+
+<template>
+  <img v-if="iconUrl" :src="iconUrl" class="w-4 h-4 rounded-sm object-cover" alt="" />
+  <svg v-else class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" :d="icon" />
+  </svg>
+</template>

--- a/frontend/src/components/Navbar.vue
+++ b/frontend/src/components/Navbar.vue
@@ -20,6 +20,9 @@ import { useThemeStore } from "@/stores/theme";
 import Icon from "@/components/common/Icon.vue";
 import UnreadBadge from "@/components/common/UnreadBadge.vue";
 import WorkspaceSwitcher from "@/components/WorkspaceSwitcher.vue";
+import NavLinkIcon from "@/components/NavLinkIcon.vue";
+import { getSlotRegistrations } from "@/plugins/loader";
+import { pluginPagePath } from "@/plugins/pluginPage";
 
 // Global search
 const { openSearch } = useGlobalSearch();
@@ -135,6 +138,12 @@ interface NavLink {
      *  only "active" trigger. Without this, e.g. `/` would
      *  match every route (since every path starts with `/`). */
     exact?: boolean;
+    /** Pre-resolved literal label (plugin nav items). When set, rendered
+     *  instead of `$t(text)` — plugin labels aren't FTL keys. */
+    rawLabel?: string;
+    /** Icon URL (plugin nav items). When set, rendered as an `<img>` instead of
+     *  the `icon` SVG path. */
+    iconUrl?: string;
 }
 interface NavGroup {
     label: string;
@@ -143,7 +152,7 @@ interface NavGroup {
 // `text` and `label` are FTL keys; templates render them via
 // `$t(link.text)` / `$t(group.label)` so the nav re-renders
 // when the active locale flips.
-const navGroups: NavGroup[] = [
+const staticNavGroups: NavGroup[] = [
     {
         label: "nav-group-work",
         links: [
@@ -187,10 +196,33 @@ const navGroups: NavGroup[] = [
     },
 ];
 
+// Plugin `nav.item` contributions become a trailing "Plugins" group linking to
+// each plugin's full-page surface. Labels are pre-resolved at load time; icons
+// are plugin icon URLs (rendered as <img>, not an SVG path). The group appears
+// only when a plugin contributes one.
+const pluginNavGroup = computed<NavGroup | null>(() => {
+    const regs = getSlotRegistrations('nav.item');
+    if (regs.length === 0) return null;
+    return {
+        label: "nav-group-plugins",
+        links: regs.map((r) => ({
+            to: pluginPagePath(r.pluginUuid, r.componentName),
+            icon: "",
+            iconUrl: r.icon,
+            text: "",
+            rawLabel: r.label ?? r.pluginName,
+        })),
+    };
+});
+
+const navGroups = computed<NavGroup[]>(() =>
+    pluginNavGroup.value ? [...staticNavGroups, pluginNavGroup.value] : staticNavGroups,
+);
+
 /** Flat list used by the collapsed / compact-nav layouts where
  *  section headers wouldn't fit. Kept derived so adding a new
  *  link only ever requires editing the grouped source. */
-const navLinks: NavLink[] = navGroups.flatMap((g) => g.links);
+const navLinks = computed<NavLink[]>(() => navGroups.value.flatMap((g) => g.links));
 
 /** Synthetic NavLink for the inbox. Kept out of `navGroups` (which
  *  drives the desktop sidebar) because Inbox lives in the header
@@ -203,11 +235,14 @@ const INBOX_MOBILE_LINK: NavLink = {
     text: 'nav-inbox',
 };
 
-/** All routes a user can pin to the mobile bar. The full set is
- *  the sidebar's navLinks plus the synthetic Inbox entry; Search
- *  stays a fixed cell on the bar (it's a button, not a route)
- *  and "More" is the overflow opener, also fixed. */
-const pinnableLinks = computed<NavLink[]>(() => [INBOX_MOBILE_LINK, ...navLinks]);
+/** All routes a user can pin to the mobile bar. The static core routes plus the
+ *  synthetic Inbox entry; Search stays a fixed cell on the bar (it's a button,
+ *  not a route) and "More" is the overflow opener, also fixed. Plugin nav items
+ *  are intentionally excluded — the mobile pin set is a curated core-route set. */
+const pinnableLinks = computed<NavLink[]>(() => [
+    INBOX_MOBILE_LINK,
+    ...staticNavGroups.flatMap((g) => g.links),
+]);
 
 const { pinnedPaths, isPinned, togglePin, resetToDefaults, remainingSlots } =
     useMobileNavPins();
@@ -423,20 +458,13 @@ const isOverflowRouteActive = computed(() =>
                             ? 'bg-surface-alt/80 text-primary font-medium'
                             : 'text-secondary hover:bg-surface-hover hover:text-primary'
                     "
-                    :title="$t(link.text)"
+                    :title="link.rawLabel ?? $t(link.text)"
                 >
                     <div
                         v-if="isRouteActive(link.to, link.exact)"
                         class="absolute left-0 top-0 bottom-0 w-1 bg-accent w-full h-0.5 top-auto"
                     ></div>
-                    <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor">
-                        <path
-                            stroke-linecap="round"
-                            stroke-linejoin="round"
-                            stroke-width="2"
-                            :d="link.icon"
-                        />
-                    </svg>
+                    <NavLinkIcon :icon="link.icon" :icon-url="link.iconUrl" />
                 </RouterLink>
             </div>
 
@@ -452,20 +480,13 @@ const isOverflowRouteActive = computed(() =>
                             ? 'bg-surface-alt/80 text-primary font-medium'
                             : 'text-secondary hover:bg-surface-hover hover:text-primary'
                     "
-                    :title="$t(link.text)"
+                    :title="link.rawLabel ?? $t(link.text)"
                 >
                     <div
                         v-if="isRouteActive(link.to, link.exact)"
                         class="absolute left-0 top-0 bottom-0 w-1 bg-accent"
                     ></div>
-                    <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor">
-                        <path
-                            stroke-linecap="round"
-                            stroke-linejoin="round"
-                            stroke-width="2"
-                            :d="link.icon"
-                        />
-                    </svg>
+                    <NavLinkIcon :icon="link.icon" :icon-url="link.iconUrl" />
                 </RouterLink>
             </div>
 
@@ -496,15 +517,8 @@ const isOverflowRouteActive = computed(() =>
                             v-if="isRouteActive(link.to, link.exact)"
                             class="absolute left-0 top-0 bottom-0 w-1 bg-accent"
                         ></div>
-                        <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor">
-                            <path
-                                stroke-linecap="round"
-                                stroke-linejoin="round"
-                                stroke-width="2"
-                                :d="link.icon"
-                            />
-                        </svg>
-                        <span class="text-sm whitespace-nowrap">{{ $t(link.text) }}</span>
+                        <NavLinkIcon :icon="link.icon" :icon-url="link.iconUrl" />
+                        <span class="text-sm whitespace-nowrap">{{ link.rawLabel ?? $t(link.text) }}</span>
                     </RouterLink>
                 </div>
             </div>

--- a/frontend/src/plugins/pluginPage.ts
+++ b/frontend/src/plugins/pluginPage.ts
@@ -1,0 +1,14 @@
+/**
+ * Full-page plugin surface (`nav.item`).
+ *
+ * A `nav.item` contribution is a nav link to a route that renders the plugin's
+ * component full-page (not an iframe embedded in host chrome, not a modal). This
+ * is the single place the route name + path shape live, shared by the router,
+ * the Navbar link injection, and the page view.
+ */
+export const PLUGIN_PAGE_ROUTE = 'plugin-page';
+
+/** Route path for a plugin's full-page component. */
+export function pluginPagePath(pluginUuid: string, componentName: string): string {
+  return `/plugins/${pluginUuid}/pages/${encodeURIComponent(componentName)}`;
+}

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -196,6 +196,18 @@ const router = createRouter({
       }
     },
     {
+      // Full-page plugin surface for a `nav.item` contribution (see
+      // plugins/pluginPage.ts). The view resolves the plugin + component from
+      // the params and renders it in a sandbox frame.
+      path: '/plugins/:uuid/pages/:component',
+      name: 'plugin-page',
+      component: () => import('@/views/PluginPageView.vue'),
+      meta: {
+        requiresAuth: true,
+        titleKey: 'route-title-plugin-page',
+      }
+    },
+    {
       path: '/tickets/:id',
       name: 'ticket-view',
       component: TicketView,

--- a/frontend/src/views/PluginPageView.vue
+++ b/frontend/src/views/PluginPageView.vue
@@ -1,0 +1,54 @@
+<!--
+PluginPageView — the full-page host for a plugin `nav.item` contribution.
+
+Routed at /plugins/:uuid/pages/:component. Resolves the loaded plugin + the
+named component from the route params and renders it full-page in a sandbox
+frame. If the plugin isn't loaded (disabled / uninstalled) or doesn't declare a
+nav.item component by that name, shows a not-available state rather than a blank
+page.
+-->
+<script setup lang="ts">
+import { computed } from 'vue';
+import { useRoute } from 'vue-router';
+import { useFluent } from 'fluent-vue';
+import PluginSandboxFrame from '@/plugins/components/PluginSandboxFrame.vue';
+import NotFoundIllustration from '@/components/common/NotFoundIllustration.vue';
+import { getLoadedPlugin, getSlotRegistrations } from '@/plugins/loader';
+
+const route = useRoute();
+const fluent = useFluent();
+const t = (k: string, args?: Record<string, string | number>) => fluent.$t(k, args);
+
+const uuid = computed(() => String(route.params.uuid ?? ''));
+const componentName = computed(() => String(route.params.component ?? ''));
+
+const loaded = computed(() => (uuid.value ? getLoadedPlugin(uuid.value) : undefined));
+
+// The component must actually be a declared nav.item on this plugin, so a route
+// can't render an arbitrary component full-page.
+const registration = computed(() =>
+  getSlotRegistrations('nav.item').find(
+    (r) => r.pluginUuid === uuid.value && r.componentName === componentName.value,
+  ),
+);
+
+const available = computed(() => !!loaded.value && !!registration.value);
+const title = computed(() => registration.value?.label ?? loaded.value?.plugin.name ?? '');
+</script>
+
+<template>
+  <div class="h-full">
+    <div v-if="available && loaded" class="mx-auto max-w-5xl p-4">
+      <h1 v-if="title" class="mb-4 text-lg font-semibold text-primary">{{ title }}</h1>
+      <PluginSandboxFrame
+        :key="`${uuid}:${componentName}`"
+        :plugin="loaded.plugin"
+        :component="{ name: componentName, slot: 'nav.item' }"
+      />
+    </div>
+    <div v-else class="flex h-full flex-col items-center justify-center gap-3 p-8 text-center">
+      <NotFoundIllustration class="w-40" />
+      <p class="text-sm text-secondary">{{ t('plugin-page-unavailable') }}</p>
+    </div>
+  </div>
+</template>

--- a/i18n/locales/en-US/main.ftl
+++ b/i18n/locales/en-US/main.ftl
@@ -287,6 +287,7 @@ empty-plugins-installed-description = Plugins extend { $app } with custom integr
 # Persistent shell — strings that render on every page.
 nav-group-work = Work
 nav-group-resources = Resources
+nav-group-plugins = Plugins
 nav-dashboard = Dashboard
 nav-tickets = Tickets
 nav-projects = Projects
@@ -5634,6 +5635,8 @@ route-title-help = Help
 route-title-dashboard = Dashboard
 route-title-inbox = Inbox
 route-title-tickets = Tickets
+route-title-plugin-page = Plugin
+plugin-page-unavailable = This plugin page is not available.
 route-title-ticket-view = View ticket
 route-title-user-profile = User profile
 route-title-user-settings = User settings

--- a/i18n/locales/fr-FR/main.ftl
+++ b/i18n/locales/fr-FR/main.ftl
@@ -238,6 +238,8 @@ empty-plugins-installed-description = Les plugins étendent { $app } avec des in
 # Persistent shell.
 nav-group-work = Travail
 nav-group-resources = Ressources
+# machine, à relire par un locuteur natif
+nav-group-plugins = Extensions
 nav-dashboard = Tableau de bord
 nav-tickets = Tickets
 nav-projects = Projets
@@ -5423,6 +5425,9 @@ route-title-help = Aide
 route-title-dashboard = Tableau de bord
 route-title-inbox = Boîte de réception
 route-title-tickets = Tickets
+# machine, à relire par un locuteur natif
+route-title-plugin-page = Extension
+plugin-page-unavailable = Cette page d'extension n'est pas disponible.
 route-title-ticket-view = Voir le ticket
 route-title-user-profile = Profil utilisateur
 route-title-user-settings = Paramètres utilisateur

--- a/i18n/locales/nl-NL/main.ftl
+++ b/i18n/locales/nl-NL/main.ftl
@@ -235,6 +235,8 @@ empty-plugins-installed-description = Plugins breiden { $app } uit met aangepast
 # Persistent shell.
 nav-group-work = Werk
 nav-group-resources = Bronnen
+# machine, door een moedertaalspreker te controleren
+nav-group-plugins = Plug-ins
 nav-dashboard = Dashboard
 nav-tickets = Tickets
 nav-projects = Projecten
@@ -5414,6 +5416,9 @@ route-title-help = Hulp
 route-title-dashboard = Dashboard
 route-title-inbox = Inbox
 route-title-tickets = Tickets
+# machine, door een moedertaalspreker te controleren
+route-title-plugin-page = Plug-in
+plugin-page-unavailable = Deze plug-inpagina is niet beschikbaar.
 route-title-ticket-view = Ticket bekijken
 route-title-user-profile = Gebruikersprofiel
 route-title-user-settings = Gebruikersinstellingen

--- a/packages/core/src/types/pluginSlots.ts
+++ b/packages/core/src/types/pluginSlots.ts
@@ -163,9 +163,9 @@ export const SLOT_REGISTRY = [
     context: 'none',
     cardinality: 'many',
     order: 100,
-    status: 'reserved',
+    status: 'stable',
     aliases: ['navbar-items'],
-    description: 'Links in the navigation sidebar',
+    description: 'A nav-sidebar link to a full-page plugin surface',
   },
 ] as const satisfies readonly SlotDef[];
 


### PR DESCRIPTION
Second of the P-d action slots. Plugins can now contribute a nav-sidebar entry that opens a full-page plugin surface.

## What
`nav.item` is now `stable`. Per the design, it's a **route + link, not an iframe-in-chrome or a modal**:

- **Full-page surface.** `PluginPageView` (routed at `/plugins/:uuid/pages/:component`) resolves the loaded plugin + the named `nav.item` component and renders it full-page in a sandbox frame. Shows a not-available state if the plugin is disabled/uninstalled or the component isn't a declared `nav.item`. Path/route-name centralized in `plugins/pluginPage.ts`.
- **Sidebar link.** `navGroups` becomes a computed that appends a trailing "Plugins" group built from `getSlotRegistrations('nav.item')`. `NavLink` gains optional `rawLabel` (plugin labels are literals, not FTL keys) and `iconUrl` (URL icon vs the core SVG-path icons), rendered via a small `NavLinkIcon` component across the sidebar's three variants (compact / collapsed / grouped) so it's consistent everywhere.
- **Scope**: plugin items are excluded from the curated **mobile pin set** (that bar is a fixed set of core routes) — a deliberate default, not an omission.

## Verification
- core + frontend type-check, frontend lint (mount-parity sees 6 stable slots here; view-roots 65 views)
- slot registry regenerated + drift-clean
- new i18n keys (en-US + machine fr/nl)