### PR TITLE
Plugin slots: responsive signals for sandboxed panels

### DIFF
--- a/backend/src/handlers/plugin_sandbox/runtime.js
+++ b/backend/src/handlers/plugin_sandbox/runtime.js
@@ -534,6 +534,42 @@ a { color: var(--nd-accent, #FF6B1A); }
 
 .nd-label { font-weight: 600; color: var(--nd-text, #1f2937); }
 .nd-muted { color: var(--nd-text-tertiary, #6b7280); }
+
+/* --- Responsive contract ---------------------------------------------------
+ *
+ * READ THIS BEFORE WRITING A MEDIA QUERY. A plugin runs in its own document, so
+ * a media query here resolves against the PANEL, not the app window. In a
+ * ~336px sidebar panel, \`@media (min-width: 768px)\` is false on every display
+ * ever made. That is container behaviour, and it is usually what you want, but
+ * it is not what "min-width: 768px" suggests.
+ *
+ * Two attributes are stamped on \`<html>\`, plus \`--nd-container-width\`:
+ *
+ *   [data-nd-container]      narrow | medium | wide   how wide THIS panel is
+ *   [data-nd-app-breakpoint] base | sm | md | lg | xl what the APP is doing
+ *   [data-nd-pointer]        coarse | fine            touch or mouse
+ *
+ * \`data-nd-pointer\` is a convenience for JS; in CSS just write
+ * \`@media (pointer: coarse)\`, which resolves correctly in here because pointer
+ * is a device capability rather than a size.
+ *
+ * Lay the panel out against \`data-nd-container\` (or a plain media query, which
+ * means the same thing). Reach for \`data-nd-app-breakpoint\` only to MATCH an
+ * app-level decision, e.g. going flat because the app went to its stacked
+ * mobile layout even though the panel itself did not get narrower.
+ *
+ *   [data-nd-container="narrow"] .my-grid { grid-template-columns: 1fr; }
+ *   [data-nd-app-breakpoint="base"] .my-toolbar { display: none; }
+ *
+ * \`context.layout.breakpoint\` carries the app breakpoint for JS; the other two
+ * are readable from the document itself.
+ */
+
+/* Touch targets. The app sizes its own controls to 44px under a coarse
+ * pointer; the kit's controls follow so a plugin gets it without asking. */
+@media (pointer: coarse) {
+  .nd-btn, .nd-input, .nd-textarea { min-height: 44px; }
+}
 `;
 
 // src/runtime.ts
@@ -565,11 +601,48 @@ ${vars}
   document.documentElement.setAttribute("data-nd-color-scheme", theme.colorScheme);
   document.documentElement.setAttribute("data-nd-theme", theme.name);
 }
+var CONTAINER_NARROW_MAX = 480;
+var CONTAINER_MEDIUM_MAX = 768;
+function containerSize(width) {
+  if (width < CONTAINER_NARROW_MAX) return "narrow";
+  if (width < CONTAINER_MEDIUM_MAX) return "medium";
+  return "wide";
+}
+function observeContainer() {
+  const el = document.documentElement;
+  let lastWidth = -1;
+  let lastBucket = "";
+  const apply = () => {
+    const width = el.clientWidth;
+    if (width === lastWidth) return;
+    lastWidth = width;
+    el.style.setProperty("--nd-container-width", `${width}px`);
+    const bucket = containerSize(width);
+    if (bucket !== lastBucket) {
+      lastBucket = bucket;
+      el.setAttribute("data-nd-container", bucket);
+    }
+  };
+  new ResizeObserver(apply).observe(el);
+  apply();
+}
+function observePointer() {
+  if (!window.matchMedia) return;
+  const mq = window.matchMedia("(pointer: coarse)");
+  const apply = () => document.documentElement.setAttribute("data-nd-pointer", mq.matches ? "coarse" : "fine");
+  mq.addEventListener("change", apply);
+  apply();
+}
+function applyLayout(context) {
+  if (!context.layout) return;
+  document.documentElement.setAttribute("data-nd-app-breakpoint", context.layout.breakpoint);
+}
 var HAS_CONTENT_UNMEASURED = -1;
 var CHASE_INTERVAL_MS = 50;
 var CHASE_MAX_TRIES = 40;
+var MOUNT_SETTLE_TIMEOUT_MS = 3e3;
 function observeHeight(el) {
-  let last = -1;
+  let last = null;
   const report = () => {
     const isEmpty = el.children.length === 0 && !el.textContent?.trim();
     if (isEmpty) {
@@ -619,6 +692,9 @@ async function boot() {
   injectBaseCss();
   injectTokens(runtime.theme);
   runtime.onThemeChange(injectTokens);
+  observeContainer();
+  observePointer();
+  applyLayout(runtime.context);
   const bundleUrl = `./bundle?t=${encodeURIComponent(token)}`;
   let mod;
   try {
@@ -636,9 +712,18 @@ async function boot() {
   const plugin = mod.default;
   const mounted = plugin.mount(root, runtime.api, runtime.context);
   let instance = toInstance(mounted);
-  void Promise.resolve(mounted).catch(() => {
-  }).then(() => observeHeight(root));
+  void Promise.race([
+    Promise.resolve(mounted).catch(() => {
+    }),
+    // A mount that never settles must not disable height reporting outright.
+    // Awaiting it unconditionally means one hung await inside a plugin (a host
+    // call that never resolves) leaves the frame stuck at the iframe's default
+    // 150px forever, chrome and all. Observed with a real bundle, so this is a
+    // failure mode plugins hit in practice, not a theoretical one.
+    new Promise((resolve) => setTimeout(resolve, MOUNT_SETTLE_TIMEOUT_MS))
+  ]).then(() => observeHeight(root));
   runtime.onContextChange((ctx) => {
+    applyLayout(ctx);
     if (instance.update) {
       instance.update(ctx);
       return;

--- a/frontend/src/plugins/components/PluginSandboxFrame.vue
+++ b/frontend/src/plugins/components/PluginSandboxFrame.vue
@@ -25,6 +25,7 @@ import type { UserAddress } from '@nosdesk/core/services/userContactService';
 import { useThemeStore } from '@/stores/theme';
 import type { PluginSlotContext } from '../context';
 import { snapshotPluginTheme } from '../theme';
+import { usePluginLayout } from '../layout';
 import { createHostApiImpl } from '../sandboxHostApi';
 import { registerPluginInstance } from '../pluginInstances';
 
@@ -63,6 +64,7 @@ const pinnedHeight = computed(() =>
 );
 
 const themeStore = useThemeStore();
+const layout = usePluginLayout();
 
 // The host design tokens for the plugin sandbox, read fresh so they reflect the
 // active theme (and accent override). The runtime injects them as `--nd-*`.
@@ -119,6 +121,7 @@ function snapshot(): PluginContext {
     address: toPluginAddress(props.context?.address),
     ticketIds: plain(props.context?.ticketIds),
     component: { name: props.component.name, slot: props.component.slot },
+    layout: { ...layout.value },
     actionActivated: props.actionActivated,
   };
 }
@@ -184,8 +187,18 @@ onMounted(() => {
 // action counter changes. `deep` is required: the sync pool patches ticket/asset
 // rows IN PLACE (same object identity), so a shallow, reference-keyed watch would
 // miss field updates and leave the plugin on stale context.
+// The breakpoint is watched as a STRING, not as `layout` itself. The computed
+// re-evaluates on every debounced resize and returns a fresh object, so
+// watching the ref would re-post the whole context (a full JSON clone of the
+// ticket / asset / user bag, per frame) every 150ms for the length of a drag.
+// Watching the bucket means one push per breakpoint crossing.
 watch(
-  [() => props.context, () => props.component, () => props.actionActivated],
+  [
+    () => props.context,
+    () => props.component,
+    () => props.actionActivated,
+    () => layout.value.breakpoint,
+  ],
   () => {
     const win = frameRef.value?.contentWindow;
     if (connected && win) postContext(win, snapshot());

--- a/frontend/src/plugins/layout.ts
+++ b/frontend/src/plugins/layout.ts
@@ -1,0 +1,40 @@
+import { computed, type ComputedRef } from 'vue';
+import type { PluginLayout } from '@nosdesk/plugin-sdk';
+import { useMobileDetection, BREAKPOINTS } from '@/composables/useMobileDetection';
+
+/**
+ * The host layout facts pushed into a plugin sandbox.
+ *
+ * A sandboxed panel measures its own iframe, so it can see how wide IT is but
+ * not what the app around it is doing. This supplies the missing half: the
+ * app's active breakpoint, on the host's own `BREAKPOINTS` scale, so a plugin
+ * branching on `md` means the same thing the app does.
+ *
+ * Only the breakpoint. Anything the guest can resolve for itself (pointer type,
+ * colour scheme, reduced motion) is left to the guest: those media features are
+ * device-level and evaluate correctly inside an iframe, so mirroring them here
+ * would be a second source of truth that can only go stale.
+ */
+
+/** The app's active breakpoint for a viewport width, matching `BREAKPOINTS`. */
+export function breakpointFor(width: number): PluginLayout['breakpoint'] {
+  if (width >= BREAKPOINTS.xl) return 'xl';
+  if (width >= BREAKPOINTS.lg) return 'lg';
+  if (width >= BREAKPOINTS.md) return 'md';
+  if (width >= BREAKPOINTS.sm) return 'sm';
+  return 'base';
+}
+
+/**
+ * Reactive host layout for the sandbox frames. Rides `useMobileDetection`'s
+ * single shared, debounced resize listener rather than adding another one.
+ *
+ * Callers should watch `.value.breakpoint`, NOT the ref: the computed
+ * re-evaluates on every debounced resize and hands back a fresh object each
+ * time, so watching the object itself fires continuously through a drag even
+ * though the bucket has not moved.
+ */
+export function usePluginLayout(): ComputedRef<PluginLayout> {
+  const { windowWidth } = useMobileDetection();
+  return computed(() => ({ breakpoint: breakpointFor(windowWidth.value) }));
+}

--- a/packages/plugin-runtime/src/pluginUiCss.ts
+++ b/packages/plugin-runtime/src/pluginUiCss.ts
@@ -109,4 +109,40 @@ a { color: var(--nd-accent, #FF6B1A); }
 
 .nd-label { font-weight: 600; color: var(--nd-text, #1f2937); }
 .nd-muted { color: var(--nd-text-tertiary, #6b7280); }
+
+/* --- Responsive contract ---------------------------------------------------
+ *
+ * READ THIS BEFORE WRITING A MEDIA QUERY. A plugin runs in its own document, so
+ * a media query here resolves against the PANEL, not the app window. In a
+ * ~336px sidebar panel, \`@media (min-width: 768px)\` is false on every display
+ * ever made. That is container behaviour, and it is usually what you want, but
+ * it is not what "min-width: 768px" suggests.
+ *
+ * Two attributes are stamped on \`<html>\`, plus \`--nd-container-width\`:
+ *
+ *   [data-nd-container]      narrow | medium | wide   how wide THIS panel is
+ *   [data-nd-app-breakpoint] base | sm | md | lg | xl what the APP is doing
+ *   [data-nd-pointer]        coarse | fine            touch or mouse
+ *
+ * \`data-nd-pointer\` is a convenience for JS; in CSS just write
+ * \`@media (pointer: coarse)\`, which resolves correctly in here because pointer
+ * is a device capability rather than a size.
+ *
+ * Lay the panel out against \`data-nd-container\` (or a plain media query, which
+ * means the same thing). Reach for \`data-nd-app-breakpoint\` only to MATCH an
+ * app-level decision, e.g. going flat because the app went to its stacked
+ * mobile layout even though the panel itself did not get narrower.
+ *
+ *   [data-nd-container="narrow"] .my-grid { grid-template-columns: 1fr; }
+ *   [data-nd-app-breakpoint="base"] .my-toolbar { display: none; }
+ *
+ * \`context.layout.breakpoint\` carries the app breakpoint for JS; the other two
+ * are readable from the document itself.
+ */
+
+/* Touch targets. The app sizes its own controls to 44px under a coarse
+ * pointer; the kit's controls follow so a plugin gets it without asking. */
+@media (pointer: coarse) {
+  .nd-btn, .nd-input, .nd-textarea { min-height: 44px; }
+}
 `;

--- a/packages/plugin-runtime/src/runtime.ts
+++ b/packages/plugin-runtime/src/runtime.ts
@@ -10,7 +10,12 @@
 // standalone: connectToHost() resolves only once the host posts the init message
 // with the transferred MessageChannel port (the host bridge, sandbox step 4).
 import { connectToHost, reportHeight } from '@nosdesk/plugin-sdk';
-import type { PluginInstance, PluginModule, PluginTheme } from '@nosdesk/plugin-sdk';
+import type {
+  PluginContext,
+  PluginInstance,
+  PluginModule,
+  PluginTheme,
+} from '@nosdesk/plugin-sdk';
 import { PLUGIN_UI_CSS } from './pluginUiCss';
 
 /** Normalize the value a plugin's `mount` returns into a `PluginInstance`. */
@@ -51,6 +56,86 @@ function injectTokens(theme: PluginTheme): void {
   document.documentElement.setAttribute('data-nd-theme', theme.name);
 }
 
+// --- Responsive signals ------------------------------------------------------
+//
+// Two independent axes, and conflating them is the trap:
+//
+//   * `data-nd-container` — how wide THIS PANEL is. Measured here, because the
+//     iframe's viewport IS the panel's container. This is what a plugin should
+//     lay itself out against, and it is also why a plugin's own media queries
+//     behave like container queries: `@media (min-width: 768px)` is false in a
+//     336px sidebar panel no matter how wide the display is. That is correct,
+//     and usually what you want, but it surprises authors who expect "desktop".
+//
+//   * `data-nd-app-breakpoint` — what the APP around the panel is doing. Cannot
+//     be measured from in here (a sidebar panel is the same width on a phone as
+//     on a 4K display), so the host pushes it on the context channel. Use it
+//     only to match an app-level decision.
+//
+//   * `data-nd-pointer` — touch or mouse. Resolved HERE, not pushed: pointer is
+//     a device capability, so `matchMedia` answers correctly inside the iframe.
+//     Mirroring it from the host would add a second source of truth that can
+//     only go stale.
+//
+// All three are stamped on `<html>` so plugin CSS can select on them, and the
+// app breakpoint is also on `context.layout` for JS.
+
+/** Upper bounds (exclusive) for the container scale. Deliberately NOT the app's
+ *  breakpoints: a panel lives in 300-700px, where `sm`/`md`/`lg` would bucket
+ *  almost everything into one value and tell a plugin nothing. */
+const CONTAINER_NARROW_MAX = 480;
+const CONTAINER_MEDIUM_MAX = 768;
+
+function containerSize(width: number): 'narrow' | 'medium' | 'wide' {
+  if (width < CONTAINER_NARROW_MAX) return 'narrow';
+  if (width < CONTAINER_MEDIUM_MAX) return 'medium';
+  return 'wide';
+}
+
+/** Stamp the panel's own width onto `<html>`, live. `--nd-container-width` is
+ *  the exact px for plugins that need to compute; `data-nd-container` is the
+ *  bucket for CSS selectors. */
+function observeContainer(): void {
+  const el = document.documentElement;
+  let lastWidth = -1;
+  let lastBucket = '';
+  const apply = (): void => {
+    const width = el.clientWidth;
+    // Guarded: a ResizeObserver fires per frame through a host drag, and every
+    // write here invalidates style for anything reading the variable. Writing
+    // only on change also keeps a plugin that SIZES itself from
+    // `--nd-container-width` from feeding its own observer.
+    if (width === lastWidth) return;
+    lastWidth = width;
+    el.style.setProperty('--nd-container-width', `${width}px`);
+    const bucket = containerSize(width);
+    if (bucket !== lastBucket) {
+      lastBucket = bucket;
+      el.setAttribute('data-nd-container', bucket);
+    }
+  };
+  new ResizeObserver(apply).observe(el);
+  apply();
+}
+
+/** Stamp the pointer type, live. A device can gain or lose a fine pointer mid
+ *  session (tablet docked to a trackpad), and the listener costs nothing. */
+function observePointer(): void {
+  if (!window.matchMedia) return;
+  const mq = window.matchMedia('(pointer: coarse)');
+  const apply = (): void =>
+    document.documentElement.setAttribute('data-nd-pointer', mq.matches ? 'coarse' : 'fine');
+  mq.addEventListener('change', apply);
+  apply();
+}
+
+/** Stamp the host's app breakpoint. Called on every context push; the value is
+ *  bucketed host-side, so this is a handful of writes, not a resize firehose. */
+function applyLayout(context: PluginContext): void {
+  if (!context.layout) return;
+  document.documentElement.setAttribute('data-nd-app-breakpoint', context.layout.breakpoint);
+}
+
 /**
  * Sentinel height meaning "this plugin has content, but its height cannot be
  * measured right now". See the recovery path in `observeHeight`.
@@ -68,11 +153,19 @@ const HAS_CONTENT_UNMEASURED = -1;
 const CHASE_INTERVAL_MS = 50;
 const CHASE_MAX_TRIES = 40;
 
+/** How long to wait for `mount` to settle before observing height anyway. */
+const MOUNT_SETTLE_TIMEOUT_MS = 3000;
+
 // Report content height to the host on every change so it can size the iframe
 // (a cross-origin sandboxed iframe can't self-size). Deduped to avoid a resize
 // feedback loop.
 function observeHeight(el: HTMLElement): void {
-  let last = -1;
+  // `null`, not -1: -1 IS the HAS_CONTENT_UNMEASURED sentinel, so seeding with
+  // it would make the "already reported unmeasured" guard below true on the
+  // very first measurement and swallow the report. A panel whose first measure
+  // is non-empty but unmeasurable (mounted inside an already-hidden container)
+  // would then never announce itself and would sit at the default height.
+  let last: number | null = null;
   const report = (): void => {
     // "Drew nothing" is reported as an explicit 0 so the host can collapse the
     // whole contribution (chrome included) instead of leaving an empty card.
@@ -155,6 +248,13 @@ async function boot(): Promise<void> {
   injectTokens(runtime.theme);
   runtime.onThemeChange(injectTokens);
 
+  // Responsive signals, both stamped before the plugin paints so its first
+  // render already sees the right container bucket and app breakpoint rather
+  // than laying out once and reflowing.
+  observeContainer();
+  observePointer();
+  applyLayout(runtime.context);
+
   // Built as a runtime string (not a literal) so the bundler treats it as an
   // external runtime import: the bundle is fetched from the sandbox origin at
   // load time, never bundled here.
@@ -181,17 +281,24 @@ async function boot(): Promise<void> {
   // observing immediately measured a root that was merely still rendering as
   // "the plugin drew nothing" — every async plugin reported empty within ~200ms
   // of load and the host collapsed its chrome before it ever painted.
-  void Promise.resolve(mounted)
-    .catch(() => {
+  void Promise.race([
+    Promise.resolve(mounted).catch(() => {
       // A failed mount still needs observation: it reports empty, which is the
       // honest signal, and the host collapses rather than framing a blank card.
-    })
-    .then(() => observeHeight(root));
+    }),
+    // A mount that never settles must not disable height reporting outright.
+    // Awaiting it unconditionally means one hung await inside a plugin (a host
+    // call that never resolves) leaves the frame stuck at the iframe's default
+    // 150px forever, chrome and all. Observed with a real bundle, so this is a
+    // failure mode plugins hit in practice, not a theoretical one.
+    new Promise<void>((resolve) => setTimeout(resolve, MOUNT_SETTLE_TIMEOUT_MS)),
+  ]).then(() => observeHeight(root));
 
   // On context change (ticket/device/action), prefer the plugin's in-place
   // `update` (no re-mount, keeps state — needed for action signals); fall back to
   // unmount + re-mount for simple plugins that returned void / a cleanup fn.
   runtime.onContextChange((ctx) => {
+    applyLayout(ctx);
     if (instance.update) {
       instance.update(ctx);
       return;

--- a/packages/plugin-sdk/src/index.ts
+++ b/packages/plugin-sdk/src/index.ts
@@ -28,6 +28,7 @@ export type {
   PluginHostApi,
   PluginContext,
   PluginAddress,
+  PluginLayout,
   PluginTheme,
   PluginModule,
   PluginInstance,

--- a/packages/plugin-sdk/src/types.ts
+++ b/packages/plugin-sdk/src/types.ts
@@ -251,6 +251,32 @@ export interface PluginAddress {
 /** The host-provided context, snapshotted into the iframe. It is not a live
  * object (it can't cross postMessage reactively); updates arrive via
  * `onContextChange`. */
+/**
+ * Host layout facts a plugin cannot derive from inside its own iframe.
+ *
+ * A sandboxed panel is a separate document, so its media queries resolve
+ * against the IFRAME box, not the app viewport. That is the right default for
+ * laying a panel out (see `data-nd-container` in the runtime), but it means a
+ * plugin has no way to see app-level decisions: a 336px sidebar panel measures
+ * the same on a phone as on a 4K display, while the app around it has switched
+ * layout entirely.
+ *
+ * Deliberately only what the guest CANNOT work out for itself. Pointer type,
+ * colour scheme and reduced-motion are device-level and resolve correctly
+ * inside the iframe, so they stay guest-side rather than being mirrored here;
+ * the app's viewport width is the one fact that does not survive the boundary.
+ *
+ * The value is BUCKETED, never raw pixels, so the host pushes only when the
+ * bucket actually flips rather than on every resize. A plugin that wants its
+ * own width should measure itself or read `--nd-container-width`.
+ */
+export interface PluginLayout {
+  /** The app's active viewport breakpoint, on the host's own scale
+   *  (`sm` 640, `md` 768, `lg` 1024, `xl` 1280; `base` below `sm`). Use this to
+   *  MATCH an app-level decision, not to lay out the panel itself. */
+  breakpoint: 'base' | 'sm' | 'md' | 'lg' | 'xl';
+}
+
 export interface PluginContext {
   ticket: Ticket | null;
   asset: Asset | null;
@@ -266,6 +292,8 @@ export interface PluginContext {
    * may declare several (different slots); the plugin switches its UI on `name`
    * (the manifest `components` map key) / `slot`. */
   component: { name: string; slot: string };
+  /** Host layout signals; see `PluginLayout`. Absent on an older host. */
+  layout?: PluginLayout;
   /** Monotonic counter for this component's declared `action` (a host menu
    * trigger). Increments on each activation; absent if the component declares no
    * action. The plugin reacts (e.g. opens a panel) when it changes. */


### PR DESCRIPTION
## What

Follow-up to #191, which deliberately left responsiveness out.

A sandboxed panel is its own document, so a media query written by a plugin resolves against the **iframe**, not the app window. That is the correct default for laying a panel out, and it is also a trap: `@media (min-width: 768px)` is false in a 336px sidebar panel on every display ever made. Meanwhile a plugin had no way at all to see what the app around it was doing, because a sidebar panel is the same width on a phone as on a 4K display.

Those are two independent axes, and conflating them is what made plugin panels feel unlike built-in UI. They are now separate signals, all stamped on the guest's `<html>`:

| attribute | values | resolved by |
| --- | --- | --- |
| `data-nd-container` (+ `--nd-container-width`) | `narrow` / `medium` / `wide` | the guest, whose viewport **is** the panel's container |
| `data-nd-app-breakpoint` | `base` / `sm` / `md` / `lg` / `xl` | the host, pushed on the context channel |
| `data-nd-pointer` | `coarse` / `fine` | the guest |

Lay a panel out against `data-nd-container`. Reach for `data-nd-app-breakpoint` only to *match* an app-level decision. The container buckets (480 / 768) are deliberately not the app's scale: a panel lives in 300-700px, where `sm`/`md`/`lg` would put nearly everything in one bucket and tell a plugin nothing.

`PluginLayout` carries **only** the breakpoint. Pointer, colour scheme and reduced-motion are device-level media features that already evaluate correctly inside an iframe, so mirroring them across the boundary would be a second source of truth that can only go stale. The app breakpoint is the one fact that genuinely does not survive the boundary.

The kit CSS documents the distinction and takes the app's 44px touch targets under a coarse pointer.

## Two height fixes

Both are failure modes reached with a real bundle, not theoretical:

- **A `mount` that never settles no longer disables height reporting.** #191 deferred observation until the mount settled, so one hung `await` inside a plugin left its frame pinned at the iframe's default 150px, chrome and all. Observation is now raced against a settle timeout.
- **The dedupe seed moved off `-1`,** which *is* the `HAS_CONTENT_UNMEASURED` sentinel. A panel whose first measurement was non-empty but unmeasurable (mounted inside an already-hidden container) hit the "already reported unmeasured" guard as true, silently skipped its report, and sat at the default height forever.

## Verification

Driven in a browser against the dev compose stack, with a locally-signed test plugin. One run, final code:

| component | behaviour |
| --- | --- |
| content panel | renders, pinned to 210px |
| renders-nothing panel | collapsed, `display: none` |
| mount-never-settles panel | collapsed at t=3255ms via the settle fallback |
| fills-in-late panel | `-1` at 1768ms, real 63px at 1819ms |

Responsive signals, resizing the host viewport:

| host viewport | container | app breakpoint | pointer |
| --- | --- | --- | --- |
| 1680 | `narrow` (334px) | `xl` | `fine` |
| 700 | `narrow` (334px) | `sm` | `fine` |
| 500 | `narrow` (334px) | `base` | `fine` |
| 900, touch emulated | `medium` (570px) | `md` | `coarse` |

The app breakpoint tracks the host live while the panel's own bucket correctly ignores it, which is exactly the case that was unreachable before. The sentinel fix is visible in the trace: an extra `-1` now precedes the `210`, where previously nothing was emitted.

`type-check` clean across frontend, plugin-sdk and plugin-runtime; ESLint clean on changed files; `cargo check --lib` clean.

## Not covered

The `wide` container bucket (>= 768px) has not been observed firing. It is the same code path as `medium` with a different threshold, but I did not see it: the plugin's full-page nav surface rendered no probe and the admin route needs an account the test user does not have.

A registration whose plugin is not loaded would render an empty titled card, since with no frame there is no height report and so nothing to collapse. I believe it is unreachable, because registrations are removed with the plugin, but I did not prove it.