### PR TITLE
plugin: pin bootstrap workspace on local install paths

### DIFF
--- a/backend/src/bin/nosdesk_cli.rs
+++ b/backend/src/bin/nosdesk_cli.rs
@@ -522,8 +522,17 @@ fn plugin_install(zip_path: &Path) -> Result<()> {
         skip_if_unchanged: false,
     };
 
-    let outcome = install::install_verified(&mut conn, &verified.files, signer, tier, options)
-        .map_err(|e| anyhow!("install failed: {e}"))?;
+    // Pin the bootstrap workspace: `plugins` is workspace-scoped with FORCE RLS
+    // and its `workspace_id` defaults from `app.workspace_id`, so the INSERT
+    // needs a workspace context to satisfy the RLS WITH CHECK (and the NOT NULL
+    // default). `bootstrap` is the purpose-built helper for CLI-time install.
+    let actor = backend::sync::actor::ActorContext::bootstrap("cli:plugin_install");
+    let outcome = backend::sync::session::with_actor_context::<_, install::InstallError>(
+        &mut conn,
+        &actor,
+        |conn| install::install_verified(conn, &verified.files, signer, tier, options),
+    )
+    .map_err(|e| anyhow!("install failed: {e}"))?;
 
     let (action, plugin) = match &outcome {
         install::InstallOutcome::Created(p) => ("installed", p),

--- a/backend/src/services/plugins/provisioning.rs
+++ b/backend/src/services/plugins/provisioning.rs
@@ -281,11 +281,15 @@ fn provision_zip(conn: &mut DbConnection, zip_path: &Path, label: &str) -> Provi
         skip_if_unchanged: true,
     };
 
-    // System actor so the audit_log row carries an attribution
-    // rather than a NULL actor_uuid. The install_verified
-    // transaction becomes a savepoint that inherits the GUCs set
-    // by with_actor_context.
-    let actor = ActorContext::system("background:plugin_provisioner");
+    // Bootstrap actor: a system actor PINNED to the bootstrap workspace. The
+    // pin is required, not cosmetic — `plugins` is workspace-scoped with FORCE
+    // RLS and its `workspace_id` defaults from `app.workspace_id`, so an unpinned
+    // actor makes the INSERT violate the RLS WITH CHECK (and the NOT NULL
+    // default). `bootstrap` is the purpose-built helper for exactly this
+    // (bootstrap-time plugin install); it also gives the audit row a real
+    // attribution. Filesystem-provisioned plugins land in the bootstrap
+    // workspace (the self-hosted single-tenant case); hosted ships no baked zips.
+    let actor = ActorContext::bootstrap("background:plugin_provisioner");
     let result =
         actor_session::with_actor_context::<_, install::InstallError>(conn, &actor, |conn| {
             install::install_verified(conn, &files, signer, tier, options)


### PR DESCRIPTION
A real bug surfaced while setting up an end-to-end plugin test: **no local plugin install path works** under the RLS-strict posture (which dev deliberately mirrors from hosted).

## The bug
The `plugins` table is workspace-scoped with `FORCE RLS`; its `workspace_id` defaults from `current_setting('app.workspace_id')` and is `NOT NULL`, and the RLS policy requires that GUC to match. But:
- The **boot-time `plugins/` provisioner** ran `install_verified` under `ActorContext::system(...)` — no workspace pin → `app.workspace_id` unset → `new row violates row-level security policy for table "plugins"`.
- The **CLI `plugin install`** called `install_verified` with no actor context at all → same failure.

(The web sideload UI is unaffected — it pins the admin's workspace — but it also rejects local/unsigned plugins by design, so it isn't a local-install path.)

Net: on an RLS-enforcing instance (`nosdesk_app`, NOBYPASSRLS — the dev default and the hosted posture), you could not install a local/self-hosted plugin at all.

## The fix
Both paths now use `ActorContext::bootstrap(...)` — a system actor pinned to the bootstrap workspace. This is the **existing, purpose-built helper**, whose own doc comment already lists *"bootstrap-time plugin install, CLI tools"* as its use case; the provisioner simply used `system()` instead. Two-line change per path.

## Verification
Verified **live** on the dev stack: a dev-mode unsigned plugin that previously failed now provisions successfully —
```
Plugin provisioning complete: 1 created, 0 updated, 0 unchanged, 0 failed
```
and the row lands in the bootstrap workspace (`workspace_id=1`, `state=installed`, `trust_level=local`). `cargo check --lib --bin nosdesk-cli` clean. `ActorContext::bootstrap` has its own existing unit test (`bootstrap_is_a_system_actor_pinned_to_workspace_one`).