### PR TITLE
Notifications: in-app tri-state (instant/quiet/off) by interrupt class

### DIFF
--- a/backend/migrations/2026-08-01-000003_notification_type_interrupts/down.sql
+++ b/backend/migrations/2026-08-01-000003_notification_type_interrupts/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE notification_types DROP COLUMN interrupts;

--- a/backend/migrations/2026-08-01-000003_notification_type_interrupts/up.sql
+++ b/backend/migrations/2026-08-01-000003_notification_type_interrupts/up.sql
@@ -1,0 +1,17 @@
+-- Alarm-discipline #2: whether a notification kind interrupts by default.
+-- Drives the default in-app frequency — `true` -> 'instant' (toast + desktop),
+-- `false` -> 'quiet' (lands in the bell + badge, no interrupt). A user can still
+-- override per (type, channel) via notification_preferences.
+ALTER TABLE notification_types ADD COLUMN interrupts BOOLEAN NOT NULL DEFAULT true;
+
+-- Informational kinds default to quiet; alarm / direct-human-comms kinds
+-- (mentioned, comment_added, ticket_assigned, sla_breached, loan_overdue) keep
+-- the interrupting default.
+UPDATE notification_types SET interrupts = false
+  WHERE code IN (
+    'ticket_status_changed',
+    'asset_low_stock',
+    'loan_due_soon',
+    'doc_page_updated',
+    'ticket_created_requester'
+  );

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -5516,6 +5516,10 @@ pub struct NotificationType {
     pub category: String,
     pub default_channels: serde_json::Value,
     pub created_at: NaiveDateTime,
+    /// Whether this kind interrupts by default: drives the default in-app
+    /// frequency (`true` → `instant`/toast, `false` → `quiet`/bell-only). A user
+    /// can still override per channel. Must stay LAST to match `schema.rs`.
+    pub interrupts: bool,
 }
 
 /// Persistent notification record

--- a/backend/src/schema.rs
+++ b/backend/src/schema.rs
@@ -1028,6 +1028,7 @@ diesel::table! {
         category -> Varchar,
         default_channels -> Jsonb,
         created_at -> Timestamptz,
+        interrupts -> Bool,
     }
 }
 

--- a/backend/src/services/notifications/preferences.rs
+++ b/backend/src/services/notifications/preferences.rs
@@ -43,7 +43,14 @@ pub struct PreferenceService {
     /// Cache keyed by (user, workspace) → type code → the channels that resolve
     /// to `instant` (i.e. deliver now). Workspace is part of the key because a
     /// user's effective delivery depends on the workspace's admin defaults.
-    cache: Arc<RwLock<HashMap<(Uuid, i32), HashMap<String, Vec<NotificationChannel>>>>>,
+    cache: Arc<
+        RwLock<
+            HashMap<
+                (Uuid, i32),
+                HashMap<String, Vec<(NotificationChannel, NotificationFrequency)>>,
+            >,
+        >,
+    >,
 }
 
 impl PreferenceService {
@@ -57,25 +64,30 @@ impl PreferenceService {
     /// Channels to deliver *immediately* (`instant`) for this user, in this
     /// workspace, for this type. `digest` rows are collected later by the digest
     /// batcher; `off` never delivers.
-    pub async fn get_enabled_channels(
+    /// The resolved deliver-now `(channel, frequency)` pairs for this (user,
+    /// workspace, type): every channel to deliver immediately. For in-app that is
+    /// `instant` OR `quiet` (both land in the bell; they differ only in whether
+    /// the client interrupts); for email/push only `instant`. `digest` (collected
+    /// later by the batcher) and `off` never appear here. Cached.
+    async fn resolve_delivery(
         &self,
         user_uuid: &Uuid,
         workspace_id: i32,
         notification_type: &NotificationTypeCode,
-    ) -> Result<Vec<NotificationChannel>, String> {
+    ) -> Result<Vec<(NotificationChannel, NotificationFrequency)>, String> {
         let type_code = notification_type.as_str().to_string();
         let key = (*user_uuid, workspace_id);
 
         {
             let cache = self.cache.read().await;
             if let Some(user_prefs) = cache.get(&key) {
-                if let Some(channels) = user_prefs.get(&type_code) {
-                    return Ok(channels.clone());
+                if let Some(pairs) = user_prefs.get(&type_code) {
+                    return Ok(pairs.clone());
                 }
             }
         }
 
-        let channels = self
+        let pairs = self
             .load_preferences_from_db(user_uuid, workspace_id, &type_code)
             .await?;
 
@@ -84,10 +96,44 @@ impl PreferenceService {
             cache
                 .entry(key)
                 .or_default()
-                .insert(type_code, channels.clone());
+                .insert(type_code, pairs.clone());
         }
 
-        Ok(channels)
+        Ok(pairs)
+    }
+
+    /// Channels to deliver *now* for this (user, workspace, type). Thin wrapper
+    /// over `resolve_delivery` (drops the resolved frequency).
+    pub async fn get_enabled_channels(
+        &self,
+        user_uuid: &Uuid,
+        workspace_id: i32,
+        notification_type: &NotificationTypeCode,
+    ) -> Result<Vec<NotificationChannel>, String> {
+        Ok(self
+            .resolve_delivery(user_uuid, workspace_id, notification_type)
+            .await?
+            .into_iter()
+            .map(|(channel, _)| channel)
+            .collect())
+    }
+
+    /// Whether the recipient's resolved IN-APP frequency is `instant` (the client
+    /// should interrupt with a toast + desktop notification) vs `quiet` (land in
+    /// the bell only). `false` when in-app doesn't deliver at all.
+    pub async fn in_app_interrupts(
+        &self,
+        user_uuid: &Uuid,
+        workspace_id: i32,
+        notification_type: &NotificationTypeCode,
+    ) -> Result<bool, String> {
+        Ok(self
+            .resolve_delivery(user_uuid, workspace_id, notification_type)
+            .await?
+            .into_iter()
+            .any(|(channel, freq)| {
+                channel == NotificationChannel::InApp && freq == NotificationFrequency::Instant
+            }))
     }
 
     /// Resolve the `instant` channels for one (user, workspace, type) across the
@@ -97,7 +143,7 @@ impl PreferenceService {
         user_uuid_val: &Uuid,
         workspace_id_val: i32,
         type_code: &str,
-    ) -> Result<Vec<NotificationChannel>, String> {
+    ) -> Result<Vec<(NotificationChannel, NotificationFrequency)>, String> {
         use crate::schema::{
             notification_preferences as np, notification_types as nt,
             workspace_notification_defaults as wnd,
@@ -113,30 +159,40 @@ impl PreferenceService {
         // workspace_notification_defaults is scoped by the explicit workspace_id
         // filter in the query below.
         // cross-tenant: notification_preferences is global per user (unique key excludes workspace_id); wnd is filtered by workspace_id in the query.
-        let (default_channels, ws_defaults, user_prefs) = crate::sync::session::background_run(
-            &self.pool,
-            "background:notification_pref_load",
-            |conn| {
-                let (type_id, default_channels): (i32, serde_json::Value) = nt::table
-                    .filter(nt::code.eq(type_code))
-                    .select((nt::id, nt::default_channels))
-                    .first(conn)?;
-                let ws_defaults: Vec<(String, String, bool)> = wnd::table
-                    .filter(wnd::workspace_id.eq(workspace_id_val))
-                    .filter(wnd::notification_type_id.eq(type_id))
-                    .select((wnd::channel, wnd::frequency, wnd::locked))
-                    .load(conn)
-                    .unwrap_or_default();
-                let user_prefs: Vec<(String, bool, Option<String>)> = np::table
-                    .filter(np::user_uuid.eq(user_uuid_val))
-                    .filter(np::notification_type_id.eq(type_id))
-                    .select((np::channel, np::enabled, np::frequency))
-                    .load(conn)
-                    .unwrap_or_default();
-                Ok::<_, diesel::result::Error>((default_channels, ws_defaults, user_prefs))
-            },
-        )
-        .map_err(|e| format!("Failed to load notification preferences: {e}"))?;
+        let (default_channels, type_interrupts, ws_defaults, user_prefs) =
+            crate::sync::session::background_run(
+                &self.pool,
+                "background:notification_pref_load",
+                |conn| {
+                    let (type_id, default_channels, type_interrupts): (
+                        i32,
+                        serde_json::Value,
+                        bool,
+                    ) = nt::table
+                        .filter(nt::code.eq(type_code))
+                        .select((nt::id, nt::default_channels, nt::interrupts))
+                        .first(conn)?;
+                    let ws_defaults: Vec<(String, String, bool)> = wnd::table
+                        .filter(wnd::workspace_id.eq(workspace_id_val))
+                        .filter(wnd::notification_type_id.eq(type_id))
+                        .select((wnd::channel, wnd::frequency, wnd::locked))
+                        .load(conn)
+                        .unwrap_or_default();
+                    let user_prefs: Vec<(String, bool, Option<String>)> = np::table
+                        .filter(np::user_uuid.eq(user_uuid_val))
+                        .filter(np::notification_type_id.eq(type_id))
+                        .select((np::channel, np::enabled, np::frequency))
+                        .load(conn)
+                        .unwrap_or_default();
+                    Ok::<_, diesel::result::Error>((
+                        default_channels,
+                        type_interrupts,
+                        ws_defaults,
+                        user_prefs,
+                    ))
+                },
+            )
+            .map_err(|e| format!("Failed to load notification preferences: {e}"))?;
 
         let system_defaults = self.parse_default_channels(&default_channels);
         let ws_map = Self::ws_default_map(ws_defaults);
@@ -144,9 +200,27 @@ impl PreferenceService {
 
         Ok(RESOLVED_CHANNELS
             .into_iter()
-            .filter(|ch| {
-                Self::resolve_channel(ch, &system_defaults, &ws_map, &user_map).0
-                    == NotificationFrequency::Instant
+            .filter_map(|ch| {
+                let freq = Self::resolve_channel(
+                    &ch,
+                    type_interrupts,
+                    &system_defaults,
+                    &ws_map,
+                    &user_map,
+                )
+                .0;
+                // A channel that can't be quiet (email/push) coerces quiet ->
+                // instant, so a mis-set quiet still delivers rather than vanishing.
+                let freq = if freq == NotificationFrequency::Quiet && !ch.supports_quiet() {
+                    NotificationFrequency::Instant
+                } else {
+                    freq
+                };
+                // Deliver-now = instant on any channel, or quiet on in-app (bell
+                // without an interrupt). digest/off are not delivered here.
+                let delivers_now = freq == NotificationFrequency::Instant
+                    || (freq == NotificationFrequency::Quiet && ch.supports_quiet());
+                delivers_now.then_some((ch, freq))
             })
             .collect())
     }
@@ -154,18 +228,25 @@ impl PreferenceService {
     /// Effective `(frequency, locked)` for one channel across the inheritance.
     fn resolve_channel(
         channel: &NotificationChannel,
+        type_interrupts: bool,
         system_defaults: &[NotificationChannel],
         ws_map: &HashMap<String, (NotificationFrequency, bool)>,
         user_map: &HashMap<String, NotificationFrequency>,
     ) -> (NotificationFrequency, bool) {
         let key = channel.as_str();
-        // Base = workspace default if set, else the system default (listed
-        // channel → instant, else off).
+        // Base = workspace default if set, else the system default. A listed
+        // channel defaults to `instant`, EXCEPT in-app on an informational
+        // (non-interrupting) type, which defaults to `quiet` (bell only). A
+        // channel not in the default list is `off`.
         let (base, locked) = match ws_map.get(key) {
             Some((freq, locked)) => (*freq, *locked),
             None => {
                 let f = if system_defaults.contains(channel) {
-                    NotificationFrequency::Instant
+                    if channel.supports_quiet() && !type_interrupts {
+                        NotificationFrequency::Quiet
+                    } else {
+                        NotificationFrequency::Instant
+                    }
                 } else {
                     NotificationFrequency::Off
                 };
@@ -225,12 +306,18 @@ impl PreferenceService {
         use crate::schema::notification_preferences::dsl::*;
         use crate::schema::notification_types;
 
-        let frequency_val =
-            if frequency_val == NotificationFrequency::Digest && !channel_val.supports_digest() {
+        // Coerce a frequency the channel can't honour to `instant` (rather than
+        // silently dropping delivery): `digest` is email-only, `quiet` is
+        // in-app-only.
+        let frequency_val = match frequency_val {
+            NotificationFrequency::Digest if !channel_val.supports_digest() => {
                 NotificationFrequency::Instant
-            } else {
-                frequency_val
-            };
+            }
+            NotificationFrequency::Quiet if !channel_val.supports_quiet() => {
+                NotificationFrequency::Instant
+            }
+            other => other,
+        };
         let enabled_val = frequency_val.to_enabled();
 
         // notification_preferences carries an audit trigger but has no
@@ -387,8 +474,13 @@ impl PreferenceService {
             let mut frequencies = HashMap::new();
             let mut locked = HashMap::new();
             for ch in RESOLVED_CHANNELS {
-                let (freq, is_locked) =
-                    Self::resolve_channel(&ch, &system_defaults, &ws_map, &user_map);
+                let (freq, is_locked) = Self::resolve_channel(
+                    &ch,
+                    notif_type.interrupts,
+                    &system_defaults,
+                    &ws_map,
+                    &user_map,
+                );
                 channels.insert(ch.as_str().to_string(), freq.to_enabled());
                 frequencies.insert(ch.as_str().to_string(), freq.as_str().to_string());
                 locked.insert(ch.as_str().to_string(), is_locked);
@@ -498,12 +590,18 @@ impl PreferenceService {
         use crate::schema::notification_types;
         use crate::schema::workspace_notification_defaults::dsl::*;
 
-        let frequency_val =
-            if frequency_val == NotificationFrequency::Digest && !channel_val.supports_digest() {
+        // Coerce a frequency the channel can't honour to `instant` (rather than
+        // silently dropping delivery): `digest` is email-only, `quiet` is
+        // in-app-only.
+        let frequency_val = match frequency_val {
+            NotificationFrequency::Digest if !channel_val.supports_digest() => {
                 NotificationFrequency::Instant
-            } else {
-                frequency_val
-            };
+            }
+            NotificationFrequency::Quiet if !channel_val.supports_quiet() => {
+                NotificationFrequency::Instant
+            }
+            other => other,
+        };
 
         let mut conn = self
             .pool
@@ -559,11 +657,11 @@ mod tests {
         let ws = HashMap::new();
         let user = HashMap::new();
         assert_eq!(
-            PreferenceService::resolve_channel(&ch("in_app"), &sys, &ws, &user),
+            PreferenceService::resolve_channel(&ch("in_app"), true, &sys, &ws, &user),
             (NotificationFrequency::Instant, false)
         );
         assert_eq!(
-            PreferenceService::resolve_channel(&ch("email"), &sys, &ws, &user),
+            PreferenceService::resolve_channel(&ch("email"), true, &sys, &ws, &user),
             (NotificationFrequency::Off, false)
         );
     }
@@ -575,7 +673,7 @@ mod tests {
         ws.insert("email".to_string(), (NotificationFrequency::Digest, false));
         let user = HashMap::new();
         assert_eq!(
-            PreferenceService::resolve_channel(&ch("email"), &sys, &ws, &user),
+            PreferenceService::resolve_channel(&ch("email"), true, &sys, &ws, &user),
             (NotificationFrequency::Digest, false)
         );
     }
@@ -590,15 +688,43 @@ mod tests {
         // Unlocked workspace default → the user's override wins.
         ws.insert("email".to_string(), (NotificationFrequency::Instant, false));
         assert_eq!(
-            PreferenceService::resolve_channel(&ch("email"), &sys, &ws, &user).0,
+            PreferenceService::resolve_channel(&ch("email"), true, &sys, &ws, &user).0,
             NotificationFrequency::Off
         );
 
         // Locked workspace default → the user cannot override it.
         ws.insert("email".to_string(), (NotificationFrequency::Instant, true));
         assert_eq!(
-            PreferenceService::resolve_channel(&ch("email"), &sys, &ws, &user),
+            PreferenceService::resolve_channel(&ch("email"), true, &sys, &ws, &user),
             (NotificationFrequency::Instant, true)
+        );
+    }
+
+    #[test]
+    fn in_app_default_follows_type_interrupt_classification() {
+        // in_app is a system default. An interrupting type defaults it to
+        // instant (toast); an informational type defaults it to quiet (bell
+        // only). Email ignores the quiet notion regardless.
+        let sys = vec![NotificationChannel::InApp, NotificationChannel::Email];
+        let ws = HashMap::new();
+        let user = HashMap::new();
+
+        assert_eq!(
+            PreferenceService::resolve_channel(&ch("in_app"), true, &sys, &ws, &user).0,
+            NotificationFrequency::Instant,
+            "interrupting type → in-app instant"
+        );
+        assert_eq!(
+            PreferenceService::resolve_channel(&ch("in_app"), false, &sys, &ws, &user).0,
+            NotificationFrequency::Quiet,
+            "informational type → in-app quiet"
+        );
+        // Email has no quiet tier: it stays instant even for an informational
+        // (non-interrupting) type.
+        assert_eq!(
+            PreferenceService::resolve_channel(&ch("email"), false, &sys, &ws, &user).0,
+            NotificationFrequency::Instant,
+            "email default is instant regardless of interrupt classification"
         );
     }
 }

--- a/backend/src/services/notifications/preferences.rs
+++ b/backend/src/services/notifications/preferences.rs
@@ -158,8 +158,8 @@ impl PreferenceService {
         // user's prefs. So read under bypass; the per-workspace
         // workspace_notification_defaults is scoped by the explicit workspace_id
         // filter in the query below.
-        // cross-tenant: notification_preferences is global per user (unique key excludes workspace_id); wnd is filtered by workspace_id in the query.
         let (default_channels, type_interrupts, ws_defaults, user_prefs) =
+            // cross-tenant: notification_preferences is global per user (unique key excludes workspace_id); wnd is filtered by workspace_id in the query.
             crate::sync::session::background_run(
                 &self.pool,
                 "background:notification_pref_load",

--- a/backend/src/services/notifications/service.rs
+++ b/backend/src/services/notifications/service.rs
@@ -141,9 +141,19 @@ impl NotificationService {
             return Ok(());
         }
 
-        // 3. Persist notification to database
+        // 3. Persist notification to database. The in-app payload carries whether
+        //    the client should interrupt (resolved in-app frequency == instant)
+        //    vs land quietly in the bell.
+        let interrupts = self
+            .preference_service
+            .in_app_interrupts(
+                &payload.recipient_uuid,
+                payload.workspace_id,
+                &payload.notification_type,
+            )
+            .await?;
         let notification_id = self
-            .persist_notification(&payload, &deliverable_channels)
+            .persist_notification(&payload, &deliverable_channels, interrupts)
             .await?;
 
         // 4. Create deliverable notification
@@ -212,6 +222,7 @@ impl NotificationService {
         &self,
         payload: &NotificationPayload,
         channels: &[NotificationChannel],
+        interrupts: bool,
     ) -> Result<i32, String> {
         use crate::schema::notifications;
 
@@ -322,6 +333,7 @@ impl NotificationService {
                         actor: payload.actor.clone(),
                         metadata: payload.metadata.clone(),
                         timestamp: payload.created_at,
+                        interrupts,
                     };
                     emit::record(
                         conn,

--- a/backend/src/services/notifications/types.rs
+++ b/backend/src/services/notifications/types.rs
@@ -146,6 +146,13 @@ impl NotificationChannel {
     pub fn supports_digest(&self) -> bool {
         matches!(self, Self::Email)
     }
+
+    /// Whether `quiet` (deliver-but-don't-interrupt) is meaningful. Only in-app
+    /// has an inbox that can hold a notification without interrupting; email and
+    /// push are deliver-or-not, so they coerce a `quiet` preference to `instant`.
+    pub fn supports_quiet(&self) -> bool {
+        matches!(self, Self::InApp)
+    }
 }
 
 /// Per-(user, type, channel) delivery frequency — replaces the binary
@@ -154,8 +161,12 @@ impl NotificationChannel {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum NotificationFrequency {
-    /// Deliver immediately on this channel.
+    /// Deliver immediately on this channel (in-app: toast + desktop interrupt).
     Instant,
+    /// Deliver to the in-app inbox (bell + unseen badge) WITHOUT interrupting —
+    /// no toast / desktop popup. In-app only (see `supports_quiet`); other
+    /// channels coerce it to `Instant`.
+    Quiet,
     /// Batch into a periodic summary (email only — see `supports_digest`).
     Digest,
     /// Never deliver on this channel.
@@ -166,6 +177,7 @@ impl NotificationFrequency {
     pub fn as_str(&self) -> &'static str {
         match self {
             Self::Instant => "instant",
+            Self::Quiet => "quiet",
             Self::Digest => "digest",
             Self::Off => "off",
         }
@@ -174,6 +186,7 @@ impl NotificationFrequency {
     pub fn from_str(s: &str) -> Option<Self> {
         match s {
             "instant" => Some(Self::Instant),
+            "quiet" => Some(Self::Quiet),
             "digest" => Some(Self::Digest),
             "off" => Some(Self::Off),
             _ => None,
@@ -366,6 +379,16 @@ pub struct NotificationEvent {
     #[serde(default)]
     pub metadata: serde_json::Value,
     pub timestamp: DateTime<Utc>,
+    /// Whether the client should INTERRUPT (toast + desktop) for this event, vs
+    /// let it land quietly in the bell. Reflects the recipient's RESOLVED in-app
+    /// frequency (`instant` → true, `quiet` → false). Defaults to `true` on the
+    /// legacy `From` path (which lacks the resolved frequency).
+    #[serde(default = "default_true")]
+    pub interrupts: bool,
+}
+
+fn default_true() -> bool {
+    true
 }
 
 impl From<&DeliverableNotification> for NotificationEvent {
@@ -381,6 +404,7 @@ impl From<&DeliverableNotification> for NotificationEvent {
             actor: notification.payload.actor.clone(),
             metadata: notification.payload.metadata.clone(),
             timestamp: notification.payload.created_at,
+            interrupts: true,
         }
     }
 }

--- a/frontend/src/components/settings/NotificationSettings.vue
+++ b/frontend/src/components/settings/NotificationSettings.vue
@@ -10,6 +10,7 @@ import {
   getNotificationPreferences,
   updateNotificationPreference,
   channelSupportsDigest,
+  channelSupportsQuiet,
   NOTIFICATION_CHANNELS,
   type NotificationPreference,
   type NotificationFrequency,
@@ -107,11 +108,15 @@ const typeDescription = (row: NotificationPreference) =>
     row.description ?? ''
   );
 
-// Frequency choices for a channel — `digest` only where the channel batches.
+// Frequency choices for a channel — `quiet` only for in-app (bell without a
+// toast), `digest` only where the channel batches (email).
 const frequencyOptions = (channelCode: string): DropdownOption[] => {
   const options: DropdownOption[] = [
     { value: 'instant', label: t('settings-notifications-frequency-instant') },
   ];
+  if (channelSupportsQuiet(channelCode)) {
+    options.push({ value: 'quiet', label: t('settings-notifications-frequency-quiet') });
+  }
   if (channelSupportsDigest(channelCode)) {
     options.push({ value: 'digest', label: t('settings-notifications-frequency-digest') });
   }

--- a/frontend/src/composables/useNotificationSSE.ts
+++ b/frontend/src/composables/useNotificationSSE.ts
@@ -17,34 +17,6 @@ import type { NotificationReceivedEventData } from '@nosdesk/core/types/sse';
 
 type NotificationEventData = NotificationReceivedEventData['notification'];
 
-// Which notification kinds may reach the INTERRUPT channel (a toast + desktop
-// popup + sound). Per the alarm-discipline review: only signals that require the
-// recipient to act — or are direct human communication — should interrupt; the
-// rest land quietly in the bell/inbox (which updates via the notifications
-// store's own SSE handler, independent of this gate). So an informational kind
-// still appears in the bell and bumps the unseen badge, it just doesn't pop.
-//
-//   Interrupt: mentioned, comment_added, ticket_assigned, sla_breached, loan_overdue
-//   Quiet:     ticket_status_changed, asset_low_stock, loan_due_soon,
-//              doc_page_updated, ticket_created_requester
-const INTERRUPTING_TYPES = new Set<string>([
-  'mentioned',
-  'comment_added',
-  'ticket_assigned',
-  'sla_breached',
-  'loan_overdue',
-]);
-
-/**
- * True when a notification kind warrants an interrupt (toast + desktop), vs
- * landing quietly in the bell. Unknown kinds default to QUIET: a new signal must
- * be classified into the interrupt set to earn the interrupt, it doesn't inherit
- * it (the review's "default new sources to non-interruptive" principle).
- */
-function shouldInterrupt(notificationType: string | undefined): boolean {
-  return !!notificationType && INTERRUPTING_TYPES.has(notificationType);
-}
-
 export function useNotificationSSE() {
   const authStore = useAuthStore();
   const toastStore = useToastStore();
@@ -59,11 +31,12 @@ export function useNotificationSSE() {
         return;
       }
 
-      // Rationalize the interrupt channel: informational kinds still land in the
-      // bell (via the notifications store's separate handler) but do not toast,
-      // raise a desktop notification, or sound. Only alarm / human-comms kinds
-      // interrupt.
-      if (!shouldInterrupt(notification.notification_type)) {
+      // Rationalize the interrupt channel: the backend resolves whether this
+      // event interrupts (the recipient's in-app frequency — instant vs quiet).
+      // A `quiet` notification still lands in the bell (via the notifications
+      // store's separate handler) but does not toast, raise a desktop
+      // notification, or sound. `interrupts` absent (legacy payload) → interrupt.
+      if (notification.interrupts === false) {
         return;
       }
 

--- a/i18n/locales/en-US/main.ftl
+++ b/i18n/locales/en-US/main.ftl
@@ -3653,6 +3653,7 @@ settings-notifications-info-footer = Email notifications are rate limited to pre
 
 # Notification frequency, push channel + admin defaults (2026-07-16)
 settings-notifications-frequency-instant = Instant
+settings-notifications-frequency-quiet = Quiet (no popup)
 settings-notifications-frequency-digest = Daily digest
 settings-notifications-frequency-off = Off
 settings-notifications-frequency-mixed = Mixed

--- a/i18n/locales/fr-FR/main.ftl
+++ b/i18n/locales/fr-FR/main.ftl
@@ -3503,6 +3503,8 @@ settings-notifications-info-footer = Les notifications par e-mail sont limitées
 
 # Fréquence de notification, canal push + valeurs par défaut admin (2026-07-16)
 settings-notifications-frequency-instant = Instantané
+# MACHINE TRANSLATION, pending native review
+settings-notifications-frequency-quiet = Discret (sans pop-up)
 settings-notifications-frequency-digest = Résumé quotidien
 settings-notifications-frequency-off = Désactivé
 settings-notifications-frequency-mixed = Mixte

--- a/i18n/locales/nl-NL/main.ftl
+++ b/i18n/locales/nl-NL/main.ftl
@@ -3494,6 +3494,8 @@ settings-notifications-info-footer = E-mailmeldingen zijn snelheidsbeperkt om uw
 
 # Meldingsfrequentie, pushkanaal + standaardinstellingen beheerder (2026-07-16)
 settings-notifications-frequency-instant = Direct
+# MACHINE TRANSLATION, pending native review
+settings-notifications-frequency-quiet = Stil (geen pop-up)
 settings-notifications-frequency-digest = Dagelijks overzicht
 settings-notifications-frequency-off = Uit
 settings-notifications-frequency-mixed = Gemengd

--- a/packages/core/src/services/notificationService.ts
+++ b/packages/core/src/services/notificationService.ts
@@ -12,7 +12,7 @@ import apiClient from '../apiClient';
  * - `digest`  — batch into a periodic summary (email only; see `channelSupportsDigest`)
  * - `off`     — never deliver on this channel
  */
-export type NotificationFrequency = 'instant' | 'digest' | 'off';
+export type NotificationFrequency = 'instant' | 'quiet' | 'digest' | 'off';
 
 /** Whether `digest` is a meaningful frequency for a channel. Only the email
  *  channel batches into a summary; in-app is a live stream and push is
@@ -20,6 +20,13 @@ export type NotificationFrequency = 'instant' | 'digest' | 'off';
  *  the backend `NotificationChannel::supports_digest`. */
 export function channelSupportsDigest(channelCode: string): boolean {
   return channelCode === 'email';
+}
+
+/** Whether `quiet` (deliver to the bell but don't toast/interrupt) is a
+ *  meaningful frequency for a channel. Only in-app has an inbox that can hold a
+ *  notification without interrupting. Mirrors `NotificationChannel::supports_quiet`. */
+export function channelSupportsQuiet(channelCode: string): boolean {
+  return channelCode === 'in_app';
 }
 
 export interface NotificationPreference {

--- a/packages/core/src/types/sse.ts
+++ b/packages/core/src/types/sse.ts
@@ -76,6 +76,11 @@ export interface NotificationReceivedEventData {
     actor: NotificationActor
     metadata?: Record<string, unknown>
     timestamp: string
+    /** Whether the client should INTERRUPT (toast + desktop) vs let it land
+     *  quietly in the bell. Reflects the recipient's resolved in-app frequency
+     *  (instant → true, quiet → false). Absent on pre-#2 payloads → treat as
+     *  true (interrupt) so nothing is silently dropped mid-rollout. */
+    interrupts?: boolean
   }
 }
 


### PR DESCRIPTION
## What

Second pass from the notification-system review (alarm-discipline rubric). Promotes the "which notifications should interrupt" decision out of a hardcoded client list and into the data model, and makes the in-app channel tri-state.

- New column `notification_types.interrupts` classifies each type as an **alarm** (requires action) or **informational**. Seeded: alarm (`mentioned`, `comment_added`, `ticket_assigned`, `sla_breached`, `loan_overdue`); informational (`ticket_status_changed`, `asset_low_stock`, `loan_due_soon`, `doc_page_updated`, `ticket_created_requester`).
- New `NotificationFrequency::Quiet` (in-app only): delivers to the bell/inbox but does not pop a toast or desktop notification. In-app defaults to **Quiet** for informational types and **Instant** for alarms; users override per type in settings. Email/push don't support Quiet, so it coerces to Instant there.
- `notify()` resolves the recipient's in-app frequency and stamps a resolved `interrupts` flag on the SSE payload. `useNotificationSSE` gates toast/sound/desktop Notification on that flag (replaces the client-side `INTERRUPTING_TYPES` set from pass #1).

## Why

Pass #1 gated the interrupt channel with a hardcoded type list on the client. This moves classification server-side so it's a first-class, per-type, per-user setting, and the toast actually respects a user's quiet override instead of firing for every notification.

## Verification

- Backend compiles; 4 preference tests pass incl. new `in_app_default_follows_type_interrupt_classification`.
- Migration applied on dev; `interrupts` seeded correctly; backend serves clean (no schema/notification errors).
- core + frontend type-check pass; settings UI shows the **Quiet (no popup)** in-app option.