### PR TITLE
SLA: activation-anchored clock with per-policy clock_start (P2)

### DIFF
--- a/backend/migrations/2026-08-01-000001_sla_activation_clock/down.sql
+++ b/backend/migrations/2026-08-01-000001_sla_activation_clock/down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE tickets DROP COLUMN sla_paused_at;
+ALTER TABLE tickets DROP COLUMN sla_clock_started_at;
+ALTER TABLE sla_policies DROP COLUMN clock_start;

--- a/backend/migrations/2026-08-01-000001_sla_activation_clock/up.sql
+++ b/backend/migrations/2026-08-01-000001_sla_activation_clock/up.sql
@@ -1,0 +1,18 @@
+-- P2: activation-anchored SLA clock.
+--
+-- clock_start declares when a policy's clock starts:
+--   'created'   — from ticket creation (client-facing "respond within N of
+--                 submission" SLAs, which legitimately run during triage).
+--   'activated' — from the ticket's first entry into a non-pausing (Active)
+--                 state (internal targets that shouldn't burn while a ticket
+--                 waits in backlog). Default: fixes the instant-breach bug.
+ALTER TABLE sla_policies ADD COLUMN clock_start VARCHAR(16) NOT NULL DEFAULT 'activated';
+
+-- The effective SLA start for a ticket (also pushed forward by paused business
+-- time, so pausing subtracts). NULL = the clock has never started (an 'activated'
+-- policy renders no SLA yet). Metadata-only add, no backfill: pre-migration
+-- tickets self-heal on their next workflow transition (see services::sla).
+ALTER TABLE tickets ADD COLUMN sla_clock_started_at TIMESTAMPTZ;
+-- When the current pause began, so a resume can add back the paused business
+-- time. NULL = not currently paused.
+ALTER TABLE tickets ADD COLUMN sla_paused_at TIMESTAMPTZ;

--- a/backend/src/handlers/sla.rs
+++ b/backend/src/handlers/sla.rs
@@ -365,6 +365,8 @@ pub struct SlaExplainPolicy {
     /// When true the matched policy grants NO SLA — the popover explains why the
     /// ticket has no timer despite a policy matching.
     pub no_sla: bool,
+    /// `"created"` or `"activated"` — when this policy's clock starts.
+    pub clock_start: String,
     pub target_response_minutes: Option<i32>,
     pub target_resolution_minutes: Option<i32>,
     pub calendar: Option<SlaExplainCalendar>,
@@ -465,6 +467,7 @@ pub async fn explain_for_ticket(
                     name: policy.name.clone(),
                     is_default: policy.is_default,
                     no_sla: policy.no_sla,
+                    clock_start: policy.clock_start.clone(),
                     target_response_minutes: policy.target_response_minutes,
                     target_resolution_minutes: policy.target_resolution_minutes,
                     calendar,

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -382,6 +382,11 @@ pub struct SlaPolicy {
     /// tickets (e.g. requests) by adding a more-specific No-SLA policy that beats
     /// the catch-all default. Targets / calendar are irrelevant when set.
     pub no_sla: bool,
+    /// When the clock starts: `"created"` (from ticket creation) or `"activated"`
+    /// (from the ticket's first entry into a non-pausing state). Parsed via
+    /// [`crate::services::sla::ClockStart`]; unknown values fall back to
+    /// `activated`. Must stay the LAST field (positional Queryable).
+    pub clock_start: String,
 }
 
 /// Operation kind recorded in `sync_actions.op`. The fourth variant
@@ -971,9 +976,17 @@ pub struct Ticket {
     /// Optional planning start for the gantt timeline. NULL means
     /// unplanned; the gantt falls back to created_at for a bar's left
     /// edge. A planning field, distinct from the factual created_at.
-    /// Must stay the LAST field to match `schema.rs` column order
-    /// (positional Queryable).
     pub start_date: Option<NaiveDateTime>,
+    /// P2 SLA clock: the effective start of the SLA window (also pushed forward
+    /// by paused business time, so pausing subtracts). NULL = the clock has
+    /// never started; for an `activated`-clock policy that means `not_started`
+    /// (no pill). Set when the ticket first enters a non-pausing state.
+    pub sla_clock_started_at: Option<NaiveDateTime>,
+    /// When the current SLA pause began, so a resume can add the paused business
+    /// time back onto `sla_clock_started_at`. NULL = not currently paused. Must
+    /// stay the LAST two fields to match `schema.rs` column order (positional
+    /// Queryable).
+    pub sla_paused_at: Option<NaiveDateTime>,
 }
 
 /// Merge metadata for a ticket that was merged into another (the satellite of

--- a/backend/src/repository/sla_admin.rs
+++ b/backend/src/repository/sla_admin.rs
@@ -103,6 +103,7 @@ pub struct NewSlaPolicy {
     pub assignee_group_id_filter: Option<i32>,
     pub is_default: bool,
     pub no_sla: bool,
+    pub clock_start: String,
     pub created_by: Option<Uuid>,
 }
 
@@ -118,6 +119,7 @@ pub struct SlaPolicyPatch {
     pub assignee_group_id_filter: Option<Option<i32>>,
     pub is_default: Option<bool>,
     pub no_sla: Option<bool>,
+    pub clock_start: Option<String>,
     pub updated_at: Option<chrono::DateTime<Utc>>,
 }
 
@@ -133,6 +135,9 @@ pub struct SlaPolicyBody {
     pub is_default: Option<bool>,
     #[serde(default)]
     pub no_sla: Option<bool>,
+    /// `"created"` or `"activated"` (default). See services::sla::ClockStart.
+    #[serde(default)]
+    pub clock_start: Option<String>,
 }
 
 pub fn list_policies(conn: &mut DbConnection) -> QueryResult<Vec<SlaPolicy>> {
@@ -158,6 +163,7 @@ pub fn create_policy(
             assignee_group_id_filter: body.assignee_group_id_filter,
             is_default: body.is_default.unwrap_or(false),
             no_sla: body.no_sla.unwrap_or(false),
+            clock_start: body.clock_start.unwrap_or_else(|| "activated".to_string()),
             created_by: actor,
         })
         .get_result(conn)
@@ -217,6 +223,7 @@ pub fn seed_defaults_if_empty(
             assignee_group_id_filter: None,
             is_default: Some(true),
             no_sla: Some(false),
+            clock_start: None, // -> "activated" (the instant-breach fix)
         },
         created_by,
     )?;
@@ -240,6 +247,7 @@ pub fn update_policy(
         assignee_group_id_filter: Some(body.assignee_group_id_filter),
         is_default: body.is_default,
         no_sla: body.no_sla,
+        clock_start: body.clock_start,
         updated_at: Some(Utc::now()),
     };
     diesel::update(sla_policies::table.find(id))

--- a/backend/src/schema.rs
+++ b/backend/src/schema.rs
@@ -1524,6 +1524,8 @@ diesel::table! {
         workspace_id -> Int4,
         assignee_group_id_filter -> Nullable<Int4>,
         no_sla -> Bool,
+        #[max_length = 16]
+        clock_start -> Varchar,
     }
 }
 
@@ -1756,6 +1758,8 @@ diesel::table! {
         uuid -> Uuid,
         spam_suspected -> Bool,
         start_date -> Nullable<Timestamptz>,
+        sla_clock_started_at -> Nullable<Timestamptz>,
+        sla_paused_at -> Nullable<Timestamptz>,
     }
 }
 

--- a/backend/src/services/assignment.rs
+++ b/backend/src/services/assignment.rs
@@ -388,6 +388,8 @@ mod tests {
             sla_resolution_target_at: None,
             sla_resolution_breached_at: None,
             spam_suspected: false,
+            sla_clock_started_at: None,
+            sla_paused_at: None,
         };
         overrides(&mut ticket);
         ticket

--- a/backend/src/services/channels/auto_ack.rs
+++ b/backend/src/services/channels/auto_ack.rs
@@ -367,6 +367,8 @@ mod tests {
             sla_resolution_target_at: None,
             sla_resolution_breached_at: None,
             spam_suspected: false,
+            sla_clock_started_at: None,
+            sla_paused_at: None,
         }
     }
 

--- a/backend/src/services/sla.rs
+++ b/backend/src/services/sla.rs
@@ -26,7 +26,8 @@
 //! transitions.
 
 use chrono::{
-    DateTime, Datelike, Duration, NaiveDate, NaiveTime, TimeZone, Timelike, Utc, Weekday,
+    DateTime, Datelike, Duration, NaiveDate, NaiveDateTime, NaiveTime, TimeZone, Timelike, Utc,
+    Weekday,
 };
 use chrono_tz::Tz;
 use std::collections::{HashMap, HashSet};
@@ -161,6 +162,57 @@ pub fn add_business_minutes(
     // Fall-through: refuse to lie about the breach time when the
     // schedule has no working hours at all.
     start
+}
+
+/// Business minutes elapsed in `[start, end)` for a calendar — the inverse of
+/// [`add_business_minutes`]. Used to advance the SLA anchor past a pause: on
+/// resume we push the anchor forward by exactly the working time that elapsed
+/// while paused, so paused time doesn't count against the target. Nights,
+/// weekends, and holidays contribute zero.
+pub fn business_minutes_between(
+    start: DateTime<Utc>,
+    end: DateTime<Utc>,
+    calendar: &WorkingCalendar,
+    holidays: &HashSet<NaiveDate>,
+) -> i64 {
+    if end <= start {
+        return 0;
+    }
+    let tz = parse_tz(&calendar.timezone);
+    let schedule = parse_schedule(&calendar.schedule);
+    let end_local = end.with_timezone(&tz);
+    let mut local = start.with_timezone(&tz);
+    let mut total: i64 = 0;
+
+    const MAX_DAYS: u32 = 365 * 5;
+    for _ in 0..MAX_DAYS {
+        if local >= end_local {
+            break;
+        }
+        let date = local.date_naive();
+        let day_ranges = &schedule.days[day_index(date.weekday())];
+        if day_ranges.is_empty() || holidays.contains(&date) {
+            local = next_day_midnight(&tz, date);
+            continue;
+        }
+        // On the first day `local` carries the start time; on later days it's
+        // midnight (cursor 0). Cap the final day at `end`'s minute.
+        let cursor = local.hour() as i32 * 60 + local.minute() as i32;
+        let day_cap = if end_local.date_naive() == date {
+            end_local.hour() as i32 * 60 + end_local.minute() as i32
+        } else {
+            24 * 60
+        };
+        for range in day_ranges {
+            let seg_start = cursor.max(range.open_minutes);
+            let seg_end = range.close_minutes.min(day_cap);
+            if seg_end > seg_start {
+                total += (seg_end - seg_start) as i64;
+            }
+        }
+        local = next_day_midnight(&tz, date);
+    }
+    total
 }
 
 fn next_day_midnight(tz: &Tz, date: NaiveDate) -> DateTime<Tz> {
@@ -303,11 +355,34 @@ fn compute_timer(
     }
 }
 
+/// When a policy's SLA clock starts.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ClockStart {
+    /// From ticket creation; the clock runs continuously (the workflow pause is
+    /// ignored — the promise is measured from submission).
+    Created,
+    /// From the ticket's first entry into a non-pausing (Active) state; pause
+    /// then subtracts. Until that first activation the clock is `not_started`.
+    Activated,
+}
+
+impl ClockStart {
+    /// Parse the policy's stored string; anything unrecognised (incl. legacy
+    /// rows) falls back to `Activated`, the bug-fixing default.
+    pub fn parse(s: &str) -> Self {
+        match s {
+            "created" => ClockStart::Created,
+            _ => ClockStart::Activated,
+        }
+    }
+}
+
 /// Compute the SLA pill payload for a ticket — both response +
 /// resolution timers, gated on which policy targets are configured.
 /// `paused` is the workflow state's own `pauses_sla` flag (resolved
 /// at the caller from `WorkflowState::pauses_sla`); when true the
-/// timers stop counting. The response timer also stops counting once
+/// timers stop counting (for an `activated`-clock policy; a `created`
+/// policy runs continuously and ignores it). The response timer also stops counting once
 /// `first_response_at` is stamped, regardless of pause state — at
 /// that point the response was either met or breached, and the wall
 /// clock has nothing left to say about it.
@@ -333,6 +408,30 @@ pub fn compute_pill(
 
     let created_utc = DateTime::<Utc>::from_naive_utc_and_offset(ticket.created_at, Utc);
 
+    // Resolve the effective anchor (where the clock counts from) and whether it's
+    // currently frozen, per the policy's clock-start mode. This is the P2 fix for
+    // the created_at-anchored instant-breach.
+    let (anchor, effective_paused) = match ClockStart::parse(&policy.clock_start) {
+        // Runs continuously from submission; the workflow pause doesn't apply
+        // (the promise is measured from when the client contacted us).
+        ClockStart::Created => (created_utc, false),
+        ClockStart::Activated => match ticket.sla_clock_started_at {
+            // Started: the anchor already absorbed prior paused time (pushed
+            // forward on each resume). Honour the current workflow pause — it
+            // freezes the timer now and is subtracted on the next resume.
+            Some(started) => (
+                DateTime::<Utc>::from_naive_utc_and_offset(started, Utc),
+                paused,
+            ),
+            // No anchor yet. A currently-active ticket predates the stamp (a
+            // pre-migration row) — fall back to created_at so it keeps showing an
+            // SLA and self-heals on its next transition. Currently paused
+            // (backlog/triage) means the clock genuinely never started: no pill.
+            None if !paused => (created_utc, false),
+            None => return None,
+        },
+    };
+
     let response = policy
         .target_response_minutes
         .filter(|m| *m > 0)
@@ -342,9 +441,9 @@ pub fn compute_pill(
                 .map(|t| DateTime::<Utc>::from_naive_utc_and_offset(t, Utc));
             compute_timer(
                 minutes as i64,
-                created_utc,
+                anchor,
                 met_at,
-                paused,
+                effective_paused,
                 calendar,
                 holidays,
                 now,
@@ -357,9 +456,9 @@ pub fn compute_pill(
         .map(|minutes| {
             compute_timer(
                 minutes as i64,
-                created_utc,
+                anchor,
                 None,
-                paused,
+                effective_paused,
                 calendar,
                 holidays,
                 now,
@@ -412,12 +511,120 @@ pub fn recompute_and_stamp_sla_for_ticket(
     conn: &mut crate::db::DbConnection,
     ticket: &Ticket,
 ) -> serde_json::Value {
-    let pill = load_pill_for_ticket(conn, ticket);
+    // Advance the activation-clock state machine first (stamp the anchor on first
+    // activation, record a pause start, or push the anchor past a finished pause)
+    // so the pill below reflects the fresh anchor. Runs under the caller's actor
+    // context, so the audited write on the ticket carries workspace context.
+    let mut ticket = ticket.clone();
+    advance_sla_clock(conn, &mut ticket);
+
+    let pill = load_pill_for_ticket(conn, &ticket);
     let (response_target, resolution_target) =
         pill.as_ref().map(targets_from_pill).unwrap_or((None, None));
     set_sla_targets(conn, ticket.id, response_target, resolution_target);
     pill.and_then(|p| serde_json::to_value(p).ok())
         .unwrap_or(serde_json::Value::Null)
+}
+
+/// Advance one ticket's SLA clock after a workflow transition. Only
+/// `activated`-clock policies use the anchor; a `created` / No-SLA / unmatched
+/// ticket is left untouched. Mutates the ticket's anchor fields in memory to
+/// match the persisted write so the caller's pill computation sees the fresh
+/// values. State machine over `(sla_clock_started_at, sla_paused_at)`:
+///   - no anchor + now active        -> stamp the anchor (first activation)
+///   - anchor, running + now paused   -> record the pause start
+///   - anchor, paused + now active    -> push the anchor past the paused business
+///                                       time (pausing subtracts) and clear it
+fn advance_sla_clock(conn: &mut crate::db::DbConnection, ticket: &mut Ticket) {
+    use crate::schema::{sla_policies, tickets, workflow_states};
+    use diesel::prelude::*;
+
+    let Ok(policies) = sla_policies::table.load::<SlaPolicy>(conn) else {
+        return;
+    };
+    let group_ids = ticket
+        .assignee_uuid
+        .and_then(|u| crate::repository::groups::get_group_ids_for_user(conn, &u).ok())
+        .unwrap_or_default();
+    let Some(policy) = pick_policy(&policies, ticket, &group_ids) else {
+        return;
+    };
+    if policy.no_sla || ClockStart::parse(&policy.clock_start) != ClockStart::Activated {
+        return;
+    }
+
+    // Missing state row defaults to paused (mirrors load_pill_for_ticket).
+    let now_paused = workflow_states::table
+        .find(ticket.workflow_state_id)
+        .select(workflow_states::pauses_sla)
+        .first::<bool>(conn)
+        .unwrap_or(true);
+    let now = Utc::now();
+
+    let (new_anchor, new_paused_at): (Option<NaiveDateTime>, Option<NaiveDateTime>) =
+        match (ticket.sla_clock_started_at, ticket.sla_paused_at) {
+            (None, _) if now_paused => (None, None), // still not started
+            (None, _) => (Some(now.naive_utc()), None), // first activation
+            (Some(anchor), None) if now_paused => (Some(anchor), Some(now.naive_utc())), // pause
+            (Some(anchor), None) => (Some(anchor), None), // running
+            (Some(anchor), Some(paused_at)) if now_paused => (Some(anchor), Some(paused_at)), // held
+            (Some(anchor), Some(paused_at)) => {
+                // Resume: advance the anchor past the paused working time.
+                (
+                    Some(push_anchor_past_pause(conn, policy, anchor, paused_at, now)),
+                    None,
+                )
+            }
+        };
+
+    if new_anchor != ticket.sla_clock_started_at || new_paused_at != ticket.sla_paused_at {
+        let _ = diesel::update(tickets::table.find(ticket.id))
+            .set((
+                tickets::sla_clock_started_at.eq(new_anchor),
+                tickets::sla_paused_at.eq(new_paused_at),
+            ))
+            .execute(conn);
+        ticket.sla_clock_started_at = new_anchor;
+        ticket.sla_paused_at = new_paused_at;
+    }
+}
+
+/// Push the SLA anchor forward by the business time that elapsed during a pause,
+/// so the paused window doesn't count toward the target. Falls back to the
+/// unchanged anchor if the policy has no calendar to measure against.
+fn push_anchor_past_pause(
+    conn: &mut crate::db::DbConnection,
+    policy: &SlaPolicy,
+    anchor: NaiveDateTime,
+    paused_at: NaiveDateTime,
+    now: DateTime<Utc>,
+) -> NaiveDateTime {
+    use crate::schema::{working_calendar_holidays, working_calendars};
+    use diesel::prelude::*;
+
+    let Some(cal_id) = policy.working_calendar_id else {
+        return anchor;
+    };
+    let Ok(calendar) = working_calendars::table
+        .find(cal_id)
+        .first::<WorkingCalendar>(conn)
+    else {
+        return anchor;
+    };
+    let holiday_rows: Vec<WorkingCalendarHoliday> = working_calendar_holidays::table
+        .filter(working_calendar_holidays::calendar_id.eq(cal_id))
+        .load(conn)
+        .unwrap_or_default();
+    let year = Utc::now().year();
+    let holidays: HashSet<NaiveDate> = holiday_rows
+        .iter()
+        .flat_map(|h| crate::repository::sla::expand_holiday(h, year))
+        .collect();
+
+    let paused_from = DateTime::<Utc>::from_naive_utc_and_offset(paused_at, Utc);
+    let paused_business = business_minutes_between(paused_from, now, &calendar, &holidays);
+    let anchor_utc = DateTime::<Utc>::from_naive_utc_and_offset(anchor, Utc);
+    add_business_minutes(anchor_utc, paused_business, &calendar, &holidays).naive_utc()
 }
 
 /// Load every input the engine needs for one ticket and run
@@ -760,6 +967,7 @@ mod tests {
             created_by: None,
             workspace_id: 1,
             no_sla: false,
+            clock_start: "created".to_string(),
             // No need to backfill new ticket fields; the matcher
             // doesn't read them and Ticket is built per-test.
         }
@@ -797,6 +1005,8 @@ mod tests {
             sla_resolution_target_at: None,
             sla_resolution_breached_at: None,
             spam_suspected: false,
+            sla_clock_started_at: None,
+            sla_paused_at: None,
         }
     }
 
@@ -832,6 +1042,157 @@ mod tests {
             Utc::now(),
         );
         assert!(pill.is_none(), "a No-SLA policy must produce no pill");
+    }
+
+    fn all_hours_cal() -> WorkingCalendar {
+        cal(serde_json::json!({
+            "mon": [["00:00", "23:59"]], "tue": [["00:00", "23:59"]],
+            "wed": [["00:00", "23:59"]], "thu": [["00:00", "23:59"]],
+            "fri": [["00:00", "23:59"]], "sat": [["00:00", "23:59"]],
+            "sun": [["00:00", "23:59"]]
+        }))
+    }
+
+    fn business_cal() -> WorkingCalendar {
+        cal(serde_json::json!({
+            "mon": [["09:00", "17:00"]], "tue": [["09:00", "17:00"]],
+            "wed": [["09:00", "17:00"]], "thu": [["09:00", "17:00"]],
+            "fri": [["09:00", "17:00"]], "sat": [], "sun": []
+        }))
+    }
+
+    #[test]
+    fn business_minutes_between_counts_within_day() {
+        let start = Utc.with_ymd_and_hms(2026, 5, 4, 10, 0, 0).unwrap(); // Monday
+        let end = start + Duration::hours(3);
+        assert_eq!(
+            business_minutes_between(start, end, &all_hours_cal(), &HashSet::new()),
+            180
+        );
+    }
+
+    #[test]
+    fn business_minutes_between_skips_weekend() {
+        // Friday 16:00 -> Monday 10:00 on a 09:00-17:00 M-F calendar:
+        // Fri 16-17 = 60, weekend = 0, Mon 09-10 = 60 -> 120.
+        let start = Utc.with_ymd_and_hms(2026, 5, 1, 16, 0, 0).unwrap(); // Friday
+        let end = Utc.with_ymd_and_hms(2026, 5, 4, 10, 0, 0).unwrap(); // Monday
+        assert_eq!(
+            business_minutes_between(start, end, &business_cal(), &HashSet::new()),
+            120
+        );
+    }
+
+    fn activated_policy() -> SlaPolicy {
+        let mut p = policy(1, None, true);
+        p.clock_start = "activated".to_string();
+        p.target_response_minutes = Some(60);
+        p.target_resolution_minutes = None;
+        p
+    }
+
+    #[test]
+    fn activated_clock_not_started_yields_no_pill() {
+        // Never activated (no anchor) and currently paused (backlog) -> no SLA.
+        let t = ticket(None); // sla_clock_started_at = None
+        let pill = compute_pill(
+            &t,
+            true, // paused (in a pre-active state)
+            &activated_policy(),
+            &all_hours_cal(),
+            &HashSet::new(),
+            Utc::now(),
+        );
+        assert!(
+            pill.is_none(),
+            "an activated clock with no anchor + paused is not_started"
+        );
+    }
+
+    #[test]
+    fn activated_clock_falls_back_to_created_when_active_without_anchor() {
+        // Pre-migration active ticket (no anchor, not paused) keeps an SLA,
+        // anchored at created_at, and self-heals on its next transition.
+        let mut t = ticket(None);
+        t.created_at = Utc
+            .with_ymd_and_hms(2026, 5, 4, 10, 0, 0)
+            .unwrap()
+            .naive_utc();
+        let pill = compute_pill(
+            &t,
+            false,
+            &activated_policy(),
+            &all_hours_cal(),
+            &HashSet::new(),
+            Utc.with_ymd_and_hms(2026, 5, 4, 10, 30, 0).unwrap(),
+        )
+        .expect("active ticket keeps an SLA via the created fallback");
+        // target = created + 60 min.
+        assert_eq!(
+            pill.response.unwrap().target_at,
+            Utc.with_ymd_and_hms(2026, 5, 4, 11, 0, 0).unwrap()
+        );
+    }
+
+    #[test]
+    fn activated_clock_anchors_at_started_at_not_created() {
+        // The fix: target is anchored to activation, not creation, so a ticket
+        // that sat in backlog for days doesn't breach the instant it's activated.
+        let mut t = ticket(None);
+        t.created_at = Utc
+            .with_ymd_and_hms(2026, 5, 1, 9, 0, 0)
+            .unwrap()
+            .naive_utc();
+        t.sla_clock_started_at = Some(
+            Utc.with_ymd_and_hms(2026, 5, 4, 10, 0, 0)
+                .unwrap()
+                .naive_utc(),
+        ); // activated 3 days later
+        let pill = compute_pill(
+            &t,
+            false,
+            &activated_policy(),
+            &all_hours_cal(),
+            &HashSet::new(),
+            Utc.with_ymd_and_hms(2026, 5, 4, 10, 5, 0).unwrap(),
+        )
+        .expect("started clock renders a pill");
+        let resp = pill.response.unwrap();
+        // target = activation + 60 min (NOT created + 60), and not breached.
+        assert_eq!(
+            resp.target_at,
+            Utc.with_ymd_and_hms(2026, 5, 4, 11, 0, 0).unwrap()
+        );
+        assert!(
+            !resp.breached,
+            "freshly activated ticket is not instantly breached"
+        );
+    }
+
+    #[test]
+    fn created_clock_ignores_pause() {
+        // A created-clock policy runs continuously from submission; the workflow
+        // pause doesn't freeze it.
+        let mut p = activated_policy();
+        p.clock_start = "created".to_string();
+        let mut t = ticket(None);
+        t.created_at = Utc
+            .with_ymd_and_hms(2026, 5, 4, 10, 0, 0)
+            .unwrap()
+            .naive_utc();
+        let pill = compute_pill(
+            &t,
+            true, // workflow says paused
+            &p,
+            &all_hours_cal(),
+            &HashSet::new(),
+            Utc.with_ymd_and_hms(2026, 5, 4, 10, 30, 0).unwrap(),
+        )
+        .expect("created clock renders a pill even while the state pauses");
+        assert!(
+            !pill.response.unwrap().paused,
+            "created clock ignores the workflow pause"
+        );
     }
 
     #[test]

--- a/backend/src/services/template_vars.rs
+++ b/backend/src/services/template_vars.rs
@@ -186,6 +186,8 @@ mod tests {
             sla_resolution_target_at: None,
             sla_resolution_breached_at: None,
             spam_suspected: false,
+            sla_clock_started_at: None,
+            sla_paused_at: None,
         }
     }
 

--- a/frontend/src/components/views/TicketPreviewPane.vue
+++ b/frontend/src/components/views/TicketPreviewPane.vue
@@ -30,7 +30,7 @@ import {
   buildWorkflowDropdownOptions,
   isCategoryHeaderValue,
 } from '@nosdesk/core/types/workflow'
-import { useSlaState, useSlaTimers, isSlaDormant, type SlaState } from '@/composables/useSlaState'
+import { useSlaState, useSlaTimers, type SlaState } from '@/composables/useSlaState'
 import {
   formatCleanRelativeTime,
   formatDateTime,
@@ -115,10 +115,6 @@ function fullDateTime(iso: string | null | undefined): string {
 
 const slaState = useSlaState(toRef(props, 'card'))
 const slaTimers = useSlaTimers(toRef(props, 'card'))
-
-// Hide the SLA chrome for a dormant SLA (paused + never started, e.g. a backlog
-// request) so tickets that don't need one aren't cluttered with a frozen timer.
-const slaDormant = computed(() => isSlaDormant(props.card))
 
 // What the SLA section renders: both timers labelled when the policy
 // has both targets configured, otherwise the one timer unlabeled.
@@ -278,7 +274,7 @@ async function updateDueDate(iso: string | null): Promise<void> {
                 />
               </span>
               <span
-                v-if="slaState && !slaDormant"
+                v-if="slaState"
                 class="inline-flex items-center gap-1 text-[10px] font-medium px-1.5 h-6 rounded-md border border-subtle transition-colors duration-200"
                 :class="slaState.toneClass"
               >
@@ -384,7 +380,7 @@ async function updateDueDate(iso: string | null): Promise<void> {
                row is unlabeled (the section heading already names
                what it is). The bar gives peripheral urgency; the
                detail line carries the precise time + target. -->
-          <section v-if="slaRows.length > 0 && !slaDormant" class="px-4 pt-3 pb-3 border-t border-subtle/60 flex flex-col gap-2.5">
+          <section v-if="slaRows.length > 0" class="px-4 pt-3 pb-3 border-t border-subtle/60 flex flex-col gap-2.5">
             <h3 class="text-[10px] uppercase tracking-wider font-semibold text-tertiary">
               {{ $t('views-ticket-preview-sla') }}
             </h3>

--- a/frontend/src/composables/useSlaState.ts
+++ b/frontend/src/composables/useSlaState.ts
@@ -23,32 +23,7 @@
  */
 import { computed, onMounted, onUnmounted, ref, type ComputedRef, type Ref } from 'vue'
 import type { CardData } from '@nosdesk/core/sync/views/types'
-import type { WorkflowStateCategory } from '@nosdesk/core/types/workflow'
 import { getDateConfig } from '@nosdesk/core/utils/dateUtils'
-
-// Categories where a ticket hasn't started being worked, so its SLA clock has
-// never run. Used to hide a dormant (paused, never-started) SLA from tickets
-// that don't really need one — a backlog request shouldn't surface a frozen
-// "Paused" timer with concrete targets.
-const PRE_ACTIVE_CATEGORIES: readonly WorkflowStateCategory[] = ['triage', 'backlog']
-
-/**
- * True when a card's SLA is present but DORMANT: paused while the ticket is
- * still in a pre-active state (triage/backlog), i.e. the clock has never
- * started. Consumers hide the SLA chrome for these so a backlog/request ticket
- * doesn't display a meaningless frozen SLA. A genuine on-hold SLA (paused in a
- * post-active state like `in_review`, which HAS run) is not dormant and stays
- * visible.
- *
- * The payload carries no "has ever run" signal, so we proxy "never started"
- * with the current pre-active category. A ticket reopened from active back to
- * backlog reads as dormant — acceptable for a de-noise gate; a precise
- * signal belongs to a future SLA-state model.
- */
-export function isSlaDormant(card: CardData | null | undefined): boolean {
-  if (!card?.sla?.paused) return false
-  return PRE_ACTIVE_CATEGORIES.includes(card.workflow_state.category)
-}
 
 // Single shared tick: re-emits the wall clock so every consumer's
 // computed re-evaluates together. 30s is a sweet spot — fast enough

--- a/frontend/src/views/SlaAdminView.vue
+++ b/frontend/src/views/SlaAdminView.vue
@@ -410,6 +410,7 @@ function emptyPolicyDraft(): SlaPolicyBody {
     assignee_group_id_filter: null,
     is_default: false,
     no_sla: false,
+    clock_start: 'activated',
   }
 }
 
@@ -437,6 +438,7 @@ function openEditPolicy(p: SlaPolicy): void {
     assignee_group_id_filter: p.assignee_group_id_filter,
     is_default: p.is_default,
     no_sla: p.no_sla,
+    clock_start: p.clock_start,
   }
   policyOpen.value = true
 }
@@ -506,6 +508,7 @@ async function togglePolicyDefault(p: SlaPolicy): Promise<void> {
       assignee_group_id_filter: p.assignee_group_id_filter,
       is_default: !p.is_default,
       no_sla: p.no_sla,
+      clock_start: p.clock_start,
     })
     queryCache.setQueryData(
       POLICIES_KEY,
@@ -620,6 +623,10 @@ const calendarDropdownOptions = computed(() => [
 const holidayImportOptions = computed(() => [
   { value: '', label: t('admin-sla-holiday-import-placeholder') },
   ...HOLIDAY_TEMPLATE_LIST.map((tpl) => ({ value: tpl.code, label: tpl.name })),
+])
+const clockStartOptions = computed(() => [
+  { value: 'activated', label: t('admin-sla-clock-start-activated') },
+  { value: 'created', label: t('admin-sla-clock-start-created') },
 ])
 </script>
 
@@ -1129,6 +1136,16 @@ const holidayImportOptions = computed(() => [
               :min="0"
               @update:model-value="(v) => (policyDraft.target_resolution_minutes = v ?? undefined)"
             />
+          </div>
+          <div class="flex flex-col gap-1">
+            <BaseDropdown
+              :label="$t('admin-sla-field-clock-start')"
+              :model-value="policyDraft.clock_start ?? 'activated'"
+              :options="clockStartOptions"
+              size="sm"
+              @update:model-value="(v) => (policyDraft.clock_start = String(v))"
+            />
+            <p class="text-[11px] text-tertiary">{{ $t('admin-sla-field-clock-start-hint') }}</p>
           </div>
         </fieldset>
 

--- a/i18n/locales/en-US/main.ftl
+++ b/i18n/locales/en-US/main.ftl
@@ -1723,6 +1723,10 @@ admin-sla-workspace-default = Workspace default
 admin-sla-field-no-sla = No SLA
 admin-sla-field-no-sla-hint = Tickets this policy matches get no SLA. Scope it with a filter above to remove SLAs from a class of tickets.
 admin-sla-no-sla-label = No SLA
+admin-sla-field-clock-start = Clock starts
+admin-sla-field-clock-start-hint = From activation: the clock starts when the ticket first becomes active, so backlog time isn't counted. From submission: the clock runs from ticket creation.
+admin-sla-clock-start-activated = From activation
+admin-sla-clock-start-created = From submission
 admin-sla-create = Create
 
 # Admin: Branding (BrandingSettingsView). Custom app name, primary

--- a/i18n/locales/fr-FR/main.ftl
+++ b/i18n/locales/fr-FR/main.ftl
@@ -1576,6 +1576,14 @@ admin-sla-field-no-sla = Aucun SLA
 admin-sla-field-no-sla-hint = Les tickets correspondant à cette politique n'ont aucun SLA. Restreignez-la avec un filtre ci-dessus pour retirer les SLA d'une catégorie de tickets.
 # MACHINE TRANSLATION, pending native review
 admin-sla-no-sla-label = Aucun SLA
+# MACHINE TRANSLATION, pending native review
+admin-sla-field-clock-start = Départ du compteur
+# MACHINE TRANSLATION, pending native review
+admin-sla-field-clock-start-hint = À l'activation : le compteur démarre lorsque le ticket devient actif pour la première fois, le temps en attente n'est donc pas compté. À la soumission : le compteur part de la création du ticket.
+# MACHINE TRANSLATION, pending native review
+admin-sla-clock-start-activated = À l'activation
+# MACHINE TRANSLATION, pending native review
+admin-sla-clock-start-created = À la soumission
 admin-sla-create = Créer
 
 # Admin : Marque.

--- a/i18n/locales/nl-NL/main.ftl
+++ b/i18n/locales/nl-NL/main.ftl
@@ -1573,6 +1573,14 @@ admin-sla-field-no-sla = Geen SLA
 admin-sla-field-no-sla-hint = Tickets die aan dit beleid voldoen krijgen geen SLA. Beperk het met een filter hierboven om SLA's voor een groep tickets te verwijderen.
 # MACHINE TRANSLATION, pending native review
 admin-sla-no-sla-label = Geen SLA
+# MACHINE TRANSLATION, pending native review
+admin-sla-field-clock-start = Klok start
+# MACHINE TRANSLATION, pending native review
+admin-sla-field-clock-start-hint = Bij activering: de klok start wanneer het ticket voor het eerst actief wordt, wachtrijtijd telt dus niet mee. Bij indiening: de klok loopt vanaf het aanmaken van het ticket.
+# MACHINE TRANSLATION, pending native review
+admin-sla-clock-start-activated = Bij activering
+# MACHINE TRANSLATION, pending native review
+admin-sla-clock-start-created = Bij indiening
 admin-sla-create = Aanmaken
 
 # Beheer: Branding.

--- a/packages/core/src/services/slaService.ts
+++ b/packages/core/src/services/slaService.ts
@@ -24,6 +24,9 @@ export interface SlaPolicy {
   /** When true this policy grants NO SLA to the tickets it matches (via the
    *  most-specific-wins precedence) — targets / calendar are irrelevant. */
   no_sla: boolean
+  /** When the clock starts: `'created'` (from submission) or `'activated'`
+   *  (from the ticket's first active state; default). */
+  clock_start: string
   created_at: string
   updated_at: string
   created_by: string | null
@@ -65,6 +68,7 @@ export interface SlaPolicyBody {
   assignee_group_id_filter?: number | null
   is_default?: boolean
   no_sla?: boolean
+  clock_start?: string
 }
 
 export const slaService = {
@@ -166,6 +170,8 @@ export interface SlaExplainPolicy {
   is_default: boolean
   /** When true the matched policy grants no SLA (targets/calendar irrelevant). */
   no_sla: boolean
+  /** `'created'` or `'activated'` — when the matched policy's clock starts. */
+  clock_start: string
   target_response_minutes: number | null
   target_resolution_minutes: number | null
   calendar: SlaExplainCalendar | null


### PR DESCRIPTION
Fixes the instant-breach-on-activation bug and makes the SLA clock measure active work instead of wall-clock age. Follows the merged No-SLA/dormant work (#180) and the SLA research thread.

### The bug
The clock was anchored to `created_at` and pause only froze the breach flag. A ticket that sat in backlog past its would-be target showed **Breached the moment it was picked up** (target = `created + N`, already in the past). Pause never subtracted, so it was inconsistent with its own "don't count backlog time" intent.

### The fix
- **Per-policy `clock_start`** (`created` | `activated`, default `activated`): a policy declares when its clock starts.
  - `activated` — from the ticket's first non-pausing (Active) state. Backlog time isn't counted.
  - `created` — continuous from submission; ignores the workflow pause (client "respond within N of contacting us" SLAs).
- **`compute_pill` anchors per `clock_start`.** An `activated` policy with no anchor yet is `not_started` → **no pill** (a backlog request genuinely has no SLA). This makes increment A's dormant-hide backend-authoritative, so the frontend `isSlaDormant` heuristic is **retired**. A pre-migration active ticket falls back to `created_at` and self-heals on its next transition — so the **migration adds columns only, no backfill** on the audited `tickets` table.
- **Pause subtracts** (the higher-quality option): `sla_paused_at` + `business_minutes_between` push the anchor past the paused working time on resume, so On-Hold extends the deadline.
- Stamping runs at the workflow-transition hook (`advance_sla_clock`), under the caller's actor context so the audited ticket write carries workspace context.
- Admin form: a **Clock starts** selector; `slaService` + the explain DTO carry `clock_start`; en-US + machine fr/nl i18n.

### Verify
23 SLA unit tests pass, incl. `activated_clock_anchors_at_started_at_not_created` (no instant breach), `business_minutes_between_*` (the subtract primitive), and `created_clock_ignores_pause`. Backend + core + frontend type-checks clean. Migration applied on the dev DB; rebuilt backend serves without schema mismatch.

> Migration (`sla_policies.clock_start` + `tickets.sla_clock_started_at` + `tickets.sla_paused_at`) — `make migrate` after pulling; CI runs it against a fresh DB.