### PR TITLE
Project views: mobile compatibility and quality pass

### DIFF
--- a/frontend/src/components/SiteHeader.vue
+++ b/frontend/src/components/SiteHeader.vue
@@ -209,7 +209,7 @@ const handleCreateClick = () => {
         v-if="showBackArrow"
         type="button"
         aria-label="Go back"
-        class="flex-shrink-0 -ml-1 p-1.5 text-secondary hover:text-primary rounded"
+        class="flex-shrink-0 -ml-1 p-1.5 min-h-[44px] min-w-[44px] sm:min-h-0 sm:min-w-0 inline-flex items-center justify-center text-secondary hover:text-primary rounded"
         @click="goBack()"
       >
         <Icon name="chevronLeft" size="md" />
@@ -316,7 +316,7 @@ const handleCreateClick = () => {
         <button
           v-if="props.showCreateButton"
           @click="handleCreateClick"
-          class="group flex create-button px-2.5 py-1.5 sm:px-3 text-sm font-medium text-secondary border border-default rounded-lg hover:text-primary hover:border-accent hover:bg-accent-muted transition-colors items-center gap-2"
+          class="group flex create-button px-2.5 py-1.5 sm:px-3 min-h-[44px] sm:min-h-0 text-sm font-medium text-secondary border border-default rounded-lg hover:text-primary hover:border-accent hover:bg-accent-muted transition-colors items-center gap-2"
           :aria-label="t('ui-site-header-create-aria', { action: resolvedCreateButtonText })"
           :title="resolvedCreateButtonText"
         >
@@ -352,7 +352,7 @@ const handleCreateClick = () => {
           <button
             ref="buttonRef"
             @click="toggleUserMenu"
-            class="flex items-center justify-center hover:ring-2 hover:ring-accent rounded-full focus:outline-none focus:ring-2 focus:ring-accent"
+            class="flex items-center justify-center min-h-[44px] min-w-[44px] sm:min-h-0 sm:min-w-0 hover:ring-2 hover:ring-accent rounded-full focus:outline-none focus:ring-2 focus:ring-accent"
             aria-haspopup="true"
             :aria-expanded="showUserMenu"
           >

--- a/frontend/src/components/projectComponents/ProjectActionsMenu.vue
+++ b/frontend/src/components/projectComponents/ProjectActionsMenu.vue
@@ -55,7 +55,7 @@ function handleSelect(id: string) {
     <button
       ref="triggerRef"
       type="button"
-      class="p-1.5 rounded-md hover:bg-surface-hover transition-colors text-secondary hover:text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+      class="p-1.5 rounded-md hover:bg-surface-hover transition-colors text-secondary hover:text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-accent inline-flex items-center justify-center min-h-[44px] min-w-[44px] sm:min-h-0 sm:min-w-0"
       :class="{ 'bg-surface-hover text-primary': isOpen }"
       :title="t('project-actions-menu-trigger')"
       :aria-label="t('project-actions-menu-trigger')"

--- a/frontend/src/components/projectComponents/ProjectQuickNav.vue
+++ b/frontend/src/components/projectComponents/ProjectQuickNav.vue
@@ -20,7 +20,7 @@ const links = [
       v-for="link in links"
       :key="link.suffix"
       :to="`/projects/${projectId}${link.suffix}`"
-      class="rounded px-1.5 py-0.5 text-tertiary transition-colors hover:bg-surface-hover hover:text-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+      class="rounded px-1.5 py-0.5 min-h-[44px] sm:min-h-0 inline-flex items-center text-tertiary transition-colors hover:bg-surface-hover hover:text-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
     >
       {{ $t(link.labelKey) }}
     </RouterLink>

--- a/frontend/src/components/views/GanttToolbar.vue
+++ b/frontend/src/components/views/GanttToolbar.vue
@@ -87,7 +87,7 @@ function handleSelect(id: string): void {
         v-for="z in GANTT_ZOOMS"
         :key="z"
         type="button"
-        class="text-xs px-2.5 py-1 transition-colors"
+        class="text-xs px-2.5 py-1 min-h-[44px] sm:min-h-0 inline-flex items-center justify-center transition-colors"
         :class="viewport.zoom.value === z
           ? 'bg-accent text-on-accent font-medium'
           : 'text-secondary hover:bg-surface-hover'"
@@ -137,7 +137,7 @@ function handleSelect(id: string): void {
       <button
         ref="triggerRef"
         type="button"
-        class="p-1.5 rounded-md hover:bg-surface-hover transition-colors text-secondary hover:text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+        class="p-1.5 rounded-md hover:bg-surface-hover transition-colors text-secondary hover:text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-accent inline-flex items-center justify-center min-h-[44px] min-w-[44px] sm:min-h-0 sm:min-w-0"
         :class="{ 'bg-surface-hover text-primary': isOpen }"
         :title="$t('gantt-more-controls')"
         :aria-label="$t('gantt-more-controls')"

--- a/frontend/src/components/views/ProjectTabBar.vue
+++ b/frontend/src/components/views/ProjectTabBar.vue
@@ -62,7 +62,7 @@ function go(tab: Tab): void {
         type="button"
         role="tab"
         :aria-selected="tab.id === activeId"
-        class="text-sm font-medium px-3 py-2 -mb-px border-b-2 transition-colors"
+        class="text-sm font-medium px-3 py-2 min-h-[44px] sm:min-h-0 inline-flex items-center -mb-px border-b-2 transition-colors"
         :class="tab.id === activeId
           ? 'text-primary border-accent'
           : 'text-tertiary border-transparent hover:text-secondary hover:border-subtle'"

--- a/frontend/src/sync/views/KanbanBoard.vue
+++ b/frontend/src/sync/views/KanbanBoard.vue
@@ -22,7 +22,7 @@
  * on, one sub-lane up/down. Mirrors the drag dispatch path; both
  * end up in `dispatchMove`.
  */
-import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { storeToRefs } from 'pinia'
 import { useFluent } from 'fluent-vue'
 
@@ -488,6 +488,52 @@ function onKeyDown(event: KeyboardEvent): void {
   moveSelectionByKey(direction)
 }
 
+const boardEl = ref<HTMLElement | null>(null)
+
+/**
+ * Open the board on work, not on empty columns.
+ *
+ * Columns render in workflow order, so the board opens on Triage / Backlog —
+ * routinely empty, while the actual tickets sit further right. On a desktop
+ * every column is on screen and that costs nothing, but on a phone one column
+ * fills the viewport, so a project could open on a blank board with its
+ * tickets several swipes away.
+ *
+ * Fires on the first render that actually HAS cards, not on mount: the sync
+ * pool fills in after mount, so on mount every lane is still empty, the search
+ * below finds nothing and the board would stay on the empty columns forever.
+ *
+ * Runs once, and only when the target is genuinely off screen, so it reads as
+ * where the board opened rather than as a jump. Anyone who scrolls afterwards
+ * keeps their position: the `landed` latch stops this re-running.
+ */
+function scrollToFirstPopulatedLane(): void {
+  const el = boardEl.value
+  if (!el) return
+  // All columns already fit: there is nothing to land on.
+  if (el.scrollWidth <= el.clientWidth + 1) return
+  const idx = lanes.value.findIndex((lane) => lane.totalCards > 0)
+  if (idx <= 0) return // no cards at all, or the first column already has them
+  const inner = el.firstElementChild
+  const column = inner?.children[idx] as HTMLElement | undefined
+  if (!column) return
+  const left = column.getBoundingClientRect().left - el.getBoundingClientRect().left + el.scrollLeft
+  // Already visible — don't move the board just to align it.
+  if (left < el.clientWidth) return
+  el.scrollLeft = left
+}
+
+const landed = ref(false)
+watch(
+  () => props.cards.length,
+  (count) => {
+    if (landed.value || count === 0) return
+    landed.value = true
+    void nextTick(scrollToFirstPopulatedLane)
+  },
+  { immediate: true },
+)
+
 onMounted(() => {
   window.addEventListener('keydown', onKeyDown)
   document.addEventListener('dragend', onExternalDragEnd)
@@ -738,6 +784,7 @@ function affectedDevicesTooltip(card: CardData): string {
          headers use position:sticky against this element so they pin while
          the board scrolls. -->
     <div
+      ref="boardEl"
       class="kanban-board flex flex-1 min-h-0 min-w-0 overflow-x-auto overflow-y-auto max-md:snap-x max-md:snap-mandatory"
       @click="clearSelection"
       @dragover="onExternalDragOver"

--- a/frontend/src/sync/views/drag.ts
+++ b/frontend/src/sync/views/drag.ts
@@ -64,6 +64,25 @@ export interface UseDragDropOptions {
 
 const CLICK_THRESHOLD_PX = 5
 
+/**
+ * Touch activation. A horizontal swipe on a card is ambiguous: pan the board,
+ * or pick the card up? Distance alone cannot tell them apart, and the browser
+ * resolves the ambiguity first and in favour of panning, cancelling the drag
+ * (measured: a touch-drag scrolled the board 612 -> 1212 and the card never
+ * moved). So touch presses activate on TIME, not distance: swipe to pan, hold
+ * to pick up, which is what every touch board does.
+ *
+ * Note this is deliberately NOT solved with `touch-action: none` on the card.
+ * That would hand every card-originated gesture to the drag and leave a phone
+ * user almost no surface to pan the board from, since cards cover most of a
+ * column. Instead the window-level `touchmove` listener below preventDefaults
+ * only AFTER the hold has activated: until then the browser pans normally, and
+ * once activated the scroll never starts, so pointer events keep flowing.
+ */
+const LONG_PRESS_MS = 350
+/** Movement during the hold that aborts it and lets the browser pan instead. */
+const TOUCH_SLOP_PX = 10
+
 export function useDragDrop(options: UseDragDropOptions): {
   state: Reactive<DragState>
   onPointerDown: (cardId: number, event: PointerEvent) => void
@@ -81,6 +100,8 @@ export function useDragDrop(options: UseDragDropOptions): {
   let startX = 0
   let startY = 0
   let activeCardId: number | null = null
+  let isTouchPress = false
+  let longPressTimer: ReturnType<typeof setTimeout> | null = null
   const clickThreshold = options.clickThreshold ?? CLICK_THRESHOLD_PX
   const getEdgeScrollTargets = options.getEdgeScrollTargets ?? getDefaultDragScrollTargets
   const edgeScroller = createDragEdgeScroller({
@@ -92,7 +113,42 @@ export function useDragDrop(options: UseDragDropOptions): {
     },
   })
 
+  function cancelLongPress(): void {
+    if (longPressTimer !== null) {
+      clearTimeout(longPressTimer)
+      longPressTimer = null
+    }
+  }
+
+  /** Promote the press to a drag. Shared by the mouse path (moved past the
+   *  click threshold) and the touch path (held long enough). */
+  function activateDrag(): void {
+    if (state.isDragging || activeCardId === null) return
+    // Compute the dragged set from the selection if the active card is in it;
+    // otherwise just the active card. This is what makes "select 5, drag any
+    // one of them, all 5 move" work.
+    const sel = options.selection?.() ?? null
+    if (sel && sel.has(activeCardId)) {
+      state.draggedCardIds = [activeCardId, ...Array.from(sel).filter((id) => id !== activeCardId)]
+    } else {
+      state.draggedCardIds = [activeCardId]
+    }
+    state.isDragging = true
+    // Suppress text selection during drag.
+    document.body.style.userSelect = 'none'
+    edgeScroller.start()
+  }
+
+  /** Non-passive so `preventDefault` can still stop the scroll from starting.
+   *  Chrome makes window-level `touchmove` listeners passive by default, which
+   *  would silently make this a no-op, hence the explicit option below. */
+  function onTouchMove(event: TouchEvent): void {
+    if (state.isDragging && event.cancelable) event.preventDefault()
+  }
+
   function reset(): void {
+    cancelLongPress()
+    isTouchPress = false
     edgeScroller.stop()
     state.draggedCardIds = []
     state.hoverLane = null
@@ -110,11 +166,19 @@ export function useDragDrop(options: UseDragDropOptions): {
     startX = event.clientX
     startY = event.clientY
     activeCardId = cardId
+    isTouchPress = event.pointerType === 'touch'
     state.dragPosition = { x: event.clientX, y: event.clientY }
     window.addEventListener('pointermove', onPointerMove)
     window.addEventListener('pointerup', onPointerUp)
     window.addEventListener('pointercancel', onPointerCancel)
     window.addEventListener('keydown', onKeyDown)
+    if (isTouchPress) {
+      window.addEventListener('touchmove', onTouchMove, { passive: false })
+      longPressTimer = setTimeout(() => {
+        longPressTimer = null
+        activateDrag()
+      }, LONG_PRESS_MS)
+    }
   }
 
   function onKeyDown(event: KeyboardEvent): void {
@@ -131,22 +195,19 @@ export function useDragDrop(options: UseDragDropOptions): {
     const dx = event.clientX - startX
     const dy = event.clientY - startY
     const moved = Math.hypot(dx, dy) > clickThreshold
-    if (!state.isDragging && moved) {
-      // Promote press to drag. Compute the dragged set from the
-      // selection if the active card is in it; otherwise just the
-      // active card. This is what makes "select 5, drag any one of
-      // them, all 5 move" work.
-      const sel = options.selection?.() ?? null
-      if (sel && sel.has(activeCardId)) {
-        state.draggedCardIds = [activeCardId, ...Array.from(sel).filter((id) => id !== activeCardId)]
-      } else {
-        state.draggedCardIds = [activeCardId]
+    if (!state.isDragging && isTouchPress) {
+      // Still inside the hold window. Movement here means the user is swiping
+      // to pan, not picking the card up: drop the press and let the browser
+      // have the gesture. (It will usually follow with `pointercancel` once it
+      // takes over, which resets the rest.)
+      if (Math.hypot(dx, dy) > TOUCH_SLOP_PX) {
+        cancelLongPress()
+        cleanupListeners()
+        reset()
       }
-      state.isDragging = true
-      // Suppress text selection during drag.
-      document.body.style.userSelect = 'none'
-      edgeScroller.start()
+      return
     }
+    if (!state.isDragging && moved) activateDrag()
     if (state.isDragging) {
       state.dragPosition = { x: event.clientX, y: event.clientY }
       state.hoverLane = options.resolveLaneAt(event.clientX, event.clientY)
@@ -188,9 +249,11 @@ export function useDragDrop(options: UseDragDropOptions): {
   }
 
   function cleanupListeners(): void {
+    cancelLongPress()
     window.removeEventListener('pointermove', onPointerMove)
     window.removeEventListener('pointerup', onPointerUp)
     window.removeEventListener('pointercancel', onPointerCancel)
+    window.removeEventListener('touchmove', onTouchMove)
     window.removeEventListener('keydown', onKeyDown)
   }
 

--- a/frontend/src/sync/views/gantt/GanttBoard.vue
+++ b/frontend/src/sync/views/gantt/GanttBoard.vue
@@ -741,12 +741,19 @@ function open(card: CardData): void {
          and timeline bars are the SAME grid rows, so they align by
          construction. The timeline column is the full canvas width
          (the viewport derives the range from content bounds), so
-         horizontal navigation is native scrolling. Lane width is the
-         --lane-w CSS var. -->
+         horizontal navigation is native scrolling.
+
+         Lane width is the --lane-w CSS var, scaled by container width.
+         A flat 200px ate more than half a 390px phone and left ~190px of
+         actual timeline, which is not enough to read a schedule against;
+         140px keeps titles legible (they truncate, with a `title`) while
+         roughly doubling the timeline. `useGanttViewport` measures the
+         lane element rather than assuming a constant, so the viewport
+         maths follows this automatically. -->
     <div
       v-else
       ref="scrollerEl"
-      class="grid flex-1 min-h-0 overflow-auto outline-none [--lane-w:200px] @3xl:[--lane-w:240px]"
+      class="grid flex-1 min-h-0 overflow-auto outline-none [--lane-w:140px] @lg:[--lane-w:200px] @3xl:[--lane-w:240px]"
       :style="{
         gridTemplateColumns: `var(--lane-w) ${totalWidth}px`,
         gridTemplateRows: 'auto 1fr',
@@ -1121,11 +1128,18 @@ function open(card: CardData): void {
 
         <!-- Tickets exist, but nothing is scheduled (all in the tray).
              Anchored to the visible window, not the canvas, so the
-             hint stays centered while scrolling. -->
+             hint stays centered while scrolling.
+
+             The width is the MEASURED visible timeline (`viewportWidth`
+             already nets off the lane column). It used to carry a 240px
+             floor, which on a phone exceeded the ~190px actually on screen:
+             the box overflowed to the right and clipped its own centred
+             text mid-sentence. The floor now only covers the first paint,
+             before the scroller has been measured. -->
         <div
           v-if="bars.length === 0"
-          class="absolute inset-y-0 flex flex-col items-center justify-center gap-3 px-6 text-center"
-          :style="{ left: `${scrollX}px`, width: `${Math.max(viewportWidth, 240)}px` }"
+          class="absolute inset-y-0 flex flex-col items-center justify-center gap-3 px-4 text-center"
+          :style="{ left: `${scrollX}px`, width: `${viewportWidth > 0 ? viewportWidth : 240}px` }"
         >
           <p class="text-sm text-tertiary max-w-sm">{{ t('gantt-nothing-scheduled') }}</p>
         </div>

--- a/frontend/src/sync/views/gantt/GanttBoard.vue
+++ b/frontend/src/sync/views/gantt/GanttBoard.vue
@@ -1099,7 +1099,7 @@ function open(card: CardData): void {
               @click.stop
             >
               <span
-                class="h-3 w-px bg-strong opacity-0 group-hover/bar:opacity-60 transition-opacity"
+                class="h-3 w-px bg-strong opacity-0 group-hover/bar:opacity-60 pointer-coarse:opacity-60 transition-opacity"
               ></span>
             </span>
             <span
@@ -1109,7 +1109,7 @@ function open(card: CardData): void {
               @click.stop
             >
               <span
-                class="h-3 w-px bg-strong opacity-0 group-hover/bar:opacity-60 transition-opacity"
+                class="h-3 w-px bg-strong opacity-0 group-hover/bar:opacity-60 pointer-coarse:opacity-60 transition-opacity"
               ></span>
             </span>
           </button>

--- a/frontend/src/sync/views/gantt/useBarDrag.ts
+++ b/frontend/src/sync/views/gantt/useBarDrag.ts
@@ -26,6 +26,15 @@ import { addDays } from 'date-fns'
 import { createDragEdgeScroller } from '@/composables/useDragEdgeScroll'
 import { daysBetween } from '@/composables/useGanttViewport'
 
+/** Hold before a touch press on a bar BODY becomes a drag. Matches the kanban
+ *  (`views/drag.ts`): on touch, swipe pans the timeline and hold picks the bar
+ *  up, because the browser resolves that ambiguity in favour of panning and
+ *  cancels the drag otherwise. Resize handles are exempt: grabbing one is
+ *  already unambiguous, so those drag from the first move. */
+const LONG_PRESS_MS = 350
+/** Movement during the hold that abandons it in favour of panning. */
+const TOUCH_SLOP_PX = 10
+
 export type BarDragMode = 'move' | 'start' | 'due'
 
 export interface BarDragPreview {
@@ -65,6 +74,8 @@ export function useBarDrag(options: {
   let downX = 0
   let downDay = 0
   let suppressClick = false
+  let isTouchPress = false
+  let longPressTimer: ReturnType<typeof setTimeout> | null = null
 
   const edgeScroller = createDragEdgeScroller({
     getTargets: () => {
@@ -96,6 +107,7 @@ export function useBarDrag(options: {
     mode = m
     downX = event.clientX
     downDay = dayAt(event.clientX)
+    isTouchPress = event.pointerType === 'touch'
     dragging = m !== 'move' // handles drag immediately; body waits for threshold
     preview.value = {
       cardId: bar.cardId,
@@ -113,6 +125,29 @@ export function useBarDrag(options: {
     window.addEventListener('pointerup', onPointerUp)
     window.addEventListener('pointercancel', cancel)
     window.addEventListener('keydown', onKeyDown)
+    if (isTouchPress) {
+      // Non-passive, or `preventDefault` below is ignored: Chrome makes
+      // window-level `touchmove` listeners passive by default.
+      window.addEventListener('touchmove', onTouchMove, { passive: false })
+      // Grabbing a resize handle is unambiguous, so it drags from the first
+      // move. Grabbing the bar BODY competes with panning the timeline, which
+      // the browser would otherwise win, so that one waits for a hold.
+      if (m === 'move') {
+        longPressTimer = setTimeout(() => {
+          longPressTimer = null
+          if (mode !== 'move' || dragging) return
+          dragging = true
+          options.onDragStart?.()
+          edgeScroller.start()
+          document.body.style.userSelect = 'none'
+        }, LONG_PRESS_MS)
+      }
+    }
+  }
+
+  /** Stops the timeline scrolling once a drag owns the gesture. */
+  function onTouchMove(event: TouchEvent): void {
+    if (dragging && event.cancelable) event.preventDefault()
   }
 
   function applyPointer(clientX: number): void {
@@ -139,6 +174,12 @@ export function useBarDrag(options: {
   function onPointerMove(event: PointerEvent): void {
     if (event.pointerId !== pointerId) return
     if (!dragging && mode === 'move') {
+      // On touch, movement before the hold completes is a pan, not a drag.
+      // Abandon the press so the browser keeps the gesture.
+      if (isTouchPress) {
+        if (Math.abs(event.clientX - downX) > TOUCH_SLOP_PX) teardown()
+        return
+      }
       if (Math.abs(event.clientX - downX) <= 4) return
       dragging = true
       options.onDragStart?.()
@@ -179,9 +220,15 @@ export function useBarDrag(options: {
   }
 
   function teardown(): void {
+    if (longPressTimer !== null) {
+      clearTimeout(longPressTimer)
+      longPressTimer = null
+    }
+    isTouchPress = false
     window.removeEventListener('pointermove', onPointerMove)
     window.removeEventListener('pointerup', onPointerUp)
     window.removeEventListener('pointercancel', cancel)
+    window.removeEventListener('touchmove', onTouchMove)
     window.removeEventListener('keydown', onKeyDown)
     edgeScroller.stop()
     document.body.style.userSelect = ''

--- a/frontend/src/views/ProjectCyclesView.vue
+++ b/frontend/src/views/ProjectCyclesView.vue
@@ -296,7 +296,7 @@ async function onMoveMenuSelect(id: string): Promise<void> {
       <template #actions>
         <button
           type="button"
-          class="text-xs font-medium rounded-md px-3 py-1.5 bg-accent text-on-accent hover:opacity-90 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+          class="text-xs font-medium rounded-md px-3 py-1.5 min-h-[44px] sm:min-h-0 inline-flex items-center justify-center bg-accent text-on-accent hover:opacity-90 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
           @click="showCreate = true"
         >{{ $t('project-cycles-new-button') }}</button>
       </template>
@@ -333,7 +333,7 @@ async function onMoveMenuSelect(id: string): Promise<void> {
             </span>
             <button
               type="button"
-              class="text-xs font-medium rounded-md px-3 py-1.5 border border-status-warning/50 hover:bg-status-warning/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-status-warning"
+              class="text-xs font-medium rounded-md px-3 py-1.5 min-h-[44px] sm:min-h-0 inline-flex items-center justify-center border border-status-warning/50 hover:bg-status-warning/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-status-warning"
               @click="requestCompleteCycle(activeCycle.uuid)"
             >{{ $t('project-cycles-action-complete') }}</button>
           </div>
@@ -348,7 +348,7 @@ async function onMoveMenuSelect(id: string): Promise<void> {
             </span>
             <button
               type="button"
-              class="text-xs font-medium rounded-md px-3 py-1.5 bg-accent text-on-accent hover:opacity-90 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+              class="text-xs font-medium rounded-md px-3 py-1.5 min-h-[44px] sm:min-h-0 inline-flex items-center justify-center bg-accent text-on-accent hover:opacity-90 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
               @click="promoteToActive(upcomingCycles[0].uuid)"
             >{{ $t('project-cycles-action-start') }}</button>
           </div>
@@ -415,9 +415,13 @@ async function onMoveMenuSelect(id: string): Promise<void> {
                           class="shrink-0"
                         />
                       </button>
+                      <!-- `pointer-coarse:opacity-100`: there is no hover on touch, so
+                           without it this menu is permanently invisible, and it is the
+                           only way to move a ticket between cycles from this view. Same
+                           convention as `TicketDetails` / `CustomDropdown`. -->
                       <button
                         type="button"
-                        class="mr-2 p-1 rounded text-tertiary opacity-0 group-hover/row:opacity-100 focus:opacity-100 hover:text-primary hover:bg-surface-alt focus:outline-none focus-visible:ring-2 focus-visible:ring-accent transition-opacity"
+                        class="mr-2 p-1 min-h-[44px] min-w-[44px] sm:min-h-0 sm:min-w-0 inline-flex items-center justify-center rounded text-tertiary opacity-0 group-hover/row:opacity-100 pointer-coarse:opacity-100 focus:opacity-100 hover:text-primary hover:bg-surface-alt focus:outline-none focus-visible:ring-2 focus-visible:ring-accent transition-opacity"
                         :aria-label="$t('project-cycles-ticket-menu')"
                         @click="openMoveMenu(ticket, $event)"
                       >
@@ -546,12 +550,12 @@ async function onMoveMenuSelect(id: string): Promise<void> {
         <div class="flex justify-end gap-2">
           <button
             type="button"
-            class="text-xs font-medium rounded-md px-3 py-1.5 border border-default hover:bg-surface-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+            class="text-xs font-medium rounded-md px-3 py-1.5 min-h-[44px] sm:min-h-0 inline-flex items-center justify-center border border-default hover:bg-surface-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
             @click="showCreate = false"
           >{{ $t('project-cycles-cancel-button') }}</button>
           <button
             type="button"
-            class="text-xs font-medium rounded-md px-3 py-1.5 bg-accent text-on-accent hover:opacity-90 disabled:opacity-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+            class="text-xs font-medium rounded-md px-3 py-1.5 min-h-[44px] sm:min-h-0 inline-flex items-center justify-center bg-accent text-on-accent hover:opacity-90 disabled:opacity-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
             :disabled="!newCycleName.trim() || createPending"
             @click="createCycle"
           >{{ $t('project-cycles-create-submit') }}</button>

--- a/frontend/src/views/ProjectsView.vue
+++ b/frontend/src/views/ProjectsView.vue
@@ -280,7 +280,7 @@ function handleProjectContextMenuSelect(actionId: string): void {
         v-for="option in statusFilterOptions"
         :key="option.value"
         type="button"
-        class="inline-flex items-center gap-1.5 h-7 px-2.5 rounded-md text-sm font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+        class="inline-flex items-center gap-1.5 h-7 min-h-[44px] sm:min-h-0 px-2.5 rounded-md text-sm font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
         :class="statusFilter === option.value
           ? 'bg-accent/15 text-accent'
           : 'text-secondary hover:bg-surface-hover'"

--- a/frontend/src/views/ProjectsView.vue
+++ b/frontend/src/views/ProjectsView.vue
@@ -295,12 +295,17 @@ function handleProjectContextMenuSelect(actionId: string): void {
 
       <div class="flex-1 min-w-2" />
 
-      <!-- Row density. Desktop table only (lg+). -->
-      <ListDensityToggle
-        class="hidden lg:inline-flex"
-        :density="density"
-        @set-density="setDensity"
-      />
+      <!-- Row density. Desktop table only (lg+).
+
+           Hidden via a WRAPPER, not a class on the component. Passing
+           `hidden lg:inline-flex` here merged with the toggle's own root
+           `inline-flex`, and which one wins is decided by stylesheet order
+           rather than attribute order, so the control stayed visible on a
+           phone and overflowed the toolbar (measured right edge 414px on a
+           390px viewport). Same wrapper pattern as `TicketsHeader`. -->
+      <div class="hidden lg:block">
+        <ListDensityToggle :density="density" @set-density="setDensity" />
+      </div>
     </div>
 
     <!-- Loading skeleton -->


### PR DESCRIPTION
## What

Mobile compatibility and quality pass over the four project views, from a review that drove them in a real browser at 390px rather than reading the markup.

**Drag-and-drop did not work on touch at all.** Both boards use pointer events and handle `pointercancel` cleanly, so the intent was there, but computed `touch-action` was `auto` on both the card and its scroller, and `preventDefault()` on `pointerdown` does not suppress touch panning. The browser arbitrated every gesture to the scroll container. Measured: a drag on a kanban card scrolled the board from 612 to 1204 and the card never moved. Since moving cards between states is the board's purpose, both boards were effectively read-only on a phone, with only a keyboard fallback.

Touch presses now activate on **time**, not distance: swipe to pan, hold to pick up. `touch-action: none` on the cards is the obvious fix and the wrong one here, because cards cover most of a column and it would leave almost no surface to pan from. Instead a window-level `touchmove` listener preventDefaults only once the hold has activated, registered non-passive since Chrome makes window-level `touchmove` passive by default and would otherwise ignore it. Gantt resize handles are exempt and still drag from the first move; only the bar body waits.

**The gantt was unusable on a phone.** A flat 200px lane left ~190px of timeline, about one and a half week columns, and the "nothing is scheduled" hint carried a 240px minimum against that, so it overflowed and clipped its own text mid-sentence — the one thing telling a user what to do. Lane now scales with the container (140 / 200 / 240); `useGanttViewport` measures the lane element rather than assuming a constant, so the viewport maths followed automatically.

**The board opened on empty columns.** Columns render in workflow order, so both demo projects opened on Triage and Backlog showing zero cards, with the tickets several swipes right. It now scrolls once to the first populated column, and only when that column is off-screen, so desktop is untouched. It fires on the first render that *has* cards, not on mount: the sync pool fills in after mount, so an `onMounted` hook silently did nothing.

**A desktop-only control rendered on phones.** `hidden lg:inline-flex` passed to `ListDensityToggle`, whose root already sets `inline-flex`. Vue merges them and stylesheet order decides, so `hidden` lost and the toggle overflowed the toolbar. Wrapped in a div, matching what `TicketsHeader` already does.

**A hover-only control was unreachable on touch.** The per-ticket move menu on the cycles view is `opacity-0 group-hover/row:opacity-100`, and there is no hover on a phone, so it was permanently invisible — and it is the only way to move a ticket between cycles from that view. Now carries `pointer-coarse:opacity-100`, the convention `TicketDetails` and `CustomDropdown` already use. Same for the gantt's bar-resize grips.

**Tap targets** raised using the existing `min-h-[44px] sm:min-h-0` convention, so desktop metrics are unchanged.

## Verification

Driven in a browser against the dev stack, with real touch events through CDP (a synthesised pointer event would bypass the gesture arbitration being tested).

| gesture | result |
| --- | --- |
| quick swipe on a card | board panned 612 → 1204 (panning preserved) |
| hold 500ms, then drag | drag activated, board held at 612 throughout |
| drop into a lane | ticket moved Active → In Review |
| desktop mouse drag | ticket moved Backlog → Active (no regression) |
| gantt tray drag | scheduled a ticket, 0 → 1 bars |
| gantt bar drag | bar moved, left 574 → 874 |

Layout at 390px: gantt lane 140px with the hint spanning 156–374px so it reads in full; board opens at scrollLeft 612 on Active / In Review with 6 and 10 cards; controls under 44px went list 24 → 3, kanban 14 → 7, gantt 12 → 3, cycles 10 → 2; elements overflowing the viewport 6 → 0.

## Not covered

The gantt is still a desktop visualisation squeezed onto a phone; a timeline wants width, and the real answer is probably a different mobile representation rather than a narrower lane. Left as product work.

The 10px uppercase tracked labels (lane counts, sublane headers, chart axes) are deliberately unchanged: non-interactive, internally consistent, and resizing them is a density decision about the whole app rather than a mobile fix.

21 hover-reveals elsewhere in the app lack the coarse-pointer fallback and may be unreachable on touch. Each needs a judgement about whether it is genuinely desktop-only, so they are noted rather than swept.