### PR TITLE
Frontend test suite, plus the plugin-collapse simplification it enabled

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,6 +178,12 @@ jobs:
       - name: vue-tsc
         run: pnpm --filter nosdesk-frontend run type-check
 
+      # Unit tests only. The Playwright suite under frontend/e2e needs the full
+      # dev stack (backend + postgres + seeded demo data), so it runs on demand
+      # against a running stack rather than in CI; see playwright.config.ts.
+      - name: Frontend unit tests
+        run: pnpm --filter nosdesk-frontend run test
+
       - name: Core type-check (@nosdesk/core)
         run: pnpm --filter @nosdesk/core run type-check
 
@@ -195,6 +201,11 @@ jobs:
 
       - name: Plugin runtime lint (@nosdesk/plugin-runtime)
         run: pnpm --filter @nosdesk/plugin-runtime run lint
+
+      # The guest -> host height protocol (0 / -1 / >0). Pure, and subtle
+      # enough to have produced two shipped bugs, so it is asserted directly.
+      - name: Plugin runtime tests (@nosdesk/plugin-runtime)
+        run: pnpm --filter @nosdesk/plugin-runtime run test
 
       # Build the runtime and assert the committed, backend-served bundle is in
       # sync with its source. Doubles as an integration check that the runtime +

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -55,12 +55,14 @@ jobs:
       - name: Install
         run: pnpm install --frozen-lockfile
 
-      # compose reads .env for the postgres credentials and secrets. The
-      # example file carries working defaults for everything the stack needs
-      # locally; CI only has to override what must not be a placeholder.
+      # compose reads the ROOT .env, not backend/env.example: the latter is the
+      # backend process's own config and carries no POSTGRES_* variables, so
+      # copying it left the postgres container with no superuser password and
+      # it refused to initialise. The root example carries working defaults for
+      # the whole stack; CI only overrides what must not be a placeholder.
       - name: Compose env
         run: |
-          cp backend/env.example .env
+          cp .env.example .env
           {
             echo "JWT_SECRET=$(openssl rand -hex 32)"
             echo "MFA_KEK_V1=$(openssl rand -hex 32)"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,133 @@
+name: E2E
+
+# Playwright against a real stack.
+#
+# Deliberately a SEPARATE workflow from ci.yml rather than another job in it.
+# This one boots the whole application — postgres, migrations, a bootstrapped
+# admin, seeded demo data, a built frontend — and that is a lot of moving parts
+# to stabilise. Keeping it separate means a flake here does not block merges on
+# the type-check and unit-test signal that ci.yml provides.
+#
+# STATUS: written from the known-good local sequence but not yet observed
+# passing in CI; the first runs are expected to need adjustment. Promote it to
+# a required check once it has been green for a while.
+#
+# It uses docker compose (the same path `make dev` uses) rather than
+# reassembling the stack from parts in YAML. The dev compose already knows how
+# to provision the unprivileged `nosdesk_app` runtime role, run migrations under
+# a separate privileged URL, and wire the frontend build into the directory the
+# backend serves. Replicating that here would be a second source of truth that
+# silently drifts from the one developers actually run.
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Nightly, so drift is caught without adding latency to every push.
+    - cron: '0 15 * * *'
+  pull_request:
+    paths:
+      - 'frontend/e2e/**'
+      - 'frontend/playwright.config.ts'
+      - '.github/workflows/e2e.yml'
+
+jobs:
+  e2e:
+    name: Playwright
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      # The Rust image build plus the runner's preinstalled toolchains will
+      # otherwise fill the disk, as the backend job already found.
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          large-packages: false
+
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: pnpm
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      # compose reads .env for the postgres credentials and secrets. The
+      # example file carries working defaults for everything the stack needs
+      # locally; CI only has to override what must not be a placeholder.
+      - name: Compose env
+        run: |
+          cp backend/env.example .env
+          {
+            echo "JWT_SECRET=$(openssl rand -hex 32)"
+            echo "MFA_KEK_V1=$(openssl rand -hex 32)"
+            # The app enforces its own origin on collab websockets, so this has
+            # to match the origin Playwright drives.
+            echo "FRONTEND_URL=http://localhost:8080"
+            # The seeded demo agents would otherwise be gated behind one-time
+            # MFA enrolment, which the specs do not automate.
+            echo "REQUIRE_ADMIN_MFA=false"
+          } >> .env
+
+      - name: Start the stack
+        run: docker compose -f compose.yaml -f compose.dev.yaml up -d --build
+
+      # The backend runs its own migrations on boot, so "serving" means the
+      # schema is in place too.
+      - name: Wait for the backend
+        run: |
+          for i in $(seq 1 90); do
+            if curl -sf -o /dev/null http://localhost:8080/; then echo "up"; exit 0; fi
+            sleep 5
+          done
+          echo "backend did not come up"
+          docker compose -f compose.yaml -f compose.dev.yaml logs --tail 200 nosdesk
+          exit 1
+
+      # `seed_demo` needs a workspace and an admin, which normally come from the
+      # web onboarding flow. The CLI is the documented headless equivalent.
+      - name: Bootstrap admin
+        run: |
+          printf 'CiAdmin1234!' | docker compose -f compose.yaml -f compose.dev.yaml exec -T nosdesk \
+            nosdesk-cli admin create --name "CI Admin" --email ci-admin@example.test --password-stdin
+
+      - name: Seed demo data
+        run: |
+          docker compose -f compose.yaml -f compose.dev.yaml exec -T nosdesk \
+            cargo run --bin seed_demo
+
+      # frontend-watch builds into the directory the backend serves; the specs
+      # assert on rendered layout, so the build has to have landed first.
+      - name: Wait for the frontend build
+        run: |
+          for i in $(seq 1 60); do
+            if docker compose -f compose.yaml -f compose.dev.yaml logs frontend-watch 2>/dev/null | grep -q "built in"; then
+              echo "built"; exit 0
+            fi
+            sleep 5
+          done
+          echo "frontend build did not complete"
+          docker compose -f compose.yaml -f compose.dev.yaml logs --tail 100 frontend-watch
+          exit 1
+
+      - name: Install Playwright chromium
+        run: pnpm --filter nosdesk-frontend exec playwright install --with-deps chromium
+
+      - name: Run e2e
+        env:
+          E2E_BASE_URL: http://localhost:8080
+        run: pnpm --filter nosdesk-frontend run test:e2e
+
+      - name: Stack logs on failure
+        if: failure()
+        run: docker compose -f compose.yaml -f compose.dev.yaml logs --tail 300
+
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: playwright-report
+          path: frontend/playwright-report/
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,7 @@ backend/license_private.pem
 
 # Firebase client config (per-machine; contains the FCM API key)
 google-services.json
+
+# Playwright e2e artifacts (frontend/)
+test-results/
+playwright-report/

--- a/backend/src/handlers/plugin_sandbox/runtime.js
+++ b/backend/src/handlers/plugin_sandbox/runtime.js
@@ -572,6 +572,29 @@ a { color: var(--nd-accent, #FF6B1A); }
 }
 `;
 
+// src/heightProtocol.ts
+var HAS_CONTENT_UNMEASURED = -1;
+function decideHeightReport(input) {
+  const { isEmpty, measuredPx, last } = input;
+  if (isEmpty) {
+    if (last === 0) return { report: null, last, chase: false };
+    return { report: 0, last: 0, chase: false };
+  }
+  if (measuredPx > 0) {
+    if (measuredPx === last) return { report: null, last, chase: false };
+    return { report: measuredPx, last: measuredPx, chase: false };
+  }
+  if (last === HAS_CONTENT_UNMEASURED) return { report: null, last, chase: false };
+  return { report: HAS_CONTENT_UNMEASURED, last: HAS_CONTENT_UNMEASURED, chase: true };
+}
+var CONTAINER_NARROW_MAX = 480;
+var CONTAINER_MEDIUM_MAX = 768;
+function containerSize(width) {
+  if (width < CONTAINER_NARROW_MAX) return "narrow";
+  if (width < CONTAINER_MEDIUM_MAX) return "medium";
+  return "wide";
+}
+
 // src/runtime.ts
 function toInstance(result) {
   if (typeof result === "function") return { unmount: result };
@@ -600,13 +623,6 @@ ${vars}
 }`;
   document.documentElement.setAttribute("data-nd-color-scheme", theme.colorScheme);
   document.documentElement.setAttribute("data-nd-theme", theme.name);
-}
-var CONTAINER_NARROW_MAX = 480;
-var CONTAINER_MEDIUM_MAX = 768;
-function containerSize(width) {
-  if (width < CONTAINER_NARROW_MAX) return "narrow";
-  if (width < CONTAINER_MEDIUM_MAX) return "medium";
-  return "wide";
 }
 function observeContainer() {
   const el = document.documentElement;
@@ -637,45 +653,34 @@ function applyLayout(context) {
   if (!context.layout) return;
   document.documentElement.setAttribute("data-nd-app-breakpoint", context.layout.breakpoint);
 }
-var HAS_CONTENT_UNMEASURED = -1;
 var CHASE_INTERVAL_MS = 50;
 var CHASE_MAX_TRIES = 40;
 var MOUNT_SETTLE_TIMEOUT_MS = 3e3;
 function observeHeight(el) {
   let last = null;
+  const measure = () => Math.ceil(el.getBoundingClientRect().height);
+  const isEmpty = () => el.children.length === 0 && !el.textContent?.trim();
   const report = () => {
-    const isEmpty = el.children.length === 0 && !el.textContent?.trim();
-    if (isEmpty) {
-      if (last !== 0) {
-        last = 0;
-        reportHeight(0);
+    const decision = decideHeightReport({
+      isEmpty: isEmpty(),
+      measuredPx: measure(),
+      last
+    });
+    last = decision.last;
+    if (decision.report !== null) reportHeight(decision.report);
+    if (!decision.chase) return;
+    let tries = 0;
+    const chase = () => {
+      if (last !== HAS_CONTENT_UNMEASURED) return;
+      const px = measure();
+      if (px > 0) {
+        last = px;
+        reportHeight(px);
+        return;
       }
-      return;
-    }
-    const h = Math.ceil(el.getBoundingClientRect().height);
-    if (h > 0) {
-      if (h !== last) {
-        last = h;
-        reportHeight(h);
-      }
-      return;
-    }
-    if (last !== HAS_CONTENT_UNMEASURED) {
-      last = HAS_CONTENT_UNMEASURED;
-      reportHeight(HAS_CONTENT_UNMEASURED);
-      let tries = 0;
-      const chase = () => {
-        if (last !== HAS_CONTENT_UNMEASURED) return;
-        const px = Math.ceil(el.getBoundingClientRect().height);
-        if (px > 0) {
-          last = px;
-          reportHeight(px);
-          return;
-        }
-        if (++tries < CHASE_MAX_TRIES) setTimeout(chase, CHASE_INTERVAL_MS);
-      };
-      setTimeout(chase, CHASE_INTERVAL_MS);
-    }
+      if (++tries < CHASE_MAX_TRIES) setTimeout(chase, CHASE_INTERVAL_MS);
+    };
+    setTimeout(chase, CHASE_INTERVAL_MS);
   };
   new ResizeObserver(report).observe(el);
   new MutationObserver(report).observe(el, {

--- a/backend/src/handlers/plugin_sandbox/runtime.js
+++ b/backend/src/handlers/plugin_sandbox/runtime.js
@@ -573,19 +573,11 @@ a { color: var(--nd-accent, #FF6B1A); }
 `;
 
 // src/heightProtocol.ts
-var HAS_CONTENT_UNMEASURED = -1;
 function decideHeightReport(input) {
   const { isEmpty, measuredPx, last } = input;
-  if (isEmpty) {
-    if (last === 0) return { report: null, last, chase: false };
-    return { report: 0, last: 0, chase: false };
-  }
-  if (measuredPx > 0) {
-    if (measuredPx === last) return { report: null, last, chase: false };
-    return { report: measuredPx, last: measuredPx, chase: false };
-  }
-  if (last === HAS_CONTENT_UNMEASURED) return { report: null, last, chase: false };
-  return { report: HAS_CONTENT_UNMEASURED, last: HAS_CONTENT_UNMEASURED, chase: true };
+  const height = isEmpty ? 0 : Math.max(0, measuredPx);
+  if (height === last) return { report: null, last };
+  return { report: height, last: height };
 }
 var CONTAINER_NARROW_MAX = 480;
 var CONTAINER_MEDIUM_MAX = 768;
@@ -653,34 +645,20 @@ function applyLayout(context) {
   if (!context.layout) return;
   document.documentElement.setAttribute("data-nd-app-breakpoint", context.layout.breakpoint);
 }
-var CHASE_INTERVAL_MS = 50;
-var CHASE_MAX_TRIES = 40;
 var MOUNT_SETTLE_TIMEOUT_MS = 3e3;
 function observeHeight(el) {
   let last = null;
-  const measure = () => Math.ceil(el.getBoundingClientRect().height);
-  const isEmpty = () => el.children.length === 0 && !el.textContent?.trim();
   const report = () => {
     const decision = decideHeightReport({
-      isEmpty: isEmpty(),
-      measuredPx: measure(),
+      // Emptiness is read from CONTENT, never from height: a root that measures
+      // 0 only because the host collapsed the frame must not read as empty, or
+      // the two latch each other at zero and it can never grow back.
+      isEmpty: el.children.length === 0 && !el.textContent?.trim(),
+      measuredPx: Math.ceil(el.getBoundingClientRect().height),
       last
     });
     last = decision.last;
     if (decision.report !== null) reportHeight(decision.report);
-    if (!decision.chase) return;
-    let tries = 0;
-    const chase = () => {
-      if (last !== HAS_CONTENT_UNMEASURED) return;
-      const px = measure();
-      if (px > 0) {
-        last = px;
-        reportHeight(px);
-        return;
-      }
-      if (++tries < CHASE_MAX_TRIES) setTimeout(chase, CHASE_INTERVAL_MS);
-    };
-    setTimeout(chase, CHASE_INTERVAL_MS);
   };
   new ResizeObserver(report).observe(el);
   new MutationObserver(report).observe(el, {

--- a/frontend/e2e/README.md
+++ b/frontend/e2e/README.md
@@ -1,0 +1,47 @@
+# End-to-end tests
+
+Cover what jsdom cannot: touch gesture arbitration, scroll position, and real
+layout measurement. Several of these behaviours failed silently in production
+code before being caught by hand — a board whose drag is stolen by the scroll
+container still renders perfectly.
+
+## Running
+
+The suite drives the dev stack rather than starting its own. Spinning up a
+multi-container app with a database per run would be slower and flakier than
+pointing at the one already running.
+
+```bash
+make dev          # backend + postgres + frontend watch
+make seed-demo    # demo users, projects and tickets the specs navigate to
+pnpm --filter nosdesk-frontend run test:e2e
+```
+
+Point elsewhere with `E2E_BASE_URL=https://host pnpm ... run test:e2e`.
+
+Two projects run: `phone` (390x844, touch) and `desktop` (1680x1000). Specs opt
+in with `test.skip(({ hasTouch }) => ...)`, so touch and pointer behaviour are
+asserted on the surface each belongs to.
+
+## Why this is not in CI
+
+It needs the full stack and seeded data. Wiring that into CI is worthwhile but
+is its own piece of work; until then this runs on demand, and the unit tests
+(`pnpm --filter nosdesk-frontend run test`) cover the pure logic in CI.
+
+## Notes for editing these specs
+
+- **They mutate demo data.** The drag specs move tickets between columns and do
+  not restore them, so repeated runs drift the board. Re-run `make seed-demo` to
+  reset. Assertions therefore check that a card *changed* column, never that it
+  landed in a named one.
+- **Select on `data-card-id`, not geometry.** An earlier version matched cards by
+  size and silently found nothing once the cards moved and the incidental
+  wrapper sizes changed.
+- **Never wait for `networkidle`.** The app holds an SSE connection open, so the
+  network never goes idle and the wait always times out.
+- **The sync pool fills in after mount.** `gotoAndSettle` waits for it; asserting
+  immediately reads an empty board.
+- **Touch goes through CDP** (`Input.dispatchTouchEvent`), which is Chromium
+  only. The `phone` project is spelled out rather than using an `iPhone` preset,
+  because those imply WebKit and would fail to launch.

--- a/frontend/e2e/README.md
+++ b/frontend/e2e/README.md
@@ -23,11 +23,18 @@ Two projects run: `phone` (390x844, touch) and `desktop` (1680x1000). Specs opt
 in with `test.skip(({ hasTouch }) => ...)`, so touch and pointer behaviour are
 asserted on the surface each belongs to.
 
-## Why this is not in CI
+## In CI
 
-It needs the full stack and seeded data. Wiring that into CI is worthwhile but
-is its own piece of work; until then this runs on demand, and the unit tests
-(`pnpm --filter nosdesk-frontend run test`) cover the pure logic in CI.
+`.github/workflows/e2e.yml` boots the stack with docker compose, bootstraps an
+admin via `nosdesk-cli admin create`, seeds demo data and runs this suite. It is
+a **separate workflow** from `ci.yml`, on a nightly schedule plus manual
+dispatch, so a flake in a 45-minute full-stack job never blocks a merge on the
+type-check and unit-test signal.
+
+It was written from the sequence that works locally but has not yet been
+observed green in CI; expect the first runs to need adjustment, and treat it as
+informational until it has settled. `ci.yml` runs the unit tests
+(`pnpm --filter nosdesk-frontend run test`) on every push regardless.
 
 ## Notes for editing these specs
 

--- a/frontend/e2e/board-touch-drag.spec.ts
+++ b/frontend/e2e/board-touch-drag.spec.ts
@@ -1,0 +1,120 @@
+import { test, expect } from '@playwright/test'
+import {
+  BOARD,
+  PROJECT_WITH_TICKETS,
+  Touch,
+  boardScrollLeft,
+  columnOfCard,
+  panDirection,
+  gotoAndSettle,
+  login,
+  visibleCard,
+} from './helpers'
+
+/**
+ * Kanban drag-and-drop on touch.
+ *
+ * This is the spec that matters most, because its failure mode is invisible:
+ * the board renders perfectly while dragging a card silently pans it instead.
+ * That shipped, and was only found by driving a real touch gesture.
+ *
+ * The rule is swipe-to-pan, hold-to-drag. Both halves are asserted, because
+ * "fixing" the drag by making cards `touch-action: none` would pass a
+ * drag-works test while destroying the ability to scroll the board at all.
+ */
+test.describe('kanban touch drag', () => {
+  test.skip(({ hasTouch }) => !hasTouch, 'touch-only behaviour')
+
+  test('a quick swipe on a card pans the board', async ({ page, context }) => {
+    await login(page)
+    await gotoAndSettle(page, `/projects/${PROJECT_WITH_TICKETS}`)
+
+    const card = await visibleCard(page)
+    expect(card, 'a card should be on screen; the board lands on a populated column').not.toBeNull()
+
+    const before = await boardScrollLeft(page)
+    const dx = await panDirection(page)
+    const touch = await Touch.create(context, page)
+    await touch.start(card!.x, card!.y)
+    await touch.drag(card!.x, card!.y, dx, page)
+    await touch.end()
+    await page.waitForTimeout(500)
+
+    expect(await boardScrollLeft(page), 'swiping a card must still scroll the board').not.toBe(
+      before,
+    )
+  })
+
+  test('holding a card picks it up, and the board stays put', async ({ page, context }) => {
+    await login(page)
+    await gotoAndSettle(page, `/projects/${PROJECT_WITH_TICKETS}`)
+
+    const card = await visibleCard(page)
+    expect(card).not.toBeNull()
+
+    const before = await boardScrollLeft(page)
+    const touch = await Touch.create(context, page)
+    await touch.start(card!.x, card!.y)
+    // Past the long-press threshold (350ms) without moving.
+    await page.waitForTimeout(500)
+    await touch.drag(card!.x, card!.y, 200, page, 14)
+
+    const during = await boardScrollLeft(page)
+    await touch.end()
+    await page.waitForTimeout(1200)
+
+    expect(during, 'once the hold has activated, the drag owns the gesture').toBe(before)
+  })
+
+  test('dropping on another column moves the card', async ({ page, context }) => {
+    await login(page)
+    await gotoAndSettle(page, `/projects/${PROJECT_WITH_TICKETS}`)
+
+    const card = await visibleCard(page)
+    expect(card).not.toBeNull()
+    const from = await columnOfCard(page, card!.id)
+    expect(from, 'card should start in a resolvable column').not.toBeNull()
+
+    const touch = await Touch.create(context, page)
+    await touch.start(card!.x, card!.y)
+    await page.waitForTimeout(500)
+    // Rightwards, onto the neighbouring column that is partly on screen.
+    await touch.drag(card!.x, card!.y, 200, page, 14)
+    await touch.end()
+    await page.waitForTimeout(1500)
+
+    // Assert it MOVED rather than landing anywhere specific: these specs run
+    // against shared demo data, so the starting column varies between runs.
+    const after = await columnOfCard(page, card!.id)
+    expect(after, `#${card!.id} should have left "${from}"`).not.toBe(from)
+  })
+})
+
+test.describe('kanban mouse drag', () => {
+  test.skip(({ hasTouch }) => hasTouch, 'pointer-device behaviour')
+
+  /** The touch work refactored the shared activation path, so the mouse path
+   *  is asserted too: it must still promote on distance, with no hold. */
+  test('dragging with a mouse still moves a card', async ({ page }) => {
+    await login(page)
+    await gotoAndSettle(page, `/projects/${PROJECT_WITH_TICKETS}`)
+
+    const card = await visibleCard(page)
+    expect(card).not.toBeNull()
+    const from = await columnOfCard(page, card!.id)
+    expect(from).not.toBeNull()
+
+    await page.mouse.move(card!.x, card!.y)
+    await page.mouse.down()
+    for (let i = 1; i <= 12; i++) {
+      await page.mouse.move(card!.x + i * 28, card!.y)
+      await page.waitForTimeout(16)
+    }
+    await page.mouse.up()
+    await page.waitForTimeout(1500)
+
+    const after = await columnOfCard(page, card!.id)
+    expect(after, `#${card!.id} should have left "${from}"`).not.toBe(from)
+    await expect(page.locator(BOARD)).toBeVisible()
+  })
+})

--- a/frontend/e2e/board-touch-drag.spec.ts
+++ b/frontend/e2e/board-touch-drag.spec.ts
@@ -5,6 +5,7 @@ import {
   Touch,
   boardScrollLeft,
   columnOfCard,
+  dragDirection,
   panDirection,
   gotoAndSettle,
   login,
@@ -75,11 +76,12 @@ test.describe('kanban touch drag', () => {
     const from = await columnOfCard(page, card!.id)
     expect(from, 'card should start in a resolvable column').not.toBeNull()
 
+    const dir = await dragDirection(page, card!.id)
     const touch = await Touch.create(context, page)
     await touch.start(card!.x, card!.y)
     await page.waitForTimeout(500)
-    // Rightwards, onto the neighbouring column that is partly on screen.
-    await touch.drag(card!.x, card!.y, 200, page, 14)
+    // Onto a neighbouring column that actually exists in that direction.
+    await touch.drag(card!.x, card!.y, 200 * dir, page, 14)
     await touch.end()
     await page.waitForTimeout(1500)
 
@@ -104,10 +106,11 @@ test.describe('kanban mouse drag', () => {
     const from = await columnOfCard(page, card!.id)
     expect(from).not.toBeNull()
 
+    const dir = await dragDirection(page, card!.id)
     await page.mouse.move(card!.x, card!.y)
     await page.mouse.down()
     for (let i = 1; i <= 12; i++) {
-      await page.mouse.move(card!.x + i * 28, card!.y)
+      await page.mouse.move(card!.x + i * 28 * dir, card!.y)
       await page.waitForTimeout(16)
     }
     await page.mouse.up()

--- a/frontend/e2e/helpers.ts
+++ b/frontend/e2e/helpers.ts
@@ -1,0 +1,162 @@
+import type { BrowserContext, Page } from '@playwright/test'
+
+/** Demo account seeded by `make seed-demo`. A member, deliberately: it is the
+ *  least-privileged account that can still reach the project views, so the
+ *  specs exercise what an ordinary user sees. Agents are gated behind one-time
+ *  MFA enrolment, which is not worth automating for layout assertions. */
+export const DEMO_EMAIL = 'noah@demo.nosdesk.test'
+export const DEMO_PASSWORD = 'Demo1234!'
+
+/** Demo projects. `WITH_TICKETS` has tickets spread across several columns,
+ *  which is what makes the landing and drag specs meaningful. */
+export const PROJECT_WITH_TICKETS = 3
+export const PROJECT_SPARSE = 2
+
+export async function login(page: Page): Promise<void> {
+  await page.goto('/login', { waitUntil: 'domcontentloaded' })
+  await page.waitForSelector('input[type="email"]')
+  await page.fill('input[type="email"]', DEMO_EMAIL)
+  await page.fill('input[type="password"]', DEMO_PASSWORD)
+  await page.click('button[type="submit"]')
+  // Not `networkidle`: the app holds an SSE connection open, so the network
+  // never goes idle and waiting for it always times out.
+  await page.waitForURL((u) => !u.pathname.includes('/login'))
+}
+
+/**
+ * Go to a route and wait for the sync pool to have filled in.
+ *
+ * The pool loads AFTER mount, so asserting immediately reads an empty board.
+ * This is not cosmetic: the kanban landing scroll originally hooked `onMounted`
+ * and silently did nothing for exactly this reason.
+ */
+export async function gotoAndSettle(page: Page, path: string): Promise<void> {
+  await page.goto(path, { waitUntil: 'domcontentloaded' })
+  await page.waitForTimeout(4000)
+}
+
+/** Real touch events through CDP. Playwright's `touchscreen` only taps, and a
+ *  synthesised pointer event would bypass the browser's gesture arbitration —
+ *  which is the very thing these specs are testing. */
+export class Touch {
+  private constructor(private readonly cdp: Awaited<ReturnType<BrowserContext['newCDPSession']>>) {}
+
+  static async create(context: BrowserContext, page: Page): Promise<Touch> {
+    return new Touch(await context.newCDPSession(page))
+  }
+
+  start(x: number, y: number): Promise<unknown> {
+    return this.cdp.send('Input.dispatchTouchEvent', {
+      type: 'touchStart',
+      touchPoints: [{ x, y, id: 1 }],
+    })
+  }
+
+  move(x: number, y: number): Promise<unknown> {
+    return this.cdp.send('Input.dispatchTouchEvent', {
+      type: 'touchMove',
+      touchPoints: [{ x, y, id: 1 }],
+    })
+  }
+
+  end(): Promise<unknown> {
+    return this.cdp.send('Input.dispatchTouchEvent', { type: 'touchEnd', touchPoints: [] })
+  }
+
+  /** Drag in steps, so the browser sees a gesture rather than a teleport. */
+  async drag(fromX: number, y: number, dx: number, page: Page, steps = 10): Promise<void> {
+    for (let i = 1; i <= steps; i++) {
+      await this.move(fromX + (dx * i) / steps, y)
+      await page.waitForTimeout(16)
+    }
+  }
+}
+
+/** The kanban's horizontal scroll container. */
+export const BOARD = '.kanban-board'
+
+/** Scroll offset of the board, for asserting pan-versus-drag. */
+export function boardScrollLeft(page: Page): Promise<number> {
+  return page.evaluate((sel) => {
+    const el = document.querySelector(sel)
+    return el ? Math.round(el.scrollLeft) : -1
+  }, BOARD)
+}
+
+/**
+ * Which way the board can still scroll, as a drag delta.
+ *
+ * The board lands on the first populated column, which is often the far right,
+ * so a hardcoded leftward swipe can start pinned at maximum scroll and appear
+ * not to pan at all. Negative drags the content left (scrollLeft grows).
+ */
+export function panDirection(page: Page): Promise<number> {
+  return page.evaluate((sel) => {
+    const el = document.querySelector(sel)
+    if (!el) return -150
+    const max = el.scrollWidth - el.clientWidth
+    return el.scrollLeft >= max - 1 ? 150 : -150
+  }, BOARD)
+}
+
+export interface BoardCard {
+  /** Ticket id, so a move can be asserted about THIS card. Comparing "the
+   *  first visible card" before and after silently compares two different
+   *  cards once a drag reorders the board. */
+  id: string
+  x: number
+  y: number
+}
+
+/** The first card fully on screen, or null when none is — which is itself
+ *  meaningful on a phone, where a board can open on empty columns.
+ *
+ *  Selected by `data-card-id`, a stable hook on the card root. An earlier
+ *  version matched on element geometry and silently started finding nothing
+ *  when the cards moved and the incidental wrapper sizes changed. */
+export function visibleCard(page: Page): Promise<BoardCard | null> {
+  return page.evaluate((sel) => {
+    const board = document.querySelector(sel)
+    if (!board) return null
+    const card = [...board.querySelectorAll('[data-card-id]')].find((el) => {
+      const r = el.getBoundingClientRect()
+      return (
+        r.width > 0 && r.height > 0 &&
+        r.left >= 0 && r.right <= window.innerWidth &&
+        r.top > 0 && r.bottom < window.innerHeight
+      )
+    })
+    if (!card) return null
+    const r = card.getBoundingClientRect()
+    return {
+      id: card.getAttribute('data-card-id') ?? '',
+      x: Math.round(r.left + r.width / 2),
+      y: Math.round(r.top + r.height / 2),
+    }
+  }, BOARD)
+}
+
+/**
+ * Which column a specific ticket is in, by id.
+ *
+ * Resolved from the COLUMN down rather than from the card up: walking up from a
+ * card and taking the first ancestor in a plausible width range picked up the
+ * wrong heading and reported a column the card was never in.
+ */
+export function columnOfCard(page: Page, id: string): Promise<string | null> {
+  return page.evaluate(
+    ({ sel, id }) => {
+      const board = document.querySelector(sel)
+      if (!board) return null
+      const inner = board.firstElementChild
+      if (!inner) return null
+      for (const column of [...inner.children]) {
+        const heading = column.querySelector('h2, h3')?.textContent?.trim()
+        if (!heading) continue
+        if (column.querySelector(`[data-card-id="${id}"]`)) return heading
+      }
+      return null
+    },
+    { sel: BOARD, id },
+  )
+}

--- a/frontend/e2e/helpers.ts
+++ b/frontend/e2e/helpers.ts
@@ -108,13 +108,35 @@ export interface BoardCard {
   y: number
 }
 
-/** The first card fully on screen, or null when none is — which is itself
- *  meaningful on a phone, where a board can open on empty columns.
+/**
+ * A card to drive a gesture against, scrolling it into view if needed.
  *
- *  Selected by `data-card-id`, a stable hook on the card root. An earlier
+ * Scrolling matters because the specs run against shared demo data that drifts:
+ * a card can end up in a column that is off-screen, and a spec asserting drag
+ * BEHAVIOUR should not fail because of where a previous run left the data.
+ * Whether a card is on screen *without* scrolling is a separate question, and
+ * `project-views-mobile.spec.ts` asserts that one directly.
+ */
+export async function visibleCard(page: Page): Promise<BoardCard | null> {
+  const found = await firstOnScreenCard(page)
+  if (found) return found
+  // Bring the first column that has a card into view, then look again.
+  await page.evaluate((sel) => {
+    const board = document.querySelector(sel)
+    const card = board?.querySelector('[data-card-id]')
+    if (board && card) {
+      const r = card.getBoundingClientRect()
+      board.scrollLeft += r.left - board.getBoundingClientRect().left
+    }
+  }, BOARD)
+  await page.waitForTimeout(600)
+  return firstOnScreenCard(page)
+}
+
+/** Selected by `data-card-id`, a stable hook on the card root. An earlier
  *  version matched on element geometry and silently started finding nothing
  *  when the cards moved and the incidental wrapper sizes changed. */
-export function visibleCard(page: Page): Promise<BoardCard | null> {
+function firstOnScreenCard(page: Page): Promise<BoardCard | null> {
   return page.evaluate((sel) => {
     const board = document.querySelector(sel)
     if (!board) return null
@@ -156,6 +178,28 @@ export function columnOfCard(page: Page, id: string): Promise<string | null> {
         if (column.querySelector(`[data-card-id="${id}"]`)) return heading
       }
       return null
+    },
+    { sel: BOARD, id },
+  )
+}
+
+/**
+ * Which way to drag a card so it lands on a column that exists: +1 right, -1
+ * left. A card already in the last column has nowhere to go rightwards.
+ *
+ * Without this the drag specs pile every card into the rightmost column over
+ * repeated runs against the same demo data, and then fail because the move they
+ * ask for is impossible. Choosing the direction also keeps the data balanced:
+ * cards oscillate instead of drifting to an edge.
+ */
+export function dragDirection(page: Page, id: string): Promise<number> {
+  return page.evaluate(
+    ({ sel, id }) => {
+      const inner = document.querySelector(sel)?.firstElementChild
+      if (!inner) return 1
+      const columns = [...inner.children]
+      const index = columns.findIndex((c) => c.querySelector(`[data-card-id="${id}"]`))
+      return index >= 0 && index === columns.length - 1 ? -1 : 1
     },
     { sel: BOARD, id },
   )

--- a/frontend/e2e/project-views-mobile.spec.ts
+++ b/frontend/e2e/project-views-mobile.spec.ts
@@ -1,0 +1,106 @@
+import { test, expect } from '@playwright/test'
+import { BOARD, PROJECT_SPARSE, PROJECT_WITH_TICKETS, gotoAndSettle, login } from './helpers'
+
+const PROJECT_ROUTES = (id: number): Array<[string, string]> => [
+  ['projects list', '/projects'],
+  ['board', `/projects/${id}`],
+  ['gantt', `/projects/${id}/gantt`],
+  ['cycles', `/projects/${id}/cycles`],
+]
+
+/**
+ * Layout invariants for the project views on a phone.
+ *
+ * These assert the properties that stay true regardless of design changes,
+ * rather than pinning pixel values that would make every visual tweak a test
+ * failure.
+ */
+test.describe('project views on a phone', () => {
+  test.skip(({ hasTouch }) => !hasTouch, 'phone layout')
+
+  for (const [name, path] of PROJECT_ROUTES(PROJECT_SPARSE)) {
+    test(`${name} does not overflow the viewport`, async ({ page }) => {
+      await login(page)
+      await gotoAndSettle(page, path)
+
+      // The cardinal mobile bug: the page itself scrolling sideways. Content
+      // that scrolls horizontally on purpose (a board, a timeline) lives in its
+      // own container and does not widen the document.
+      const overflow = await page.evaluate(
+        () =>
+          Math.max(document.documentElement.scrollWidth, document.body.scrollWidth) -
+          window.innerWidth,
+      )
+      expect(overflow, `${name} should not scroll sideways`).toBeLessThanOrEqual(0)
+    })
+  }
+
+  test('no control renders outside the viewport', async ({ page }) => {
+    await login(page)
+    await gotoAndSettle(page, '/projects')
+
+    // Regression: `hidden lg:inline-flex` passed to a component merged with the
+    // component root's own `inline-flex`, so a desktop-only density toggle
+    // rendered on phones and its buttons hung off the right edge.
+    const bleeding = await page.evaluate(() => {
+      const vw = window.innerWidth
+      const scrollers = new Set<Element>()
+      document.querySelectorAll('*').forEach((el) => {
+        if (
+          /(auto|scroll)/.test(getComputedStyle(el).overflowX) &&
+          el.scrollWidth > el.clientWidth + 1
+        ) {
+          scrollers.add(el)
+        }
+      })
+      const inScroller = (el: Element): boolean => {
+        for (let p = el.parentElement; p; p = p.parentElement) if (scrollers.has(p)) return true
+        return false
+      }
+      const out: string[] = []
+      document.querySelectorAll('button, a, input, select').forEach((el) => {
+        const r = el.getBoundingClientRect()
+        if (r.width === 0 || r.height === 0) return
+        if (r.right <= vw + 1) return
+        if (inScroller(el) || getComputedStyle(el).position === 'fixed') return
+        out.push(`${el.tagName.toLowerCase()} "${(el.textContent ?? '').trim().slice(0, 20)}"`)
+      })
+      return out
+    })
+    expect(bleeding, 'controls hanging off the right edge').toEqual([])
+  })
+
+  test('the board opens on a column that has work in it', async ({ page }) => {
+    await login(page)
+    await gotoAndSettle(page, `/projects/${PROJECT_WITH_TICKETS}`)
+
+    // Columns render in workflow order, so the board would otherwise open on
+    // Triage / Backlog — routinely empty — with the tickets several swipes away.
+    const cardsOnScreen = await page.evaluate((sel) => {
+      const board = document.querySelector(sel)
+      if (!board) return -1
+      return [...board.querySelectorAll('[data-card-id]')].filter((el) => {
+        const r = el.getBoundingClientRect()
+        return r.width > 0 && r.left >= 0 && r.right <= window.innerWidth
+      }).length
+    }, BOARD)
+    expect(cardsOnScreen, 'at least one card should be visible on open').toBeGreaterThan(0)
+  })
+
+  test('the gantt keeps its empty state on screen', async ({ page }) => {
+    await login(page)
+    await gotoAndSettle(page, `/projects/${PROJECT_SPARSE}/gantt`)
+
+    // Regression: the hint carried a 240px minimum against a ~190px visible
+    // timeline, so it overflowed and clipped its own text mid-sentence — the
+    // one thing telling a user what to do next.
+    const hint = page.locator('p', { hasText: /scheduled|due date/i }).first()
+    if ((await hint.count()) === 0) test.skip(true, 'project has scheduled work; no empty state')
+
+    const box = await hint.boundingBox()
+    expect(box).not.toBeNull()
+    const vw = page.viewportSize()!.width
+    expect(box!.x, 'hint starts on screen').toBeGreaterThanOrEqual(0)
+    expect(box!.x + box!.width, 'hint ends on screen').toBeLessThanOrEqual(vw + 1)
+  })
+})

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,8 @@
     "preview": "vite preview",
     "build-only": "vite build",
     "type-check": "vue-tsc --build",
+    "test": "vitest run",
+    "test:e2e": "playwright test",
     "lint": "eslint . && node scripts/check-view-roots.mjs && node scripts/check-plugin-slot-mounts.mjs",
     "lint:fix": "eslint . --fix && node scripts/check-view-roots.mjs && node scripts/check-plugin-slot-mounts.mjs",
     "lint:views": "node scripts/check-view-roots.mjs"
@@ -22,8 +24,8 @@
     "@date-fns/tz": "^1.4.1",
     "@fluent/bundle": "^0.19.1",
     "@nosdesk/core": "workspace:*",
-    "@nosdesk/plugin-sdk": "workspace:*",
     "@nosdesk/mobile": "workspace:*",
+    "@nosdesk/plugin-sdk": "workspace:*",
     "@pinia/colada": "^1.2.0",
     "@simplewebauthn/browser": "^13.2.2",
     "@simplewebauthn/types": "^12.0.0",
@@ -66,6 +68,7 @@
     "yjs": "^13.6.29"
   },
   "devDependencies": {
+    "@playwright/test": "^1.62.1",
     "@tailwindcss/postcss": "^4.0.15",
     "@tailwindcss/typography": "^0.5.10",
     "@tsconfig/node24": "^24.0.0",
@@ -81,6 +84,7 @@
     "eslint": "^10.2.1",
     "eslint-plugin-unused-imports": "^4.4.1",
     "eslint-plugin-vue": "^10.9.0",
+    "jsdom": "^30.0.1",
     "npm-run-all2": "^8.0.0",
     "postcss": "^8.5.3",
     "tailwindcss": "^4.0.15",
@@ -88,6 +92,7 @@
     "typescript": "^6.0.0",
     "typescript-eslint": "^8.59.1",
     "vite": "^8.0.0",
+    "vitest": "^3.2.7",
     "vue-tsc": "^3.2.0"
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,8 +16,8 @@
     "type-check": "vue-tsc --build",
     "test": "vitest run",
     "test:e2e": "playwright test",
-    "lint": "eslint . && node scripts/check-view-roots.mjs && node scripts/check-plugin-slot-mounts.mjs",
-    "lint:fix": "eslint . --fix && node scripts/check-view-roots.mjs && node scripts/check-plugin-slot-mounts.mjs",
+    "lint": "eslint . && node scripts/check-view-roots.mjs && node scripts/check-plugin-slot-mounts.mjs && node scripts/check-component-display-classes.mjs",
+    "lint:fix": "eslint . --fix && node scripts/check-view-roots.mjs && node scripts/check-plugin-slot-mounts.mjs && node scripts/check-component-display-classes.mjs",
     "lint:views": "node scripts/check-view-roots.mjs"
   },
   "dependencies": {

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -27,8 +27,12 @@ export default defineConfig({
   workers: 1,
   retries: process.env.CI ? 1 : 0,
   reporter: process.env.CI ? [['github'], ['list']] : [['list']],
-  timeout: 60_000,
-  expect: { timeout: 10_000 },
+  // Generous on CI. Each spec logs in, waits for the sync pool to fill, and
+  // then drives a multi-step gesture; on a shared runner that is comfortably
+  // slower than a dev machine, and the first CI run timed out on the last and
+  // slowest test at 60s while asserting nothing wrong.
+  timeout: process.env.CI ? 150_000 : 60_000,
+  expect: { timeout: process.env.CI ? 20_000 : 10_000 },
   use: {
     baseURL: process.env.E2E_BASE_URL ?? 'http://localhost:8080',
     // The dev stack may be served over a self-signed cert on some hosts.

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,60 @@
+import { defineConfig, devices } from '@playwright/test'
+
+/**
+ * End-to-end tests against the running dev stack.
+ *
+ * These cover the things jsdom cannot: touch gesture arbitration, scroll
+ * position, and real layout measurement. Several of the behaviours here were
+ * regressions found by hand that would otherwise fail silently — a board whose
+ * drag is stolen by the scroll container still renders perfectly.
+ *
+ * Prerequisites (not started by this config, deliberately — the stack is a
+ * multi-container app with a database, and spinning it up per run would be
+ * slower and flakier than pointing at the one that is already running):
+ *
+ *   make dev          # or: docker compose -f compose.yaml -f compose.dev.yaml up -d
+ *   make seed-demo    # demo users + projects the specs navigate to
+ *
+ * Then: pnpm --filter nosdesk-frontend run test:e2e
+ *
+ * Override the target with E2E_BASE_URL when the stack is not on :8080.
+ */
+export default defineConfig({
+  testDir: './e2e',
+  // The specs drive one shared app instance and some of them move tickets
+  // between columns, so they must not race each other.
+  fullyParallel: false,
+  workers: 1,
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI ? [['github'], ['list']] : [['list']],
+  timeout: 60_000,
+  expect: { timeout: 10_000 },
+  use: {
+    baseURL: process.env.E2E_BASE_URL ?? 'http://localhost:8080',
+    // The dev stack may be served over a self-signed cert on some hosts.
+    ignoreHTTPSErrors: true,
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+  },
+  projects: [
+    {
+      // Spelled out rather than using an `iPhone` preset: those imply WebKit,
+      // and the touch specs drive real gestures through CDP
+      // (`Input.dispatchTouchEvent`), which is Chromium-only. A preset would
+      // silently switch engines and fail to launch. 390x844 is the iPhone 14
+      // viewport, which is what the layout numbers in these specs refer to.
+      name: 'phone',
+      use: {
+        ...devices['Desktop Chrome'],
+        viewport: { width: 390, height: 844 },
+        hasTouch: true,
+        isMobile: true,
+        deviceScaleFactor: 3,
+      },
+    },
+    {
+      name: 'desktop',
+      use: { ...devices['Desktop Chrome'], viewport: { width: 1680, height: 1000 } },
+    },
+  ],
+})

--- a/frontend/scripts/check-component-display-classes.mjs
+++ b/frontend/scripts/check-component-display-classes.mjs
@@ -1,0 +1,181 @@
+#!/usr/bin/env node
+/**
+ * Guard against a display utility passed to a component that already sets one.
+ *
+ * Vue MERGES a class passed to a component with the class on that component's
+ * root element. Two display utilities then coexist in one class list, and which
+ * one wins is decided by their order in the generated stylesheet, not by the
+ * order they appear in the attribute. The result is a control that ignores the
+ * class you gave it.
+ *
+ * This shipped. `<ListDensityToggle class="hidden lg:inline-flex">` merged with
+ * the toggle's own root `inline-flex`, `hidden` lost, and a desktop-only
+ * control rendered on phones and overflowed the toolbar (its buttons measured
+ * right edges of 400px and 414px against a 390px viewport).
+ *
+ * The fix is always the same: wrap the component in a plain element and put the
+ * display class on the wrapper, as `TicketsHeader` already does.
+ *
+ *     <div class="hidden lg:block">
+ *       <ListDensityToggle ... />
+ *     </div>
+ *
+ * Only flags when BOTH sides declare a display utility, resolved by reading the
+ * imported component's own root class. A display class passed to a component
+ * whose root sets none is fine and stays quiet.
+ *
+ * Limits, deliberately: static `class` attributes only. A `:class` binding is
+ * computed and cannot be resolved here, and dynamic display switching on a
+ * component root is rare enough that a false sense of coverage would be worse
+ * than the gap. Multi-root (fragment) components are skipped: Vue cannot
+ * auto-inherit attributes onto them, so the merge never happens.
+ *
+ * Runs in the frontend `lint` script, alongside the other guards.
+ */
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url))
+const srcDir = join(__dirname, '..', 'src')
+
+const DISPLAY = String.raw`(?:flex|inline-flex|block|inline-block|inline|grid|inline-grid|table|contents|hidden)`
+
+/**
+ * UNPREFIXED display utilities only.
+ *
+ * A variant-prefixed one (`print:hidden`, `sm:flex`, `group-hover:hidden`) is
+ * not the hazard: either it applies in conditions the base utility does not, or
+ * Tailwind emits variants after base utilities so it wins deterministically.
+ * The bug is two unconditional display utilities in one class list, where
+ * nothing decides between them but stylesheet order — which is what
+ * `class="hidden lg:inline-flex"` on a root that already sets `inline-flex`
+ * came down to.
+ */
+const BARE_DISPLAY = new RegExp(String.raw`(?:^|\s)${DISPLAY}(?=\s|$)`, 'g')
+
+/** The unprefixed display utilities in a class list. */
+function bareDisplayUtilities(classList) {
+  return [...classList.matchAll(BARE_DISPLAY)].map((m) => m[0].trim())
+}
+
+function walk(dir, out = []) {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry)
+    const st = statSync(full)
+    if (st.isDirectory()) walk(full, out)
+    else if (entry.endsWith('.vue')) out.push(full)
+  }
+  return out
+}
+
+/** Template body of an SFC, so `<script>` contents never match. */
+function templateOf(source) {
+  const open = source.indexOf('<template>')
+  if (open === -1) return ''
+  const close = source.lastIndexOf('</template>')
+  if (close <= open) return ''
+  return source.slice(open + '<template>'.length, close)
+}
+
+/** Strip HTML comments so commented-out markup is not scanned. */
+const stripComments = (s) => s.replace(/<!--[\s\S]*?-->/g, '')
+
+/** Map of local component name -> resolved .vue path, from the SFC's imports. */
+function componentImports(source, fromFile) {
+  const map = new Map()
+  const re = /import\s+([A-Z][A-Za-z0-9_]*)\s*(?:,\s*\{[^}]*\})?\s+from\s+['"]([^'"]+)['"]/g
+  let m
+  while ((m = re.exec(source))) {
+    const [, name, spec] = m
+    if (!spec.endsWith('.vue')) continue
+    let path
+    if (spec.startsWith('@/')) path = join(srcDir, spec.slice(2))
+    else if (spec.startsWith('.')) path = resolve(dirname(fromFile), spec)
+    else continue // workspace package; not ours to resolve
+    map.set(name, path)
+  }
+  return map
+}
+
+/** The static class on a component's single root element, or null when the
+ *  component has no single root or no static class on it. */
+const rootClassCache = new Map()
+function rootClassOf(file) {
+  if (rootClassCache.has(file)) return rootClassCache.get(file)
+  let result = null
+  try {
+    const tpl = stripComments(templateOf(readFileSync(file, 'utf8'))).trim()
+    // The first tag is the root. If a sibling tag follows at depth 0 the
+    // component is multi-root and Vue does not auto-inherit onto it.
+    const first = tpl.match(/^<([A-Za-z][\w.-]*)([^>]*)>/)
+    if (first) {
+      const attrs = first[2]
+      const cls = attrs.match(/(?:^|\s)class="([^"]*)"/)
+      result = cls ? cls[1] : null
+    }
+  } catch {
+    result = null
+  }
+  rootClassCache.set(file, result)
+  return result
+}
+
+const failures = []
+let scanned = 0
+
+for (const file of walk(srcDir)) {
+  const source = readFileSync(file, 'utf8')
+  const imports = componentImports(source, file)
+  if (imports.size === 0) continue
+  const tpl = stripComments(templateOf(source))
+  if (!tpl) continue
+  scanned++
+
+  // Every opening tag whose name is an imported component.
+  const tagRe = /<([A-Z][A-Za-z0-9_]*)((?:[^>"']|"[^"]*"|'[^']*')*)\/?>/g
+  let m
+  while ((m = tagRe.exec(tpl))) {
+    const [, tag, attrs] = m
+    const target = imports.get(tag)
+    if (!target) continue
+    const cls = attrs.match(/(?:^|\s)class="([^"]*)"/)
+    if (!cls) continue
+    const passed = bareDisplayUtilities(cls[1])
+    if (passed.length === 0) continue
+
+    const rootClass = rootClassOf(target)
+    if (!rootClass) continue
+    const root = bareDisplayUtilities(rootClass)
+    if (root.length === 0) continue
+
+    // Passing the same utility the root already sets is redundant, not a
+    // conflict: the merged list says the same thing twice.
+    if (passed.every((u) => root.includes(u))) continue
+
+    const line = tpl.slice(0, m.index).split('\n').length
+    const offset = source.slice(0, source.indexOf('<template>')).split('\n').length - 1
+    failures.push({
+      file: file.replace(join(__dirname, '..', '..'), '.'),
+      line: line + offset,
+      tag,
+      passed: cls[1],
+      root: rootClass,
+    })
+  }
+}
+
+if (failures.length > 0) {
+  console.error('[check-component-display-classes] display utility passed to a component that sets its own\n')
+  for (const f of failures) {
+    console.error(`  ${f.file}:${f.line}  <${f.tag} class="${f.passed}">`)
+    console.error(`    ${f.tag}'s root already sets display: "${f.root}"`)
+    console.error(
+      '    Vue merges these; the winner is stylesheet order, not attribute order.\n' +
+        '    Put the display class on a wrapper element instead.\n',
+    )
+  }
+  process.exit(1)
+}
+
+console.log(`[check-component-display-classes] OK (${scanned} templates scanned)`)

--- a/frontend/src/plugins/components/PluginSandboxFrame.vue
+++ b/frontend/src/plugins/components/PluginSandboxFrame.vue
@@ -41,10 +41,11 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   /** Latest content height the plugin reported. `0` means it rendered nothing,
-   *  which lets a parent collapse its chrome; `null` means nothing reported
-   *  yet. Parents must keep this component MOUNTED when collapsing (height 0,
-   *  not `v-if`), or a plugin that starts empty and fills in later can never
-   *  report its way back. */
+   *  which lets a parent drop its chrome; `null` means nothing reported yet.
+   *  Parents must keep this component MOUNTED and LAID OUT when collapsing
+   *  (zero height and clipping, never `v-if` or `display: none`), or the guest
+   *  stops being able to measure itself and a plugin that fills in later can
+   *  never report its way back. */
   (e: 'contentHeight', px: number | null): void;
 }>();
 
@@ -55,13 +56,11 @@ const iframeHeight = ref<number | null>(null);
 
 watch(iframeHeight, (px) => emit('contentHeight', px));
 
-/** Only a real, positive measurement pins the iframe's height. `0` (rendered
- *  nothing) and `-1` (has content, unmeasurable while the host hides it) are
- *  signals for the parent's chrome, not sizes; letting either reach the inline
- *  style would emit `height: -1px` or lock a recovering frame at zero. */
-const pinnedHeight = computed(() =>
-  iframeHeight.value != null && iframeHeight.value > 0 ? iframeHeight.value : null,
-);
+/** Every report is a size, so it pins directly: `0` collapses the frame, which
+ *  is exactly what the parent wants when the plugin drew nothing. `null` means
+ *  nothing has been reported yet, so the iframe keeps its natural height until
+ *  the first measurement rather than flashing to zero. */
+const pinnedHeight = computed(() => iframeHeight.value);
 
 const themeStore = useThemeStore();
 const layout = usePluginLayout();

--- a/frontend/src/plugins/components/PluginSlotItem.vue
+++ b/frontend/src/plugins/components/PluginSlotItem.vue
@@ -54,15 +54,19 @@ const title = computed(
 </script>
 
 <template>
-  <!-- The wrapper is hidden when the plugin draws nothing, but the frame stays
-       MOUNTED inside it: a plugin that starts empty and fills in after a fetch
-       has to keep reporting, and unmounting the iframe would strand it empty
-       forever (it would re-mount, draw nothing, and report empty again).
+  <!-- Collapsed to zero height when the plugin draws nothing, with the frame
+       still MOUNTED inside: a plugin that starts empty and fills in after a
+       fetch has to keep reporting, and unmounting the iframe would strand it
+       empty forever (it would re-mount, draw nothing, and report empty again).
 
-       `display: none` rather than a zero height, because these stacks are
-       `flex flex-col gap-3` and a zero-height child still draws a gap. Hiding
-       suspends layout in the guest, which is why the runtime falls back to the
-       HAS_CONTENT sentinel to ask for layout back. -->
+       Zero height rather than `display: none` on purpose. Hiding suspends
+       layout inside the iframe, so the guest could no longer measure itself and
+       needed a third protocol state to ask for layout back plus a timer loop to
+       chase the height once it returned. Clipping keeps layout alive, so a
+       late-filling plugin is just another content change. The cost is that
+       these stacks are `flex flex-col gap-3`, so a collapsed item still leaves
+       one gap's worth of space; that is invisible whitespace between two cards,
+       and far cheaper than the machinery it replaces. -->
   <div
     class="plugin-slot-item"
     :class="{ 'plugin-slot-item--empty': isEmpty }"
@@ -114,8 +118,11 @@ const title = computed(
   contain: layout style;
 }
 
-/* Hidden, not unmounted — see the template comment. */
+/* Collapsed, not unmounted and not hidden — see the template comment. Clipping
+   keeps the frame laid out, which is what lets the guest keep measuring. */
 .plugin-slot-item--empty {
-  display: none;
+  block-size: 0;
+  overflow: hidden;
+  pointer-events: none;
 }
 </style>

--- a/frontend/src/plugins/layout.spec.ts
+++ b/frontend/src/plugins/layout.spec.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest'
+import { breakpointFor } from './layout'
+import { BREAKPOINTS } from '@/composables/useMobileDetection'
+
+/**
+ * The app breakpoint is the one layout fact a sandboxed plugin cannot work out
+ * for itself: a 336px sidebar panel measures the same on a phone as on a 4K
+ * display. It has to agree with the host's own scale, or a plugin branching on
+ * `md` means something different from the app branching on `md`.
+ */
+describe('breakpointFor', () => {
+  it('agrees with the host breakpoint scale at every boundary', () => {
+    expect(breakpointFor(BREAKPOINTS.sm - 1)).toBe('base')
+    expect(breakpointFor(BREAKPOINTS.sm)).toBe('sm')
+    expect(breakpointFor(BREAKPOINTS.md - 1)).toBe('sm')
+    expect(breakpointFor(BREAKPOINTS.md)).toBe('md')
+    expect(breakpointFor(BREAKPOINTS.lg - 1)).toBe('md')
+    expect(breakpointFor(BREAKPOINTS.lg)).toBe('lg')
+    expect(breakpointFor(BREAKPOINTS.xl - 1)).toBe('lg')
+    expect(breakpointFor(BREAKPOINTS.xl)).toBe('xl')
+  })
+
+  it('classifies the viewports the mobile audit drives', () => {
+    expect(breakpointFor(390)).toBe('base')
+    expect(breakpointFor(700)).toBe('sm')
+    expect(breakpointFor(900)).toBe('md')
+    expect(breakpointFor(1680)).toBe('xl')
+  })
+
+  it('is total for degenerate widths', () => {
+    expect(breakpointFor(0)).toBe('base')
+    expect(breakpointFor(99_999)).toBe('xl')
+  })
+})

--- a/frontend/src/sync/views/KanbanBoard.vue
+++ b/frontend/src/sync/views/KanbanBoard.vue
@@ -855,6 +855,7 @@ function affectedDevicesTooltip(card: CardData): string {
               <article
                 v-for="card in sublane.cards"
                 :key="card.id"
+                :data-card-id="card.id"
                 class="bg-surface rounded-lg border border-default hover:border-strong p-2 cursor-grab select-none transition-colors"
                 :class="{
                   'ring-2 ring-accent': isSelected(card.id),

--- a/frontend/src/sync/views/drag.ts
+++ b/frontend/src/sync/views/drag.ts
@@ -19,6 +19,7 @@
  *   callback runs.
  */
 import { onUnmounted, reactive, type Reactive } from 'vue'
+import { createTouchHold } from './touchHold'
 import {
   createDragEdgeScroller,
   getDefaultDragScrollTargets,
@@ -64,25 +65,6 @@ export interface UseDragDropOptions {
 
 const CLICK_THRESHOLD_PX = 5
 
-/**
- * Touch activation. A horizontal swipe on a card is ambiguous: pan the board,
- * or pick the card up? Distance alone cannot tell them apart, and the browser
- * resolves the ambiguity first and in favour of panning, cancelling the drag
- * (measured: a touch-drag scrolled the board 612 -> 1212 and the card never
- * moved). So touch presses activate on TIME, not distance: swipe to pan, hold
- * to pick up, which is what every touch board does.
- *
- * Note this is deliberately NOT solved with `touch-action: none` on the card.
- * That would hand every card-originated gesture to the drag and leave a phone
- * user almost no surface to pan the board from, since cards cover most of a
- * column. Instead the window-level `touchmove` listener below preventDefaults
- * only AFTER the hold has activated: until then the browser pans normally, and
- * once activated the scroll never starts, so pointer events keep flowing.
- */
-const LONG_PRESS_MS = 350
-/** Movement during the hold that aborts it and lets the browser pan instead. */
-const TOUCH_SLOP_PX = 10
-
 export function useDragDrop(options: UseDragDropOptions): {
   state: Reactive<DragState>
   onPointerDown: (cardId: number, event: PointerEvent) => void
@@ -100,8 +82,8 @@ export function useDragDrop(options: UseDragDropOptions): {
   let startX = 0
   let startY = 0
   let activeCardId: number | null = null
-  let isTouchPress = false
-  let longPressTimer: ReturnType<typeof setTimeout> | null = null
+  // Hold-to-drag on touch; see ./touchHold for why time and not distance.
+  const touchHold = createTouchHold(() => state.isDragging)
   const clickThreshold = options.clickThreshold ?? CLICK_THRESHOLD_PX
   const getEdgeScrollTargets = options.getEdgeScrollTargets ?? getDefaultDragScrollTargets
   const edgeScroller = createDragEdgeScroller({
@@ -112,13 +94,6 @@ export function useDragDrop(options: UseDragDropOptions): {
       }
     },
   })
-
-  function cancelLongPress(): void {
-    if (longPressTimer !== null) {
-      clearTimeout(longPressTimer)
-      longPressTimer = null
-    }
-  }
 
   /** Promote the press to a drag. Shared by the mouse path (moved past the
    *  click threshold) and the touch path (held long enough). */
@@ -139,16 +114,8 @@ export function useDragDrop(options: UseDragDropOptions): {
     edgeScroller.start()
   }
 
-  /** Non-passive so `preventDefault` can still stop the scroll from starting.
-   *  Chrome makes window-level `touchmove` listeners passive by default, which
-   *  would silently make this a no-op, hence the explicit option below. */
-  function onTouchMove(event: TouchEvent): void {
-    if (state.isDragging && event.cancelable) event.preventDefault()
-  }
-
   function reset(): void {
-    cancelLongPress()
-    isTouchPress = false
+    touchHold.end()
     edgeScroller.stop()
     state.draggedCardIds = []
     state.hoverLane = null
@@ -166,19 +133,12 @@ export function useDragDrop(options: UseDragDropOptions): {
     startX = event.clientX
     startY = event.clientY
     activeCardId = cardId
-    isTouchPress = event.pointerType === 'touch'
     state.dragPosition = { x: event.clientX, y: event.clientY }
     window.addEventListener('pointermove', onPointerMove)
     window.addEventListener('pointerup', onPointerUp)
     window.addEventListener('pointercancel', onPointerCancel)
     window.addEventListener('keydown', onKeyDown)
-    if (isTouchPress) {
-      window.addEventListener('touchmove', onTouchMove, { passive: false })
-      longPressTimer = setTimeout(() => {
-        longPressTimer = null
-        activateDrag()
-      }, LONG_PRESS_MS)
-    }
+    touchHold.begin(event, activateDrag)
   }
 
   function onKeyDown(event: KeyboardEvent): void {
@@ -195,13 +155,12 @@ export function useDragDrop(options: UseDragDropOptions): {
     const dx = event.clientX - startX
     const dy = event.clientY - startY
     const moved = Math.hypot(dx, dy) > clickThreshold
-    if (!state.isDragging && isTouchPress) {
+    if (!state.isDragging && touchHold.isTouch) {
       // Still inside the hold window. Movement here means the user is swiping
       // to pan, not picking the card up: drop the press and let the browser
       // have the gesture. (It will usually follow with `pointercancel` once it
       // takes over, which resets the rest.)
-      if (Math.hypot(dx, dy) > TOUCH_SLOP_PX) {
-        cancelLongPress()
+      if (touchHold.exceedsSlop(dx, dy)) {
         cleanupListeners()
         reset()
       }
@@ -249,11 +208,10 @@ export function useDragDrop(options: UseDragDropOptions): {
   }
 
   function cleanupListeners(): void {
-    cancelLongPress()
+    touchHold.end()
     window.removeEventListener('pointermove', onPointerMove)
     window.removeEventListener('pointerup', onPointerUp)
     window.removeEventListener('pointercancel', onPointerCancel)
-    window.removeEventListener('touchmove', onTouchMove)
     window.removeEventListener('keydown', onKeyDown)
   }
 

--- a/frontend/src/sync/views/gantt/useBarDrag.ts
+++ b/frontend/src/sync/views/gantt/useBarDrag.ts
@@ -25,15 +25,9 @@ import { ref, type Ref } from 'vue'
 import { addDays } from 'date-fns'
 import { createDragEdgeScroller } from '@/composables/useDragEdgeScroll'
 import { daysBetween } from '@/composables/useGanttViewport'
+import { createTouchHold } from '@/sync/views/touchHold'
 
-/** Hold before a touch press on a bar BODY becomes a drag. Matches the kanban
- *  (`views/drag.ts`): on touch, swipe pans the timeline and hold picks the bar
- *  up, because the browser resolves that ambiguity in favour of panning and
- *  cancels the drag otherwise. Resize handles are exempt: grabbing one is
- *  already unambiguous, so those drag from the first move. */
-const LONG_PRESS_MS = 350
-/** Movement during the hold that abandons it in favour of panning. */
-const TOUCH_SLOP_PX = 10
+
 
 export type BarDragMode = 'move' | 'start' | 'due'
 
@@ -74,8 +68,9 @@ export function useBarDrag(options: {
   let downX = 0
   let downDay = 0
   let suppressClick = false
-  let isTouchPress = false
-  let longPressTimer: ReturnType<typeof setTimeout> | null = null
+  // Hold-to-drag on touch, shared with the kanban. Resize handles are exempt:
+  // grabbing one is already unambiguous, so only the bar BODY waits for a hold.
+  const touchHold = createTouchHold(() => dragging)
 
   const edgeScroller = createDragEdgeScroller({
     getTargets: () => {
@@ -107,7 +102,6 @@ export function useBarDrag(options: {
     mode = m
     downX = event.clientX
     downDay = dayAt(event.clientX)
-    isTouchPress = event.pointerType === 'touch'
     dragging = m !== 'move' // handles drag immediately; body waits for threshold
     preview.value = {
       cardId: bar.cardId,
@@ -125,29 +119,13 @@ export function useBarDrag(options: {
     window.addEventListener('pointerup', onPointerUp)
     window.addEventListener('pointercancel', cancel)
     window.addEventListener('keydown', onKeyDown)
-    if (isTouchPress) {
-      // Non-passive, or `preventDefault` below is ignored: Chrome makes
-      // window-level `touchmove` listeners passive by default.
-      window.addEventListener('touchmove', onTouchMove, { passive: false })
-      // Grabbing a resize handle is unambiguous, so it drags from the first
-      // move. Grabbing the bar BODY competes with panning the timeline, which
-      // the browser would otherwise win, so that one waits for a hold.
-      if (m === 'move') {
-        longPressTimer = setTimeout(() => {
-          longPressTimer = null
-          if (mode !== 'move' || dragging) return
-          dragging = true
-          options.onDragStart?.()
-          edgeScroller.start()
-          document.body.style.userSelect = 'none'
-        }, LONG_PRESS_MS)
-      }
-    }
-  }
-
-  /** Stops the timeline scrolling once a drag owns the gesture. */
-  function onTouchMove(event: TouchEvent): void {
-    if (dragging && event.cancelable) event.preventDefault()
+    touchHold.begin(event, () => {
+      if (mode !== 'move' || dragging) return
+      dragging = true
+      options.onDragStart?.()
+      edgeScroller.start()
+      document.body.style.userSelect = 'none'
+    })
   }
 
   function applyPointer(clientX: number): void {
@@ -176,8 +154,8 @@ export function useBarDrag(options: {
     if (!dragging && mode === 'move') {
       // On touch, movement before the hold completes is a pan, not a drag.
       // Abandon the press so the browser keeps the gesture.
-      if (isTouchPress) {
-        if (Math.abs(event.clientX - downX) > TOUCH_SLOP_PX) teardown()
+      if (touchHold.isTouch) {
+        if (touchHold.exceedsSlop(event.clientX - downX)) teardown()
         return
       }
       if (Math.abs(event.clientX - downX) <= 4) return
@@ -220,15 +198,10 @@ export function useBarDrag(options: {
   }
 
   function teardown(): void {
-    if (longPressTimer !== null) {
-      clearTimeout(longPressTimer)
-      longPressTimer = null
-    }
-    isTouchPress = false
+    touchHold.end()
     window.removeEventListener('pointermove', onPointerMove)
     window.removeEventListener('pointerup', onPointerUp)
     window.removeEventListener('pointercancel', cancel)
-    window.removeEventListener('touchmove', onTouchMove)
     window.removeEventListener('keydown', onKeyDown)
     edgeScroller.stop()
     document.body.style.userSelect = ''

--- a/frontend/src/sync/views/touchHold.ts
+++ b/frontend/src/sync/views/touchHold.ts
@@ -1,0 +1,102 @@
+/**
+ * Hold-to-drag on touch, shared by the kanban cards and the gantt bars.
+ *
+ * A horizontal swipe on a draggable is ambiguous: pan the surface, or pick the
+ * thing up? Distance cannot tell them apart, and the browser resolves the
+ * ambiguity first and in favour of panning, cancelling the drag. Measured on a
+ * 390px touch viewport, a drag gesture on a kanban card scrolled the board from
+ * 612 to 1204 and the card never moved.
+ *
+ * So touch presses activate on TIME, not distance: swipe to pan, hold to pick
+ * up, as every touch board does.
+ *
+ * This is deliberately NOT solved with `touch-action: none` on the draggable.
+ * Cards cover most of a column and bars most of a row, so that would leave a
+ * phone user almost no surface to pan from. Instead the window-level
+ * `touchmove` listener preventDefaults only once the hold has activated: until
+ * then the browser pans normally, and after activation the scroll never starts,
+ * so pointer events keep flowing.
+ *
+ * Both drag implementations consumed a verbatim copy of this policy, including
+ * its constants. One copy, so it cannot drift.
+ */
+
+/** Hold before a touch press becomes a drag. */
+export const LONG_PRESS_MS = 350
+/** Movement during the hold that abandons it in favour of panning. */
+export const TOUCH_SLOP_PX = 10
+
+export interface TouchHold {
+  /** True while the in-flight press came from a touch pointer. */
+  readonly isTouch: boolean
+  /**
+   * Call on `pointerdown`. For a touch pointer this arms the hold timer and
+   * attaches the scroll suppressor, and `onActivate` fires once the hold
+   * completes. For mouse and pen it does nothing and returns false, leaving the
+   * caller's existing distance-based promotion in charge.
+   */
+  begin(event: PointerEvent, onActivate: () => void): boolean
+  /** True when movement during the hold means the user is panning, not
+   *  dragging, and the press should be abandoned to the browser. */
+  exceedsSlop(dx: number, dy?: number): boolean
+  /** Cancel a pending hold without tearing down the listener. */
+  cancelPending(): void
+  /** Tear down: timer and listener. Safe to call repeatedly. */
+  end(): void
+}
+
+/**
+ * @param isDragging Read at `touchmove` time to decide whether to suppress the
+ * scroll. Passed as a callback rather than a flag because the caller owns the
+ * drag state and it flips after `begin`.
+ */
+export function createTouchHold(isDragging: () => boolean): TouchHold {
+  let timer: ReturnType<typeof setTimeout> | null = null
+  let listening = false
+  let isTouch = false
+
+  // Non-passive, or the `preventDefault` is ignored: Chrome makes window-level
+  // `touchmove` listeners passive by default, which would silently make this a
+  // no-op and hand every gesture back to the scroller.
+  const onTouchMove = (event: TouchEvent): void => {
+    if (isDragging() && event.cancelable) event.preventDefault()
+  }
+
+  function cancelPending(): void {
+    if (timer !== null) {
+      clearTimeout(timer)
+      timer = null
+    }
+  }
+
+  function end(): void {
+    cancelPending()
+    if (listening) {
+      window.removeEventListener('touchmove', onTouchMove)
+      listening = false
+    }
+    isTouch = false
+  }
+
+  return {
+    get isTouch() {
+      return isTouch
+    },
+    begin(event, onActivate) {
+      isTouch = event.pointerType === 'touch'
+      if (!isTouch) return false
+      window.addEventListener('touchmove', onTouchMove, { passive: false })
+      listening = true
+      timer = setTimeout(() => {
+        timer = null
+        onActivate()
+      }, LONG_PRESS_MS)
+      return true
+    },
+    exceedsSlop(dx, dy = 0) {
+      return Math.hypot(dx, dy) > TOUCH_SLOP_PX
+    },
+    cancelPending,
+    end,
+  }
+}

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,0 +1,28 @@
+import { fileURLToPath } from 'node:url'
+import { defineConfig } from 'vitest/config'
+
+/**
+ * Unit tests for the frontend's pure logic.
+ *
+ * Deliberately separate from `vite.config.ts` rather than merged into it: the
+ * app config targets the browser and injects `@vite/env`, which needs a DOM at
+ * import time, so running tests through it fails before collection. This keeps
+ * the test setup to what tests actually need — the `@` alias and a DOM
+ * environment for modules that touch `window` at import.
+ *
+ * Scope is unit-level. Anything that needs a real browser (touch gestures,
+ * scroll, layout measurement) belongs in the Playwright suite under `e2e/`,
+ * because jsdom does not lay out and would happily pass on a broken layout.
+ */
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    include: ['src/**/*.spec.ts'],
+  },
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
+      '@nosdesk/core': fileURLToPath(new URL('../packages/core/src', import.meta.url)),
+    },
+  },
+})

--- a/packages/plugin-runtime/package.json
+++ b/packages/plugin-runtime/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "build": "esbuild src/runtime.ts --bundle --format=esm --target=es2022 --banner:js='// GENERATED from @nosdesk/plugin-runtime src/runtime.ts by `pnpm --filter @nosdesk/plugin-runtime build`. Do not edit by hand; CI drift-checks it.' --outfile=../../backend/src/handlers/plugin_sandbox/runtime.js",
     "type-check": "tsc --noEmit",
-    "lint": "eslint src"
+    "lint": "eslint src",
+    "test": "vitest run"
   },
   "dependencies": {
     "@nosdesk/plugin-sdk": "workspace:*"
@@ -17,6 +18,7 @@
     "esbuild": "^0.25.0",
     "eslint": "^10.2.1",
     "typescript": "^6.0.0",
-    "typescript-eslint": "^8.59.1"
+    "typescript-eslint": "^8.59.1",
+    "vitest": "^3.2.7"
   }
 }

--- a/packages/plugin-runtime/src/heightProtocol.spec.ts
+++ b/packages/plugin-runtime/src/heightProtocol.spec.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect } from 'vitest'
+import {
+  HAS_CONTENT_UNMEASURED,
+  containerSize,
+  decideHeightReport,
+  type HeightInput,
+} from './heightProtocol'
+
+/** Convenience: start from "nothing reported yet". */
+const at = (over: Partial<HeightInput> = {}): HeightInput => ({
+  isEmpty: false,
+  measuredPx: 0,
+  last: null,
+  ...over,
+})
+
+describe('decideHeightReport', () => {
+  it('reports a measured height and carries it forward', () => {
+    expect(decideHeightReport(at({ measuredPx: 210 }))).toEqual({
+      report: 210,
+      last: 210,
+      chase: false,
+    })
+  })
+
+  it('stays quiet when the height has not changed', () => {
+    expect(decideHeightReport(at({ measuredPx: 210, last: 210 }))).toEqual({
+      report: null,
+      last: 210,
+      chase: false,
+    })
+  })
+
+  it('reports 0 when the plugin drew nothing, so the host can collapse it', () => {
+    expect(decideHeightReport(at({ isEmpty: true }))).toEqual({
+      report: 0,
+      last: 0,
+      chase: false,
+    })
+  })
+
+  it('announces empty only once', () => {
+    expect(decideHeightReport(at({ isEmpty: true, last: 0 }))).toEqual({
+      report: null,
+      last: 0,
+      chase: false,
+    })
+  })
+
+  it('emptiness wins over a stale measurement', () => {
+    // The host may still be reporting the old box while the root has emptied.
+    expect(decideHeightReport(at({ isEmpty: true, measuredPx: 210, last: 210 }))).toEqual({
+      report: 0,
+      last: 0,
+      chase: false,
+    })
+  })
+
+  describe('has content but cannot be measured (host has hidden us)', () => {
+    it('asks for layout back and starts chasing', () => {
+      expect(decideHeightReport(at({ measuredPx: 0, last: 0 }))).toEqual({
+        report: HAS_CONTENT_UNMEASURED,
+        last: HAS_CONTENT_UNMEASURED,
+        chase: true,
+      })
+    })
+
+    /**
+     * Regression: `last` used to be seeded with -1, which IS the sentinel, so
+     * this first measurement hit the "already announced" guard and reported
+     * nothing. A panel mounted inside an already-hidden container then never
+     * announced itself and sat at the iframe's default height forever. Seeding
+     * with null is what makes this case reachable.
+     */
+    it('announces on the very first measurement, with nothing reported yet', () => {
+      expect(decideHeightReport(at({ measuredPx: 0, last: null }))).toEqual({
+        report: HAS_CONTENT_UNMEASURED,
+        last: HAS_CONTENT_UNMEASURED,
+        chase: true,
+      })
+    })
+
+    it('does not re-announce while still unmeasurable', () => {
+      expect(
+        decideHeightReport(at({ measuredPx: 0, last: HAS_CONTENT_UNMEASURED })),
+      ).toEqual({ report: null, last: HAS_CONTENT_UNMEASURED, chase: false })
+    })
+
+    it('reports the real height once layout comes back', () => {
+      expect(
+        decideHeightReport(at({ measuredPx: 63, last: HAS_CONTENT_UNMEASURED })),
+      ).toEqual({ report: 63, last: 63, chase: false })
+    })
+  })
+
+  it('never reports a negative height as a size', () => {
+    // The sentinel is a signal, not a measurement: any run of the machine must
+    // only ever emit 0, -1, or a positive number.
+    const inputs: HeightInput[] = [
+      at({ isEmpty: true }),
+      at({ measuredPx: 0, last: 0 }),
+      at({ measuredPx: 120, last: HAS_CONTENT_UNMEASURED }),
+      at({ measuredPx: 0, last: null }),
+    ]
+    for (const input of inputs) {
+      const { report } = decideHeightReport(input)
+      if (report === null) continue
+      expect(report === 0 || report === HAS_CONTENT_UNMEASURED || report > 0).toBe(true)
+    }
+  })
+
+  it('a plugin that empties then refills round-trips back to a real height', () => {
+    // The full recovery sequence, driven as the observers would.
+    let last: number | null = null
+    const seen: number[] = []
+    const step = (isEmpty: boolean, measuredPx: number): void => {
+      const d = decideHeightReport({ isEmpty, measuredPx, last })
+      last = d.last
+      if (d.report !== null) seen.push(d.report)
+    }
+    step(false, 210) // rendered
+    step(true, 0) // emptied -> host collapses
+    step(false, 0) // refilled, but hidden so unmeasurable
+    step(false, 63) // host restored layout, chase measures for real
+    expect(seen).toEqual([210, 0, HAS_CONTENT_UNMEASURED, 63])
+  })
+})
+
+describe('containerSize', () => {
+  it('buckets a sidebar panel as narrow', () => {
+    expect(containerSize(334)).toBe('narrow')
+  })
+
+  it('buckets by the panel scale, not the app breakpoints', () => {
+    expect(containerSize(0)).toBe('narrow')
+    expect(containerSize(479)).toBe('narrow')
+    expect(containerSize(480)).toBe('medium')
+    expect(containerSize(570)).toBe('medium')
+    expect(containerSize(767)).toBe('medium')
+    expect(containerSize(768)).toBe('wide')
+    expect(containerSize(1200)).toBe('wide')
+  })
+})

--- a/packages/plugin-runtime/src/heightProtocol.spec.ts
+++ b/packages/plugin-runtime/src/heightProtocol.spec.ts
@@ -1,12 +1,6 @@
 import { describe, it, expect } from 'vitest'
-import {
-  HAS_CONTENT_UNMEASURED,
-  containerSize,
-  decideHeightReport,
-  type HeightInput,
-} from './heightProtocol'
+import { containerSize, decideHeightReport, type HeightInput } from './heightProtocol'
 
-/** Convenience: start from "nothing reported yet". */
 const at = (over: Partial<HeightInput> = {}): HeightInput => ({
   isEmpty: false,
   measuredPx: 0,
@@ -16,101 +10,43 @@ const at = (over: Partial<HeightInput> = {}): HeightInput => ({
 
 describe('decideHeightReport', () => {
   it('reports a measured height and carries it forward', () => {
-    expect(decideHeightReport(at({ measuredPx: 210 }))).toEqual({
-      report: 210,
-      last: 210,
-      chase: false,
-    })
+    expect(decideHeightReport(at({ measuredPx: 210 }))).toEqual({ report: 210, last: 210 })
   })
 
   it('stays quiet when the height has not changed', () => {
     expect(decideHeightReport(at({ measuredPx: 210, last: 210 }))).toEqual({
       report: null,
       last: 210,
-      chase: false,
     })
   })
 
   it('reports 0 when the plugin drew nothing, so the host can collapse it', () => {
-    expect(decideHeightReport(at({ isEmpty: true }))).toEqual({
-      report: 0,
-      last: 0,
-      chase: false,
-    })
+    expect(decideHeightReport(at({ isEmpty: true }))).toEqual({ report: 0, last: 0 })
   })
 
   it('announces empty only once', () => {
-    expect(decideHeightReport(at({ isEmpty: true, last: 0 }))).toEqual({
-      report: null,
-      last: 0,
-      chase: false,
-    })
+    expect(decideHeightReport(at({ isEmpty: true, last: 0 }))).toEqual({ report: null, last: 0 })
   })
 
   it('emptiness wins over a stale measurement', () => {
-    // The host may still be reporting the old box while the root has emptied.
     expect(decideHeightReport(at({ isEmpty: true, measuredPx: 210, last: 210 }))).toEqual({
       report: 0,
       last: 0,
-      chase: false,
     })
   })
 
-  describe('has content but cannot be measured (host has hidden us)', () => {
-    it('asks for layout back and starts chasing', () => {
-      expect(decideHeightReport(at({ measuredPx: 0, last: 0 }))).toEqual({
-        report: HAS_CONTENT_UNMEASURED,
-        last: HAS_CONTENT_UNMEASURED,
-        chase: true,
-      })
-    })
-
-    /**
-     * Regression: `last` used to be seeded with -1, which IS the sentinel, so
-     * this first measurement hit the "already announced" guard and reported
-     * nothing. A panel mounted inside an already-hidden container then never
-     * announced itself and sat at the iframe's default height forever. Seeding
-     * with null is what makes this case reachable.
-     */
-    it('announces on the very first measurement, with nothing reported yet', () => {
-      expect(decideHeightReport(at({ measuredPx: 0, last: null }))).toEqual({
-        report: HAS_CONTENT_UNMEASURED,
-        last: HAS_CONTENT_UNMEASURED,
-        chase: true,
-      })
-    })
-
-    it('does not re-announce while still unmeasurable', () => {
-      expect(
-        decideHeightReport(at({ measuredPx: 0, last: HAS_CONTENT_UNMEASURED })),
-      ).toEqual({ report: null, last: HAS_CONTENT_UNMEASURED, chase: false })
-    })
-
-    it('reports the real height once layout comes back', () => {
-      expect(
-        decideHeightReport(at({ measuredPx: 63, last: HAS_CONTENT_UNMEASURED })),
-      ).toEqual({ report: 63, last: 63, chase: false })
-    })
+  it('never reports a negative height', () => {
+    // Collapsed ancestors can produce odd measurements; a report is a size.
+    expect(decideHeightReport(at({ measuredPx: -5 }))).toEqual({ report: 0, last: 0 })
   })
 
-  it('never reports a negative height as a size', () => {
-    // The sentinel is a signal, not a measurement: any run of the machine must
-    // only ever emit 0, -1, or a positive number.
-    const inputs: HeightInput[] = [
-      at({ isEmpty: true }),
-      at({ measuredPx: 0, last: 0 }),
-      at({ measuredPx: 120, last: HAS_CONTENT_UNMEASURED }),
-      at({ measuredPx: 0, last: null }),
-    ]
-    for (const input of inputs) {
-      const { report } = decideHeightReport(input)
-      if (report === null) continue
-      expect(report === 0 || report === HAS_CONTENT_UNMEASURED || report > 0).toBe(true)
-    }
-  })
-
-  it('a plugin that empties then refills round-trips back to a real height', () => {
-    // The full recovery sequence, driven as the observers would.
+  /**
+   * The case the old three-state protocol existed to handle. Collapsing with
+   * `block-size: 0` instead of `display: none` keeps layout alive in the guest,
+   * so a plugin that fills in after a fetch is just another content change and
+   * needs no sentinel or chase loop.
+   */
+  it('a plugin that empties then refills round-trips with no extra machinery', () => {
     let last: number | null = null
     const seen: number[] = []
     const step = (isEmpty: boolean, measuredPx: number): void => {
@@ -118,11 +54,24 @@ describe('decideHeightReport', () => {
       last = d.last
       if (d.report !== null) seen.push(d.report)
     }
-    step(false, 210) // rendered
-    step(true, 0) // emptied -> host collapses
-    step(false, 0) // refilled, but hidden so unmeasurable
-    step(false, 63) // host restored layout, chase measures for real
-    expect(seen).toEqual([210, 0, HAS_CONTENT_UNMEASURED, 63])
+    step(true, 0) // mounted, drew nothing -> host collapses
+    step(false, 63) // filled in later; still measurable, so simply reported
+    expect(seen).toEqual([0, 63])
+  })
+
+  it('only ever emits zero or a positive height', () => {
+    const runs: HeightInput[] = [
+      at({ isEmpty: true }),
+      at({ measuredPx: 0, last: 0 }),
+      at({ measuredPx: 120, last: 0 }),
+      at({ measuredPx: -1 }),
+      at({ measuredPx: 0, last: null }),
+    ]
+    for (const input of runs) {
+      const { report } = decideHeightReport(input)
+      if (report === null) continue
+      expect(report).toBeGreaterThanOrEqual(0)
+    }
   })
 })
 

--- a/packages/plugin-runtime/src/heightProtocol.ts
+++ b/packages/plugin-runtime/src/heightProtocol.ts
@@ -1,0 +1,77 @@
+/**
+ * The guest -> host height protocol, as a pure decision.
+ *
+ * Extracted from `observeHeight` so the rules can be asserted directly. They
+ * are subtle enough to have produced two bugs already: a `requestAnimationFrame`
+ * chase that never ran because rendering is suspended in a hidden iframe, and a
+ * `last` seed of `-1` that collided with the HAS_CONTENT sentinel and swallowed
+ * the first report from a panel measured while hidden.
+ *
+ * Three states go over the wire:
+ *   * `> 0` — the content height in px. The host pins the iframe to it.
+ *   * `0`   — the plugin rendered nothing. The host collapses the whole
+ *             contribution, chrome included.
+ *   * `-1`  — the plugin HAS content but cannot be measured right now, because
+ *             the host has hidden it after a previous empty report and hiding
+ *             suspends layout. The host restores layout; the guest then chases
+ *             the real height (mutations still fire while hidden, which is how
+ *             this is noticed at all).
+ */
+
+export const HAS_CONTENT_UNMEASURED = -1
+
+export interface HeightInput {
+  /** The plugin's root drew nothing: no element children, no text. Measured
+   *  from CONTENT, never from height — a root that measures 0 only because the
+   *  host collapsed the frame must NOT read as empty, or the two latch each
+   *  other at zero and it can never grow back. */
+  isEmpty: boolean
+  /** Measured content height. 0 when layout is suspended (host hid us). */
+  measuredPx: number
+  /** Last value reported, or null if nothing has been reported yet. Null
+   *  rather than a number so no seed can collide with a sentinel. */
+  last: number | null
+}
+
+export interface HeightDecision {
+  /** Value to post to the host, or null to stay quiet (deduped). */
+  report: number | null
+  /** The `last` value to carry forward. */
+  last: number | null
+  /** Start re-measuring: we have content but could not size it, so the host
+   *  needs to give layout back before the real height can be read. */
+  chase: boolean
+}
+
+export function decideHeightReport(input: HeightInput): HeightDecision {
+  const { isEmpty, measuredPx, last } = input
+
+  if (isEmpty) {
+    // Deduped: only announce the transition into empty.
+    if (last === 0) return { report: null, last, chase: false }
+    return { report: 0, last: 0, chase: false }
+  }
+
+  if (measuredPx > 0) {
+    if (measuredPx === last) return { report: null, last, chase: false }
+    return { report: measuredPx, last: measuredPx, chase: false }
+  }
+
+  // Non-empty but unmeasurable: ask for layout back, then chase the real value.
+  if (last === HAS_CONTENT_UNMEASURED) return { report: null, last, chase: false }
+  return { report: HAS_CONTENT_UNMEASURED, last: HAS_CONTENT_UNMEASURED, chase: true }
+}
+
+/** Container-width buckets for `data-nd-container`.
+ *
+ *  Deliberately NOT the app's breakpoints: a panel lives in roughly 300-700px,
+ *  where `sm`/`md`/`lg` would put nearly everything in one bucket and tell a
+ *  plugin nothing useful about its own width. */
+export const CONTAINER_NARROW_MAX = 480
+export const CONTAINER_MEDIUM_MAX = 768
+
+export function containerSize(width: number): 'narrow' | 'medium' | 'wide' {
+  if (width < CONTAINER_NARROW_MAX) return 'narrow'
+  if (width < CONTAINER_MEDIUM_MAX) return 'medium'
+  return 'wide'
+}

--- a/packages/plugin-runtime/src/heightProtocol.ts
+++ b/packages/plugin-runtime/src/heightProtocol.ts
@@ -1,35 +1,31 @@
 /**
  * The guest -> host height protocol, as a pure decision.
  *
- * Extracted from `observeHeight` so the rules can be asserted directly. They
- * are subtle enough to have produced two bugs already: a `requestAnimationFrame`
- * chase that never ran because rendering is suspended in a hidden iframe, and a
- * `last` seed of `-1` that collided with the HAS_CONTENT sentinel and swallowed
- * the first report from a panel measured while hidden.
- *
- * Three states go over the wire:
+ * Two states go over the wire:
  *   * `> 0` — the content height in px. The host pins the iframe to it.
- *   * `0`   — the plugin rendered nothing. The host collapses the whole
- *             contribution, chrome included.
- *   * `-1`  — the plugin HAS content but cannot be measured right now, because
- *             the host has hidden it after a previous empty report and hiding
- *             suspends layout. The host restores layout; the guest then chases
- *             the real height (mutations still fire while hidden, which is how
- *             this is noticed at all).
+ *   * `0`   — the plugin rendered nothing. The host drops its chrome and
+ *             collapses the contribution to zero height.
+ *
+ * There is deliberately no "has content but cannot be measured" sentinel. An
+ * earlier version collapsed with `display: none`, which suspends layout inside
+ * the iframe, so a plugin that filled in later could no longer measure itself
+ * and needed a third state to ask for layout back, plus a timer loop to chase
+ * the real height once it returned. That chain existed only to avoid one stray
+ * flex gap, and it produced two bugs of its own. Collapsing with `block-size: 0`
+ * keeps layout alive, so the guest's ResizeObserver keeps working and a plugin
+ * that fills in late is reported the same way as any other content change.
+ *
+ * Emptiness is measured from CONTENT, never from height: a root that measures 0
+ * because the host collapsed the frame must not read as empty, or the two latch
+ * each other at zero and it can never grow back.
  */
 
-export const HAS_CONTENT_UNMEASURED = -1
-
 export interface HeightInput {
-  /** The plugin's root drew nothing: no element children, no text. Measured
-   *  from CONTENT, never from height — a root that measures 0 only because the
-   *  host collapsed the frame must NOT read as empty, or the two latch each
-   *  other at zero and it can never grow back. */
+  /** The plugin's root drew nothing: no element children, no text. */
   isEmpty: boolean
-  /** Measured content height. 0 when layout is suspended (host hid us). */
+  /** Measured content height. */
   measuredPx: number
-  /** Last value reported, or null if nothing has been reported yet. Null
-   *  rather than a number so no seed can collide with a sentinel. */
+  /** Last value reported, or null if nothing has been reported yet. */
   last: number | null
 }
 
@@ -38,28 +34,14 @@ export interface HeightDecision {
   report: number | null
   /** The `last` value to carry forward. */
   last: number | null
-  /** Start re-measuring: we have content but could not size it, so the host
-   *  needs to give layout back before the real height can be read. */
-  chase: boolean
 }
 
 export function decideHeightReport(input: HeightInput): HeightDecision {
   const { isEmpty, measuredPx, last } = input
-
-  if (isEmpty) {
-    // Deduped: only announce the transition into empty.
-    if (last === 0) return { report: null, last, chase: false }
-    return { report: 0, last: 0, chase: false }
-  }
-
-  if (measuredPx > 0) {
-    if (measuredPx === last) return { report: null, last, chase: false }
-    return { report: measuredPx, last: measuredPx, chase: false }
-  }
-
-  // Non-empty but unmeasurable: ask for layout back, then chase the real value.
-  if (last === HAS_CONTENT_UNMEASURED) return { report: null, last, chase: false }
-  return { report: HAS_CONTENT_UNMEASURED, last: HAS_CONTENT_UNMEASURED, chase: true }
+  // Clamp: a measurement can only ever be a size, never negative.
+  const height = isEmpty ? 0 : Math.max(0, measuredPx)
+  if (height === last) return { report: null, last }
+  return { report: height, last: height }
 }
 
 /** Container-width buckets for `data-nd-container`.

--- a/packages/plugin-runtime/src/runtime.ts
+++ b/packages/plugin-runtime/src/runtime.ts
@@ -17,11 +17,7 @@ import type {
   PluginTheme,
 } from '@nosdesk/plugin-sdk';
 import { PLUGIN_UI_CSS } from './pluginUiCss';
-import {
-  HAS_CONTENT_UNMEASURED,
-  containerSize,
-  decideHeightReport,
-} from './heightProtocol';
+import { containerSize, decideHeightReport } from './heightProtocol';
 
 /** Normalize the value a plugin's `mount` returns into a `PluginInstance`. */
 function toInstance(result: void | (() => void) | PluginInstance): PluginInstance {
@@ -133,61 +129,27 @@ function applyLayout(context: PluginContext): void {
   document.documentElement.setAttribute('data-nd-app-breakpoint', context.layout.breakpoint);
 }
 
-/** Re-measure cadence after announcing HAS_CONTENT, and how many attempts
- *  before giving up. ~2s total: long enough to cover the host's un-hide and
- *  reflow, short enough that a genuinely zero-height plugin stops cheaply. */
-const CHASE_INTERVAL_MS = 50;
-const CHASE_MAX_TRIES = 40;
-
 /** How long to wait for `mount` to settle before observing height anyway. */
 const MOUNT_SETTLE_TIMEOUT_MS = 3000;
 
 // Report content height to the host on every change so it can size the iframe
 // (a cross-origin sandboxed iframe can't self-size). Deduped to avoid a resize
-// feedback loop.
+// feedback loop. The decision itself lives in ./heightProtocol.
 function observeHeight(el: HTMLElement): void {
-  // `null`, not -1: -1 IS the HAS_CONTENT_UNMEASURED sentinel, so seeding with
-  // it would make the "already reported unmeasured" guard below true on the
-  // very first measurement and swallow the report. A panel whose first measure
-  // is non-empty but unmeasurable (mounted inside an already-hidden container)
-  // would then never announce itself and would sit at the default height.
   let last: number | null = null;
-  const measure = (): number => Math.ceil(el.getBoundingClientRect().height);
-  // Emptiness is read from CONTENT, never from height: a root that measures 0
-  // only because the host collapsed the frame must not read as empty, or the
-  // two latch each other at zero and it can never grow back.
-  const isEmpty = (): boolean => el.children.length === 0 && !el.textContent?.trim();
-
   const report = (): void => {
     const decision = decideHeightReport({
-      isEmpty: isEmpty(),
-      measuredPx: measure(),
+      // Emptiness is read from CONTENT, never from height: a root that measures
+      // 0 only because the host collapsed the frame must not read as empty, or
+      // the two latch each other at zero and it can never grow back.
+      isEmpty: el.children.length === 0 && !el.textContent?.trim(),
+      measuredPx: Math.ceil(el.getBoundingClientRect().height),
       last,
     });
     last = decision.last;
     if (decision.report !== null) reportHeight(decision.report);
-    if (!decision.chase) return;
-
-    // Re-measure until it takes. The ResizeObserver does NOT fire when the host
-    // flips `display` back on — observed: the frame un-hid but stayed at the
-    // iframe's default 150px forever — so the true height has to be chased
-    // rather than waited for. Bounded, so a genuinely zero-height plugin stops.
-    let tries = 0;
-    const chase = (): void => {
-      if (last !== HAS_CONTENT_UNMEASURED) return; // a real height landed
-      const px = measure();
-      if (px > 0) {
-        last = px;
-        reportHeight(px);
-        return;
-      }
-      if (++tries < CHASE_MAX_TRIES) setTimeout(chase, CHASE_INTERVAL_MS);
-    };
-    // `setTimeout`, NOT `requestAnimationFrame`: rendering is suspended in a
-    // `display: none` iframe, so a rAF callback queued here never runs and the
-    // chase would silently do nothing. Timers still fire while hidden.
-    setTimeout(chase, CHASE_INTERVAL_MS);
   };
+
   new ResizeObserver(report).observe(el);
   // The ResizeObserver only fires on a size CHANGE, and a root that starts
   // empty and stays empty never changes size, so the initial 0 would never be

--- a/packages/plugin-runtime/src/runtime.ts
+++ b/packages/plugin-runtime/src/runtime.ts
@@ -17,6 +17,11 @@ import type {
   PluginTheme,
 } from '@nosdesk/plugin-sdk';
 import { PLUGIN_UI_CSS } from './pluginUiCss';
+import {
+  HAS_CONTENT_UNMEASURED,
+  containerSize,
+  decideHeightReport,
+} from './heightProtocol';
 
 /** Normalize the value a plugin's `mount` returns into a `PluginInstance`. */
 function toInstance(result: void | (() => void) | PluginInstance): PluginInstance {
@@ -80,17 +85,9 @@ function injectTokens(theme: PluginTheme): void {
 // All three are stamped on `<html>` so plugin CSS can select on them, and the
 // app breakpoint is also on `context.layout` for JS.
 
-/** Upper bounds (exclusive) for the container scale. Deliberately NOT the app's
- *  breakpoints: a panel lives in 300-700px, where `sm`/`md`/`lg` would bucket
- *  almost everything into one value and tell a plugin nothing. */
-const CONTAINER_NARROW_MAX = 480;
-const CONTAINER_MEDIUM_MAX = 768;
-
-function containerSize(width: number): 'narrow' | 'medium' | 'wide' {
-  if (width < CONTAINER_NARROW_MAX) return 'narrow';
-  if (width < CONTAINER_MEDIUM_MAX) return 'medium';
-  return 'wide';
-}
+// Container bucketing and the height-report rules are pure, and subtle enough
+// to have caused two bugs, so they live in ./heightProtocol where they can be
+// unit-tested directly. This module keeps only the DOM wiring.
 
 /** Stamp the panel's own width onto `<html>`, live. `--nd-container-width` is
  *  the exact px for plugins that need to compute; `data-nd-container` is the
@@ -136,17 +133,6 @@ function applyLayout(context: PluginContext): void {
   document.documentElement.setAttribute('data-nd-app-breakpoint', context.layout.breakpoint);
 }
 
-/**
- * Sentinel height meaning "this plugin has content, but its height cannot be
- * measured right now". See the recovery path in `observeHeight`.
- *
- * The height wire contract is three-state:
- *   * `> 0` — the content height, in px.
- *   * `0`   — the plugin rendered nothing; the host collapses its chrome.
- *   * `-1`  — has content, height unknown; the host restores layout and waits.
- */
-const HAS_CONTENT_UNMEASURED = -1;
-
 /** Re-measure cadence after announcing HAS_CONTENT, and how many attempts
  *  before giving up. ~2s total: long enough to cover the host's un-hide and
  *  reflow, short enough that a genuinely zero-height plugin stops cheaply. */
@@ -166,60 +152,41 @@ function observeHeight(el: HTMLElement): void {
   // is non-empty but unmeasurable (mounted inside an already-hidden container)
   // would then never announce itself and would sit at the default height.
   let last: number | null = null;
+  const measure = (): number => Math.ceil(el.getBoundingClientRect().height);
+  // Emptiness is read from CONTENT, never from height: a root that measures 0
+  // only because the host collapsed the frame must not read as empty, or the
+  // two latch each other at zero and it can never grow back.
+  const isEmpty = (): boolean => el.children.length === 0 && !el.textContent?.trim();
+
   const report = (): void => {
-    // "Drew nothing" is reported as an explicit 0 so the host can collapse the
-    // whole contribution (chrome included) instead of leaving an empty card.
-    // Deliberately measured from the CONTENT, not the height: a plugin whose
-    // root measures 0 because the host collapsed the iframe must not be read as
-    // empty, or the two would latch each other at zero and it could never grow
-    // back. An empty root cannot feedback-loop, since it does not depend on the
-    // iframe's own size.
-    const isEmpty = el.children.length === 0 && !el.textContent?.trim();
-    if (isEmpty) {
-      if (last !== 0) {
-        last = 0;
-        reportHeight(0);
+    const decision = decideHeightReport({
+      isEmpty: isEmpty(),
+      measuredPx: measure(),
+      last,
+    });
+    last = decision.last;
+    if (decision.report !== null) reportHeight(decision.report);
+    if (!decision.chase) return;
+
+    // Re-measure until it takes. The ResizeObserver does NOT fire when the host
+    // flips `display` back on — observed: the frame un-hid but stayed at the
+    // iframe's default 150px forever — so the true height has to be chased
+    // rather than waited for. Bounded, so a genuinely zero-height plugin stops.
+    let tries = 0;
+    const chase = (): void => {
+      if (last !== HAS_CONTENT_UNMEASURED) return; // a real height landed
+      const px = measure();
+      if (px > 0) {
+        last = px;
+        reportHeight(px);
+        return;
       }
-      return;
-    }
-    const h = Math.ceil(el.getBoundingClientRect().height);
-    if (h > 0) {
-      if (h !== last) {
-        last = h;
-        reportHeight(h);
-      }
-      return;
-    }
-    // Non-empty but unmeasurable. This is the recovery path: after an empty
-    // report the host hides the frame with `display: none`, which suspends
-    // layout here, so a plugin that fills in after a fetch measures 0 and its
-    // real height could never be reported. Mutations still fire while hidden,
-    // so announce HAS_CONTENT and the host restores layout.
-    if (last !== HAS_CONTENT_UNMEASURED) {
-      last = HAS_CONTENT_UNMEASURED;
-      reportHeight(HAS_CONTENT_UNMEASURED);
-      // Then re-measure until it takes. The ResizeObserver above does NOT fire
-      // when the host flips `display` back on — observed: the frame un-hid but
-      // stayed at the iframe's default 150px forever — so the true height has
-      // to be chased here rather than waited for. Bounded, so a plugin that is
-      // legitimately zero-height doesn't spin.
-      let tries = 0;
-      const chase = (): void => {
-        if (last !== HAS_CONTENT_UNMEASURED) return; // a real height landed
-        const px = Math.ceil(el.getBoundingClientRect().height);
-        if (px > 0) {
-          last = px;
-          reportHeight(px);
-          return;
-        }
-        if (++tries < CHASE_MAX_TRIES) setTimeout(chase, CHASE_INTERVAL_MS);
-      };
-      // `setTimeout`, NOT `requestAnimationFrame`: rendering is suspended in a
-      // `display: none` iframe, so a rAF callback queued here never runs and
-      // the chase would silently do nothing (observed: the frame un-hid and
-      // stayed at the iframe's default 150px). Timers still fire while hidden.
-      setTimeout(chase, CHASE_INTERVAL_MS);
-    }
+      if (++tries < CHASE_MAX_TRIES) setTimeout(chase, CHASE_INTERVAL_MS);
+    };
+    // `setTimeout`, NOT `requestAnimationFrame`: rendering is suspended in a
+    // `display: none` iframe, so a rAF callback queued here never runs and the
+    // chase would silently do nothing. Timers still fire while hidden.
+    setTimeout(chase, CHASE_INTERVAL_MS);
   };
   new ResizeObserver(report).observe(el);
   // The ResizeObserver only fires on a size CHANGE, and a root that starts

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -129,7 +129,7 @@ importers:
         version: 3.5.39(typescript@6.0.3)
       vue-router:
         specifier: ^5.0.6
-        version: 5.1.0(@pinia/colada@1.3.1(pinia@3.0.4(typescript@6.0.3)(vue@3.5.39(typescript@6.0.3)))(vue@3.5.39(typescript@6.0.3)))(@vue/compiler-sfc@3.5.39)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.39(typescript@6.0.3)))(rolldown@1.1.3)(vite@8.1.0(@types/node@24.13.2)(jiti@2.7.0)(yaml@2.9.0))(vue@3.5.39(typescript@6.0.3))
+        version: 5.1.0(@pinia/colada@1.3.1(pinia@3.0.4(typescript@6.0.3)(vue@3.5.39(typescript@6.0.3)))(vue@3.5.39(typescript@6.0.3)))(@vue/compiler-sfc@3.5.39)(esbuild@0.28.1)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.39(typescript@6.0.3)))(rolldown@1.1.3)(rollup@4.62.4)(vite@8.1.0(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(vue@3.5.39(typescript@6.0.3))
       y-indexeddb:
         specifier: ^9.0.12
         version: 9.0.12(yjs@13.6.31)
@@ -146,6 +146,9 @@ importers:
         specifier: ^13.6.29
         version: 13.6.31
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.62.1
+        version: 1.62.1
       '@tailwindcss/postcss':
         specifier: ^4.0.15
         version: 4.3.1
@@ -169,7 +172,7 @@ importers:
         version: 1.24.0
       '@vitejs/plugin-vue':
         specifier: ^6.0.0
-        version: 6.0.7(vite@8.1.0(@types/node@24.13.2)(jiti@2.7.0)(yaml@2.9.0))(vue@3.5.39(typescript@6.0.3))
+        version: 6.0.7(vite@8.1.0(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(vue@3.5.39(typescript@6.0.3))
       '@vue/compiler-sfc':
         specifier: 3.5.39
         version: 3.5.39
@@ -191,6 +194,9 @@ importers:
       eslint-plugin-vue:
         specifier: ^10.9.0
         version: 10.9.2(@typescript-eslint/parser@8.62.0(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(vue-eslint-parser@10.4.1(eslint@10.5.0(jiti@2.7.0)))
+      jsdom:
+        specifier: ^30.0.1
+        version: 30.0.1
       npm-run-all2:
         specifier: ^8.0.0
         version: 8.0.4
@@ -211,7 +217,10 @@ importers:
         version: 8.62.0(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)
       vite:
         specifier: ^8.0.0
-        version: 8.1.0(@types/node@24.13.2)(jiti@2.7.0)(yaml@2.9.0)
+        version: 8.1.0(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)
+      vitest:
+        specifier: ^3.2.7
+        version: 3.2.7(@types/node@24.13.2)(jiti@2.7.0)(jsdom@30.0.1)(lightningcss@1.32.0)(yaml@2.9.0)
       vue-tsc:
         specifier: ^3.2.0
         version: 3.3.5(typescript@6.0.3)
@@ -311,6 +320,9 @@ importers:
       typescript-eslint:
         specifier: ^8.59.1
         version: 8.62.0(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)
+      vitest:
+        specifier: ^3.2.7
+        version: 3.2.7(@types/node@24.13.2)(jiti@2.7.0)(jsdom@30.0.1)(lightningcss@1.32.0)(yaml@2.9.0)
 
   packages/plugin-sdk:
     dependencies:
@@ -339,6 +351,14 @@ packages:
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@asamuzakjp/css-color@6.0.7':
+    resolution: {integrity: sha512-vC/bk1Lz7Tn/EfU9/apOTBk80/8dyGyWMowPoV1tJ52muDGsDqt2HPT2klrFUiY60MQmQv9q8yIht15JnBgDGw==}
+    engines: {node: ^22.13.0 || >=24.0.0}
+
+  '@asamuzakjp/dom-selector@8.3.2':
+    resolution: {integrity: sha512-93Z1N+BQNXysodoicpOIyNh2drHfz/CTf9nnT0FEx72GJcIiwgydD7tGAr78j41LsYn3hlRn+LdGPuBLn1Bl8Q==}
+    engines: {node: ^22.13.0 || >=24.0.0}
 
   '@babel/generator@8.0.0':
     resolution: {integrity: sha512-NT9NrVwJsbSV6Y2FSstWa71EETOnzrjkL5/wX3D2mYHtKM+qvqB1DvR4D0Setb/gDBsHzRICifwEWMO8CnTF6g==}
@@ -382,9 +402,49 @@ packages:
     resolution: {integrity: sha512-K8ponJDxBwDHigkeFqaqT5wLGl4bTlwMafR8k7b5CPxr6Ww+UG9ls8Yx6Tcpboxu97eeGVEEyKcHmEyOwN1vSw==}
     engines: {node: ^22.18.0 || >=24.11.0}
 
+  '@bramus/specificity@2.4.2':
+    resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
+    hasBin: true
+
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
+
+  '@csstools/color-helpers@6.1.0':
+    resolution: {integrity: sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/css-calc@3.3.0':
+    resolution: {integrity: sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-color-parser@4.1.10':
+    resolution: {integrity: sha512-UZhQLIUyJaaMepqehrCODwCg2KW25vFvLWBmqYFaPclYvvxzj/sG8LBOhBFCp11i9uE7t1EyS+RAoV9tztPFyw==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.7':
+    resolution: {integrity: sha512-fQ+05118eQS1cofO3aJpB5efgpBZMvIzwr/sbC8kDLVA5XLG8q1kJV5yzrUAI1f7lvhPnm8fgIjzFB8/O/5Dig==}
+    peerDependencies:
+      css-tree: ^3.2.1
+    peerDependenciesMeta:
+      css-tree:
+        optional: true
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
 
   '@date-fns/tz@1.5.0':
     resolution: {integrity: sha512-lwYN/vDPeNRULcepoE/LO2Pgx+7/RV+S9ARfbc9lr2DtGkOD7pAiruHvbR1RX3Qyf6ja47EWJDMsNK5vK08DJg==}
@@ -404,8 +464,20 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.28.1':
+    resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/android-arm64@0.25.12':
     resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.28.1':
+    resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -416,8 +488,20 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.28.1':
+    resolution: {integrity: sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-x64@0.25.12':
     resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.1':
+    resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -428,8 +512,20 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.28.1':
+    resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-x64@0.25.12':
     resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.1':
+    resolution: {integrity: sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -440,8 +536,20 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.28.1':
+    resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-x64@0.25.12':
     resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.1':
+    resolution: {integrity: sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -452,8 +560,20 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.28.1':
+    resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm@0.25.12':
     resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.1':
+    resolution: {integrity: sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -464,8 +584,20 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.28.1':
+    resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-loong64@0.25.12':
     resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.1':
+    resolution: {integrity: sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -476,8 +608,20 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.28.1':
+    resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-ppc64@0.25.12':
     resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.1':
+    resolution: {integrity: sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -488,8 +632,20 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.28.1':
+    resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.25.12':
     resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.1':
+    resolution: {integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -500,8 +656,20 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.28.1':
+    resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/netbsd-arm64@0.25.12':
     resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
@@ -512,8 +680,20 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.28.1':
+    resolution: {integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/openbsd-arm64@0.25.12':
     resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -524,8 +704,20 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.28.1':
+    resolution: {integrity: sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
   '@esbuild/openharmony-arm64@0.25.12':
     resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/openharmony-arm64@0.28.1':
+    resolution: {integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
@@ -536,8 +728,20 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/sunos-x64@0.28.1':
+    resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/win32-arm64@0.25.12':
     resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.28.1':
+    resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
@@ -548,8 +752,20 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.28.1':
+    resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-x64@0.25.12':
     resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.1':
+    resolution: {integrity: sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -583,6 +799,15 @@ packages:
   '@eslint/plugin-kit@0.7.2':
     resolution: {integrity: sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@exodus/bytes@1.15.1':
+    resolution: {integrity: sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
 
   '@fluent/bundle@0.19.1':
     resolution: {integrity: sha512-SWJLZrPamDPsJlFFOW1nkgN0j0rbPbmSdmK0XAoXlyqKieLtMVl4vzng3aR5pwKoUx0scug8+YY2oct3fdfy9A==}
@@ -708,6 +933,13 @@ packages:
     resolution: {integrity: sha512-xglYA6q3XO5P3BNJYxVZ1IV7DLVjp1Py6nwag88YntrS+3vKHyYcMqXVS4ZztJmwz2uGvz1FWhI/4LgbR5uQDA==}
     engines: {node: '>= 10'}
 
+  '@napi-rs/lzma-linux-x64-gnu@1.5.1':
+    resolution: {integrity: sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==}
+    engines: {node: ^22.20 || ^24.12 || >=25}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
   '@napi-rs/wasm-runtime@1.1.6':
     resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
     peerDependencies:
@@ -734,6 +966,11 @@ packages:
     peerDependencies:
       pinia: ^2.2.6 || ^3.0.0
       vue: ^3.5.17
+
+  '@playwright/test@1.62.1':
+    resolution: {integrity: sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   '@rolldown/binding-android-arm64@1.1.3':
     resolution: {integrity: sha512-DT6Z3PhvioeHMvxo+xHc3KtqggrI7CCTXCmC2h/5zUlp5jVitv7XEy+9q5/7v8IolhlioawpMo8Kg0EEBy7J0g==}
@@ -832,6 +1069,144 @@ packages:
 
   '@rolldown/pluginutils@1.0.1':
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
+
+  '@rollup/rollup-android-arm-eabi@4.62.4':
+    resolution: {integrity: sha512-RrPokAb7dmbxFoeO3TloqHyOjgye8RkBhSqmp4aJMIex4c9r46ZstPnleDQOq1t46VOVjwIuwNogIqbodV1Vvg==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.62.4':
+    resolution: {integrity: sha512-JKuJc+pnpks2pjy7L/N3v/cAkZxYlnmuZoD840ldbMI5KDbC4iO9NKwPKYdjYFCMAIIlBzYSFHxIJVYzRo2/8A==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.62.4':
+    resolution: {integrity: sha512-krw5uS2STmvJ02x0uTXHbqQNuz+9eZ1iw+qXk9dmW2gvV4jV7O2hEoOnuhFrpOPiel1mBFtqbxYZZtC46hXLOw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.62.4':
+    resolution: {integrity: sha512-wsTxtgApb4PrOsNJIm0FZ1h3WvCC+k9uxLJ4ad75hgoS4NiRes2SoJFlDAyMwiUY8IssDqGcHbXuN0sx1tfF1A==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.62.4':
+    resolution: {integrity: sha512-GUOnQlyZe3yAXhWOtOMsn5Qkrv5E5mZXa0thbARWi5Ei2szlVXJFQhddZ4HbAzh8q92w5twp+CQvs/eFanz9YQ==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.62.4':
+    resolution: {integrity: sha512-/Y7f3QuxjzPKsjA/rfEDa3+0vXqyjmJ50Ln8dPpCmWkKTrUoWHG1cWhTqaAMLob2m2nESWuC7yGrREz019Ztqg==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.4':
+    resolution: {integrity: sha512-81wiiX3v7aqy+T+bT61TJ78yJjRquqFFTTbAPt08imfQQzkPIW8t6aJbkTagtCCrXMNc9D66+geqlK7ydLPNqA==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.62.4':
+    resolution: {integrity: sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ==}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-arm64-gnu@4.62.4':
+    resolution: {integrity: sha512-CcnXHWnXg69g+DX5VWL3FHts3qMRN2uVEHX+BZvGLdd07/gXkn3ePjYtO1LDJvxkGKVHMclKBRa1QUTH+6toYQ==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm64-musl@4.62.4':
+    resolution: {integrity: sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-loong64-gnu@4.62.4':
+    resolution: {integrity: sha512-XnWYMI7euHlb5a871xPja+Gm7DRCFU+FGRrtS2sMq9N8FvqtpagUy6gD4YOemC5MRk9xbh8+jYMEJbigFQwsgA==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-loong64-musl@4.62.4':
+    resolution: {integrity: sha512-qGDAlO0U8xedCcsdRm9oaoQY8DAx/QT7uIxJWhCdx0ceIWX783UC9QSYkdpzAe29wNiVfp24+bZdQmn49o45SQ==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.62.4':
+    resolution: {integrity: sha512-ru4H6ezD7ysA5EiEK6qkkaEb4modH8CTej6kUy/gQi20u3kB3G7Zn8snXXkeJSCOFKG/rbPPtM/+9Wgas1961w==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-ppc64-musl@4.62.4':
+    resolution: {integrity: sha512-2W4MO5WQVJnbJaZdvDb9rhBDuFU1nKIepPFpJUBsTh2k1YY2g+ODViaWuyOAjQ5cOP7NvrvLzt3wvHOoiAvc7w==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.62.4':
+    resolution: {integrity: sha512-+fxjfuoAmVMCYV5QyjoIpu0cp5DOiOTeqYFk1AVaxGr+/ravWLX89XfQmptsoWcaVy/TGf2hexzbUOrCQIL1CQ==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-riscv64-musl@4.62.4':
+    resolution: {integrity: sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-s390x-gnu@4.62.4':
+    resolution: {integrity: sha512-oCJCJL4pXsoDcP2QZ+JVlPTIRc6266zsIaeJJsWImmF7HO0W8nb6HuSgZlMWxJwaPf8ehbSw8yo0EUw925hKsA==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-gnu@4.62.4':
+    resolution: {integrity: sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-musl@4.62.4':
+    resolution: {integrity: sha512-qiXbGG2jkjXhzXpsFZSR2Xpb8DN/UaxYsbb/STbuR/6fpaDgRmmaq1B/LmtF2wQFOFOSsK2jdE0RZ3a0zHn4QA==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-openbsd-x64@4.62.4':
+    resolution: {integrity: sha512-nWeM//hxv8mIo6jD7Hu4o48DVmV9pbV6gsKaWU+4NFyqHoPKwrkRiZGLKUhOBk8qNmDmpwFtPKg80Bo/Tn4xiQ==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.62.4':
+    resolution: {integrity: sha512-s62SQ/vgsRSvMwDkOEfTqfgASF0f26ZNaQuTA6Aok5lrikf89yI2W0gFHvZb2Jpgc6N8JnOKZgCK2iciO3CsxQ==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.62.4':
+    resolution: {integrity: sha512-J6wGf8TVGbXJq+HH+ttTvrcfNKPbuZecV6KT1B8I18BC5IURUh5kl4Yl5OEP5eFIUoI5BWxCsyYMhFsDx8kekw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.62.4':
+    resolution: {integrity: sha512-zmfrQd/0wu6oJs8Vq8KwY/YtsKSsLtKe/HwAP4Wqy8LhWjeT55fHRAkOhYQ12wI3ayS4Tt12d5CDRD7N96SAYQ==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.62.4':
+    resolution: {integrity: sha512-qPzHqdj9rfUD+w79dtE07zi/kFwKyCJqplp5K5ygeLTp7jLpAoc16OAH39HSmRC9UpozaecsleI8uAdEj6v2yw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.62.4':
+    resolution: {integrity: sha512-zD6NdeWEByGE9QF9vCrlJ5YQB4oq9q91kPZS37Jwj5hOkvR1lTBSpsKhKDw4IJtbQ35LsTS1HD9DZYGKIshU1Q==}
+    cpu: [x64]
+    os: [win32]
 
   '@simplewebauthn/browser@13.3.0':
     resolution: {integrity: sha512-BE/UWv6FOToAdVk0EokzkqQQDOWtNydYlY6+OrmiZ5SCNmb41VehttboTetUM3T/fr6EAFYVXjz4My2wg230rQ==}
@@ -1052,6 +1427,12 @@ packages:
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
   '@types/dompurify@3.2.0':
     resolution: {integrity: sha512-Fgg31wv9QbLDA0SpTOXO3MaxySc4DKGLi8sna4/Utjo4r3ZRPdCt4UQee8BWr+Q5z21yifghREPJGYaEOEIACg==}
     deprecated: This is a stub types definition. dompurify provides its own type definitions, so you do not need this installed.
@@ -1169,6 +1550,35 @@ packages:
     peerDependencies:
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
       vue: ^3.2.25
+
+  '@vitest/expect@3.2.7':
+    resolution: {integrity: sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==}
+
+  '@vitest/mocker@3.2.7':
+    resolution: {integrity: sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@3.2.7':
+    resolution: {integrity: sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==}
+
+  '@vitest/runner@3.2.7':
+    resolution: {integrity: sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==}
+
+  '@vitest/snapshot@3.2.7':
+    resolution: {integrity: sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==}
+
+  '@vitest/spy@3.2.7':
+    resolution: {integrity: sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==}
+
+  '@vitest/utils@3.2.7':
+    resolution: {integrity: sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==}
 
   '@volar/language-core@2.4.28':
     resolution: {integrity: sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==}
@@ -1303,6 +1713,10 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   ast-kit@2.2.0:
     resolution: {integrity: sha512-m1Q/RaVOnTp9JxPX+F+Zn7IcLYMzM8kZofDImfsKZd8MbR+ikdOzTeztStWqfrqIxZnYWryyI9ePm3NGjnZgGw==}
     engines: {node: '>=20.19.0'}
@@ -1337,6 +1751,9 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
+
   birpc@2.9.0:
     resolution: {integrity: sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw==}
 
@@ -1359,6 +1776,10 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
   cached-iterable@0.3.0:
     resolution: {integrity: sha512-MDqM6TpBVebZD4UDtmlFp8EjVtRcsB6xt9aRdWymjk0fWVUUGgmt/V7o0H0gkI2Tkvv8B0ucjidZm4mLosdlWw==}
     engines: {node: '>=8.9.0'}
@@ -1373,6 +1794,14 @@ packages:
 
   caniuse-lite@1.0.30001799:
     resolution: {integrity: sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==}
+
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
 
   chokidar@5.0.0:
     resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
@@ -1418,6 +1847,10 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
   cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
@@ -1425,6 +1858,10 @@ packages:
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  data-urls@7.0.0:
+    resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   date-fns@4.4.0:
     resolution: {integrity: sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==}
@@ -1441,6 +1878,13 @@ packages:
   decamelize@1.2.0:
     resolution: {integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==}
     engines: {node: '>=0.10.0'}
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
+
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
 
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
@@ -1492,6 +1936,10 @@ packages:
     resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
 
+  entities@8.0.0:
+    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
+    engines: {node: '>=20.19.0'}
+
   es-define-property@1.0.1:
     resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
     engines: {node: '>= 0.4'}
@@ -1499,6 +1947,9 @@ packages:
   es-errors@1.3.0:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
+
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
 
   es-object-atoms@1.1.2:
     resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
@@ -1510,6 +1961,11 @@ packages:
 
   esbuild@0.25.12:
     resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  esbuild@0.28.1:
+    resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -1585,9 +2041,16 @@ packages:
   estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
 
   exsolve@1.1.0:
     resolution: {integrity: sha512-D+42+T12DdIlJM3uepa55qGiL3sYdLBOxIl2ifQCzCHz4c7eiolaHsi3BIqEr7JxBzxv2pYZQX9kw16ziMcEmw==}
@@ -1686,6 +2149,11 @@ packages:
     resolution: {integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==}
     engines: {node: '>=6 <7 || >=8'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1743,6 +2211,10 @@ packages:
   hookable@5.5.3:
     resolution: {integrity: sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==}
 
+  html-encoding-sniffer@6.0.0:
+    resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   https-proxy-agent@5.0.1:
     resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
     engines: {node: '>= 6'}
@@ -1781,6 +2253,9 @@ packages:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   is-what@5.5.0:
     resolution: {integrity: sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw==}
     engines: {node: '>=18'}
@@ -1801,6 +2276,18 @@ packages:
   jiti@2.7.0:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
+
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
+
+  jsdom@30.0.1:
+    resolution: {integrity: sha512-52v7mUVUfNQVYYqE1lcdaymWL0njO7lTLUog6ZvW2U5KsbiLk/GnZlVJ+qx0xfNJZ6Gn+KSpPNE52vurbxZwrA==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
+    peerDependencies:
+      canvas: ^3.2.3
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
@@ -1938,8 +2425,15 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
   lowlight@3.3.0:
     resolution: {integrity: sha512-0JNhgFoPvP6U6lE/UdVsSq99tn6DhjjpAj5MxG49ewd2mOBVtwWYIT8ClyABhq198aXXODMU6Ox8DrGy/CpTZQ==}
+
+  lru-cache@11.5.2:
+    resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
+    engines: {node: 20 || >=22}
 
   magic-string-ast@1.0.3:
     resolution: {integrity: sha512-CvkkH1i81zl7mmb94DsRiFeG9V2fR2JeuK8yDgS8oiZSFa++wWLEgZ5ufEOyLHbvSbD1gTRKv9NdX69Rnvr9JA==}
@@ -1963,6 +2457,9 @@ packages:
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
+
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
   mdurl@2.0.0:
     resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
@@ -2070,6 +2567,9 @@ packages:
   pako@1.0.11:
     resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
 
+  parse5@8.0.1:
+    resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
+
   path-browserify@1.0.1:
     resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
 
@@ -2083,6 +2583,10 @@ packages:
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
 
   pdfjs-dist@5.7.284:
     resolution: {integrity: sha512-h4EdYQczmGhbOlqc3PPZwxevn7ApdWPbovAuWXOB/DjIyigSnwfy2oze7c6mRcSr9XgLp3eN3EeL4DyySTPMFw==}
@@ -2124,6 +2628,16 @@ packages:
 
   pkg-types@2.3.1:
     resolution: {integrity: sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==}
+
+  playwright-core@1.62.1:
+    resolution: {integrity: sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  playwright@1.62.1:
+    resolution: {integrity: sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   pngjs@5.0.0:
     resolution: {integrity: sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==}
@@ -2281,6 +2795,10 @@ packages:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
 
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
   require-main-filename@2.0.0:
     resolution: {integrity: sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==}
 
@@ -2296,6 +2814,11 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
+  rollup@4.62.4:
+    resolution: {integrity: sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
   rope-sequence@1.3.4:
     resolution: {integrity: sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==}
 
@@ -2307,6 +2830,10 @@ packages:
 
   safe-buffer@5.1.2:
     resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   scule@1.3.0:
     resolution: {integrity: sha512-6FtHJEvt+pVMIB9IBY+IcCJ6Z5f1iQnytgyfKMhDKgmzYG+TeH/wx1y3l27rshSbLiSanrR9ffZDrEsmjlQF2g==}
@@ -2334,6 +2861,9 @@ packages:
     resolution: {integrity: sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -2342,8 +2872,14 @@ packages:
     resolution: {integrity: sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ==}
     engines: {node: '>=0.10.0'}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   standardized-audio-context@25.3.77:
     resolution: {integrity: sha512-Ki9zNz6pKcC5Pi+QPjPyVsD9GwJIJWgryji0XL9cAJXMGyn+dPOf6Qik1AHei0+UNVcc4BOCa0hWLBzlwqsW/A==}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -2356,12 +2892,18 @@ packages:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
 
+  strip-literal@3.1.0:
+    resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
+
   subscribable-things@2.1.60:
     resolution: {integrity: sha512-6gamStlTGrZAHmIMKUxnrZGW1y0b2N3ofQMX/ZrWdYCcNytk/wRyiRB8eGE4Jg+bYFLypoQAb7UpmWjqpiWCKA==}
 
   superjson@2.2.6:
     resolution: {integrity: sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA==}
     engines: {node: '>=16'}
+
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
   tailwindcss@4.3.1:
     resolution: {integrity: sha512-hk+TB1m+K8CYNrP6rjQaq/Y+4Zylwpa87mLYBKCunwnnQ9p+fHb7kmSfGqyEJoxF/O6CDyABWVFEafNSYKll+Q==}
@@ -2373,13 +2915,46 @@ packages:
   tauri-plugin-web-auth-api@1.0.0:
     resolution: {integrity: sha512-g1uPl2OvFlDZBPUz+4B+AEPsGSMdH6BdnCl7UKXWu0sApRaoe+84rukh3C5o+QgZMVBUf1SyDYZB1hoL2UZwRA==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
 
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@4.0.4:
+    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
+    engines: {node: '>=14.0.0'}
+
+  tldts-core@7.4.10:
+    resolution: {integrity: sha512-KnQjp53ZekKgm/r3l+u8kJGGzYgrWdP8+Mql7a4vijh2WE0IrZWspQj/TpTxDho/YxO+AnOZnIjQcCD+q6iJsw==}
+
+  tldts@7.4.10:
+    resolution: {integrity: sha512-GgouD1B+sWwvkaEq8vXC15DjQitxbvs12oIXELpconwm+Tg3zfcEv4jgzq3vtKverDXsg3VI8aRgNL2Nra0Iog==}
+    hasBin: true
+
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
+
+  tough-cookie@6.0.2:
+    resolution: {integrity: sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==}
+    engines: {node: '>=16'}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
 
   ts-api-utils@2.5.0:
     resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
@@ -2428,6 +3003,10 @@ packages:
 
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
+
+  undici@8.10.0:
+    resolution: {integrity: sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==}
+    engines: {node: '>=22.19.0'}
 
   universalify@0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
@@ -2485,6 +3064,51 @@ packages:
   v8-compile-cache-lib@3.0.1:
     resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
 
+  vite-node@3.2.4:
+    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+
+  vite@7.3.6:
+    resolution: {integrity: sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      lightningcss: ^1.21.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
   vite@8.1.0:
     resolution: {integrity: sha512-BuJcQK/56NQTWDGn4ABea3q4SSBdNPWwNZKTkkUpcMPnLoquSYH8llRtSUIgoL1KSCpHt5eghLShn50mH36y7Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -2526,6 +3150,34 @@ packages:
       tsx:
         optional: true
       yaml:
+        optional: true
+
+  vitest@3.2.7:
+    resolution: {integrity: sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.2.7
+      '@vitest/ui': 3.2.7
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
         optional: true
 
   vscode-uri@3.1.0:
@@ -2583,8 +3235,28 @@ packages:
   w3c-keyname@2.2.8:
     resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
+
   webpack-virtual-modules@0.6.2:
     resolution: {integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==}
+
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
+    engines: {node: '>=20'}
+
+  whatwg-url@16.0.1:
+    resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  whatwg-url@17.1.0:
+    resolution: {integrity: sha512-3GeworPmc2ZfEEHP7lEbUfBX/L75wdEsi0rLNhXcXxnoN5jyq0SL5gCy06SGW2cyTIZdTvWIDQNQoza++vKeaw==}
+    engines: {node: ^22.14.0 || >=24.0.0}
 
   which-module@2.0.1:
     resolution: {integrity: sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==}
@@ -2597,6 +3269,11 @@ packages:
   which@5.0.0:
     resolution: {integrity: sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==}
     engines: {node: ^18.17.0 || >=20.5.0}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   word-wrap@1.2.5:
@@ -2613,6 +3290,13 @@ packages:
   xml-name-validator@4.0.0:
     resolution: {integrity: sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==}
     engines: {node: '>=12'}
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
   y-indexeddb@9.0.12:
     resolution: {integrity: sha512-9oCFRSPPzBK7/w5vOkJBaVCQZKHXB/v6SIT+WYhnJxlEC61juqG0hBrAf+y3gmSMLFLwICNH9nQ53uscuse6Hg==}
@@ -2674,6 +3358,21 @@ snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
 
+  '@asamuzakjp/css-color@6.0.7':
+    dependencies:
+      '@csstools/css-calc': 3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.1.10(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+      lru-cache: 11.5.2
+
+  '@asamuzakjp/dom-selector@8.3.2':
+    dependencies:
+      bidi-js: 1.0.3
+      css-tree: 3.2.1
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.5.2
+
   '@babel/generator@8.0.0':
     dependencies:
       '@babel/parser': 8.0.0
@@ -2711,9 +3410,37 @@ snapshots:
       '@babel/helper-string-parser': 8.0.0
       '@babel/helper-validator-identifier': 8.0.2
 
+  '@bramus/specificity@2.4.2':
+    dependencies:
+      css-tree: 3.2.1
+
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
+
+  '@csstools/color-helpers@6.1.0': {}
+
+  '@csstools/css-calc@3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-color-parser@4.1.10(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/color-helpers': 6.1.0
+      '@csstools/css-calc': 3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.7(css-tree@3.2.1)':
+    optionalDependencies:
+      css-tree: 3.2.1
+
+  '@csstools/css-tokenizer@4.0.0': {}
 
   '@date-fns/tz@1.5.0': {}
 
@@ -2736,79 +3463,157 @@ snapshots:
   '@esbuild/aix-ppc64@0.25.12':
     optional: true
 
+  '@esbuild/aix-ppc64@0.28.1':
+    optional: true
+
   '@esbuild/android-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.1':
     optional: true
 
   '@esbuild/android-arm@0.25.12':
     optional: true
 
+  '@esbuild/android-arm@0.28.1':
+    optional: true
+
   '@esbuild/android-x64@0.25.12':
+    optional: true
+
+  '@esbuild/android-x64@0.28.1':
     optional: true
 
   '@esbuild/darwin-arm64@0.25.12':
     optional: true
 
+  '@esbuild/darwin-arm64@0.28.1':
+    optional: true
+
   '@esbuild/darwin-x64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.1':
     optional: true
 
   '@esbuild/freebsd-arm64@0.25.12':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.28.1':
+    optional: true
+
   '@esbuild/freebsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.1':
     optional: true
 
   '@esbuild/linux-arm64@0.25.12':
     optional: true
 
+  '@esbuild/linux-arm64@0.28.1':
+    optional: true
+
   '@esbuild/linux-arm@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.1':
     optional: true
 
   '@esbuild/linux-ia32@0.25.12':
     optional: true
 
+  '@esbuild/linux-ia32@0.28.1':
+    optional: true
+
   '@esbuild/linux-loong64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.1':
     optional: true
 
   '@esbuild/linux-mips64el@0.25.12':
     optional: true
 
+  '@esbuild/linux-mips64el@0.28.1':
+    optional: true
+
   '@esbuild/linux-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.1':
     optional: true
 
   '@esbuild/linux-riscv64@0.25.12':
     optional: true
 
+  '@esbuild/linux-riscv64@0.28.1':
+    optional: true
+
   '@esbuild/linux-s390x@0.25.12':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.1':
     optional: true
 
   '@esbuild/linux-x64@0.25.12':
     optional: true
 
+  '@esbuild/linux-x64@0.28.1':
+    optional: true
+
   '@esbuild/netbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.1':
     optional: true
 
   '@esbuild/netbsd-x64@0.25.12':
     optional: true
 
+  '@esbuild/netbsd-x64@0.28.1':
+    optional: true
+
   '@esbuild/openbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.1':
     optional: true
 
   '@esbuild/openbsd-x64@0.25.12':
     optional: true
 
+  '@esbuild/openbsd-x64@0.28.1':
+    optional: true
+
   '@esbuild/openharmony-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.1':
     optional: true
 
   '@esbuild/sunos-x64@0.25.12':
     optional: true
 
+  '@esbuild/sunos-x64@0.28.1':
+    optional: true
+
   '@esbuild/win32-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.1':
     optional: true
 
   '@esbuild/win32-ia32@0.25.12':
     optional: true
 
+  '@esbuild/win32-ia32@0.28.1':
+    optional: true
+
   '@esbuild/win32-x64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.1':
     optional: true
 
   '@eslint-community/eslint-utils@4.9.1(eslint@10.5.0(jiti@2.7.0))':
@@ -2840,6 +3645,8 @@ snapshots:
     dependencies:
       '@eslint/core': 1.2.1
       levn: 0.4.1
+
+  '@exodus/bytes@1.15.1': {}
 
   '@fluent/bundle@0.19.1': {}
 
@@ -2935,6 +3742,9 @@ snapshots:
       '@napi-rs/canvas-win32-x64-msvc': 0.1.100
     optional: true
 
+  '@napi-rs/lzma-linux-x64-gnu@1.5.1':
+    optional: true
+
   '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:
       '@emnapi/core': 1.11.1
@@ -2960,6 +3770,10 @@ snapshots:
     dependencies:
       pinia: 3.0.4(typescript@6.0.3)(vue@3.5.39(typescript@6.0.3))
       vue: 3.5.39(typescript@6.0.3)
+
+  '@playwright/test@1.62.1':
+    dependencies:
+      playwright: 1.62.1
 
   '@rolldown/binding-android-arm64@1.1.3':
     optional: true
@@ -3011,6 +3825,81 @@ snapshots:
     optional: true
 
   '@rolldown/pluginutils@1.0.1': {}
+
+  '@rollup/rollup-android-arm-eabi@4.62.4':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.62.4':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.62.4':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.62.4':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.62.4':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.62.4':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.62.4':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.62.4':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.62.4':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.62.4':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.62.4':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.62.4':
+    optional: true
 
   '@simplewebauthn/browser@13.3.0': {}
 
@@ -3179,6 +4068,13 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
   '@types/dompurify@3.2.0':
     dependencies:
       dompurify: 3.4.11
@@ -3320,11 +4216,53 @@ snapshots:
       '@typescript-eslint/types': 8.62.0
       eslint-visitor-keys: 5.0.1
 
-  '@vitejs/plugin-vue@6.0.7(vite@8.1.0(@types/node@24.13.2)(jiti@2.7.0)(yaml@2.9.0))(vue@3.5.39(typescript@6.0.3))':
+  '@vitejs/plugin-vue@6.0.7(vite@8.1.0(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(vue@3.5.39(typescript@6.0.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
-      vite: 8.1.0(@types/node@24.13.2)(jiti@2.7.0)(yaml@2.9.0)
+      vite: 8.1.0(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)
       vue: 3.5.39(typescript@6.0.3)
+
+  '@vitest/expect@3.2.7':
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/spy': 3.2.7
+      '@vitest/utils': 3.2.7
+      chai: 5.3.3
+      tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.2.7(vite@7.3.6(@types/node@24.13.2)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 3.2.7
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.6(@types/node@24.13.2)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0)
+
+  '@vitest/pretty-format@3.2.7':
+    dependencies:
+      tinyrainbow: 2.0.0
+
+  '@vitest/runner@3.2.7':
+    dependencies:
+      '@vitest/utils': 3.2.7
+      pathe: 2.0.3
+      strip-literal: 3.1.0
+
+  '@vitest/snapshot@3.2.7':
+    dependencies:
+      '@vitest/pretty-format': 3.2.7
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@3.2.7':
+    dependencies:
+      tinyspy: 4.0.4
+
+  '@vitest/utils@3.2.7':
+    dependencies:
+      '@vitest/pretty-format': 3.2.7
+      loupe: 3.2.1
+      tinyrainbow: 2.0.0
 
   '@volar/language-core@2.4.28':
     dependencies:
@@ -3498,6 +4436,8 @@ snapshots:
 
   argparse@2.0.1: {}
 
+  assertion-error@2.0.1: {}
+
   ast-kit@2.2.0:
     dependencies:
       '@babel/parser': 7.29.7
@@ -3539,6 +4479,10 @@ snapshots:
 
   baseline-browser-mapping@2.10.40: {}
 
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
+
   birpc@2.9.0: {}
 
   boolbase@1.0.0: {}
@@ -3566,6 +4510,8 @@ snapshots:
       node-releases: 2.0.50
       update-browserslist-db: 1.2.3(browserslist@4.28.4)
 
+  cac@6.7.14: {}
+
   cached-iterable@0.3.0: {}
 
   call-bind-apply-helpers@1.0.2:
@@ -3576,6 +4522,16 @@ snapshots:
   camelcase@5.3.1: {}
 
   caniuse-lite@1.0.30001799: {}
+
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
+  check-error@2.1.3: {}
 
   chokidar@5.0.0:
     dependencies:
@@ -3619,9 +4575,21 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
+
   cssesc@3.0.0: {}
 
   csstype@3.2.3: {}
+
+  data-urls@7.0.0:
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   date-fns@4.4.0: {}
 
@@ -3630,6 +4598,10 @@ snapshots:
       ms: 2.1.3
 
   decamelize@1.2.0: {}
+
+  decimal.js@10.6.0: {}
+
+  deep-eql@5.0.2: {}
 
   deep-is@0.1.4: {}
 
@@ -3670,9 +4642,13 @@ snapshots:
 
   entities@7.0.1: {}
 
+  entities@8.0.0: {}
+
   es-define-property@1.0.1: {}
 
   es-errors@1.3.0: {}
+
+  es-module-lexer@1.7.0: {}
 
   es-object-atoms@1.1.2:
     dependencies:
@@ -3713,6 +4689,35 @@ snapshots:
       '@esbuild/win32-arm64': 0.25.12
       '@esbuild/win32-ia32': 0.25.12
       '@esbuild/win32-x64': 0.25.12
+
+  esbuild@0.28.1:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.1
+      '@esbuild/android-arm': 0.28.1
+      '@esbuild/android-arm64': 0.28.1
+      '@esbuild/android-x64': 0.28.1
+      '@esbuild/darwin-arm64': 0.28.1
+      '@esbuild/darwin-x64': 0.28.1
+      '@esbuild/freebsd-arm64': 0.28.1
+      '@esbuild/freebsd-x64': 0.28.1
+      '@esbuild/linux-arm': 0.28.1
+      '@esbuild/linux-arm64': 0.28.1
+      '@esbuild/linux-ia32': 0.28.1
+      '@esbuild/linux-loong64': 0.28.1
+      '@esbuild/linux-mips64el': 0.28.1
+      '@esbuild/linux-ppc64': 0.28.1
+      '@esbuild/linux-riscv64': 0.28.1
+      '@esbuild/linux-s390x': 0.28.1
+      '@esbuild/linux-x64': 0.28.1
+      '@esbuild/netbsd-arm64': 0.28.1
+      '@esbuild/netbsd-x64': 0.28.1
+      '@esbuild/openbsd-arm64': 0.28.1
+      '@esbuild/openbsd-x64': 0.28.1
+      '@esbuild/openharmony-arm64': 0.28.1
+      '@esbuild/sunos-x64': 0.28.1
+      '@esbuild/win32-arm64': 0.28.1
+      '@esbuild/win32-ia32': 0.28.1
+      '@esbuild/win32-x64': 0.28.1
 
   escalade@3.2.0: {}
 
@@ -3803,7 +4808,13 @@ snapshots:
 
   estree-walker@2.0.2: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
   esutils@2.0.3: {}
+
+  expect-type@1.4.0: {}
 
   exsolve@1.1.0: {}
 
@@ -3916,6 +4927,9 @@ snapshots:
       jsonfile: 4.0.0
       universalify: 0.1.2
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -3969,6 +4983,12 @@ snapshots:
 
   hookable@5.5.3: {}
 
+  html-encoding-sniffer@6.0.0:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
@@ -3996,6 +5016,8 @@ snapshots:
 
   is-number@7.0.0: {}
 
+  is-potential-custom-element-name@1.0.1: {}
+
   is-what@5.5.0: {}
 
   isarray@1.0.0: {}
@@ -4007,6 +5029,34 @@ snapshots:
   isomorphic.js@0.2.5: {}
 
   jiti@2.7.0: {}
+
+  js-tokens@9.0.1: {}
+
+  jsdom@30.0.1:
+    dependencies:
+      '@asamuzakjp/css-color': 6.0.7
+      '@asamuzakjp/dom-selector': 8.3.2
+      '@bramus/specificity': 2.4.2
+      '@csstools/css-syntax-patches-for-csstree': 1.1.7(css-tree@3.2.1)
+      '@exodus/bytes': 1.15.1
+      css-tree: 3.2.1
+      data-urls: 7.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.5.2
+      parse5: 8.0.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.2
+      undici: 8.10.0
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 17.1.0
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   jsesc@3.1.0: {}
 
@@ -4121,11 +5171,15 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
+  loupe@3.2.1: {}
+
   lowlight@3.3.0:
     dependencies:
       '@types/hast': 3.0.4
       devlop: 1.1.0
       highlight.js: 11.11.1
+
+  lru-cache@11.5.2: {}
 
   magic-string-ast@1.0.3:
     dependencies:
@@ -4149,6 +5203,8 @@ snapshots:
   marked@18.0.5: {}
 
   math-intrinsics@1.1.0: {}
+
+  mdn-data@2.27.1: {}
 
   mdurl@2.0.0: {}
 
@@ -4265,6 +5321,10 @@ snapshots:
 
   pako@1.0.11: {}
 
+  parse5@8.0.1:
+    dependencies:
+      entities: 8.0.0
+
   path-browserify@1.0.1: {}
 
   path-exists@4.0.0: {}
@@ -4272,6 +5332,8 @@ snapshots:
   path-key@3.1.1: {}
 
   pathe@2.0.3: {}
+
+  pathval@2.0.1: {}
 
   pdfjs-dist@5.7.284:
     optionalDependencies:
@@ -4307,6 +5369,14 @@ snapshots:
       confbox: 0.2.4
       exsolve: 1.1.0
       pathe: 2.0.3
+
+  playwright-core@1.62.1: {}
+
+  playwright@1.62.1:
+    dependencies:
+      playwright-core: 1.62.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   pngjs@5.0.0: {}
 
@@ -4484,6 +5554,8 @@ snapshots:
 
   require-directory@2.1.1: {}
 
+  require-from-string@2.0.2: {}
+
   require-main-filename@2.0.0: {}
 
   reusify@1.1.0: {}
@@ -4511,6 +5583,38 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.1.3
       '@rolldown/binding-win32-x64-msvc': 1.1.3
 
+  rollup@4.62.4:
+    dependencies:
+      '@types/estree': 1.0.9
+    optionalDependencies:
+      '@napi-rs/lzma-linux-x64-gnu': 1.5.1
+      '@rollup/rollup-android-arm-eabi': 4.62.4
+      '@rollup/rollup-android-arm64': 4.62.4
+      '@rollup/rollup-darwin-arm64': 4.62.4
+      '@rollup/rollup-darwin-x64': 4.62.4
+      '@rollup/rollup-freebsd-arm64': 4.62.4
+      '@rollup/rollup-freebsd-x64': 4.62.4
+      '@rollup/rollup-linux-arm-gnueabihf': 4.62.4
+      '@rollup/rollup-linux-arm-musleabihf': 4.62.4
+      '@rollup/rollup-linux-arm64-gnu': 4.62.4
+      '@rollup/rollup-linux-arm64-musl': 4.62.4
+      '@rollup/rollup-linux-loong64-gnu': 4.62.4
+      '@rollup/rollup-linux-loong64-musl': 4.62.4
+      '@rollup/rollup-linux-ppc64-gnu': 4.62.4
+      '@rollup/rollup-linux-ppc64-musl': 4.62.4
+      '@rollup/rollup-linux-riscv64-gnu': 4.62.4
+      '@rollup/rollup-linux-riscv64-musl': 4.62.4
+      '@rollup/rollup-linux-s390x-gnu': 4.62.4
+      '@rollup/rollup-linux-x64-gnu': 4.62.4
+      '@rollup/rollup-linux-x64-musl': 4.62.4
+      '@rollup/rollup-openbsd-x64': 4.62.4
+      '@rollup/rollup-openharmony-arm64': 4.62.4
+      '@rollup/rollup-win32-arm64-msvc': 4.62.4
+      '@rollup/rollup-win32-ia32-msvc': 4.62.4
+      '@rollup/rollup-win32-x64-gnu': 4.62.4
+      '@rollup/rollup-win32-x64-msvc': 4.62.4
+      fsevents: 2.3.3
+
   rope-sequence@1.3.4: {}
 
   run-parallel@1.2.0:
@@ -4520,6 +5624,10 @@ snapshots:
   rxjs-interop@2.0.0: {}
 
   safe-buffer@5.1.2: {}
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
 
   scule@1.3.0: {}
 
@@ -4537,15 +5645,21 @@ snapshots:
 
   shell-quote@1.9.0: {}
 
+  siginfo@2.0.0: {}
+
   source-map-js@1.2.1: {}
 
   speakingurl@14.0.1: {}
+
+  stackback@0.0.2: {}
 
   standardized-audio-context@25.3.77:
     dependencies:
       '@babel/runtime': 7.29.7
       automation-events: 7.1.19
       tslib: 2.8.1
+
+  std-env@3.10.0: {}
 
   string-width@4.2.3:
     dependencies:
@@ -4561,6 +5675,10 @@ snapshots:
     dependencies:
       ansi-regex: 5.0.1
 
+  strip-literal@3.1.0:
+    dependencies:
+      js-tokens: 9.0.1
+
   subscribable-things@2.1.60:
     dependencies:
       '@babel/runtime': 7.29.7
@@ -4571,6 +5689,8 @@ snapshots:
     dependencies:
       copy-anything: 4.0.5
 
+  symbol-tree@3.2.4: {}
+
   tailwindcss@4.3.1: {}
 
   tapable@2.3.3: {}
@@ -4579,14 +5699,38 @@ snapshots:
     dependencies:
       '@tauri-apps/api': 2.11.1
 
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
   tinyglobby@0.2.17:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
 
+  tinypool@1.1.1: {}
+
+  tinyrainbow@2.0.0: {}
+
+  tinyspy@4.0.4: {}
+
+  tldts-core@7.4.10: {}
+
+  tldts@7.4.10:
+    dependencies:
+      tldts-core: 7.4.10
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
+
+  tough-cookie@6.0.2:
+    dependencies:
+      tldts: 7.4.10
+
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
 
   ts-api-utils@2.5.0(typescript@6.0.3):
     dependencies:
@@ -4635,6 +5779,8 @@ snapshots:
 
   undici-types@7.18.2: {}
 
+  undici@8.10.0: {}
+
   universalify@0.1.2: {}
 
   unplugin-utils@0.3.1:
@@ -4642,14 +5788,16 @@ snapshots:
       pathe: 2.0.3
       picomatch: 4.0.4
 
-  unplugin@3.2.0(rolldown@1.1.3)(vite@8.1.0(@types/node@24.13.2)(jiti@2.7.0)(yaml@2.9.0)):
+  unplugin@3.2.0(esbuild@0.28.1)(rolldown@1.1.3)(rollup@4.62.4)(vite@8.1.0(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)):
     dependencies:
       '@jridgewell/remapping': 2.3.5
       picomatch: 4.0.4
       webpack-virtual-modules: 0.6.2
     optionalDependencies:
+      esbuild: 0.28.1
       rolldown: 1.1.3
-      vite: 8.1.0(@types/node@24.13.2)(jiti@2.7.0)(yaml@2.9.0)
+      rollup: 4.62.4
+      vite: 8.1.0(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)
 
   update-browserslist-db@1.2.3(browserslist@4.28.4):
     dependencies:
@@ -4665,7 +5813,43 @@ snapshots:
 
   v8-compile-cache-lib@3.0.1: {}
 
-  vite@8.1.0(@types/node@24.13.2)(jiti@2.7.0)(yaml@2.9.0):
+  vite-node@3.2.4(@types/node@24.13.2)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 7.3.6(@types/node@24.13.2)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vite@7.3.6(@types/node@24.13.2)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0):
+    dependencies:
+      esbuild: 0.28.1
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.15
+      rollup: 4.62.4
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 24.13.2
+      fsevents: 2.3.3
+      jiti: 2.7.0
+      lightningcss: 1.32.0
+      yaml: 2.9.0
+
+  vite@8.1.0(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -4674,9 +5858,52 @@ snapshots:
       tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 24.13.2
+      esbuild: 0.28.1
       fsevents: 2.3.3
       jiti: 2.7.0
       yaml: 2.9.0
+
+  vitest@3.2.7(@types/node@24.13.2)(jiti@2.7.0)(jsdom@30.0.1)(lightningcss@1.32.0)(yaml@2.9.0):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.7
+      '@vitest/mocker': 3.2.7(vite@7.3.6(@types/node@24.13.2)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))
+      '@vitest/pretty-format': 3.2.7
+      '@vitest/runner': 3.2.7
+      '@vitest/snapshot': 3.2.7
+      '@vitest/spy': 3.2.7
+      '@vitest/utils': 3.2.7
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.17
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.3.6(@types/node@24.13.2)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0)
+      vite-node: 3.2.4(@types/node@24.13.2)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 24.13.2
+      jsdom: 30.0.1
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
 
   vscode-uri@3.1.0: {}
 
@@ -4696,7 +5923,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vue-router@5.1.0(@pinia/colada@1.3.1(pinia@3.0.4(typescript@6.0.3)(vue@3.5.39(typescript@6.0.3)))(vue@3.5.39(typescript@6.0.3)))(@vue/compiler-sfc@3.5.39)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.39(typescript@6.0.3)))(rolldown@1.1.3)(vite@8.1.0(@types/node@24.13.2)(jiti@2.7.0)(yaml@2.9.0))(vue@3.5.39(typescript@6.0.3)):
+  vue-router@5.1.0(@pinia/colada@1.3.1(pinia@3.0.4(typescript@6.0.3)(vue@3.5.39(typescript@6.0.3)))(vue@3.5.39(typescript@6.0.3)))(@vue/compiler-sfc@3.5.39)(esbuild@0.28.1)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.39(typescript@6.0.3)))(rolldown@1.1.3)(rollup@4.62.4)(vite@8.1.0(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(vue@3.5.39(typescript@6.0.3)):
     dependencies:
       '@babel/generator': 8.0.0
       '@vue-macros/common': 3.1.2(vue@3.5.39(typescript@6.0.3))
@@ -4712,7 +5939,7 @@ snapshots:
       picomatch: 4.0.4
       scule: 1.3.0
       tinyglobby: 0.2.17
-      unplugin: 3.2.0(rolldown@1.1.3)(vite@8.1.0(@types/node@24.13.2)(jiti@2.7.0)(yaml@2.9.0))
+      unplugin: 3.2.0(esbuild@0.28.1)(rolldown@1.1.3)(rollup@4.62.4)(vite@8.1.0(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
       unplugin-utils: 0.3.1
       vue: 3.5.39(typescript@6.0.3)
       yaml: 2.9.0
@@ -4720,7 +5947,7 @@ snapshots:
       '@pinia/colada': 1.3.1(pinia@3.0.4(typescript@6.0.3)(vue@3.5.39(typescript@6.0.3)))(vue@3.5.39(typescript@6.0.3))
       '@vue/compiler-sfc': 3.5.39
       pinia: 3.0.4(typescript@6.0.3)(vue@3.5.39(typescript@6.0.3))
-      vite: 8.1.0(@types/node@24.13.2)(jiti@2.7.0)(yaml@2.9.0)
+      vite: 8.1.0(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@farmfe/core'
       - '@rspack/core'
@@ -4749,7 +5976,31 @@ snapshots:
 
   w3c-keyname@2.2.8: {}
 
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
+  webidl-conversions@8.0.1: {}
+
   webpack-virtual-modules@0.6.2: {}
+
+  whatwg-mimetype@5.0.0: {}
+
+  whatwg-url@16.0.1:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
+  whatwg-url@17.1.0:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   which-module@2.0.1: {}
 
@@ -4760,6 +6011,11 @@ snapshots:
   which@5.0.0:
     dependencies:
       isexe: 3.1.5
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   word-wrap@1.2.5: {}
 
@@ -4776,6 +6032,10 @@ snapshots:
       strip-ansi: 6.0.1
 
   xml-name-validator@4.0.0: {}
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   y-indexeddb@9.0.12(yjs@13.6.31):
     dependencies:


### PR DESCRIPTION
> Stacked on #193 (`fix/board-touch-drag`). Based on that branch so this diff is just the four commits below; it will retarget to `main` once #193 merges.

## What

The backend has ~1700 tests. The frontend, `packages/` and `mobile/` had **none** — no vitest, no Playwright, no spec files anywhere outside throwaway `spikes/`. Everything verified during the mobile and plugin work was checked with ad-hoc scripts in a scratch directory, so every one of those behaviours could regress in silence. The worst of them fail invisibly: a board whose drag is stolen by the scroll container still renders perfectly.

### Tests

**Unit (vitest, in CI).** The guest→host height protocol moves out of `runtime.ts` into a pure `decideHeightReport`, which is where the value is: it had already produced two shipped bugs. Also covers container bucketing and `breakpointFor`, which must agree with the host scale or a plugin branching on `md` means something different from the app.

**End-to-end (Playwright).** Eleven specs covering what jsdom cannot: that a swipe on a card still pans while a hold picks it up and drops it, that the mouse path still works, that no project view scrolls sideways or renders controls off-screen, that the board opens on a column with work, and that the gantt's empty state stays on screen. Both halves of the drag rule are asserted deliberately — "fixing" it with `touch-action: none` would pass a drag test while destroying the ability to scroll the board.

Cards gained a `data-card-id` hook. Selecting them by geometry silently matched nothing once they moved and wrapper sizes changed, which is exactly the quiet breakage the suite exists to catch.

### Simplification

The empty-panel collapse had grown five interlocking mechanisms to avoid one stray flex gap: report 0, hide with `display: none`, discover that hiding suspends layout in the iframe, add a third protocol state so the guest could ask for layout back, and a timer loop to chase the height once it returned. It caused two bugs of its own.

Collapsing with `block-size: 0` and clipping keeps layout alive, so the guest's ResizeObserver keeps working and a late-filling plugin is just another content change. That deletes the sentinel, the chase, and all the hidden-iframe reasoning. The protocol is now two states: a height, or `0`.

Measured, same scenarios before and after: the message trace goes from `0, 0, -1, 150, 210, -1, 63, 0` to `0, 0, 150, 210, 63, 0`. The late-filling panel reports its real 63px directly instead of a sentinel followed by a chased re-measure. The cost is that a collapsed item still leaves one gap's worth of space — invisible whitespace between two cards.

The hold-to-drag policy also moves into `views/touchHold.ts`. Its constants and non-passive `touchmove` handling were duplicated verbatim in the kanban and gantt drags, with nothing keeping them in sync.

### Guard

A static check for the density-toggle bug class: a display utility passed to a component that already sets one. It resolves the component through the importing file and reads its root class, so it only fires when both sides declare a display utility, and only for **unprefixed** ones — a variant-prefixed utility (`print:hidden`, `group-hover:hidden`) either applies in different conditions or wins deterministically. Without those exclusions it flagged four call sites that are correct as written. Verified by reintroducing the original bug; clean over 312 templates.

## Verification

13 unit tests and 11 e2e pass; lint, type-check and `cargo check --lib` clean. The e2e suite was re-run after the collapse simplification and the gesture refactor to confirm no behaviour change.

Three bugs in the specs themselves were found and fixed while writing them: comparing "first visible card" before and after (two different cards once a drag reorders the board, now tracked by id), an `iPhone` device preset that implies WebKit while the CDP touch API is Chromium-only, and a hardcoded swipe direction that started pinned at maximum scroll.

## Caveats

**The e2e workflow is unverified.** A GitHub Actions workflow cannot be run locally, so unlike everything else here, CI will be its first real execution and the early runs are expected to need adjustment. It is deliberately a **separate workflow** from `ci.yml`, nightly plus manual dispatch, so a flake in a 45-minute full-stack job never blocks a merge on the type-check and unit-test signal. It drives docker compose rather than reassembling the stack in YAML, so it cannot drift from what `make dev` does. Treat it as informational until it has been green for a while, then promote it.

**The e2e specs mutate demo data** and do not restore it, so repeated local runs drift the board until `make seed-demo` resets it. Assertions therefore check that a card *changed* column, never that it landed in a named one, and drags pick a direction where a column actually exists so cards oscillate instead of piling at an edge.

Only the unit tests gate merges today.