### PR TITLE
Plugin slots: the host draws the card chrome

### DIFF
--- a/backend/src/handlers/plugin_sandbox/runtime.js
+++ b/backend/src/handlers/plugin_sandbox/runtime.js
@@ -514,11 +514,22 @@ a { color: var(--nd-accent, #FF6B1A); }
 }
 .nd-textarea { resize: vertical; }
 
+/* An INNER sub-card, for grouping content inside a panel.
+ *
+ * This is deliberately not the app's outer card. A panel on a \`card\`-chrome
+ * slot is already wrapped by the host in the real \`SectionCard\` (border,
+ * radius, surface, header pill, 12px body padding), so a plugin that drew the
+ * outer card itself would produce a card inside a card. Use \`.nd-card\` only to
+ * subdivide, and use the surface-alt background so it reads as recessed
+ * against the host card it sits in.
+ *
+ * A contribution that genuinely needs to own its outer frame declares
+ * \`"chrome": "none"\` in its manifest and gets a bare, unwrapped iframe. */
 .nd-card {
   border: 1px solid var(--nd-border, #e5e7eb);
-  border-radius: var(--nd-radius, 8px);
+  border-radius: var(--nd-radius-sm, 6px);
   background: var(--nd-surface-alt, #f9fafb);
-  padding: 12px;
+  padding: var(--nd-space-sm, 8px);
 }
 
 .nd-label { font-weight: 600; color: var(--nd-text, #1f2937); }
@@ -554,16 +565,51 @@ ${vars}
   document.documentElement.setAttribute("data-nd-color-scheme", theme.colorScheme);
   document.documentElement.setAttribute("data-nd-theme", theme.name);
 }
+var HAS_CONTENT_UNMEASURED = -1;
+var CHASE_INTERVAL_MS = 50;
+var CHASE_MAX_TRIES = 40;
 function observeHeight(el) {
   let last = -1;
   const report = () => {
+    const isEmpty = el.children.length === 0 && !el.textContent?.trim();
+    if (isEmpty) {
+      if (last !== 0) {
+        last = 0;
+        reportHeight(0);
+      }
+      return;
+    }
     const h = Math.ceil(el.getBoundingClientRect().height);
-    if (h > 0 && h !== last) {
-      last = h;
-      reportHeight(h);
+    if (h > 0) {
+      if (h !== last) {
+        last = h;
+        reportHeight(h);
+      }
+      return;
+    }
+    if (last !== HAS_CONTENT_UNMEASURED) {
+      last = HAS_CONTENT_UNMEASURED;
+      reportHeight(HAS_CONTENT_UNMEASURED);
+      let tries = 0;
+      const chase = () => {
+        if (last !== HAS_CONTENT_UNMEASURED) return;
+        const px = Math.ceil(el.getBoundingClientRect().height);
+        if (px > 0) {
+          last = px;
+          reportHeight(px);
+          return;
+        }
+        if (++tries < CHASE_MAX_TRIES) setTimeout(chase, CHASE_INTERVAL_MS);
+      };
+      setTimeout(chase, CHASE_INTERVAL_MS);
     }
   };
   new ResizeObserver(report).observe(el);
+  new MutationObserver(report).observe(el, {
+    childList: true,
+    subtree: true,
+    characterData: true
+  });
   report();
 }
 async function boot() {
@@ -588,8 +634,10 @@ async function boot() {
     throw new Error("sandbox runtime: bundle has no default { mount } export");
   }
   const plugin = mod.default;
-  let instance = toInstance(plugin.mount(root, runtime.api, runtime.context));
-  observeHeight(root);
+  const mounted = plugin.mount(root, runtime.api, runtime.context);
+  let instance = toInstance(mounted);
+  void Promise.resolve(mounted).catch(() => {
+  }).then(() => observeHeight(root));
   runtime.onContextChange((ctx) => {
     if (instance.update) {
       instance.update(ctx);

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -6593,6 +6593,34 @@ pub struct PluginComponentConfig {
     pub label: Option<String>,
     pub icon: Option<String>,
     pub action: Option<PluginComponentAction>,
+
+    /// Override the host chrome drawn around this component, for `panel`
+    /// slots only. `None` (the usual case) takes the slot's default from
+    /// the generated slot registry. Set `Chrome::None` for genuinely
+    /// full-bleed content (a map, a media surface) that a card would frame
+    /// wrongly. Rejected on `action` slots, which have no iframe to wrap.
+    pub chrome: Option<PluginComponentChrome>,
+}
+
+/// Host chrome around a panel contribution. Mirrors the TS `SlotChrome`.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum PluginComponentChrome {
+    /// The app's `SectionCard`: border, radius, surface and a header pill
+    /// titled from `label`. The plugin fills the body only.
+    Card,
+    /// Bare frame, no host chrome.
+    None,
+}
+
+impl PluginComponentChrome {
+    /// Wire-format string (matches the serde `rename_all`).
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Card => "card",
+            Self::None => "none",
+        }
+    }
 }
 
 /// Component kind. Only `Slot` is implemented in v1; the others

--- a/backend/src/services/plugins/manifest_validate.rs
+++ b/backend/src/services/plugins/manifest_validate.rs
@@ -123,6 +123,10 @@ pub enum ManifestValidationError {
     InvalidEvent(String),
     InvalidSlot(String),
     InvalidContext(String),
+    /// `chrome` was set on an `action` slot, which draws no iframe frame.
+    ChromeOnNonPanelSlot {
+        slot: String,
+    },
     InvalidComponentKind(String),
     UnsupportedComponentKind(String),
     InvalidSettingType(String),
@@ -194,6 +198,10 @@ impl std::fmt::Display for ManifestValidationError {
             Self::InvalidEvent(e) => write!(f, "unknown event {e:?}"),
             Self::InvalidSlot(s) => write!(f, "unknown slot {s:?}"),
             Self::InvalidContext(c) => write!(f, "unknown component context {c:?}"),
+            Self::ChromeOnNonPanelSlot { slot } => write!(
+                f,
+                "slot {slot:?} renders as native host chrome, so \"chrome\" does not apply"
+            ),
             Self::InvalidComponentKind(k) => write!(f, "invalid component kind {k:?}"),
             Self::UnsupportedComponentKind(k) => write!(
                 f,
@@ -611,13 +619,22 @@ fn validate_component(component: &PluginComponentConfig) -> Result<(), ManifestV
         ));
     }
 
-    if !crate::services::plugins::slot_registry::is_known_slot(&component.slot) {
+    let Some(slot) = crate::services::plugins::slot_registry::get_slot(&component.slot) else {
         return Err(ManifestValidationError::InvalidSlot(component.slot.clone()));
-    }
+    };
     for ctx in &component.context {
         if !KNOWN_CONTEXTS.contains(&ctx.as_str()) {
             return Err(ManifestValidationError::InvalidContext(ctx.clone()));
         }
+    }
+    // `chrome` describes the frame the host draws around an iframe panel. An
+    // action slot has no iframe (the host renders a menu item / nav link and
+    // the component opens in a modal), so accepting the key there would
+    // silently do nothing. Refuse it instead of ignoring it.
+    if component.chrome.is_some() && slot.mechanism != "panel" {
+        return Err(ManifestValidationError::ChromeOnNonPanelSlot {
+            slot: component.slot.clone(),
+        });
     }
     Ok(())
 }
@@ -854,6 +871,7 @@ mod tests {
                 label: None,
                 icon: None,
                 action: None,
+                chrome: None,
             },
         );
         assert_err!(
@@ -875,12 +893,58 @@ mod tests {
                 label: None,
                 icon: None,
                 action: None,
+                chrome: None,
             },
         );
         assert_err!(
             validate(&m, &ctx_official()),
             ManifestValidationError::InvalidSlot(_)
         );
+    }
+
+    /// `chrome` describes the frame the host draws around an iframe panel, so
+    /// it is meaningless on an action slot. Refused rather than ignored, or an
+    /// author would set it, see nothing change, and have no idea why.
+    #[test]
+    fn rejects_chrome_on_an_action_slot() {
+        let mut m = baseline_manifest();
+        m.components.insert(
+            "Foo".into(),
+            PluginComponentConfig {
+                kind: PluginComponentKind::Slot,
+                slot: "ticket.header.action".into(),
+                entry: "Foo".into(),
+                context: vec![],
+                label: None,
+                icon: None,
+                action: None,
+                chrome: Some(crate::models::PluginComponentChrome::Card),
+            },
+        );
+        assert_err!(
+            validate(&m, &ctx_official()),
+            ManifestValidationError::ChromeOnNonPanelSlot { slot } if slot == "ticket.header.action",
+        );
+    }
+
+    /// The same key on a panel slot is the supported opt-out.
+    #[test]
+    fn accepts_chrome_on_a_panel_slot() {
+        let mut m = baseline_manifest();
+        m.components.insert(
+            "Foo".into(),
+            PluginComponentConfig {
+                kind: PluginComponentKind::Slot,
+                slot: "ticket.sidebar.panel".into(),
+                entry: "Foo".into(),
+                context: vec![],
+                label: None,
+                icon: None,
+                action: None,
+                chrome: Some(crate::models::PluginComponentChrome::None),
+            },
+        );
+        assert!(validate(&m, &ctx_official()).is_ok());
     }
 
     #[test]

--- a/backend/src/services/plugins/plugin_slots.generated.json
+++ b/backend/src/services/plugins/plugin_slots.generated.json
@@ -4,6 +4,7 @@
     "mechanism": "panel",
     "context": "ticket",
     "cardinality": "many",
+    "chrome": "card",
     "order": 100,
     "status": "stable",
     "aliases": [
@@ -16,6 +17,7 @@
     "mechanism": "panel",
     "context": "asset",
     "cardinality": "many",
+    "chrome": "card",
     "order": 100,
     "status": "stable",
     "aliases": [
@@ -28,6 +30,7 @@
     "mechanism": "panel",
     "context": "user",
     "cardinality": "many",
+    "chrome": "card",
     "order": 100,
     "status": "stable",
     "aliases": [],
@@ -38,6 +41,7 @@
     "mechanism": "panel",
     "context": "address",
     "cardinality": "many",
+    "chrome": "none",
     "order": 100,
     "status": "stable",
     "aliases": [],
@@ -48,6 +52,7 @@
     "mechanism": "panel",
     "context": "none",
     "cardinality": "many",
+    "chrome": "none",
     "order": 100,
     "status": "stable",
     "aliases": [
@@ -60,6 +65,7 @@
     "mechanism": "panel",
     "context": "none",
     "cardinality": "many",
+    "chrome": "none",
     "order": 100,
     "status": "stable",
     "aliases": [],
@@ -70,6 +76,7 @@
     "mechanism": "panel",
     "context": "ticket",
     "cardinality": "many",
+    "chrome": "none",
     "order": 100,
     "status": "reserved",
     "aliases": [
@@ -82,6 +89,7 @@
     "mechanism": "panel",
     "context": "documentationPage",
     "cardinality": "many",
+    "chrome": "card",
     "order": 100,
     "status": "reserved",
     "aliases": [
@@ -94,6 +102,7 @@
     "mechanism": "action",
     "context": "ticket",
     "cardinality": "many",
+    "chrome": "none",
     "order": 100,
     "status": "stable",
     "aliases": [
@@ -106,6 +115,7 @@
     "mechanism": "action",
     "context": "ticket",
     "cardinality": "many",
+    "chrome": "none",
     "order": 100,
     "status": "stable",
     "aliases": [],
@@ -116,6 +126,7 @@
     "mechanism": "action",
     "context": "asset",
     "cardinality": "many",
+    "chrome": "none",
     "order": 100,
     "status": "reserved",
     "aliases": [
@@ -128,6 +139,7 @@
     "mechanism": "action",
     "context": "documentationPage",
     "cardinality": "many",
+    "chrome": "none",
     "order": 100,
     "status": "reserved",
     "aliases": [
@@ -140,6 +152,7 @@
     "mechanism": "action",
     "context": "none",
     "cardinality": "many",
+    "chrome": "none",
     "order": 100,
     "status": "stable",
     "aliases": [

--- a/backend/src/services/plugins/slot_registry.rs
+++ b/backend/src/services/plugins/slot_registry.rs
@@ -21,12 +21,21 @@ pub struct SlotDef {
     pub mechanism: String,
     pub context: String,
     pub cardinality: String,
+    /// Host chrome drawn around a contribution ("card" / "none"), unless the
+    /// manifest component overrides it. Defaulted so an older generated JSON
+    /// (or a hand-rolled fixture) still parses.
+    #[serde(default = "default_chrome")]
+    pub chrome: String,
     pub order: i64,
     pub status: String,
     /// Legacy flat names still accepted at validation time.
     #[serde(default)]
     pub aliases: Vec<String>,
     pub description: String,
+}
+
+fn default_chrome() -> String {
+    "none".to_string()
 }
 
 static RAW: &str = include_str!("plugin_slots.generated.json");
@@ -40,9 +49,14 @@ pub static SLOT_REGISTRY: LazyLock<Vec<SlotDef>> = LazyLock::new(|| {
 
 /// True if `name` matches a canonical slot name or any of its aliases.
 pub fn is_known_slot(name: &str) -> bool {
+    get_slot(name).is_some()
+}
+
+/// Resolve a canonical-or-alias slot name to its definition.
+pub fn get_slot(name: &str) -> Option<&'static SlotDef> {
     SLOT_REGISTRY
         .iter()
-        .any(|s| s.name == name || s.aliases.iter().any(|a| a == name))
+        .find(|s| s.name == name || s.aliases.iter().any(|a| a == name))
 }
 
 #[cfg(test)]
@@ -81,6 +95,28 @@ mod tests {
             assert!(matches!(s.cardinality.as_str(), "one" | "many"));
             assert!(s.order >= 0);
             assert!(!s.description.is_empty());
+        }
+    }
+
+    #[test]
+    fn chrome_is_known_and_action_slots_carry_none() {
+        for s in SLOT_REGISTRY.iter() {
+            assert!(
+                matches!(s.chrome.as_str(), "card" | "none"),
+                "unknown chrome {} on {}",
+                s.chrome,
+                s.name
+            );
+            // An action slot is rendered as native host chrome (menu item, nav
+            // link), so there is no iframe to wrap. Anything but "none" here
+            // would mean the generator and the taxonomy have diverged.
+            if s.mechanism == "action" {
+                assert_eq!(
+                    s.chrome, "none",
+                    "action slot {} must not draw a card",
+                    s.name
+                );
+            }
         }
     }
 

--- a/frontend/src/components/plugins/PluginIcon.vue
+++ b/frontend/src/components/plugins/PluginIcon.vue
@@ -12,7 +12,9 @@ interface Props {
   uuid?: string;
   src?: string;
   alt: string;
-  size?: 'sm' | 'md' | 'lg';
+  /** `xs` matches the 16px leading glyph a `SectionCard` header expects; the
+   *  larger sizes are for list rows and detail headers. */
+  size?: 'xs' | 'sm' | 'md' | 'lg';
 }
 
 const props = withDefaults(defineProps<Props>(), { size: 'md' });
@@ -30,12 +32,14 @@ watch(resolvedSrc, () => {
 });
 
 const sizeClasses: Record<NonNullable<Props['size']>, string> = {
+  xs: 'h-4 w-4 rounded-[3px]',
   sm: 'h-8 w-8 rounded-md',
   md: 'h-10 w-10 rounded-lg',
   lg: 'h-20 w-20 rounded-2xl',
 };
 
 const glyphSizes: Record<NonNullable<Props['size']>, string> = {
+  xs: 'h-2.5 w-2.5',
   sm: 'h-4 w-4',
   md: 'h-5 w-5',
   lg: 'h-10 w-10',

--- a/frontend/src/plugins/components/PluginSandboxFrame.vue
+++ b/frontend/src/plugins/components/PluginSandboxFrame.vue
@@ -9,7 +9,7 @@
  * `sandbox="allow-scripts"` (no `allow-same-origin`), so it is a null origin:
  * no cookies, no first-party DOM, all host access flows through the bridge.
  */
-import { onBeforeUnmount, onMounted, ref, watch } from 'vue';
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue';
 import {
   createRemoteHostApi,
   postContext,
@@ -38,10 +38,29 @@ const props = defineProps<{
   actionActivated?: number;
 }>();
 
+const emit = defineEmits<{
+  /** Latest content height the plugin reported. `0` means it rendered nothing,
+   *  which lets a parent collapse its chrome; `null` means nothing reported
+   *  yet. Parents must keep this component MOUNTED when collapsing (height 0,
+   *  not `v-if`), or a plugin that starts empty and fills in later can never
+   *  report its way back. */
+  (e: 'contentHeight', px: number | null): void;
+}>();
+
 const frameRef = ref<HTMLIFrameElement | null>(null);
 const runtimeUrl = ref<string | null>(null);
 const error = ref<string | null>(null);
 const iframeHeight = ref<number | null>(null);
+
+watch(iframeHeight, (px) => emit('contentHeight', px));
+
+/** Only a real, positive measurement pins the iframe's height. `0` (rendered
+ *  nothing) and `-1` (has content, unmeasurable while the host hides it) are
+ *  signals for the parent's chrome, not sizes; letting either reach the inline
+ *  style would emit `height: -1px` or lock a recovering frame at zero. */
+const pinnedHeight = computed(() =>
+  iframeHeight.value != null && iframeHeight.value > 0 ? iframeHeight.value : null,
+);
 
 const themeStore = useThemeStore();
 
@@ -204,13 +223,14 @@ onBeforeUnmount(() => {
 
 <template>
   <div class="plugin-sandbox-frame" :data-plugin="plugin.name">
-    <!-- Error state (hidden on print) -->
+    <!-- Error state (hidden on print). Matches the app's inline error
+         treatment (centred, small, `text-status-error`) rather than drawing
+         its own red box, which read as foreign next to built-in cards. -->
     <div
       v-if="error"
-      class="print:hidden p-3 bg-red-500/10 border border-red-500/30 rounded text-sm text-red-400"
+      class="print:hidden flex items-center justify-center px-4 py-6 text-center text-xs text-status-error"
     >
-      <div class="font-medium">Plugin Error</div>
-      <div class="text-xs mt-1">{{ error }}</div>
+      {{ error }}
     </div>
 
     <iframe
@@ -220,7 +240,7 @@ onBeforeUnmount(() => {
       sandbox="allow-scripts"
       referrerpolicy="no-referrer"
       class="plugin-sandbox-iframe"
-      :style="iframeHeight ? { height: `${iframeHeight}px` } : undefined"
+      :style="pinnedHeight != null ? { height: `${pinnedHeight}px` } : undefined"
       @load="onFrameLoad"
     />
   </div>
@@ -233,9 +253,14 @@ onBeforeUnmount(() => {
   border: 0;
   background: transparent;
   /* Height tracks the plugin's reported content height (inline style, set from
-     the runtime's ResizeObserver over the bridge). min-height is the floor until
-     the first report arrives. */
-  min-height: 4rem;
+     the runtime's ResizeObserver over the bridge).
+
+     No min-height floor: one used to hold the frame at 4rem until the first
+     report landed, so every panel painted an empty 64px box and then jumped to
+     its real height, and a plugin that rendered nothing held 64px of blank
+     space forever. Starting at 0 and growing means the only motion is the
+     content arriving. The host chrome renders immediately either way, so there
+     is no blank-then-pop, and nothing here needs a skeleton. */
 }
 
 @media print {

--- a/frontend/src/plugins/components/PluginSlotItem.vue
+++ b/frontend/src/plugins/components/PluginSlotItem.vue
@@ -5,11 +5,20 @@
  * Renders one registered plugin component in a slot. Every plugin — every trust
  * tier — runs in the opaque-origin sandbox via PluginSandboxFrame; the in-process
  * Vue-component path was removed in the sandbox-all migration (4b-3c-4).
+ *
+ * This component owns the HOST CHROME around that frame. When the resolved
+ * chrome is `card` the frame is wrapped in the app's `SectionCard`, the same
+ * primitive every built-in card uses, so a plugin panel is spaced, bordered and
+ * titled identically to its neighbours without the plugin drawing any of it.
+ * When it is `none` the bare frame is mounted, for contributions whose host
+ * already supplies chrome or that sit inline inside another card.
  */
-import { onErrorCaptured, ref } from 'vue';
+import { computed, onErrorCaptured, ref } from 'vue';
 import { getLoadedPlugin, type PluginSlotRegistration } from '../loader';
 import type { PluginSlotContext } from '../context';
 import PluginSandboxFrame from './PluginSandboxFrame.vue';
+import PluginIcon from '@/components/plugins/PluginIcon.vue';
+import SectionCard from '@/components/common/SectionCard.vue';
 import { logger } from '@nosdesk/core/utils/logger';
 
 const props = defineProps<{
@@ -27,33 +36,86 @@ onErrorCaptured((err) => {
 });
 
 const loaded = getLoadedPlugin(props.registration.pluginUuid);
+
+// Latest height the plugin reported: null until the first report, 0 when it
+// rendered nothing.
+const contentHeight = ref<number | null>(null);
+
+/** A plugin that rendered nothing should leave no trace, not an empty card.
+ *  Only true once the plugin has actually reported 0 — before the first report
+ *  the chrome renders, so a panel with content never flashes in late. */
+const isEmpty = computed(() => contentHeight.value === 0 && !error.value);
+
+const withCard = computed(() => props.registration.chrome === 'card');
+
+const title = computed(
+  () => props.registration.label || loaded?.plugin.display_name || props.registration.pluginName,
+);
 </script>
 
 <template>
+  <!-- The wrapper is hidden when the plugin draws nothing, but the frame stays
+       MOUNTED inside it: a plugin that starts empty and fills in after a fetch
+       has to keep reporting, and unmounting the iframe would strand it empty
+       forever (it would re-mount, draw nothing, and report empty again).
+
+       `display: none` rather than a zero height, because these stacks are
+       `flex flex-col gap-3` and a zero-height child still draws a gap. Hiding
+       suspends layout in the guest, which is why the runtime falls back to the
+       HAS_CONTENT sentinel to ask for layout back. -->
   <div
     class="plugin-slot-item"
+    :class="{ 'plugin-slot-item--empty': isEmpty }"
+    :aria-hidden="isEmpty || undefined"
     :data-plugin="registration.pluginName"
     :data-component="registration.componentName"
   >
-    <!-- Error state (hidden on print) -->
-    <div v-if="error" class="print:hidden p-3 bg-red-500/10 border border-red-500/30 rounded text-sm text-red-400">
-      <div class="font-medium">Plugin Error</div>
-      <div class="text-xs mt-1">{{ error }}</div>
-    </div>
+    <!-- Body padding is left at SectionCard's default `p-3`, so a plugin panel
+         insets exactly like every built-in card and the plugin adds none of its
+         own. Content that genuinely needs the full bleed declares
+         `chrome: "none"` and draws its own frame. -->
+    <SectionCard v-if="withCard">
+      <template #leading>
+        <PluginIcon :uuid="registration.pluginUuid" :alt="title" size="xs" />
+      </template>
+      <template #title>{{ title }}</template>
 
-    <!-- Opaque-origin sandbox iframe over the bridge (all tiers) -->
-    <PluginSandboxFrame
-      v-else-if="loaded"
-      :plugin="loaded.plugin"
-      :component="{ name: registration.componentName, slot: slotName }"
-      :context="context"
-      :actionActivated="actionActivated"
-    />
+      <div v-if="error" class="px-4 py-6 text-center text-xs text-status-error">
+        {{ error }}
+      </div>
+      <PluginSandboxFrame
+        v-else-if="loaded"
+        :plugin="loaded.plugin"
+        :component="{ name: registration.componentName, slot: slotName }"
+        :context="context"
+        :actionActivated="actionActivated"
+        @content-height="contentHeight = $event"
+      />
+    </SectionCard>
+
+    <template v-else>
+      <div v-if="error" class="px-4 py-6 text-center text-xs text-status-error">
+        {{ error }}
+      </div>
+      <PluginSandboxFrame
+        v-else-if="loaded"
+        :plugin="loaded.plugin"
+        :component="{ name: registration.componentName, slot: slotName }"
+        :context="context"
+        :actionActivated="actionActivated"
+        @content-height="contentHeight = $event"
+      />
+    </template>
   </div>
 </template>
 
 <style scoped>
 .plugin-slot-item {
   contain: layout style;
+}
+
+/* Hidden, not unmounted — see the template comment. */
+.plugin-slot-item--empty {
+  display: none;
 }
 </style>

--- a/frontend/src/plugins/loader.ts
+++ b/frontend/src/plugins/loader.ts
@@ -13,8 +13,8 @@ import { onSyncActions } from '@nosdesk/core/sync/observers';
 import type { SyncAction } from '@nosdesk/core/sync/types';
 import { logger } from '@nosdesk/core/utils/logger';
 import { translate } from '@/i18n';
-import type { Plugin, PluginSlot, PluginManifest } from '@nosdesk/core/types/plugin';
-import { canonicalSlotName } from '@nosdesk/core/types/plugin';
+import type { Plugin, PluginSlot, PluginManifest, SlotChrome } from '@nosdesk/core/types/plugin';
+import { canonicalSlotName, getSlot } from '@nosdesk/core/types/plugin';
 
 // =============================================================================
 // Types
@@ -32,6 +32,8 @@ export interface PluginSlotRegistration {
   label?: string;
   icon?: string;
   context: string[];
+  /** Resolved host chrome: the component's override, else the slot default. */
+  chrome: SlotChrome;
 }
 
 export interface PluginActionRegistration {
@@ -152,6 +154,12 @@ async function loadPlugin(plugin: Plugin): Promise<void> {
     const l10n = (v: string | undefined): string | undefined =>
       v == null ? v : resolvePluginI18n(v, plugin.manifest.i18n, useDateStore().locale);
 
+    // Resolve the chrome once, here, so every mount reads one field instead
+    // of re-deriving the component-override-else-slot-default rule. `getSlot`
+    // is total for a canonicalised name, but fall back to 'none' rather than
+    // assert: an unwrapped panel is a smaller failure than a thrown mount.
+    const chrome: SlotChrome = config.chrome ?? getSlot(slot)?.chrome ?? 'none';
+
     const registration: PluginSlotRegistration = {
       pluginUuid: plugin.uuid,
       pluginName: plugin.name,
@@ -159,6 +167,7 @@ async function loadPlugin(plugin: Plugin): Promise<void> {
       label: l10n(config.label),
       icon: config.icon,
       context: config.context || [],
+      chrome,
     };
 
     const existing = slotRegistrations.get(slot) || [];

--- a/frontend/src/plugins/theme.ts
+++ b/frontend/src/plugins/theme.ts
@@ -31,6 +31,38 @@ const TOKEN_MAP: Record<string, string> = {
   'font-mono': '--font-mono',
 };
 
+// Metric tokens. Unlike the colours above these are NOT read off `:root` —
+// the host expresses them as Tailwind utilities (`rounded-xl`, `p-3`, `h-9`),
+// so there is no custom property to snapshot and the values are transcribed
+// here instead. They exist so guest content can match host conventions rather
+// than guessing: the same radius scale, the same spacing rhythm, and the
+// header metrics of the `SectionCard` the host draws around a `card`-chrome
+// panel.
+//
+// Transcribed, so they can drift. If `SectionCard` changes its radius, header
+// height or body padding, change these to match.
+const STATIC_TOKENS: Record<string, string> = {
+  // Radius scale. `radius` stays the general-purpose value a plugin gets for
+  // buttons and inputs; `radius-lg` is the card radius (`rounded-xl`).
+  radius: '8px',
+  'radius-sm': '6px',
+  'radius-lg': '12px',
+  // Spacing rhythm. `space-md` (12px) is the host card's body padding, so a
+  // plugin separating its own sections by `space-md` matches the surrounding
+  // vertical rhythm exactly.
+  'space-xs': '4px',
+  'space-sm': '8px',
+  'space-md': '12px',
+  'space-lg': '16px',
+  // `SectionCard` header pill: 36px tall (`h-9`), 12px inline padding
+  // (`px-3`), 13px semibold title. A plugin drawing its own header (under
+  // `chrome: "none"`) can reproduce the host's exactly.
+  'header-height': '36px',
+  'header-padding-inline': '12px',
+  'header-font-size': '13px',
+  'header-font-weight': '600',
+};
+
 /**
  * Snapshot the host's active design tokens for a plugin sandbox. Reads the
  * RESOLVED values off `:root`, so it captures whatever theme is applied
@@ -40,7 +72,7 @@ const TOKEN_MAP: Record<string, string> = {
  */
 export function snapshotPluginTheme(colorScheme: 'light' | 'dark', name: string): PluginTheme {
   const cs = getComputedStyle(document.documentElement);
-  const tokens: Record<string, string> = {};
+  const tokens: Record<string, string> = { ...STATIC_TOKENS };
   for (const [ndKey, hostVar] of Object.entries(TOKEN_MAP)) {
     const value = cs.getPropertyValue(hostVar).trim();
     if (value) tokens[ndKey] = value;

--- a/packages/core/src/types/plugin.ts
+++ b/packages/core/src/types/plugin.ts
@@ -117,6 +117,10 @@ export interface PluginComponentConfig {
   action?: {
     label: string;
   };
+  /** Override the host chrome for this contribution (`panel` slots only).
+   *  Omit to take the slot's default from `SLOT_REGISTRY`. Set `'none'` for
+   *  full-bleed content a card would frame wrongly. */
+  chrome?: SlotChrome;
 }
 
 export interface PluginSettingDefinition {
@@ -394,9 +398,15 @@ export interface PluginProxyResponse {
 // `PluginSlot` and the registry helpers keep working. `PluginSlot` accepts both
 // the canonical dotted names and the legacy flat aliases during the migration.
 // New code may import from `./pluginSlots` directly.
-export type { AnySlotName, CanonicalSlotName, LegacySlotName, SlotDef } from './pluginSlots';
+export type {
+  AnySlotName,
+  CanonicalSlotName,
+  LegacySlotName,
+  SlotChrome,
+  SlotDef,
+} from './pluginSlots';
 export { SLOT_REGISTRY, SLOT_NAMES, getSlot, isKnownSlot, canonicalSlotName } from './pluginSlots';
-import type { AnySlotName } from './pluginSlots';
+import type { AnySlotName, SlotChrome } from './pluginSlots';
 
 export type PluginSlot = AnySlotName;
 

--- a/packages/core/src/types/pluginSlots.ts
+++ b/packages/core/src/types/pluginSlots.ts
@@ -38,6 +38,25 @@ export type SlotContextType =
 export type SlotCardinality = 'one' | 'many';
 
 /**
+ * The chrome the HOST draws around a `panel` contribution.
+ *
+ *   * `card` — the host wraps the iframe in the app's `SectionCard`: same
+ *     radius, border, surface and compact header pill as every built-in card,
+ *     titled from the manifest `label`. The plugin fills the body only, so it
+ *     must NOT draw its own outer card (that reads as a double border).
+ *   * `none` — the host mounts the bare frame. For contributions whose host
+ *     already supplies chrome (a widget shell, a page heading) or that sit
+ *     inline inside another card, where a second card would be wrong.
+ *
+ * This is the slot's DEFAULT; a manifest component may override it (see
+ * `chrome` on the component config) for genuinely full-bleed content.
+ *
+ * Meaningless on `action` slots, which the host renders as native chrome
+ * already; they are declared `none` and validation rejects an override.
+ */
+export type SlotChrome = 'card' | 'none';
+
+/**
  * Lifecycle of a slot in the taxonomy.
  *   * `stable`       — has a live mount point; renders today.
  *   * `reserved`     — declared for authors to target, no mount yet (silent
@@ -52,6 +71,8 @@ export interface SlotDef {
   readonly mechanism: SlotMechanism;
   readonly context: SlotContextType;
   readonly cardinality: SlotCardinality;
+  /** Host chrome drawn around a contribution, unless the component overrides. */
+  readonly chrome: SlotChrome;
   /** Default sort order within the slot; host tiebreaks by install order. */
   readonly order: number;
   readonly status: SlotStatus;
@@ -68,6 +89,7 @@ export const SLOT_REGISTRY = [
     mechanism: 'panel',
     context: 'ticket',
     cardinality: 'many',
+    chrome: 'card',
     order: 100,
     status: 'stable',
     aliases: ['ticket-sidebar'],
@@ -78,6 +100,7 @@ export const SLOT_REGISTRY = [
     mechanism: 'panel',
     context: 'asset',
     cardinality: 'many',
+    chrome: 'card',
     order: 100,
     status: 'stable',
     aliases: ['asset-info-panels'],
@@ -88,6 +111,7 @@ export const SLOT_REGISTRY = [
     mechanism: 'panel',
     context: 'user',
     cardinality: 'many',
+    chrome: 'card',
     order: 100,
     status: 'stable',
     aliases: [],
@@ -98,6 +122,9 @@ export const SLOT_REGISTRY = [
     mechanism: 'panel',
     context: 'address',
     cardinality: 'many',
+    // Inline enrichment under an address row that is already inside the
+    // addresses card; a card here would nest one card in another.
+    chrome: 'none',
     order: 100,
     status: 'stable',
     aliases: [],
@@ -108,6 +135,8 @@ export const SLOT_REGISTRY = [
     mechanism: 'panel',
     context: 'none',
     cardinality: 'many',
+    // The detail view already frames this with its own section heading.
+    chrome: 'none',
     order: 100,
     status: 'stable',
     aliases: ['settings-integrations'],
@@ -118,6 +147,9 @@ export const SLOT_REGISTRY = [
     mechanism: 'panel',
     context: 'none',
     cardinality: 'many',
+    // `PluginDashboardWidget` already mounts these inside
+    // `DashboardWidgetShell`, which supplies the title and body metrics.
+    chrome: 'none',
     order: 100,
     status: 'stable',
     aliases: [],
@@ -128,6 +160,8 @@ export const SLOT_REGISTRY = [
     mechanism: 'panel',
     context: 'ticket',
     cardinality: 'many',
+    // A tab body is already inside the tab frame.
+    chrome: 'none',
     order: 100,
     status: 'reserved',
     aliases: ['ticket-tabs'],
@@ -138,6 +172,7 @@ export const SLOT_REGISTRY = [
     mechanism: 'panel',
     context: 'documentationPage',
     cardinality: 'many',
+    chrome: 'card',
     order: 100,
     status: 'reserved',
     aliases: ['document-sidebar'],
@@ -148,6 +183,7 @@ export const SLOT_REGISTRY = [
     mechanism: 'action',
     context: 'ticket',
     cardinality: 'many',
+    chrome: 'none',
     order: 100,
     status: 'stable',
     aliases: ['ticket-header-actions'],
@@ -158,6 +194,7 @@ export const SLOT_REGISTRY = [
     mechanism: 'action',
     context: 'ticket',
     cardinality: 'many',
+    chrome: 'none',
     order: 100,
     status: 'stable',
     aliases: [],
@@ -168,6 +205,7 @@ export const SLOT_REGISTRY = [
     mechanism: 'action',
     context: 'asset',
     cardinality: 'many',
+    chrome: 'none',
     order: 100,
     status: 'reserved',
     aliases: ['asset-header-actions'],
@@ -178,6 +216,7 @@ export const SLOT_REGISTRY = [
     mechanism: 'action',
     context: 'documentationPage',
     cardinality: 'many',
+    chrome: 'none',
     order: 100,
     status: 'reserved',
     aliases: ['document-toolbar'],
@@ -188,6 +227,7 @@ export const SLOT_REGISTRY = [
     mechanism: 'action',
     context: 'none',
     cardinality: 'many',
+    chrome: 'none',
     order: 100,
     status: 'stable',
     aliases: ['navbar-items'],

--- a/packages/plugin-runtime/src/pluginUiCss.ts
+++ b/packages/plugin-runtime/src/pluginUiCss.ts
@@ -8,6 +8,11 @@
 // The classes are the plugin contract: `.nd-btn` / `.nd-btn--primary`,
 // `.nd-input`, `.nd-textarea`, `.nd-card`, `.nd-label`, `.nd-muted`. Keep them
 // stable; they are versioned with the runtime.
+//
+// The OUTER card is the host's, not the plugin's. On a `card`-chrome slot the
+// host wraps this document in the app's `SectionCard` and supplies the border,
+// radius, header and body padding, so plugin content should start flush at the
+// top-left and add no outer frame of its own. See `.nd-card` below.
 
 export const PLUGIN_UI_CSS = `
 :root { --nd-radius: 8px; color-scheme: light dark; }
@@ -84,11 +89,22 @@ a { color: var(--nd-accent, #FF6B1A); }
 }
 .nd-textarea { resize: vertical; }
 
+/* An INNER sub-card, for grouping content inside a panel.
+ *
+ * This is deliberately not the app's outer card. A panel on a \`card\`-chrome
+ * slot is already wrapped by the host in the real \`SectionCard\` (border,
+ * radius, surface, header pill, 12px body padding), so a plugin that drew the
+ * outer card itself would produce a card inside a card. Use \`.nd-card\` only to
+ * subdivide, and use the surface-alt background so it reads as recessed
+ * against the host card it sits in.
+ *
+ * A contribution that genuinely needs to own its outer frame declares
+ * \`"chrome": "none"\` in its manifest and gets a bare, unwrapped iframe. */
 .nd-card {
   border: 1px solid var(--nd-border, #e5e7eb);
-  border-radius: var(--nd-radius, 8px);
+  border-radius: var(--nd-radius-sm, 6px);
   background: var(--nd-surface-alt, #f9fafb);
-  padding: 12px;
+  padding: var(--nd-space-sm, 8px);
 }
 
 .nd-label { font-weight: 600; color: var(--nd-text, #1f2937); }

--- a/packages/plugin-runtime/src/runtime.ts
+++ b/packages/plugin-runtime/src/runtime.ts
@@ -51,19 +51,93 @@ function injectTokens(theme: PluginTheme): void {
   document.documentElement.setAttribute('data-nd-theme', theme.name);
 }
 
+/**
+ * Sentinel height meaning "this plugin has content, but its height cannot be
+ * measured right now". See the recovery path in `observeHeight`.
+ *
+ * The height wire contract is three-state:
+ *   * `> 0` — the content height, in px.
+ *   * `0`   — the plugin rendered nothing; the host collapses its chrome.
+ *   * `-1`  — has content, height unknown; the host restores layout and waits.
+ */
+const HAS_CONTENT_UNMEASURED = -1;
+
+/** Re-measure cadence after announcing HAS_CONTENT, and how many attempts
+ *  before giving up. ~2s total: long enough to cover the host's un-hide and
+ *  reflow, short enough that a genuinely zero-height plugin stops cheaply. */
+const CHASE_INTERVAL_MS = 50;
+const CHASE_MAX_TRIES = 40;
+
 // Report content height to the host on every change so it can size the iframe
 // (a cross-origin sandboxed iframe can't self-size). Deduped to avoid a resize
 // feedback loop.
 function observeHeight(el: HTMLElement): void {
   let last = -1;
   const report = (): void => {
+    // "Drew nothing" is reported as an explicit 0 so the host can collapse the
+    // whole contribution (chrome included) instead of leaving an empty card.
+    // Deliberately measured from the CONTENT, not the height: a plugin whose
+    // root measures 0 because the host collapsed the iframe must not be read as
+    // empty, or the two would latch each other at zero and it could never grow
+    // back. An empty root cannot feedback-loop, since it does not depend on the
+    // iframe's own size.
+    const isEmpty = el.children.length === 0 && !el.textContent?.trim();
+    if (isEmpty) {
+      if (last !== 0) {
+        last = 0;
+        reportHeight(0);
+      }
+      return;
+    }
     const h = Math.ceil(el.getBoundingClientRect().height);
-    if (h > 0 && h !== last) {
-      last = h;
-      reportHeight(h);
+    if (h > 0) {
+      if (h !== last) {
+        last = h;
+        reportHeight(h);
+      }
+      return;
+    }
+    // Non-empty but unmeasurable. This is the recovery path: after an empty
+    // report the host hides the frame with `display: none`, which suspends
+    // layout here, so a plugin that fills in after a fetch measures 0 and its
+    // real height could never be reported. Mutations still fire while hidden,
+    // so announce HAS_CONTENT and the host restores layout.
+    if (last !== HAS_CONTENT_UNMEASURED) {
+      last = HAS_CONTENT_UNMEASURED;
+      reportHeight(HAS_CONTENT_UNMEASURED);
+      // Then re-measure until it takes. The ResizeObserver above does NOT fire
+      // when the host flips `display` back on — observed: the frame un-hid but
+      // stayed at the iframe's default 150px forever — so the true height has
+      // to be chased here rather than waited for. Bounded, so a plugin that is
+      // legitimately zero-height doesn't spin.
+      let tries = 0;
+      const chase = (): void => {
+        if (last !== HAS_CONTENT_UNMEASURED) return; // a real height landed
+        const px = Math.ceil(el.getBoundingClientRect().height);
+        if (px > 0) {
+          last = px;
+          reportHeight(px);
+          return;
+        }
+        if (++tries < CHASE_MAX_TRIES) setTimeout(chase, CHASE_INTERVAL_MS);
+      };
+      // `setTimeout`, NOT `requestAnimationFrame`: rendering is suspended in a
+      // `display: none` iframe, so a rAF callback queued here never runs and
+      // the chase would silently do nothing (observed: the frame un-hid and
+      // stayed at the iframe's default 150px). Timers still fire while hidden.
+      setTimeout(chase, CHASE_INTERVAL_MS);
     }
   };
   new ResizeObserver(report).observe(el);
+  // The ResizeObserver only fires on a size CHANGE, and a root that starts
+  // empty and stays empty never changes size, so the initial 0 would never be
+  // sent. A MutationObserver covers the empty <-> non-empty transitions that
+  // carry no size change of their own.
+  new MutationObserver(report).observe(el, {
+    childList: true,
+    subtree: true,
+    characterData: true,
+  });
   report();
 }
 
@@ -100,8 +174,19 @@ async function boot(): Promise<void> {
   }
   const plugin = mod.default;
 
-  let instance = toInstance(plugin.mount(root, runtime.api, runtime.context));
-  observeHeight(root);
+  const mounted = plugin.mount(root, runtime.api, runtime.context);
+  let instance = toInstance(mounted);
+  // Start height/emptiness reporting only once the mount has SETTLED. `mount`
+  // is commonly async (it awaits host-API calls before appending anything), and
+  // observing immediately measured a root that was merely still rendering as
+  // "the plugin drew nothing" — every async plugin reported empty within ~200ms
+  // of load and the host collapsed its chrome before it ever painted.
+  void Promise.resolve(mounted)
+    .catch(() => {
+      // A failed mount still needs observation: it reports empty, which is the
+      // honest signal, and the host collapses rather than framing a blank card.
+    })
+    .then(() => observeHeight(root));
 
   // On context change (ticket/device/action), prefer the plugin's in-place
   // `update` (no re-mount, keeps state — needed for action signals); fall back to


### PR DESCRIPTION
## What

Plugin panels never looked built in, because the card around them was the *plugin's* job. Every slot except `dashboard.widget` mounted a bare `PluginSandboxFrame` and left the chrome to the guest, which got `.nd-card` from the injected kit: 8px radius, 12px padding, `surface-alt`, no header. The app's actual primitive is `SectionCard`: `rounded-xl`, `bg-surface` body, and a fixed `h-9` header pill in `bg-surface-alt` with a 13px semibold title. Two different visual vocabularies, drifting independently, one of them a hand-maintained CSS string in another package.

The slot registry already documented the intent (`pluginSlots.ts`: a `panel` is "an iframe surface the plugin fills, **wrapped in host chrome**"). That chrome had only ever been built for `dashboard.widget`, via `PluginDashboardWidget` mounting the frame inside `DashboardWidgetShell`. This generalises that.

**Host draws the card.** `PluginSlotItem` wraps a panel contribution in a real `SectionCard`, titled from the manifest `label` with the plugin icon as the leading glyph (new `xs` size on `PluginIcon`, matching the 16px glyph the header expects). Body padding stays at `SectionCard`'s default `p-3`, so a plugin panel insets exactly like every built-in card and the plugin adds none of its own.

**Chrome is a per-slot default with a manifest override.** A blanket default would have been wrong in two places: `user.address.panel` is inline enrichment *inside* the addresses card, and `settings.integrations.page` already sits under the detail view's own `<h2>`. So `SlotDef` carries `chrome`, and a component may override with `"chrome": "none"` for genuinely full-bleed content.

| slot | chrome |
| --- | --- |
| `ticket.sidebar.panel`, `asset.info.panel`, `user.sidebar.panel`, `document.sidebar.panel` | `card` |
| `user.address.panel` (nested), `settings.integrations.page` (has a heading), `dashboard.widget` (already shelled) | `none` |
| all `action` slots | `none`, and an override is refused at install |

`PluginComponentConfig` is `deny_unknown_fields`, so the key needed adding backend-side too; `chrome` on an action slot is rejected rather than silently ignored, since an author would otherwise set it, see nothing change, and have no way to find out why.

## Layout fixes

**The empty panel.** A `min-height: 4rem` floor meant a plugin that rendered nothing still held a 64px blank card, and every panel painted an empty 64px box before jumping to its real height. The floor is gone and the runtime now reports an explicit `0` for "drew nothing", which collapses the whole contribution, chrome included.

Height reporting is three-state: `> 0` is the content height, `0` is empty, `-1` is "has content, height not measurable right now". The third state exists because the host collapses with `display: none` (a zero-height child still draws a gap in these `flex flex-col gap-3` stacks), which suspends layout in the guest. Mutations still fire while hidden, so the guest announces `-1`, the host restores layout, and the true height follows. The frame stays **mounted** while collapsed: unmounting a plugin that starts empty would re-mount it, have it draw nothing, and strand it empty forever.

**The error state** was a raw `bg-red-500/10` box matching nothing else in the app; it now uses the same centred `text-status-error` treatment as `DashboardWidgetShell`.

**Tokens.** `--nd-*` stopped at colour and fonts, so no plugin could reproduce the chrome even deliberately. Adds a radius scale, a spacing rhythm, and the `SectionCard` header metrics. These are transcribed from Tailwind utilities rather than snapshot off `:root`, so they can drift; noted in the source. `.nd-card` is demoted to an inner sub-card now the outer card is host-owned.

## Verification

Driven in a browser against the dev compose stack, with a locally-signed test plugin.

- A plugin panel renders with the same width, left edge, radius (12px), border and surface as the built-in details card above it in the ticket sidebar, with the plugin icon and label in a standard header pill.
- `chrome: "none"` renders bare and edge-to-edge, no host card, no header.
- An empty panel collapses to `display: none`: no blank card, no stray flex gap.
- A panel that fills in after a delay recovers: the message trace shows `-1` at 1721ms followed by a real 63px at 1774ms, and the frame pins to 63px.

Two bugs in this change were caught that way and are fixed here:

1. The runtime observed the root *before* `mount()` settled, so every async plugin (the common case: `mount` awaits host-API calls before appending) reported empty within ~200ms and had its chrome collapsed before it ever painted. Observation now waits for the mount to settle.
2. After the host un-hid a recovered panel the real height never arrived and the frame sat at the iframe's default 150px, because `requestAnimationFrame` does not run in a `display: none` iframe. The re-measure uses `setTimeout`, which does fire while hidden.

`cargo test --lib plugins::` 147 pass (3 new: chrome validation on panel vs action slots, and a registry invariant that no action slot carries a card). Frontend `type-check` clean, runtime `type-check` clean, `plugin_slots.generated.json` regenerated via `build:slots`.

## Not covered

The dev test plugin's own `ticketSidebar` / `assetPanel` components never render: their `mount` throws `TypeError: Cannot read properties of undefined (reading 'apply')` on lines that predate this branch (`api.plugin.name` concatenated against a Comlink proxy, outside any try/catch). They collapse, which is the correct new behaviour for a plugin that draws nothing, but it meant the normal content path was exercised through a different plugin rather than the tester. The tester itself is not in this PR.

Responsiveness is deliberately out of scope. The guest is a separate document, so its media queries resolve against the iframe box while the app's breakpoints are viewport-based, and a plugin still cannot express "flatten at `md`" the way a built-in does.