### PR TITLE
CI: add CodeQL, zizmor, and OSV-Scanner; pin every action to a SHA

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,44 @@
+version: 2
+
+# The github-actions ecosystem is the one that matters most here. Every action
+# in .github/workflows is pinned to a full commit SHA (mutable tags are the
+# tj-actions/changed-files shape), and a SHA pin does not update itself.
+# Dependabot rewrites the SHA and keeps the trailing `# vN` comment in step, so
+# pinning does not decay into running a year-old action.
+
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    labels: [dependencies, ci]
+    groups:
+      # One PR for the routine bumps; anything with a security advisory still
+      # comes through on its own so it is not buried in a group.
+      actions:
+        patterns: ['*']
+        update-types: [minor, patch]
+
+  - package-ecosystem: cargo
+    directory: /backend
+    schedule:
+      interval: weekly
+    labels: [dependencies, backend]
+    # The tree is large and mostly transitive. Security updates always come
+    # through; routine minor/patch churn is grouped to keep the PR count sane.
+    open-pull-requests-limit: 5
+    groups:
+      cargo-minor-patch:
+        patterns: ['*']
+        update-types: [minor, patch]
+
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    labels: [dependencies, frontend]
+    open-pull-requests-limit: 5
+    groups:
+      npm-minor-patch:
+        patterns: ['*']
+        update-types: [minor, patch]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,17 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Least privilege. This workflow runs untrusted contributor code (cargo test
+# executes build.rs and test code), so the token it does that with should be
+# able to do nothing but read the checkout. Fork PRs get a read-only token
+# regardless; this covers same-repo branch PRs, which do not.
+permissions:
+  contents: read
+
+# Third-party actions are pinned to a full commit SHA, not a tag: tags are
+# mutable by the action owner, which is the tj-actions/changed-files shape.
+# Dependabot (.github/dependabot.yml) raises the bumps and rewrites the SHA.
+
 jobs:
   backend:
     name: Backend (Rust)
@@ -69,18 +80,20 @@ jobs:
       # we never use frees ~25GB. large-packages off: the apt removal it
       # does is slow and the fast reclaimers below cover the shortfall.
       - name: Free disk space
-        uses: jlumbroso/free-disk-space@v1.3.1
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
         with:
           large-packages: false
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           toolchain: '1.95.0'
           components: rustfmt, clippy
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
         with:
           workspaces: backend
 
@@ -148,7 +161,7 @@ jobs:
         run: cargo test --test channels_email_imap_integration -- --ignored --test-threads=1
 
       - name: Install cargo-deny
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@82cd3e7658a6f96c86c0234aeeda1748937cb0a1 # v2
         with:
           tool: cargo-deny
 
@@ -160,11 +173,13 @@ jobs:
     name: Frontend (Vue)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: "24"
           cache: pnpm
@@ -224,11 +239,9 @@ jobs:
           pnpm --filter @nosdesk/core run build:slots
           git diff --exit-code backend/src/services/plugins/plugin_slots.generated.json
 
-      - name: Audit
-        # Advisory only — must not hard-block merges. npm retired the legacy
-        # audit endpoint (returns HTTP 410), which older `pnpm audit` still
-        # calls, so this step fails for infra reasons unrelated to any change.
-        # Keep it running (advisories still surface as an annotation) but
-        # non-fatal until the toolchain uses the bulk advisory endpoint.
-        continue-on-error: true
-        run: pnpm audit --prod
+      # Dependency advisories for the npm side moved to OSV-Scanner
+      # (.github/workflows/osv-scanner.yml). `pnpm audit` used to run here
+      # under continue-on-error because npm retired the legacy audit endpoint
+      # it calls (HTTP 410), so it failed for infrastructure reasons on every
+      # run and reported nothing. OSV queries osv.dev and covers Cargo.lock in
+      # the same pass. `cargo deny check` above is unaffected and still gates.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,68 @@
+name: CodeQL
+
+# First-party static analysis into the Security tab. Free on this repo (public).
+#
+# Rust is analysed with `build-mode: none`: CodeQL's Rust support went GA in
+# October 2025 and no longer needs to observe a real cargo build, so this does
+# not duplicate ci.yml's compile. That also keeps the job off the critical path
+# for merges, which is why findings land in the Security tab rather than as a
+# blocking check.
+#
+# `actions` is a language here, not a mistake: CodeQL scans workflow files for
+# injection and permission problems. It overlaps zizmor.yml deliberately (the
+# two disagree often enough to be worth both).
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  schedule:
+    # Weekly, so a new query release finds old code without waiting for a push
+    # to the relevant file.
+    - cron: '0 3 * * 1'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      # Upload results to code scanning.
+      security-events: write
+      contents: read
+    strategy:
+      # One language failing should still publish the others' results.
+      fail-fast: false
+      matrix:
+        include:
+          - language: rust
+            build-mode: none
+          - language: javascript-typescript
+            build-mode: none
+          - language: actions
+            build-mode: none
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          # security-extended over the default suite: this is a helpdesk holding
+          # customer data, and the extra false positives are triaged once in the
+          # Security tab rather than blocking a merge.
+          queries: security-extended
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4
+        with:
+          category: /language:${{ matrix.language }}

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -44,6 +44,12 @@ concurrency:
   group: dev-build-${{ inputs.ref || github.ref }}
   cancel-in-progress: true
 
+# Default for any job that does not scope its own token. The jobs below
+# narrow or widen this explicitly; without it they would inherit the
+# repository default instead.
+permissions:
+  contents: read
+
 jobs:
   image:
     name: Build & deploy dev image
@@ -52,18 +58,21 @@ jobs:
       # For the GHCR build cache only; images go to Fly.
       packages: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           ref: ${{ inputs.ref || github.ref }}
+          # Nothing here pushes, so don't leave the token in .git/config where a
+          # later step (or a cached layer) could pick it up.
+          persist-credentials: false
 
       - name: Short commit SHA
         id: vars
         run: echo "sha=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Set up Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
-      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - uses: superfly/flyctl-actions/setup-flyctl@ed8efb33836e8b2096c7fd3ba1c8afe303ebbff1 # master @ 2026-08-15
 
       # Writes credentials for registry.fly.io into the Docker config, which
       # buildx then uses to push.
@@ -75,14 +84,14 @@ jobs:
       # Cache only. Kept separate from the release cache: the fast profile
       # cooks different artifacts.
       - name: Log in to GHCR (build cache)
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: backend/Dockerfile
@@ -121,13 +130,22 @@ jobs:
             --image registry.fly.io/nosdesk-dev:dev-${{ steps.vars.outputs.sha }}
 
       - name: Summary
+        # Expressions go through `env`, not straight into the shell: a branch
+        # name is not a safe shell literal, and `${{ }}` interpolation happens
+        # before the shell ever sees the script. Dispatching this needs write
+        # access already, so this is hygiene rather than a live hole, but it is
+        # the pattern zizmor flags as template-injection.
+        env:
+          REF: ${{ inputs.ref || github.ref }}
+          SHA: ${{ steps.vars.outputs.sha }}
+          DEPLOY: ${{ inputs.deploy }}
         run: |
           {
             echo "### Dev image"
             echo ""
-            echo "Built \`${{ inputs.ref || github.ref }}\` @ \`${{ steps.vars.outputs.sha }}\`"
+            echo "Built \`$REF\` @ \`$SHA\`"
             echo ""
-            if [ "${{ inputs.deploy }}" = "true" ]; then
+            if [ "$DEPLOY" = "true" ]; then
               echo "Deployed to **nosdesk-dev**."
               echo ""
               echo "The app applies pending migrations on boot, so no separate step is needed."
@@ -136,7 +154,7 @@ jobs:
               echo ""
               echo '```sh'
               echo "fly deploy -a nosdesk-dev \\"
-              echo "  --image registry.fly.io/nosdesk-dev:dev-${{ steps.vars.outputs.sha }}"
+              echo "  --image registry.fly.io/nosdesk-dev:dev-$SHA"
               echo '```'
             fi
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -35,6 +35,12 @@ on:
       - '.github/workflows/e2e.yml'
       - 'compose.e2e.yaml'
 
+# Default for any job that does not scope its own token. The jobs below
+# narrow or widen this explicitly; without it they would inherit the
+# repository default instead.
+permissions:
+  contents: read
+
 jobs:
   e2e:
     name: Playwright
@@ -48,15 +54,17 @@ jobs:
       # The Rust image build plus the runner's preinstalled toolchains will
       # otherwise fill the disk, as the backend job already found.
       - name: Free disk space
-        uses: jlumbroso/free-disk-space@v1.3.1
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
         with:
           large-packages: false
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: '24'
           cache: pnpm
@@ -83,13 +91,13 @@ jobs:
             echo "REQUIRE_ADMIN_MFA=false"
           } >> .env
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       # Needed to READ and WRITE the build cache image below. Without it buildx
       # falls back to an anonymous token and cache-to fails the whole build with
       # a 403.
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -102,7 +110,7 @@ jobs:
       # blows past GitHub's 10 GB per-repo cap and gets evicted, which turns
       # every run back into a cold build.
       - name: Build the application image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: backend/Dockerfile
@@ -172,7 +180,7 @@ jobs:
         if: failure()
         run: docker compose -f compose.yaml -f compose.e2e.yaml logs --tail 300
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: failure()
         with:
           name: playwright-report

--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -1,0 +1,48 @@
+name: OSV-Scanner
+
+# Dependency vulnerability scanning across BOTH ecosystems from one tool
+# (Cargo.lock and pnpm-lock.yaml), replacing ci.yml's `pnpm audit --prod` step.
+# That step was advisory-only and permanently failing for infrastructure
+# reasons: npm retired the legacy audit endpoint it calls (HTTP 410). OSV
+# queries osv.dev instead, so it actually returns findings.
+#
+# This does NOT replace `cargo deny check`, which stays in ci.yml. cargo-deny
+# also gates licences, banned crates, and source allowlists, and its `ignore`
+# list is the reviewed triage record that SECURITY.md mirrors. OSV is the
+# second opinion on the advisory half, and the only opinion on the npm half.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    paths:
+      - 'backend/Cargo.lock'
+      - 'pnpm-lock.yaml'
+      - '.github/workflows/osv-scanner.yml'
+  schedule:
+    # Weekly. Most findings arrive because the world changed, not because the
+    # lockfile did, so the cron matters more than the push trigger here.
+    - cron: '0 4 * * 1'
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@8deb546fdb875b9996d27d4950be7312dac076a1 # v2.5.0
+    with:
+      # Recursive discovery rather than naming lockfiles explicitly: it picks up
+      # backend/Cargo.lock and pnpm-lock.yaml today, and any workspace added
+      # under packages/ or plugins/ later without an edit here.
+      scan-args: |-
+        --recursive
+        ./
+      # Report, do not block. The Rust advisory gate that IS allowed to fail a
+      # merge is `cargo deny check`, which has a reviewed ignore list; a raw OSV
+      # hit on a transitive crate with no reachable path should not stop work.
+      # Revisit once the first run's noise level is known.
+      fail-on-vuln: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,12 @@ concurrency:
   group: release-${{ github.ref }}
   cancel-in-progress: false
 
+# Default for any job that does not scope its own token. The jobs below
+# narrow or widen this explicitly; without it they would inherit the
+# repository default instead.
+permissions:
+  contents: read
+
 jobs:
   image:
     name: Build & push image
@@ -35,7 +41,9 @@ jobs:
       contents: write   # create the GitHub Release
       packages: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
 
       - name: Short commit SHA
         id: vars
@@ -45,7 +53,7 @@ jobs:
       # `latest` is applied only to stable tags (no -rc/-beta prerelease).
       - name: Image metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           # Prerelease tags (-rc/-beta) publish to GHCR only; Docker Hub gets
           # stable releases only. metadata-action drops the disabled image.
@@ -57,10 +65,10 @@ jobs:
             type=raw,value=latest,enable=${{ !contains(github.ref_name, '-') }}
 
       - name: Set up Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -69,13 +77,13 @@ jobs:
       - name: Log in to Docker Hub
         # Stable tags only; prereleases publish to GHCR alone (no Docker Hub push).
         if: ${{ !contains(github.ref_name, '-') }}
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: backend/Dockerfile
@@ -107,7 +115,7 @@ jobs:
       # surfaces stable releases. Idempotent: a re-run updates the release.
       - name: Create GitHub Release
         if: startsWith(github.ref, 'refs/tags/')
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           tag_name: ${{ github.ref_name }}
           name: ${{ steps.meta.outputs.version }}

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,51 @@
+name: Actions audit
+
+# zizmor: static analysis for the workflows themselves (template injection,
+# credential leaks, permission misconfiguration, unpinned actions).
+#
+# This is the cheap deterministic half of the CI-supply-chain problem. The
+# workflows here hold DOCKERHUB_TOKEN, FLY_API_TOKEN, and NOSDESK_ROOT_PUBKEY,
+# and release.yml publishes the images operators actually pull, so a regression
+# in this file set is worth a blocking check. It runs in seconds.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+      - '.github/actions/**'
+      - '.github/dependabot.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  zizmor:
+    name: zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+      # Online audits resolve action refs against the API.
+      actions: read
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
+
+      - uses: zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054 # v0.6.2
+        with:
+          # Pinned, not `latest`: the point of this workflow is supply-chain
+          # discipline, and a floating tool version is the same class of problem
+          # as a floating action tag.
+          version: 1.29.0
+          # Findings land in the Security tab. The job still fails on anything
+          # at or above min-severity, which is what makes it a real gate.
+          advanced-security: true
+          min-severity: low
+          min-confidence: medium


### PR DESCRIPTION
Tier 1 of the CI security tooling proposed in the 2026-08 audit. Deterministic, per-PR, free on a public repo.

## Supply chain

- Every action across all workflows pinned to a full commit SHA, tag kept in a trailing comment. Includes `superfly/flyctl-actions/setup-flyctl`, which tracked `master` in the job holding `FLY_API_TOKEN`.
- `permissions: contents: read` at the top of `ci.yml` (it had none, and it runs untrusted contributor code via `cargo test`), and on `dev-build.yml` / `e2e.yml` / `release.yml`, which scoped their tokens per-job only.
- `persist-credentials: false` on every `actions/checkout`. No workflow pushes.
- `dev-build.yml` summary step: `${{ }}` expressions moved into `env` so a branch name is never interpolated into the shell.

## New

| Workflow | Scope | Blocking |
|---|---|---|
| `codeql.yml` | rust + javascript-typescript + actions, `build-mode: none`, `security-extended` | no, Security tab |
| `zizmor.yml` | workflow static analysis, zizmor pinned to 1.29.0 | **yes** |
| `osv-scanner.yml` | cargo + npm advisories | no |

`dependabot.yml` covers cargo, npm, and github-actions. The last one is what keeps the SHA pins above from decaying.

## Removed

The `pnpm audit --prod` step. npm retired the endpoint it calls, so it returned HTTP 410 on every run under `continue-on-error` and reported nothing. OSV covers npm and cargo in one pass. `cargo deny check` is unchanged and still gates.

## Verification

`zizmor 1.29.0` run locally reports no findings at the gate `zizmor.yml` enforces (`--min-severity low --min-confidence medium`). All workflow files parse.

Known and deliberately left, both below that gate: unpinned CI service container images (`postgres`, `redis`, `greenmail`) and the `e2e.yml` buildx cache-poisoning warning, which needs a design decision rather than a one-line fix.

## Not included

Secret scanning. `gitleaks-action` requires a licence key for org-owned repos, so this relies on GitHub's native scanner instead. **Push protection still needs enabling by hand** in Settings > Code security.