### PR TITLE
Plugins: design-token bridge + base UI kit for sandboxes

### DIFF
--- a/backend/src/handlers/plugin_sandbox/runtime.js
+++ b/backend/src/handlers/plugin_sandbox/runtime.js
@@ -380,12 +380,14 @@ function wrapEvents(remote) {
 function connectToHost() {
   return new Promise((resolve, reject) => {
     const listeners = /* @__PURE__ */ new Set();
+    const themeListeners = /* @__PURE__ */ new Set();
     let context = {
       ticket: null,
       asset: null,
       user: null,
       component: { name: "", slot: "" }
     };
+    let theme = { tokens: {}, colorScheme: "light", name: "light" };
     let connected = false;
     const timer = setTimeout(() => {
       if (!connected) {
@@ -400,14 +402,22 @@ function connectToHost() {
         connected = true;
         clearTimeout(timer);
         context = data.context;
+        theme = data.theme;
         const { api, reset } = wrapEvents(wrap(event.ports[0]));
         resolve({
           api,
           context,
+          theme,
           onContextChange(cb) {
             listeners.add(cb);
             return () => {
               listeners.delete(cb);
+            };
+          },
+          onThemeChange(cb) {
+            themeListeners.add(cb);
+            return () => {
+              themeListeners.delete(cb);
             };
           },
           resetEvents: reset
@@ -415,6 +425,9 @@ function connectToHost() {
       } else if (data.type === "nosdesk-plugin-context") {
         context = data.context;
         for (const cb of listeners) cb(context);
+      } else if (data.type === "nosdesk-plugin-theme") {
+        theme = data.theme;
+        for (const cb of themeListeners) cb(theme);
       }
     }
     window.addEventListener("message", onMessage);
@@ -424,6 +437,83 @@ function reportHeight(height) {
   window.parent.postMessage({ type: "nosdesk-plugin-height", height }, "*");
 }
 
+// src/pluginUiCss.ts
+var PLUGIN_UI_CSS = `
+:root { --nd-radius: 8px; color-scheme: light dark; }
+
+html, body { margin: 0; padding: 0; }
+body {
+  font-family: var(--nd-font-sans, system-ui, -apple-system, sans-serif);
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--nd-text, #1f2937);
+  background: transparent;
+  -webkit-font-smoothing: antialiased;
+}
+
+/* Scrollbars matched to the app's subtle style. */
+* { scrollbar-width: thin; scrollbar-color: var(--nd-border-strong, #cbd5e1) transparent; }
+*::-webkit-scrollbar { width: 8px; height: 8px; }
+*::-webkit-scrollbar-thumb { background: var(--nd-border-strong, #cbd5e1); border-radius: 4px; }
+*::-webkit-scrollbar-thumb:hover { background: var(--nd-text-tertiary, #9ca3af); }
+*::-webkit-scrollbar-track { background: transparent; }
+
+a { color: var(--nd-accent, #FF6B1A); }
+
+.nd-btn {
+  font: inherit;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 12px;
+  border-radius: var(--nd-radius, 8px);
+  border: 1px solid var(--nd-border, #e5e7eb);
+  background: var(--nd-surface, #ffffff);
+  color: var(--nd-text, #1f2937);
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.12s ease, border-color 0.12s ease;
+}
+.nd-btn:hover { background: var(--nd-surface-hover, #f3f4f6); }
+.nd-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+.nd-btn--primary {
+  background: var(--nd-accent, #FF6B1A);
+  border-color: var(--nd-accent, #FF6B1A);
+  color: var(--nd-on-accent, #000000);
+}
+.nd-btn--primary:hover {
+  background: var(--nd-accent-hover, #EB5808);
+  border-color: var(--nd-accent-hover, #EB5808);
+}
+
+.nd-input, .nd-textarea {
+  font: inherit;
+  width: 100%;
+  box-sizing: border-box;
+  padding: 6px 8px;
+  border: 1px solid var(--nd-border, #e5e7eb);
+  border-radius: var(--nd-radius, 8px);
+  background: var(--nd-surface, #ffffff);
+  color: var(--nd-text, #1f2937);
+}
+.nd-input::placeholder, .nd-textarea::placeholder { color: var(--nd-text-tertiary, #9ca3af); }
+.nd-input:focus, .nd-textarea:focus {
+  outline: none;
+  border-color: var(--nd-accent, #FF6B1A);
+}
+.nd-textarea { resize: vertical; }
+
+.nd-card {
+  border: 1px solid var(--nd-border, #e5e7eb);
+  border-radius: var(--nd-radius, 8px);
+  background: var(--nd-surface-alt, #f9fafb);
+  padding: 12px;
+}
+
+.nd-label { font-weight: 600; color: var(--nd-text, #1f2937); }
+.nd-muted { color: var(--nd-text-tertiary, #6b7280); }
+`;
+
 // src/runtime.ts
 function toInstance(result) {
   if (typeof result === "function") return { unmount: result };
@@ -432,6 +522,27 @@ function toInstance(result) {
 }
 var token = new URLSearchParams(location.search).get("t");
 var root = document.getElementById("root");
+function injectBaseCss() {
+  if (document.getElementById("nd-base")) return;
+  const style = document.createElement("style");
+  style.id = "nd-base";
+  style.textContent = PLUGIN_UI_CSS;
+  document.head.appendChild(style);
+}
+function injectTokens(theme) {
+  let style = document.getElementById("nd-tokens");
+  if (!style) {
+    style = document.createElement("style");
+    style.id = "nd-tokens";
+    document.head.appendChild(style);
+  }
+  const vars = Object.entries(theme.tokens).map(([k, v]) => `  --nd-${k}: ${v};`).join("\n");
+  style.textContent = `:root {
+${vars}
+}`;
+  document.documentElement.setAttribute("data-nd-color-scheme", theme.colorScheme);
+  document.documentElement.setAttribute("data-nd-theme", theme.name);
+}
 function observeHeight(el) {
   let last = -1;
   const report = () => {
@@ -448,6 +559,9 @@ async function boot() {
   if (!root) throw new Error("sandbox runtime: no #root element");
   if (!token) throw new Error("sandbox runtime: missing bundle token");
   const runtime = await connectToHost();
+  injectBaseCss();
+  injectTokens(runtime.theme);
+  runtime.onThemeChange(injectTokens);
   const bundleUrl = `./bundle?t=${encodeURIComponent(token)}`;
   let mod;
   try {

--- a/frontend/src/plugins/components/PluginSandboxFrame.vue
+++ b/frontend/src/plugins/components/PluginSandboxFrame.vue
@@ -10,12 +10,20 @@
  * no cookies, no first-party DOM, all host access flows through the bridge.
  */
 import { onBeforeUnmount, onMounted, ref, watch } from 'vue';
-import { createRemoteHostApi, postContext, postInit, watchPluginHeight } from '@nosdesk/plugin-sdk';
-import type { HostBridge, PluginContext } from '@nosdesk/plugin-sdk';
+import {
+  createRemoteHostApi,
+  postContext,
+  postInit,
+  postTheme,
+  watchPluginHeight,
+} from '@nosdesk/plugin-sdk';
+import type { HostBridge, PluginContext, PluginTheme } from '@nosdesk/plugin-sdk';
 import pluginService from '@nosdesk/core/services/pluginService';
 import { logger } from '@nosdesk/core/utils/logger';
 import type { Plugin } from '@nosdesk/core/types/plugin';
+import { useThemeStore } from '@/stores/theme';
 import type { PluginSlotContext } from '../context';
+import { snapshotPluginTheme } from '../theme';
 import { createHostApiImpl } from '../sandboxHostApi';
 import { registerPluginInstance } from '../pluginInstances';
 
@@ -33,6 +41,17 @@ const frameRef = ref<HTMLIFrameElement | null>(null);
 const runtimeUrl = ref<string | null>(null);
 const error = ref<string | null>(null);
 const iframeHeight = ref<number | null>(null);
+
+const themeStore = useThemeStore();
+
+// The host design tokens for the plugin sandbox, read fresh so they reflect the
+// active theme (and accent override). The runtime injects them as `--nd-*`.
+function themeSnapshot(): PluginTheme {
+  return snapshotPluginTheme(
+    themeStore.isDarkMode ? 'dark' : 'light',
+    themeStore.effectiveTheme?.meta?.id ?? themeStore.currentTheme,
+  );
+}
 
 let bridge: HostBridge | null = null;
 let unregisterInstance: (() => void) | null = null;
@@ -74,7 +93,7 @@ function onFrameLoad(): void {
   // sandboxed plugin's `on` handlers (they land on `inproc`, over the bridge).
   unregisterInstance = registerPluginInstance(props.plugin.uuid, inproc);
   bridge = createRemoteHostApi(hostApi);
-  postInit(win, bridge, snapshot());
+  postInit(win, bridge, snapshot(), themeSnapshot());
   connected = true;
 
   // Size the iframe to the plugin's reported content height.
@@ -131,6 +150,22 @@ watch(
     if (connected && win) postContext(win, snapshot());
   },
   { deep: true },
+);
+
+// Re-push the design tokens when the host theme or accent changes. `flush: 'post'`
+// so the DOM has the new theme applied before `snapshotPluginTheme` reads the
+// resolved values off `:root`.
+watch(
+  [
+    () => themeStore.isDarkMode,
+    () => themeStore.effectiveTheme?.meta?.id,
+    () => themeStore.accentColorOverride,
+  ],
+  () => {
+    const win = frameRef.value?.contentWindow;
+    if (connected && win) postTheme(win, themeSnapshot());
+  },
+  { flush: 'post' },
 );
 
 onBeforeUnmount(() => {

--- a/frontend/src/plugins/theme.ts
+++ b/frontend/src/plugins/theme.ts
@@ -1,0 +1,49 @@
+import type { PluginTheme } from '@nosdesk/plugin-sdk';
+
+// The plugin design-token contract: the `--nd-*` name a plugin sees, mapped to
+// the host CSS variable it snapshots from (frontend/src/assets/main.css). A
+// curated, stable subset, NOT a dump of every host token, so it stays a
+// deliberate contract. Keep it in sync with the `--nd-*` table in
+// docs/plugin-design-tokens.md and the fallbacks in the runtime kit CSS.
+const TOKEN_MAP: Record<string, string> = {
+  surface: '--color-surface',
+  'surface-alt': '--color-surface-alt',
+  'surface-hover': '--color-surface-hover',
+  'app-bg': '--color-app',
+  border: '--color-default',
+  'border-subtle': '--color-subtle',
+  'border-strong': '--color-strong',
+  text: '--color-primary',
+  'text-secondary': '--color-secondary',
+  'text-tertiary': '--color-tertiary',
+  accent: '--color-accent',
+  'accent-hover': '--color-accent-hover',
+  'on-accent': '--color-on-accent',
+  success: '--color-status-success',
+  'success-muted': '--color-status-success-muted',
+  error: '--color-status-error',
+  'error-muted': '--color-status-error-muted',
+  warning: '--color-status-warning',
+  'warning-muted': '--color-status-warning-muted',
+  info: '--color-status-info',
+  'info-muted': '--color-status-info-muted',
+  'font-sans': '--font-sans',
+  'font-mono': '--font-mono',
+};
+
+/**
+ * Snapshot the host's active design tokens for a plugin sandbox. Reads the
+ * RESOLVED values off `:root`, so it captures whatever theme is applied
+ * (light / dark / named), and the runtime injects them as `--nd-*` variables.
+ * `colorScheme` / `name` come from the theme store (the caller supplies them so
+ * this stays store-agnostic).
+ */
+export function snapshotPluginTheme(colorScheme: 'light' | 'dark', name: string): PluginTheme {
+  const cs = getComputedStyle(document.documentElement);
+  const tokens: Record<string, string> = {};
+  for (const [ndKey, hostVar] of Object.entries(TOKEN_MAP)) {
+    const value = cs.getPropertyValue(hostVar).trim();
+    if (value) tokens[ndKey] = value;
+  }
+  return { tokens, colorScheme, name };
+}

--- a/packages/plugin-runtime/src/pluginUiCss.ts
+++ b/packages/plugin-runtime/src/pluginUiCss.ts
@@ -1,0 +1,86 @@
+// The base UI kit injected into every plugin sandbox document. Static (authored
+// here, bundled into runtime.js); only the `--nd-*` token VALUES are dynamic and
+// pushed by the host (see injectTokens in runtime.ts). Everything references
+// `var(--nd-*, <fallback>)` so it still renders sanely before the first token
+// push. This is what gives a plugin's raw DOM the app's fonts, colours,
+// scrollbars, buttons, and inputs without the plugin reimplementing them.
+//
+// The classes are the plugin contract: `.nd-btn` / `.nd-btn--primary`,
+// `.nd-input`, `.nd-textarea`, `.nd-card`, `.nd-label`, `.nd-muted`. Keep them
+// stable; they are versioned with the runtime.
+
+export const PLUGIN_UI_CSS = `
+:root { --nd-radius: 8px; color-scheme: light dark; }
+
+html, body { margin: 0; padding: 0; }
+body {
+  font-family: var(--nd-font-sans, system-ui, -apple-system, sans-serif);
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--nd-text, #1f2937);
+  background: transparent;
+  -webkit-font-smoothing: antialiased;
+}
+
+/* Scrollbars matched to the app's subtle style. */
+* { scrollbar-width: thin; scrollbar-color: var(--nd-border-strong, #cbd5e1) transparent; }
+*::-webkit-scrollbar { width: 8px; height: 8px; }
+*::-webkit-scrollbar-thumb { background: var(--nd-border-strong, #cbd5e1); border-radius: 4px; }
+*::-webkit-scrollbar-thumb:hover { background: var(--nd-text-tertiary, #9ca3af); }
+*::-webkit-scrollbar-track { background: transparent; }
+
+a { color: var(--nd-accent, #FF6B1A); }
+
+.nd-btn {
+  font: inherit;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 12px;
+  border-radius: var(--nd-radius, 8px);
+  border: 1px solid var(--nd-border, #e5e7eb);
+  background: var(--nd-surface, #ffffff);
+  color: var(--nd-text, #1f2937);
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.12s ease, border-color 0.12s ease;
+}
+.nd-btn:hover { background: var(--nd-surface-hover, #f3f4f6); }
+.nd-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+.nd-btn--primary {
+  background: var(--nd-accent, #FF6B1A);
+  border-color: var(--nd-accent, #FF6B1A);
+  color: var(--nd-on-accent, #000000);
+}
+.nd-btn--primary:hover {
+  background: var(--nd-accent-hover, #EB5808);
+  border-color: var(--nd-accent-hover, #EB5808);
+}
+
+.nd-input, .nd-textarea {
+  font: inherit;
+  width: 100%;
+  box-sizing: border-box;
+  padding: 6px 8px;
+  border: 1px solid var(--nd-border, #e5e7eb);
+  border-radius: var(--nd-radius, 8px);
+  background: var(--nd-surface, #ffffff);
+  color: var(--nd-text, #1f2937);
+}
+.nd-input::placeholder, .nd-textarea::placeholder { color: var(--nd-text-tertiary, #9ca3af); }
+.nd-input:focus, .nd-textarea:focus {
+  outline: none;
+  border-color: var(--nd-accent, #FF6B1A);
+}
+.nd-textarea { resize: vertical; }
+
+.nd-card {
+  border: 1px solid var(--nd-border, #e5e7eb);
+  border-radius: var(--nd-radius, 8px);
+  background: var(--nd-surface-alt, #f9fafb);
+  padding: 12px;
+}
+
+.nd-label { font-weight: 600; color: var(--nd-text, #1f2937); }
+.nd-muted { color: var(--nd-text-tertiary, #6b7280); }
+`;

--- a/packages/plugin-runtime/src/runtime.ts
+++ b/packages/plugin-runtime/src/runtime.ts
@@ -10,7 +10,8 @@
 // standalone: connectToHost() resolves only once the host posts the init message
 // with the transferred MessageChannel port (the host bridge, sandbox step 4).
 import { connectToHost, reportHeight } from '@nosdesk/plugin-sdk';
-import type { PluginInstance, PluginModule } from '@nosdesk/plugin-sdk';
+import type { PluginInstance, PluginModule, PluginTheme } from '@nosdesk/plugin-sdk';
+import { PLUGIN_UI_CSS } from './pluginUiCss';
 
 /** Normalize the value a plugin's `mount` returns into a `PluginInstance`. */
 function toInstance(result: void | (() => void) | PluginInstance): PluginInstance {
@@ -21,6 +22,34 @@ function toInstance(result: void | (() => void) | PluginInstance): PluginInstanc
 
 const token = new URLSearchParams(location.search).get('t');
 const root = document.getElementById('root');
+
+// Inject the static base UI kit once. Referencing `var(--nd-*)`, it renders
+// against the host tokens (injected below) so a plugin's DOM matches the app.
+function injectBaseCss(): void {
+  if (document.getElementById('nd-base')) return;
+  const style = document.createElement('style');
+  style.id = 'nd-base';
+  style.textContent = PLUGIN_UI_CSS;
+  document.head.appendChild(style);
+}
+
+// Inject / replace the dynamic token values pushed by the host. Called on connect
+// and on every theme change, so `--nd-*` (and the kit) track light/dark/named
+// themes live. Also stamps the scheme/name for a plugin that must branch.
+function injectTokens(theme: PluginTheme): void {
+  let style = document.getElementById('nd-tokens');
+  if (!style) {
+    style = document.createElement('style');
+    style.id = 'nd-tokens';
+    document.head.appendChild(style);
+  }
+  const vars = Object.entries(theme.tokens)
+    .map(([k, v]) => `  --nd-${k}: ${v};`)
+    .join('\n');
+  style.textContent = `:root {\n${vars}\n}`;
+  document.documentElement.setAttribute('data-nd-color-scheme', theme.colorScheme);
+  document.documentElement.setAttribute('data-nd-theme', theme.name);
+}
 
 // Report content height to the host on every change so it can size the iframe
 // (a cross-origin sandboxed iframe can't self-size). Deduped to avoid a resize
@@ -44,6 +73,13 @@ async function boot(): Promise<void> {
 
   // Establish the bridge first so the plugin's mount receives a live host API.
   const runtime = await connectToHost();
+
+  // Style the document to match the app before the plugin paints: the static kit
+  // once, the host tokens now, and re-inject the tokens whenever the host theme
+  // changes (the `--nd-*` variables and the kit update in place, no re-mount).
+  injectBaseCss();
+  injectTokens(runtime.theme);
+  runtime.onThemeChange(injectTokens);
 
   // Built as a runtime string (not a literal) so the bundler treats it as an
   // external runtime import: the bundle is fetched from the sandbox origin at

--- a/packages/plugin-sdk/src/connect.ts
+++ b/packages/plugin-sdk/src/connect.ts
@@ -4,6 +4,7 @@ import type {
   HostApi,
   PluginHostApi,
   PluginContext,
+  PluginTheme,
   PluginEvent,
   PluginEventHandler,
   PluginEventPayload,
@@ -13,10 +14,15 @@ import type {
 interface HostInitMessage {
   type: 'nosdesk-plugin-init';
   context: PluginContext;
+  theme: PluginTheme;
 }
 interface HostContextMessage {
   type: 'nosdesk-plugin-context';
   context: PluginContext;
+}
+interface HostThemeMessage {
+  type: 'nosdesk-plugin-theme';
+  theme: PluginTheme;
 }
 
 /** The ready plugin runtime handed to a plugin's `mount`. */
@@ -26,9 +32,15 @@ export interface PluginRuntime {
   api: PluginHostApi;
   /** The context snapshot at connect time. */
   context: PluginContext;
+  /** The host design tokens at connect time. The runtime injects these; a plugin
+   * rarely reads it directly. */
+  theme: PluginTheme;
   /** Subscribe to context snapshots the host pushes after connect; returns an
    * unsubscribe. */
   onContextChange(cb: (ctx: PluginContext) => void): () => void;
+  /** Subscribe to design-token snapshots the host pushes on a theme change;
+   * returns an unsubscribe. The runtime uses this to re-inject the variables. */
+  onThemeChange(cb: (theme: PluginTheme) => void): () => void;
   /** Drop all `api.on` subscriptions. The runtime calls this before re-mounting a
    * simple plugin so event handlers don't accumulate across re-mounts. */
   resetEvents(): void;
@@ -132,6 +144,7 @@ function wrapEvents(remote: Comlink.Remote<HostApi>): {
 export function connectToHost(): Promise<PluginRuntime> {
   return new Promise((resolve, reject) => {
     const listeners = new Set<(ctx: PluginContext) => void>();
+    const themeListeners = new Set<(theme: PluginTheme) => void>();
     // Placeholder until the host's init message delivers the real context; the
     // runtime resolves with `data.context`, so this is never handed to a plugin.
     let context: PluginContext = {
@@ -140,6 +153,7 @@ export function connectToHost(): Promise<PluginRuntime> {
       user: null,
       component: { name: '', slot: '' },
     };
+    let theme: PluginTheme = { tokens: {}, colorScheme: 'light', name: 'light' };
     let connected = false;
 
     // Fail loudly if the host never connects (dropped port / host disposed before
@@ -153,21 +167,33 @@ export function connectToHost(): Promise<PluginRuntime> {
     }, CONNECT_TIMEOUT_MS);
 
     function onMessage(event: MessageEvent) {
-      const data = event.data as HostInitMessage | HostContextMessage | undefined;
+      const data = event.data as
+        | HostInitMessage
+        | HostContextMessage
+        | HostThemeMessage
+        | undefined;
       if (!data || typeof data !== 'object') return;
 
       if (!connected && data.type === 'nosdesk-plugin-init' && event.ports[0]) {
         connected = true;
         clearTimeout(timer);
         context = data.context;
+        theme = data.theme;
         const { api, reset } = wrapEvents(Comlink.wrap<HostApi>(event.ports[0]));
         resolve({
           api,
           context,
+          theme,
           onContextChange(cb) {
             listeners.add(cb);
             return () => {
               listeners.delete(cb);
+            };
+          },
+          onThemeChange(cb) {
+            themeListeners.add(cb);
+            return () => {
+              themeListeners.delete(cb);
             };
           },
           resetEvents: reset,
@@ -175,6 +201,9 @@ export function connectToHost(): Promise<PluginRuntime> {
       } else if (data.type === 'nosdesk-plugin-context') {
         context = data.context;
         for (const cb of listeners) cb(context);
+      } else if (data.type === 'nosdesk-plugin-theme') {
+        theme = data.theme;
+        for (const cb of themeListeners) cb(theme);
       }
     }
 

--- a/packages/plugin-sdk/src/host.ts
+++ b/packages/plugin-sdk/src/host.ts
@@ -1,6 +1,6 @@
 import * as Comlink from 'comlink';
 
-import type { HostApi, PluginContext } from './types';
+import type { HostApi, PluginContext, PluginTheme } from './types';
 
 /**
  * The host end of the plugin bridge. `createRemoteHostApi` exposes a `HostApi`
@@ -38,13 +38,24 @@ export function createRemoteHostApi(impl: HostApi): HostBridge {
  * once the iframe has loaded. Mirrors the message the SDK's `connectToHost`
  * awaits.
  */
-export function postInit(target: Window, bridge: HostBridge, context: PluginContext): void {
-  target.postMessage({ type: 'nosdesk-plugin-init', context }, '*', [bridge.port]);
+export function postInit(
+  target: Window,
+  bridge: HostBridge,
+  context: PluginContext,
+  theme: PluginTheme,
+): void {
+  target.postMessage({ type: 'nosdesk-plugin-init', context, theme }, '*', [bridge.port]);
 }
 
 /** Push a fresh context snapshot to an already-connected plugin iframe. */
 export function postContext(target: Window, context: PluginContext): void {
   target.postMessage({ type: 'nosdesk-plugin-context', context }, '*');
+}
+
+/** Push a fresh design-token snapshot to an already-connected plugin iframe (on a
+ * host theme change). The runtime re-injects the `--nd-*` variables. */
+export function postTheme(target: Window, theme: PluginTheme): void {
+  target.postMessage({ type: 'nosdesk-plugin-theme', theme }, '*');
 }
 
 interface PluginHeightMessage {

--- a/packages/plugin-sdk/src/index.ts
+++ b/packages/plugin-sdk/src/index.ts
@@ -16,7 +16,7 @@ export { connectToHost, proxy, reportHeight } from './connect';
 export type { PluginRuntime } from './connect';
 
 // Host-side bridge (used by the app + the bridge harness, not by plugins).
-export { createRemoteHostApi, postInit, postContext, watchPluginHeight } from './host';
+export { createRemoteHostApi, postInit, postContext, postTheme, watchPluginHeight } from './host';
 export type { HostBridge } from './host';
 export { BridgeGovernor, governHostApi, DEFAULT_GOVERNOR_OPTIONS } from './governor';
 export type { GovernorOptions } from './governor';
@@ -27,6 +27,7 @@ export type {
   HostApi,
   PluginHostApi,
   PluginContext,
+  PluginTheme,
   PluginModule,
   PluginInstance,
   PluginComment,

--- a/packages/plugin-sdk/src/types.ts
+++ b/packages/plugin-sdk/src/types.ts
@@ -252,6 +252,21 @@ export interface PluginContext {
   actionActivated?: number;
 }
 
+/** The host's active design language, snapshotted into the iframe so a plugin's
+ * UI matches the app. The runtime injects `tokens` as `--nd-*` CSS variables and
+ * a base stylesheet, so most plugins never touch this object; it is exposed for
+ * the rare plugin that must branch in JS (e.g. light vs dark map tiles). Values
+ * are resolved for whatever theme is active, and re-pushed when it changes. */
+export interface PluginTheme {
+  /** Resolved `--nd-*` token values, keyed WITHOUT the `--nd-` prefix
+   * (`surface`, `text`, `accent`, ...). Injected as CSS variables by the runtime. */
+  tokens: Record<string, string>;
+  /** Coarse light/dark signal, for plugins that pick assets by scheme. */
+  colorScheme: 'light' | 'dark';
+  /** The active theme id (`light`, `dark`, `epaper`, ...). */
+  name: string;
+}
+
 /** What a plugin's `mount` may return to get granular updates instead of a
  * re-mount: `update` is called with each new context, `unmount` on teardown.
  * Both optional — omitting `update` falls back to unmount + re-mount. */

--- a/spikes/plugin-bridge/src/host-entry.ts
+++ b/spikes/plugin-bridge/src/host-entry.ts
@@ -55,6 +55,10 @@ iframe.setAttribute('sandbox', 'allow-scripts');
 iframe.src = `${sandboxOrigin}/runtime.html?t=${TOKEN}`;
 iframe.addEventListener('load', () => {
   const bridge = createRemoteHostApi(impl);
-  postInit(iframe.contentWindow as Window, bridge, context);
+  postInit(iframe.contentWindow as Window, bridge, context, {
+    tokens: {},
+    colorScheme: 'light',
+    name: 'light',
+  });
 });
 document.getElementById('frame-slot')?.appendChild(iframe);


### PR DESCRIPTION
Gives sandboxed plugins the app's design language, so a plugin's UI matches the app (fonts, colours, scrollbars, buttons, inputs) and tracks theme changes live. Motivated by the Locations plugin looking foreign against the app.

### How
The isolation stops the plugin reaching INTO the host, but the host can push its design language OUT as data (the VS Code webview / Shopify / Zendesk model). The design system is already CSS custom properties (`frontend/src/assets/main.css`), so:

1. The host snapshots the **resolved** token values off `:root` (captures whatever theme is active) and sends them over the existing Comlink bridge.
2. The runtime injects them into the sandbox document as `--nd-*` CSS variables + a static base stylesheet (document styling, scrollbars, and `.nd-btn` / `.nd-btn--primary` / `.nd-input` / `.nd-textarea` / `.nd-card` / `.nd-label` / `.nd-muted` classes).
3. On theme/accent change the host re-pushes; the variables and kit update in place.

Only CSS text crosses the bridge, so `script-src` / `connect-src` / DOM isolation are untouched, the security posture is unchanged.

### Changes
- **SDK**: `PluginTheme` type; `postTheme` + `theme` arg on `postInit` (`host.ts`); `connect.ts` exposes `theme` + `onThemeChange` on the runtime.
- **Runtime**: `pluginUiCss.ts` (the kit, bundled into `runtime.js`) + `injectBaseCss`/`injectTokens` in `runtime.ts`; `runtime.js` regenerated (drift-checked).
- **Frontend**: `snapshotPluginTheme()` reads resolved `:root` tokens; `PluginSandboxFrame` sends on init + re-pushes on theme/accent change.
- **spikes** bridge harness: `postInit` arity fix.

**Out of scope** (bigger, separate): rendering real host Vue components in the iframe (the reserved `render: 'native'` tier), and pixel-exact custom font (Inter needs an additive `font-src` allowance; text falls back to `system-ui`).

**Verified**: SDK + frontend type-checks pass; `runtime.js` regenerated + drift-clean + confirmed served by the dev backend with the kit; the Locations demo plugin restyled to the kit and reinstalled.