### PR TITLE
Plugins: regenerate runtime.js for user context field

### DIFF
--- a/backend/src/handlers/plugin_sandbox/runtime.js
+++ b/backend/src/handlers/plugin_sandbox/runtime.js
@@ -380,7 +380,12 @@ function wrapEvents(remote) {
 function connectToHost() {
   return new Promise((resolve, reject) => {
     const listeners = /* @__PURE__ */ new Set();
-    let context = { ticket: null, asset: null, component: { name: "", slot: "" } };
+    let context = {
+      ticket: null,
+      asset: null,
+      user: null,
+      component: { name: "", slot: "" }
+    };
     let connected = false;
     const timer = setTimeout(() => {
       if (!connected) {


### PR DESCRIPTION
#174 added `user: null` to `connect.ts`'s placeholder context, which esbuild bundles into the checked-in `backend/src/handlers/plugin_sandbox/runtime.js`. That regen was missed, so the CI drift check (`Frontend (Vue)` -> "Plugin runtime build + drift check") failed and main is red.

This commits the regenerated `runtime.js`. One hunk, exactly the `user: null` addition to the placeholder context (which the runtime never hands to a plugin, so no behavior change). Clears the drift.