### PR TITLE
SLA: No-SLA policy kind + hide dormant SLAs

### DIFF
--- a/backend/migrations/2026-08-01-000000_sla_policies_no_sla/down.sql
+++ b/backend/migrations/2026-08-01-000000_sla_policies_no_sla/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE sla_policies DROP COLUMN no_sla;

--- a/backend/migrations/2026-08-01-000000_sla_policies_no_sla/up.sql
+++ b/backend/migrations/2026-08-01-000000_sla_policies_no_sla/up.sql
@@ -1,0 +1,5 @@
+-- A No-SLA policy: when it is the most-specific match for a ticket, the
+-- ticket gets no SLA (compute_pill returns None). Lets an admin scope SLAs
+-- away from a class of tickets (e.g. requests) by adding a more-specific
+-- policy that beats the catch-all default, reusing the existing precedence.
+ALTER TABLE sla_policies ADD COLUMN no_sla BOOLEAN NOT NULL DEFAULT false;

--- a/backend/src/handlers/sla.rs
+++ b/backend/src/handlers/sla.rs
@@ -362,6 +362,9 @@ pub struct SlaExplainPolicy {
     pub id: i32,
     pub name: String,
     pub is_default: bool,
+    /// When true the matched policy grants NO SLA — the popover explains why the
+    /// ticket has no timer despite a policy matching.
+    pub no_sla: bool,
     pub target_response_minutes: Option<i32>,
     pub target_resolution_minutes: Option<i32>,
     pub calendar: Option<SlaExplainCalendar>,
@@ -461,6 +464,7 @@ pub async fn explain_for_ticket(
                     id: policy.id,
                     name: policy.name.clone(),
                     is_default: policy.is_default,
+                    no_sla: policy.no_sla,
                     target_response_minutes: policy.target_response_minutes,
                     target_resolution_minutes: policy.target_resolution_minutes,
                     calendar,

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -377,6 +377,11 @@ pub struct SlaPolicy {
     pub created_by: Option<Uuid>,
     pub workspace_id: i32,
     pub assignee_group_id_filter: Option<i32>,
+    /// When true, a ticket this policy matches gets NO SLA. Combined with the
+    /// most-specific-wins matching, an admin scopes SLAs away from a class of
+    /// tickets (e.g. requests) by adding a more-specific No-SLA policy that beats
+    /// the catch-all default. Targets / calendar are irrelevant when set.
+    pub no_sla: bool,
 }
 
 /// Operation kind recorded in `sync_actions.op`. The fourth variant

--- a/backend/src/repository/sla_admin.rs
+++ b/backend/src/repository/sla_admin.rs
@@ -102,6 +102,7 @@ pub struct NewSlaPolicy {
     pub category_id_filter: Option<i32>,
     pub assignee_group_id_filter: Option<i32>,
     pub is_default: bool,
+    pub no_sla: bool,
     pub created_by: Option<Uuid>,
 }
 
@@ -116,6 +117,7 @@ pub struct SlaPolicyPatch {
     pub category_id_filter: Option<Option<i32>>,
     pub assignee_group_id_filter: Option<Option<i32>>,
     pub is_default: Option<bool>,
+    pub no_sla: Option<bool>,
     pub updated_at: Option<chrono::DateTime<Utc>>,
 }
 
@@ -129,6 +131,8 @@ pub struct SlaPolicyBody {
     pub category_id_filter: Option<i32>,
     pub assignee_group_id_filter: Option<i32>,
     pub is_default: Option<bool>,
+    #[serde(default)]
+    pub no_sla: Option<bool>,
 }
 
 pub fn list_policies(conn: &mut DbConnection) -> QueryResult<Vec<SlaPolicy>> {
@@ -153,6 +157,7 @@ pub fn create_policy(
             category_id_filter: body.category_id_filter,
             assignee_group_id_filter: body.assignee_group_id_filter,
             is_default: body.is_default.unwrap_or(false),
+            no_sla: body.no_sla.unwrap_or(false),
             created_by: actor,
         })
         .get_result(conn)
@@ -211,6 +216,7 @@ pub fn seed_defaults_if_empty(
             category_id_filter: None,
             assignee_group_id_filter: None,
             is_default: Some(true),
+            no_sla: Some(false),
         },
         created_by,
     )?;
@@ -233,6 +239,7 @@ pub fn update_policy(
         category_id_filter: Some(body.category_id_filter),
         assignee_group_id_filter: Some(body.assignee_group_id_filter),
         is_default: body.is_default,
+        no_sla: body.no_sla,
         updated_at: Some(Utc::now()),
     };
     diesel::update(sla_policies::table.find(id))

--- a/backend/src/schema.rs
+++ b/backend/src/schema.rs
@@ -1523,6 +1523,7 @@ diesel::table! {
         created_by -> Nullable<Uuid>,
         workspace_id -> Int4,
         assignee_group_id_filter -> Nullable<Int4>,
+        no_sla -> Bool,
     }
 }
 

--- a/backend/src/services/sla.rs
+++ b/backend/src/services/sla.rs
@@ -323,6 +323,14 @@ pub fn compute_pill(
     holidays: &HashSet<NaiveDate>,
     now: DateTime<Utc>,
 ) -> Option<SlaPill> {
+    // A No-SLA policy that wins matching means this ticket has no SLA: no pill.
+    // Both the bootstrap read and the recompute path route through here, so this
+    // one check covers every surface (and clears the materialised targets, since
+    // callers treat `None` as "no SLA").
+    if policy.no_sla {
+        return None;
+    }
+
     let created_utc = DateTime::<Utc>::from_naive_utc_and_offset(ticket.created_at, Utc);
 
     let response = policy
@@ -661,6 +669,11 @@ pub fn scan_open_ticket_buckets(
         let Some(policy) = pick_policy(&ctx.policies, &ticket, assignee_groups) else {
             continue;
         };
+        // A No-SLA policy means this ticket has no SLA — exclude it from the SLA
+        // health counts rather than defaulting it into on_track / total.
+        if policy.no_sla {
+            continue;
+        }
 
         // No calendar attached -> no pill; the policy still matches
         // the ticket so it counts toward `total` but lands in
@@ -746,6 +759,7 @@ mod tests {
             updated_at: Utc::now(),
             created_by: None,
             workspace_id: 1,
+            no_sla: false,
             // No need to backfill new ticket fields; the matcher
             // doesn't read them and Ticket is built per-test.
         }
@@ -784,6 +798,40 @@ mod tests {
             sla_resolution_breached_at: None,
             spam_suspected: false,
         }
+    }
+
+    #[test]
+    fn no_sla_policy_wins_precedence_but_yields_no_pill() {
+        // A more-specific No-SLA policy beats the catch-all default (precedence
+        // is unchanged), and a ticket it matches gets no pill.
+        let mut no_sla_policy = policy(2, Some(10), false);
+        no_sla_policy.no_sla = true;
+        let default_policy = policy(1, None, true);
+        let policies = vec![default_policy, no_sla_policy.clone()];
+        let t = ticket(Some(Uuid::new_v4()));
+
+        // pick_policy still selects the most-specific (group) policy.
+        let picked = pick_policy(&policies, &t, &[10]).expect("a policy matches");
+        assert_eq!(picked.id, 2);
+        assert!(picked.no_sla);
+
+        // But compute_pill on a No-SLA policy renders nothing, regardless of
+        // configured targets / calendar.
+        let calendar = cal(serde_json::json!({
+            "mon": [["00:00", "23:59"]], "tue": [["00:00", "23:59"]],
+            "wed": [["00:00", "23:59"]], "thu": [["00:00", "23:59"]],
+            "fri": [["00:00", "23:59"]], "sat": [["00:00", "23:59"]],
+            "sun": [["00:00", "23:59"]]
+        }));
+        let pill = compute_pill(
+            &t,
+            false,
+            &no_sla_policy,
+            &calendar,
+            &HashSet::new(),
+            Utc::now(),
+        );
+        assert!(pill.is_none(), "a No-SLA policy must produce no pill");
     }
 
     #[test]

--- a/frontend/src/components/views/TicketPreviewPane.vue
+++ b/frontend/src/components/views/TicketPreviewPane.vue
@@ -30,7 +30,7 @@ import {
   buildWorkflowDropdownOptions,
   isCategoryHeaderValue,
 } from '@nosdesk/core/types/workflow'
-import { useSlaState, useSlaTimers, type SlaState } from '@/composables/useSlaState'
+import { useSlaState, useSlaTimers, isSlaDormant, type SlaState } from '@/composables/useSlaState'
 import {
   formatCleanRelativeTime,
   formatDateTime,
@@ -115,6 +115,10 @@ function fullDateTime(iso: string | null | undefined): string {
 
 const slaState = useSlaState(toRef(props, 'card'))
 const slaTimers = useSlaTimers(toRef(props, 'card'))
+
+// Hide the SLA chrome for a dormant SLA (paused + never started, e.g. a backlog
+// request) so tickets that don't need one aren't cluttered with a frozen timer.
+const slaDormant = computed(() => isSlaDormant(props.card))
 
 // What the SLA section renders: both timers labelled when the policy
 // has both targets configured, otherwise the one timer unlabeled.
@@ -274,7 +278,7 @@ async function updateDueDate(iso: string | null): Promise<void> {
                 />
               </span>
               <span
-                v-if="slaState"
+                v-if="slaState && !slaDormant"
                 class="inline-flex items-center gap-1 text-[10px] font-medium px-1.5 h-6 rounded-md border border-subtle transition-colors duration-200"
                 :class="slaState.toneClass"
               >
@@ -380,7 +384,7 @@ async function updateDueDate(iso: string | null): Promise<void> {
                row is unlabeled (the section heading already names
                what it is). The bar gives peripheral urgency; the
                detail line carries the precise time + target. -->
-          <section v-if="slaRows.length > 0" class="px-4 pt-3 pb-3 border-t border-subtle/60 flex flex-col gap-2.5">
+          <section v-if="slaRows.length > 0 && !slaDormant" class="px-4 pt-3 pb-3 border-t border-subtle/60 flex flex-col gap-2.5">
             <h3 class="text-[10px] uppercase tracking-wider font-semibold text-tertiary">
               {{ $t('views-ticket-preview-sla') }}
             </h3>

--- a/frontend/src/composables/useSlaState.ts
+++ b/frontend/src/composables/useSlaState.ts
@@ -23,7 +23,32 @@
  */
 import { computed, onMounted, onUnmounted, ref, type ComputedRef, type Ref } from 'vue'
 import type { CardData } from '@nosdesk/core/sync/views/types'
+import type { WorkflowStateCategory } from '@nosdesk/core/types/workflow'
 import { getDateConfig } from '@nosdesk/core/utils/dateUtils'
+
+// Categories where a ticket hasn't started being worked, so its SLA clock has
+// never run. Used to hide a dormant (paused, never-started) SLA from tickets
+// that don't really need one — a backlog request shouldn't surface a frozen
+// "Paused" timer with concrete targets.
+const PRE_ACTIVE_CATEGORIES: readonly WorkflowStateCategory[] = ['triage', 'backlog']
+
+/**
+ * True when a card's SLA is present but DORMANT: paused while the ticket is
+ * still in a pre-active state (triage/backlog), i.e. the clock has never
+ * started. Consumers hide the SLA chrome for these so a backlog/request ticket
+ * doesn't display a meaningless frozen SLA. A genuine on-hold SLA (paused in a
+ * post-active state like `in_review`, which HAS run) is not dormant and stays
+ * visible.
+ *
+ * The payload carries no "has ever run" signal, so we proxy "never started"
+ * with the current pre-active category. A ticket reopened from active back to
+ * backlog reads as dormant — acceptable for a de-noise gate; a precise
+ * signal belongs to a future SLA-state model.
+ */
+export function isSlaDormant(card: CardData | null | undefined): boolean {
+  if (!card?.sla?.paused) return false
+  return PRE_ACTIVE_CATEGORIES.includes(card.workflow_state.category)
+}
 
 // Single shared tick: re-emits the wall clock so every consumer's
 // computed re-evaluates together. 30s is a sweet spot — fast enough

--- a/frontend/src/views/SlaAdminView.vue
+++ b/frontend/src/views/SlaAdminView.vue
@@ -409,6 +409,7 @@ function emptyPolicyDraft(): SlaPolicyBody {
     category_id_filter: null,
     assignee_group_id_filter: null,
     is_default: false,
+    no_sla: false,
   }
 }
 
@@ -435,6 +436,7 @@ function openEditPolicy(p: SlaPolicy): void {
     category_id_filter: p.category_id_filter,
     assignee_group_id_filter: p.assignee_group_id_filter,
     is_default: p.is_default,
+    no_sla: p.no_sla,
   }
   policyOpen.value = true
 }
@@ -503,6 +505,7 @@ async function togglePolicyDefault(p: SlaPolicy): Promise<void> {
       category_id_filter: p.category_id_filter,
       assignee_group_id_filter: p.assignee_group_id_filter,
       is_default: !p.is_default,
+      no_sla: p.no_sla,
     })
     queryCache.setQueryData(
       POLICIES_KEY,
@@ -779,12 +782,15 @@ const holidayImportOptions = computed(() => [
                 <tr v-for="p in policies" :key="p.id" class="bg-surface">
                   <td class="px-3 py-2 text-primary">{{ p.name }}</td>
                   <td class="px-3 py-2 text-secondary tabular-nums whitespace-nowrap">
-                    {{ fmtMinutes(p.target_response_minutes) }}
-                    <span class="text-tertiary"> / </span>
-                    {{ fmtMinutes(p.target_resolution_minutes) }}
+                    <span v-if="p.no_sla" class="text-tertiary italic">{{ $t('admin-sla-no-sla-label') }}</span>
+                    <template v-else>
+                      {{ fmtMinutes(p.target_response_minutes) }}
+                      <span class="text-tertiary"> / </span>
+                      {{ fmtMinutes(p.target_resolution_minutes) }}
+                    </template>
                   </td>
                   <td class="px-3 py-2 text-secondary">
-                    {{ calendarName(p.working_calendar_id) }}
+                    {{ p.no_sla ? '—' : calendarName(p.working_calendar_id) }}
                   </td>
                   <td class="px-3 py-2 whitespace-nowrap">
                     <template v-if="countsFor(p.id).total === 0">
@@ -1078,8 +1084,22 @@ const holidayImportOptions = computed(() => [
           </div>
         </fieldset>
 
-        <!-- Targets: what the engine computes for each match. -->
-        <fieldset class="flex flex-col gap-2">
+        <!-- No SLA: this policy grants no SLA to the tickets it matches. With
+             the most-specific-wins precedence, a filtered No-SLA policy scopes
+             SLAs away from a class of tickets (e.g. requests). -->
+        <div class="flex flex-col gap-1">
+          <Checkbox
+            :model-value="!!policyDraft.no_sla"
+            size="sm"
+            :label="$t('admin-sla-field-no-sla')"
+            @update:model-value="(v: boolean) => (policyDraft.no_sla = v)"
+          />
+          <p class="text-[11px] text-tertiary pl-6">{{ $t('admin-sla-field-no-sla-hint') }}</p>
+        </div>
+
+        <!-- Targets: what the engine computes for each match. Irrelevant (and
+             hidden) for a No-SLA policy. -->
+        <fieldset v-if="!policyDraft.no_sla" class="flex flex-col gap-2">
           <legend
             class="text-[11px] font-medium text-tertiary uppercase tracking-wide mb-1"
           >

--- a/i18n/locales/en-US/main.ftl
+++ b/i18n/locales/en-US/main.ftl
@@ -1720,6 +1720,9 @@ admin-sla-priority-low = low
 admin-sla-priority-medium = medium
 admin-sla-priority-high = high
 admin-sla-workspace-default = Workspace default
+admin-sla-field-no-sla = No SLA
+admin-sla-field-no-sla-hint = Tickets this policy matches get no SLA. Scope it with a filter above to remove SLAs from a class of tickets.
+admin-sla-no-sla-label = No SLA
 admin-sla-create = Create
 
 # Admin: Branding (BrandingSettingsView). Custom app name, primary

--- a/i18n/locales/fr-FR/main.ftl
+++ b/i18n/locales/fr-FR/main.ftl
@@ -1570,6 +1570,12 @@ admin-sla-priority-low = basse
 admin-sla-priority-medium = moyenne
 admin-sla-priority-high = haute
 admin-sla-workspace-default = Défaut de l'espace de travail
+# MACHINE TRANSLATION, pending native review
+admin-sla-field-no-sla = Aucun SLA
+# MACHINE TRANSLATION, pending native review
+admin-sla-field-no-sla-hint = Les tickets correspondant à cette politique n'ont aucun SLA. Restreignez-la avec un filtre ci-dessus pour retirer les SLA d'une catégorie de tickets.
+# MACHINE TRANSLATION, pending native review
+admin-sla-no-sla-label = Aucun SLA
 admin-sla-create = Créer
 
 # Admin : Marque.

--- a/i18n/locales/nl-NL/main.ftl
+++ b/i18n/locales/nl-NL/main.ftl
@@ -1567,6 +1567,12 @@ admin-sla-priority-low = laag
 admin-sla-priority-medium = gemiddeld
 admin-sla-priority-high = hoog
 admin-sla-workspace-default = Werkruimtestandaard
+# MACHINE TRANSLATION, pending native review
+admin-sla-field-no-sla = Geen SLA
+# MACHINE TRANSLATION, pending native review
+admin-sla-field-no-sla-hint = Tickets die aan dit beleid voldoen krijgen geen SLA. Beperk het met een filter hierboven om SLA's voor een groep tickets te verwijderen.
+# MACHINE TRANSLATION, pending native review
+admin-sla-no-sla-label = Geen SLA
 admin-sla-create = Aanmaken
 
 # Beheer: Branding.

--- a/packages/core/src/services/slaService.ts
+++ b/packages/core/src/services/slaService.ts
@@ -21,6 +21,9 @@ export interface SlaPolicy {
   category_id_filter: number | null
   assignee_group_id_filter: number | null
   is_default: boolean
+  /** When true this policy grants NO SLA to the tickets it matches (via the
+   *  most-specific-wins precedence) — targets / calendar are irrelevant. */
+  no_sla: boolean
   created_at: string
   updated_at: string
   created_by: string | null
@@ -61,6 +64,7 @@ export interface SlaPolicyBody {
   category_id_filter?: number | null
   assignee_group_id_filter?: number | null
   is_default?: boolean
+  no_sla?: boolean
 }
 
 export const slaService = {
@@ -160,6 +164,8 @@ export interface SlaExplainPolicy {
   id: number
   name: string
   is_default: boolean
+  /** When true the matched policy grants no SLA (targets/calendar irrelevant). */
+  no_sla: boolean
   target_response_minutes: number | null
   target_resolution_minutes: number | null
   calendar: SlaExplainCalendar | null


### PR DESCRIPTION
Stops the SLA from getting in the way of tickets that don't need one. Two increments from the SLA research thread.

### No-SLA policy (P1)
A `no_sla` flag on `sla_policies`. When a No-SLA policy is the most-specific match for a ticket, the ticket gets **no SLA**: `compute_pill` returns `None` at the top, so both the bootstrap read and the recompute/mutation path drop the pill and clear the materialised targets (one insertion point covers everything). Precedence in `pick_policy` is unchanged, so a **filtered** No-SLA policy (e.g. a Requests category) beats the catch-all default, letting operators scope SLAs away from a class of tickets **without a new negative-matching axis**. No-SLA tickets are excluded from the SLA health counts, and the flag rides the explain payload.

- Migration: `no_sla BOOLEAN NOT NULL DEFAULT false` (metadata-only add, no row rewrite / no audit-trigger backfill).
- Model / schema / repository write structs / admin API body all thread `no_sla`.
- Admin form: a "No SLA" toggle that hides the target + calendar fields; the policy list shows a "No SLA" label. en-US + machine fr/nl i18n.

### Hide dormant SLAs (A)
The preview pane hides the SLA section + header chip for a **dormant** SLA, paused while the ticket is still in a pre-active `triage`/`backlog` state (the clock never started), via a reusable `isSlaDormant()` gate. A genuine on-hold SLA (paused in a post-active state) stays visible.

**Verified:** 17 SLA unit tests pass incl. a new precedence case (a more-specific No-SLA policy wins matching but yields no pill); backend + core + frontend type-checks clean; migration applied on the dev DB; rebuilt backend serves without schema mismatch.

> Heads-up: this carries a migration — `make migrate` after pulling; CI exercises it against a fresh DB.