### PR TITLE
plugin: fix sandbox-origin env var + enable local-tier self-signing

### DIFF
--- a/backend/src/bin/nosdesk_cli.rs
+++ b/backend/src/bin/nosdesk_cli.rs
@@ -160,22 +160,34 @@ enum PluginCommand {
     /// can be installed. Reads every top-level file in <DIR> (the
     /// manifest, bundle, and any other assets), computes the
     /// canonical digest, and embeds an Ed25519 signature envelope.
-    /// No database access.
+    ///
+    /// Signs with a key file (`--key`) OR the instance's own local
+    /// signing key (`--local`). `--local` reads the DB (needs
+    /// `DATABASE_URL` + the encryption env) and produces a zip that
+    /// installs at the `local` tier on this instance; `--key` needs no
+    /// database.
     Sign {
         #[arg(value_name = "DIR", help = "Plugin source directory")]
         dir: PathBuf,
         #[arg(
             long,
             value_name = "SK",
+            conflicts_with = "local",
+            required_unless_present = "local",
             help = "Path to the PKCS8 private key (the .sk file from gen-key)"
         )]
-        key: PathBuf,
+        key: Option<PathBuf>,
+        #[arg(
+            long,
+            help = "Sign with this instance's own local signing key (installs at the `local` tier). Requires DATABASE_URL + the encryption env."
+        )]
+        local: bool,
         #[arg(long, short = 'o', value_name = "ZIP", help = "Output zip path")]
         out: PathBuf,
         #[arg(
             long,
             default_value = "local",
-            help = "signer_source label stamped into the envelope"
+            help = "signer_source label stamped into the envelope (ignored with --local, which is always `local`)"
         )]
         source: String,
     },
@@ -397,9 +409,10 @@ fn run_plugin(cmd: PluginCommand) -> Result<()> {
         PluginCommand::Sign {
             dir,
             key,
+            local,
             out,
             source,
-        } => plugin_sign(&dir, &key, &out, &source),
+        } => plugin_sign(&dir, key.as_deref(), local, &out, &source),
         PluginCommand::Verify { zip } => plugin_verify(&zip),
         PluginCommand::Install { zip } => plugin_install(&zip),
     }
@@ -436,7 +449,13 @@ fn plugin_gen_key(prefix: &Path) -> Result<()> {
     Ok(())
 }
 
-fn plugin_sign(dir: &Path, key_path: &Path, out: &Path, source: &str) -> Result<()> {
+fn plugin_sign(
+    dir: &Path,
+    key_path: Option<&Path>,
+    local: bool,
+    out: &Path,
+    source: &str,
+) -> Result<()> {
     if !dir.is_dir() {
         bail!("{} is not a directory", dir.display());
     }
@@ -444,8 +463,27 @@ fn plugin_sign(dir: &Path, key_path: &Path, out: &Path, source: &str) -> Result<
         bail!("refusing to overwrite existing zip: {}", out.display());
     }
 
-    let pkcs8 = fs::read(key_path)
-        .with_context(|| format!("reading signing key {}", key_path.display()))?;
+    // Sign with the instance's own local key (`--local`) or a key file
+    // (`--key`). clap enforces exactly one, but keep the source string honest:
+    // `--local` always stamps `local` so the envelope matches the tier the
+    // install path resolves it to.
+    let (pkcs8, source): (Vec<u8>, &str) = if local {
+        // The instance key is encrypted at rest under the master key, so the
+        // keyring has to be initialised from the env first (the server binary
+        // does this in main; the CLI does it lazily for the one command needing
+        // it).
+        backend::utils::encryption::init_keyring()
+            .map_err(|e| anyhow!("initialising encryption keyring: {e}"))?;
+        let mut conn = connect_db()?;
+        let sk = backend::services::plugins::local_key::load_local_signing_pkcs8(&mut conn)
+            .map_err(|e| anyhow!("loading instance local signing key: {e}"))?;
+        (sk.to_vec(), "local")
+    } else {
+        let key_path = key_path.ok_or_else(|| anyhow!("--key or --local is required"))?;
+        let sk = fs::read(key_path)
+            .with_context(|| format!("reading signing key {}", key_path.display()))?;
+        (sk, source)
+    };
     let keypair =
         Ed25519KeyPair::from_pkcs8(&pkcs8).map_err(|e| anyhow!("parsing signing key: {e:?}"))?;
 

--- a/backend/src/middleware/security_headers.rs
+++ b/backend/src/middleware/security_headers.rs
@@ -329,7 +329,10 @@ pub struct SecurityHeaders;
 
 impl SecurityHeaders {
     fn build_csp_value() -> (String, bool) {
-        let plugin_sandbox_origin = std::env::var("PLUGIN_SANDBOX_ORIGIN")
+        // Same var the sandbox handler (handlers/plugin_sandbox.rs) and config.rs
+        // read. The CSP's frame-src has to allow exactly the origin the runtime is
+        // served from, so the name must match across all three sites.
+        let plugin_sandbox_origin = std::env::var("NOSDESK_SANDBOX_ORIGIN")
             .ok()
             .map(|s| s.trim().to_string())
             .filter(|s| !s.is_empty());

--- a/backend/src/services/plugins/local_key.rs
+++ b/backend/src/services/plugins/local_key.rs
@@ -30,6 +30,7 @@ pub enum LocalKeyError {
     DbInsert(diesel::result::Error),
     Generate(String),
     Encrypt(String),
+    Decrypt(String),
 }
 
 impl std::fmt::Display for LocalKeyError {
@@ -39,6 +40,7 @@ impl std::fmt::Display for LocalKeyError {
             Self::DbInsert(e) => write!(f, "insert local signing key: {e}"),
             Self::Generate(m) => write!(f, "generate local signing keypair: {m}"),
             Self::Encrypt(m) => write!(f, "encrypt local signing key at rest: {m}"),
+            Self::Decrypt(m) => write!(f, "decrypt local signing key: {m}"),
         }
     }
 }
@@ -112,4 +114,20 @@ pub struct LocalKeyInfo {
     /// `true` if this call generated the key (first boot); `false` if
     /// it was already present.
     pub created: bool,
+}
+
+/// Load and decrypt the instance's local signing key as PKCS8 bytes, for signing
+/// a plugin at the `local` tier (the CLI `sign --local` path). Generates the key
+/// first on a fresh instance so signing works immediately. The bytes are the raw
+/// PKCS8 an `Ed25519KeyPair` is built from; they are secret and zeroized on drop.
+pub fn load_local_signing_pkcs8(
+    conn: &mut DbConnection,
+) -> Result<zeroize::Zeroizing<Vec<u8>>, LocalKeyError> {
+    ensure_local_signing_key(conn)?;
+    let row = plugin_publishers::get_local_signing_key(conn)
+        .map_err(LocalKeyError::DbLoad)?
+        .ok_or(LocalKeyError::DbLoad(diesel::result::Error::NotFound))?;
+    encryption::keyring()
+        .decrypt(&row.encrypted_sk, AAD_CONTEXT)
+        .map_err(|e| LocalKeyError::Decrypt(e.to_string()))
 }


### PR DESCRIPTION
Two operator-facing plugin fixes, both surfaced while writing the plugin operator docs (and both verified live).

## 1. Sandbox-origin env var mismatch
The CSP builder read `PLUGIN_SANDBOX_ORIGIN` while the sandbox handler (`handlers/plugin_sandbox.rs`) and `config.rs` read `NOSDESK_SANDBOX_ORIGIN`. So the CSP `frame-src` never matched the origin the runtime is served from, and a separate sandbox origin (defense-in-depth) could not be configured. Unify on the `NOSDESK_`-prefixed name.

## 2. Local-tier self-signing was impossible
The `local` trust tier is anchored to the instance's own signing key, and the CLI's own docs say "a plugin you signed with your own key lands at the local tier" — but there was no way to sign with the instance key. `sign --key <file>` only takes an external key, which resolves to `publisher not trusted`. So an operator could not produce a `local`-tier plugin at all.

Adds `nosdesk-cli plugin sign --local`, which loads and decrypts the instance's local signing key via the keyring and signs with it (always stamping `source=local`). `load_local_signing_pkcs8` generates the key on a fresh instance so it works immediately.

## Verification
Both `cargo check` clean. Verified end-to-end in a dev container: `sign --local` then `install` now reports `installed plugin: ... (trust=local, signer_source=local)`, with the fingerprint matching the instance key. Previously the same flow failed with `publisher not trusted`.

These unblock accurate operator docs (the old docs describe the broken flow).