### PR TITLE
Plugins: add user.sidebar.panel slot on the user profile

### DIFF
--- a/backend/src/services/plugins/plugin_slots.generated.json
+++ b/backend/src/services/plugins/plugin_slots.generated.json
@@ -24,6 +24,16 @@
     "description": "Info panels on the asset view"
   },
   {
+    "name": "user.sidebar.panel",
+    "mechanism": "panel",
+    "context": "user",
+    "cardinality": "many",
+    "order": 100,
+    "status": "stable",
+    "aliases": [],
+    "description": "Info panels on the user profile view"
+  },
+  {
     "name": "settings.integrations.page",
     "mechanism": "panel",
     "context": "none",

--- a/backend/src/services/plugins/slot_registry.rs
+++ b/backend/src/services/plugins/slot_registry.rs
@@ -72,7 +72,7 @@ mod tests {
             assert!(
                 matches!(
                     s.context.as_str(),
-                    "ticket" | "asset" | "documentationPage" | "none"
+                    "ticket" | "asset" | "user" | "documentationPage" | "none"
                 ),
                 "unknown context {} on {}",
                 s.context,

--- a/frontend/src/plugins/components/PluginSandboxFrame.vue
+++ b/frontend/src/plugins/components/PluginSandboxFrame.vue
@@ -56,6 +56,7 @@ function snapshot(): PluginContext {
   return {
     ticket: plain(props.context?.ticket),
     asset: plain(props.context?.asset),
+    user: plain(props.context?.user),
     ticketIds: plain(props.context?.ticketIds),
     component: { name: props.component.name, slot: props.component.slot },
     actionActivated: props.actionActivated,

--- a/frontend/src/plugins/context.ts
+++ b/frontend/src/plugins/context.ts
@@ -1,5 +1,6 @@
 import type { Ticket } from '@nosdesk/core/types/ticket';
 import type { Asset } from '@nosdesk/core/types/asset';
+import type { User } from '@nosdesk/core/types/user';
 
 /**
  * The host-provided context bag handed to a plugin slot.
@@ -13,6 +14,8 @@ import type { Asset } from '@nosdesk/core/types/asset';
 export interface PluginSlotContext {
   ticket?: Ticket;
   asset?: Asset;
+  /** The profile being viewed (`user.sidebar.panel`). */
+  user?: User;
   /** Selected ticket ids for a bulk action (`ticket.bulk.action`). */
   ticketIds?: number[];
   // Future context types (e.g. `documentationPage`) land here alongside a

--- a/frontend/src/views/UserProfileView.vue
+++ b/frontend/src/views/UserProfileView.vue
@@ -18,6 +18,7 @@ import BaseDropdown from "@/components/common/BaseDropdown.vue";
 import Icon from "@/components/common/Icon.vue";
 import Spinner from "@/components/common/Spinner.vue";
 import SectionCard from "@/components/common/SectionCard.vue";
+import PluginSlot from "@/plugins/components/PluginSlot.vue";
 import { RouterLink } from "vue-router";
 import userService from "@/services/userService";
 import { useColorFilter } from "@/composables/useColorFilter";
@@ -67,6 +68,9 @@ const userProfile = computed<UserProfile | null>(() => {
     // Department is a placeholder until the backend carries it.
     return { ...user, department: 'IT Support', joinedDate: user.created_at };
 });
+// The raw profile handed to plugin panels: the real user record, without the
+// display-only `department`/`joinedDate` placeholders `userProfile` adds.
+const pluginUser = computed(() => profileQuery.bundle.value?.user ?? undefined);
 const devices = computed<Asset[]>(() => profileQuery.bundle.value?.devices ?? []);
 const groups = computed<Group[]>(() => profileQuery.bundle.value?.groups ?? []);
 
@@ -770,6 +774,12 @@ watch(
                                 </button>
                             </div>
                         </SectionCard>
+
+                        <!-- Plugin panels contributed to the user profile -->
+                        <PluginSlot
+                            target="user.sidebar.panel"
+                            :context="{ user: pluginUser }"
+                        />
                     </div>
 
                     <!-- Tickets Area -->

--- a/packages/core/src/types/pluginSlots.ts
+++ b/packages/core/src/types/pluginSlots.ts
@@ -26,7 +26,7 @@
 export type SlotMechanism = 'panel' | 'action';
 
 /** The single host-provided context object a mount hands to the plugin. */
-export type SlotContextType = 'ticket' | 'asset' | 'documentationPage' | 'none';
+export type SlotContextType = 'ticket' | 'asset' | 'user' | 'documentationPage' | 'none';
 
 /** Whether one plugin may contribute once or many times to a slot. */
 export type SlotCardinality = 'one' | 'many';
@@ -76,6 +76,16 @@ export const SLOT_REGISTRY = [
     status: 'stable',
     aliases: ['asset-info-panels'],
     description: 'Info panels on the asset view',
+  },
+  {
+    name: 'user.sidebar.panel',
+    mechanism: 'panel',
+    context: 'user',
+    cardinality: 'many',
+    order: 100,
+    status: 'stable',
+    aliases: [],
+    description: 'Info panels on the user profile view',
   },
   {
     name: 'settings.integrations.page',

--- a/packages/plugin-sdk/src/connect.ts
+++ b/packages/plugin-sdk/src/connect.ts
@@ -134,7 +134,12 @@ export function connectToHost(): Promise<PluginRuntime> {
     const listeners = new Set<(ctx: PluginContext) => void>();
     // Placeholder until the host's init message delivers the real context; the
     // runtime resolves with `data.context`, so this is never handed to a plugin.
-    let context: PluginContext = { ticket: null, asset: null, component: { name: '', slot: '' } };
+    let context: PluginContext = {
+      ticket: null,
+      asset: null,
+      user: null,
+      component: { name: '', slot: '' },
+    };
     let connected = false;
 
     // Fail loudly if the host never connects (dropped port / host disposed before

--- a/packages/plugin-sdk/src/types.ts
+++ b/packages/plugin-sdk/src/types.ts
@@ -17,12 +17,13 @@
 import type {
   Ticket,
   Asset,
+  User,
   CollectionRow,
   CollectionListResponse,
   PluginEvent,
 } from '@nosdesk/core/types';
 
-export type { Ticket, Asset, CollectionRow, CollectionListResponse, PluginEvent };
+export type { Ticket, Asset, User, CollectionRow, CollectionListResponse, PluginEvent };
 
 /** A comment a plugin adds to a ticket. */
 export interface PluginComment {
@@ -235,6 +236,9 @@ export type PluginHostApi = Omit<import('comlink').Remote<HostApi>, 'on'> & {
 export interface PluginContext {
   ticket: Ticket | null;
   asset: Asset | null;
+  /** The profile being viewed (`user.sidebar.panel`). Null outside a user
+   * context. */
+  user: User | null;
   /** Selected ticket ids for a bulk action (`ticket.bulk.action`). The plugin
    * operates on the whole selection. Null / absent outside a bulk context. */
   ticketIds?: number[] | null;


### PR DESCRIPTION
Adds a per-user plugin panel surface on the profile view, the sibling of `ticket.sidebar.panel` and `asset.info.panel`. This is the surface the Locations plugin (P3, separate repo) will use to show a client's saved address on their profile.

Built on the P-a single-source slot registry, so it's the intended one-place edit:

- **`pluginSlots.ts`** — `user.sidebar.panel` registry entry (panel / context `user` / stable) + `'user'` added to `SlotContextType`.
- **`plugin_slots.generated.json`** — regenerated via `build:slots` (CI drift-checked, in sync).
- **`slot_registry.rs`** — `"user"` added to the context allowlist test. (`KNOWN_CONTEXTS` already reserved `"user"`, so manifest validation needed no change.)
- **`context.ts` / `plugin-sdk/types.ts` / `PluginSandboxFrame.snapshot()` / `connect.ts`** — `user` threaded through the host context bag, the wire `PluginContext`, the snapshot projection, and the placeholder context.
- **`UserProfileView.vue`** — `<PluginSlot target="user.sidebar.panel" :context="{ user: pluginUser }" />` mounted at the end of the profile info column. `pluginUser` passes the real user record, not the `userProfile` computed that carries display-only `department`/`joinedDate` placeholders.

Independent of the declared-resources capability branch (zero file overlap); P3 is what needs both.

**Verified:** core + plugin-sdk + frontend type-checks pass; backend `slot_registry` tests pass; generator drift-clean.