### PR TITLE
Docs seed: refresh the welcome page + carry link hrefs through the converter

### DIFF
--- a/backend/seeds/getting-started.md
+++ b/backend/seeds/getting-started.md
@@ -1,29 +1,30 @@
-# Welcome to Nosdesk
+Nosdesk brings your helpdesk and your team's knowledge into one place: tickets and email, projects and cycles, the assets you support, and the documentation you are reading now.
 
-Nosdesk is your team's knowledge base and helpdesk platform. This documentation system helps you organize, share, and collaborate on information across your organization.
+## Start here
 
-## Getting Started
+- **Tickets** are the core of the helpdesk. Incoming email becomes a ticket, and your replies go back to the requester. See [working the ticket queue](https://nosdesk.com/docs/guide/ticket-queue).
+- **Getting around** covers the sidebar, search, and your dashboard: [finding your way around](https://nosdesk.com/docs/guide/getting-around).
+- **Notifications** tell you about mentions, assignments, and SLA breaches, and you choose which ones interrupt you: [notifications and mentions](https://nosdesk.com/docs/guide/notifications).
 
-Here are a few things you can do:
+## Documentation
 
-- **Create pages** using the sidebar navigation - click the + button to add new documents
-- **Organize with hierarchy** - drag and drop pages in the sidebar to nest them under parent pages
-- **Collaborate in real-time** - multiple team members can edit the same document simultaneously
-- **Use rich formatting** - headings, lists, code blocks, images, links, and more
-- **Embed documents** - use the Insert menu to embed other documents inline
-- **Export to Markdown** - download any page as a `.md` file
+You are reading a page in the **Getting Started** collection. Pages live in collections, and a page can belong to more than one.
 
-## Collections
+- Create a page with the **+** button in the sidebar, and drag pages to nest them
+- Type `/` in the editor for formatting commands, and `@` to mention a teammate
+- Edit together in real time, with everyone seeing changes as they happen
+- Paste a ticket URL into a page to link it to that ticket
+- Set collection visibility to control which groups can read it
 
-Documents can belong to multiple collections for flexible organization:
+More in [writing and sharing documentation](https://nosdesk.com/docs/guide/knowledge-base).
 
-- **Getting Started** - You're reading a page in this collection right now
-- **Tickets** - Documents created from ticket notes are automatically added here
-- Create your own collections to organize documentation by team, project, or topic
+## Also in Nosdesk
 
-## Tips
+- **Projects and cycles** group work over time: [projects and cycles](https://nosdesk.com/docs/guide/projects-and-cycles)
+- **Assets** track the devices you support and connect them to the tickets about them: [assets and devices](https://nosdesk.com/docs/guide/assets-and-devices)
 
-- Use `/` slash commands in the editor for quick formatting
-- Mention team members with `@` to reference them in documents
-- Link to tickets by pasting a ticket URL into the editor
-- Set collection visibility to control which groups can access specific documentation
+## For administrators
+
+Email, authentication, SLA policies, and workspace settings are all under **Settings**. The [configuration guide](https://nosdesk.com/docs/operations/configuration) walks through the options.
+
+Full documentation lives at [nosdesk.com/docs](https://nosdesk.com/docs).

--- a/backend/seeds/getting-started.md
+++ b/backend/seeds/getting-started.md
@@ -1,30 +1,33 @@
-Nosdesk brings your helpdesk and your team's knowledge into one place: tickets and email, projects and cycles, the assets you support, and the documentation you are reading now.
+Nosdesk is a helpdesk with a knowledge base built in. It tracks support tickets, groups work into projects and cycles, and keeps a record of the devices you support. Documentation lives here too, including the page you are reading.
 
 ## Start here
 
-- **Tickets** are the core of the helpdesk. Incoming email becomes a ticket, and your replies go back to the requester. See [working the ticket queue](https://nosdesk.com/docs/guide/ticket-queue).
-- **Getting around** covers the sidebar, search, and your dashboard: [finding your way around](https://nosdesk.com/docs/guide/getting-around).
-- **Notifications** tell you about mentions, assignments, and SLA breaches, and you choose which ones interrupt you: [notifications and mentions](https://nosdesk.com/docs/guide/notifications).
+Tickets are where most of the work happens. Incoming email becomes a ticket, and your replies go back to the requester. See [working the ticket queue](https://nosdesk.com/docs/guide/ticket-queue).
+
+For a tour of the sidebar, search, and your dashboard, read [finding your way around](https://nosdesk.com/docs/guide/getting-around).
+
+Notifications cover mentions, assignments, and SLA breaches, and you choose which of them interrupt you. See [notifications and mentions](https://nosdesk.com/docs/guide/notifications).
 
 ## Documentation
 
-You are reading a page in the **Getting Started** collection. Pages live in collections, and a page can belong to more than one.
+You are reading a page in the Getting Started collection. Pages live in collections, and a page can belong to more than one.
 
-- Create a page with the **+** button in the sidebar, and drag pages to nest them
+- Add a page with the + button in the sidebar, and drag pages to nest them
 - Type `/` in the editor for formatting commands, and `@` to mention a teammate
-- Edit together in real time, with everyone seeing changes as they happen
+- Several people can edit a page at once, and everyone sees the changes as they happen
 - Paste a ticket URL into a page to link it to that ticket
-- Set collection visibility to control which groups can read it
+- Collection visibility controls which groups can read a collection
 
 More in [writing and sharing documentation](https://nosdesk.com/docs/guide/knowledge-base).
 
-## Also in Nosdesk
+## Projects and assets
 
-- **Projects and cycles** group work over time: [projects and cycles](https://nosdesk.com/docs/guide/projects-and-cycles)
-- **Assets** track the devices you support and connect them to the tickets about them: [assets and devices](https://nosdesk.com/docs/guide/assets-and-devices)
+Projects and cycles group work over time. See [projects and cycles](https://nosdesk.com/docs/guide/projects-and-cycles).
+
+Assets track the devices you support and connect them to the tickets about them. See [assets and devices](https://nosdesk.com/docs/guide/assets-and-devices).
 
 ## For administrators
 
-Email, authentication, SLA policies, and workspace settings are all under **Settings**. The [configuration guide](https://nosdesk.com/docs/operations/configuration) walks through the options.
+Email, authentication, SLA policies, and workspace settings are under Settings. The [configuration guide](https://nosdesk.com/docs/operations/configuration) walks through the options.
 
 Full documentation lives at [nosdesk.com/docs](https://nosdesk.com/docs).

--- a/backend/src/services/seed.rs
+++ b/backend/src/services/seed.rs
@@ -329,6 +329,11 @@ enum InlineSpan<'a> {
     Bold(&'a str),
     Italic(&'a str),
     Code(&'a str),
+    /// `[text](href)` — carries the destination through as a real link mark.
+    Link {
+        text: &'a str,
+        href: &'a str,
+    },
 }
 
 /// Parse inline markdown into an XmlDeltaPrelim with proper text formatting attributes.
@@ -360,6 +365,17 @@ fn parse_inline_to_delta(text: &str) -> XmlDeltaPrelim {
                 let attrs = HashMap::from([(Arc::from("code"), Any::Bool(true))]);
                 delta.push(Delta::insert_with(s, attrs));
             }
+            InlineSpan::Link { text, href } => {
+                // Unlike the boolean marks, `link` carries attributes, so the
+                // mark value is the ProseMirror attrs map (schema: href
+                // required, title optional) rather than `true`.
+                let link_attrs = Any::from(HashMap::from([(
+                    "href".to_string(),
+                    Any::String(href.into()),
+                )]));
+                let attrs = HashMap::from([(Arc::from("link"), link_attrs)]);
+                delta.push(Delta::insert_with(text, attrs));
+            }
         }
     }
 
@@ -375,7 +391,7 @@ fn parse_inline_to_delta(text: &str) -> XmlDeltaPrelim {
 }
 
 /// Parse a line of text into inline spans, recognizing **bold**, *italic*, `code`,
-/// and [link text](url) (links rendered as plain text).
+/// and [link text](href).
 fn parse_inline_spans(text: &str) -> Vec<InlineSpan<'_>> {
     let mut spans = Vec::new();
     let mut remaining = text;
@@ -416,14 +432,24 @@ fn parse_inline_spans(text: &str) -> Vec<InlineSpan<'_>> {
                 }
             }
 
-            // Link: [text](url) -> render as plain text
+            // Link: [text](href)
             if after.starts_with('[') {
                 if let Some(bracket_end) = after.find(']') {
                     let link_text = &after[1..bracket_end];
                     let after_bracket = &after[bracket_end + 1..];
                     if after_bracket.starts_with('(') {
                         if let Some(paren_end) = after_bracket.find(')') {
-                            spans.push(InlineSpan::Plain(link_text));
+                            let href = &after_bracket[1..paren_end];
+                            // An empty href would produce a link mark with no
+                            // destination; fall back to plain text.
+                            if href.is_empty() {
+                                spans.push(InlineSpan::Plain(link_text));
+                            } else {
+                                spans.push(InlineSpan::Link {
+                                    text: link_text,
+                                    href,
+                                });
+                            }
                             remaining = &after_bracket[paren_end + 1..];
                             continue;
                         }
@@ -441,6 +467,59 @@ fn parse_inline_spans(text: &str) -> Vec<InlineSpan<'_>> {
     }
 
     spans
+}
+
+#[cfg(test)]
+mod inline_tests {
+    use super::{parse_inline_spans, InlineSpan};
+
+    /// The seeded welcome page links out to the public docs, so the converter
+    /// has to carry the destination through. It used to drop the href and
+    /// render link text as plain text.
+    #[test]
+    fn link_keeps_its_href() {
+        let spans = parse_inline_spans("see the [user guide](https://nosdesk.com/docs/guide) now");
+        let link = spans
+            .iter()
+            .find_map(|s| match s {
+                InlineSpan::Link { text, href } => Some((*text, *href)),
+                _ => None,
+            })
+            .expect("a link span");
+        assert_eq!(link, ("user guide", "https://nosdesk.com/docs/guide"));
+    }
+
+    #[test]
+    fn empty_href_falls_back_to_plain_text() {
+        let spans = parse_inline_spans("[bare]()");
+        assert!(
+            !spans.iter().any(|s| matches!(s, InlineSpan::Link { .. })),
+            "an empty href must not produce a destination-less link mark"
+        );
+    }
+
+    /// End-to-end guard on the shipped welcome page: it converts, and the
+    /// public-docs links survive into the encoded document. Fails both if the
+    /// converter drops hrefs again and if the seed file loses its links.
+    #[test]
+    fn seeded_welcome_page_encodes_real_links() {
+        let markdown = include_str!("../../seeds/getting-started.md");
+        let bytes = super::markdown_to_yjs(markdown).expect("welcome markdown converts");
+        let encoded = String::from_utf8_lossy(&bytes);
+        assert!(encoded.contains("link"), "link mark is encoded");
+        assert!(
+            encoded.contains("https://nosdesk.com/docs/guide/ticket-queue"),
+            "the href is carried into the document, not dropped"
+        );
+    }
+
+    #[test]
+    fn other_inline_marks_still_parse() {
+        let spans = parse_inline_spans("**b** *i* `c`");
+        assert!(spans.iter().any(|s| matches!(s, InlineSpan::Bold("b"))));
+        assert!(spans.iter().any(|s| matches!(s, InlineSpan::Italic("i"))));
+        assert!(spans.iter().any(|s| matches!(s, InlineSpan::Code("c"))));
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## What

The built-in "Welcome to Nosdesk" page was stale and had no way to point at the public docs. Two changes:

**1. The converter dropped link destinations.** `markdown_to_yjs` parsed `[text](href)` and kept only the text, discarding the URL (old `seed.rs:426`). Any link in a seeded page silently became plain text, so linking out was impossible as written. Added the ProseMirror `link` mark, matching the editor schema (`frontend/src/editor/schema.ts:116`: `href` required, `title` optional). Unlike the boolean marks (`strong`/`em`/`code`), the mark value is the attrs map. An empty `[text]()` still falls back to plain text rather than emitting a destination-less link. This also restores links in demo ticket bodies, which use the same converter.

**2. Rewrote the seeded welcome page.** It described Nosdesk as "your team's knowledge base" and then only covered the doc editor. It now says what the product is (tickets and email, projects and cycles, assets, documentation) and deep-links the public docs. Also dropped the redundant H1, the page title already renders from the page row.

Links point only at shipping, prerendered pages (`/docs/guide/ticket-queue`, `getting-around`, `notifications`, `knowledge-base`, `projects-and-cycles`, `assets-and-devices`, `/docs/operations/configuration`, and `/docs`). None of the `status: 'planned'` topics are linked.

## Fixed a false claim

The old copy said documents from ticket notes are "automatically added" to a **Tickets** collection. That only holds in the bootstrap workspace: the auto-add is a bare `get_collection_by_slug(conn, "tickets")` with no create-if-missing (`handlers/documentation.rs:1729`), and only the initial migration creates that collection. The new copy doesn't assert it. **The underlying gap is left as a follow-up** (get-or-create the collection, mirroring `ensure_getting_started_collection`).

## Scope

Seed content only affects workspaces whose Getting Started collection is still empty, so this reaches **new workspaces**; existing ones keep their page (and any admin edits) untouched. No migration.

Separately noted, not addressed here: self-hosted workspaces created via `admin_workspaces.rs` never call `seed_getting_started`, so they get no welcome page at all.

## Verification

- `cargo check --lib` clean, rustfmt clean.
- 5 seed tests pass: href parsing, empty-href fallback, other inline marks still parse, the existing DB-backed seed test, and an end-to-end check that the **shipped** markdown encodes its links (fails if either the converter regresses or the seed file loses its links).