### PR TITLE
dependabot: hold TypeScript on 6.x until vue-tsc supports the native compiler

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,6 +38,24 @@ updates:
       interval: weekly
     labels: [dependencies, frontend]
     open-pull-requests-limit: 5
+    ignore:
+      # TypeScript 7 is the Go-native compiler rewrite, and vue-tsc cannot
+      # drive it. vue-tsc type-checks a .vue file by splitting it into a
+      # script block, a template, and a synthesized render function in
+      # memory, then feeding those virtual files to the compiler through its
+      # programmatic API. That API is not stabilized for the native compiler
+      # until TypeScript 7.1, so vue-tsc crashes (ERR_INTERNAL_ASSERTION)
+      # rather than reporting type errors. Same blocker for svelte-check,
+      # astro check, and typescript-eslint.
+      #
+      # Nothing to fix on our side, and a weekly re-raise of an unmergeable
+      # PR is pure noise. Minor and patch updates still come through.
+      #
+      # Revisit when vue-tsc ships native-compiler support (expected within a
+      # release or two of TS 7.1, itself expected around October 2026); drop
+      # this block and let the major through.
+      - dependency-name: typescript
+        update-types: [version-update:semver-major]
     groups:
       npm-minor-patch:
         patterns: ['*']


### PR DESCRIPTION
Stops Dependabot re-raising an unmergeable TypeScript 7 bump every week. Companion to #215, which is closed with the same reasoning.

## Why TS 7 cannot land

TypeScript 7 is the Go-native compiler rewrite. `vue-tsc` type-checks a `.vue` file by splitting it into a script block, a template, and a synthesized render function in memory, then feeding those virtual files through the compiler's programmatic API. That API is not stabilized for the native compiler until **TypeScript 7.1**.

So `vue-tsc` does not report type errors under TS 7, it crashes: `ERR_INTERNAL_ASSERTION`, exit code 2. That is what failed the Frontend job on #215.

The same blocker applies to `svelte-check`, `astro check`, and `typescript-eslint`. There is no version of that PR that merges, and nothing to fix on our side.

## What this changes

Ignores TypeScript **major** updates only, in the npm ecosystem:

```yaml
ignore:
  - dependency-name: typescript
    update-types: [version-update:semver-major]
```

Minor and patch updates continue to come through, so we still track 6.x security and bugfix releases.

## Reverting this

Revisit when `vue-tsc` ships native-compiler support, expected within a release or two of TS 7.1 (itself expected around October 2026). The fix is to delete the `ignore` block and let the major through. The reasoning is recorded inline in `dependabot.yml` so it does not have to be rediscovered.