### PR TITLE
dependabot: add a 7-day cooldown to every ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,12 +5,20 @@ version: 2
 # tj-actions/changed-files shape), and a SHA pin does not update itself.
 # Dependabot rewrites the SHA and keeps the trailing `# vN` comment in step, so
 # pinning does not decay into running a year-old action.
+#
+# Every ecosystem sets a 7-day `cooldown`: a compromised package release is
+# usually caught within days, so a soak period avoids being the first consumer
+# of a bad version. Dependabot applies 3 days implicitly and zizmor's
+# dependabot-cooldown audit wants at least 7. It applies to VERSION updates
+# only, so security patches are never delayed by it.
 
 updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7   # see the note above
     labels: [dependencies, ci]
     groups:
       # One PR for the routine bumps; anything with a security advisory still
@@ -23,6 +31,8 @@ updates:
     directory: /backend
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7   # see the note above
     labels: [dependencies, backend]
     # The tree is large and mostly transitive. Security updates always come
     # through; routine minor/patch churn is grouped to keep the PR count sane.
@@ -36,6 +46,8 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7   # see the note above
     labels: [dependencies, frontend]
     open-pull-requests-limit: 5
     ignore:


### PR DESCRIPTION
Adds a 7-day `cooldown` to all three ecosystems (github-actions, cargo, npm), matching what just landed on `nosdesk-com`.

## Why

Without a `cooldown`, Dependabot applies an implicit 3 days, which leaves us a potential first consumer of a freshly published release. A compromised package release is usually caught within days, so a soak period is cheap insurance against being the one who installs it first.

**Cooldown applies to version updates only.** Dependabot security updates bypass it entirely, so vulnerability patches are not delayed by this. Verified against the Dependabot options reference before applying.

## How it was found

zizmor's `dependabot-cooldown` audit, on the `nosdesk-com` hardening PR.

This repo has had the identical finding all along; it just never failed a build, because zizmor here runs in SARIF mode and uploads to the Security tab rather than gating. The `nosdesk-com` job runs in annotations mode (SARIF upload needs GitHub Code Security, a paid add-on on private repos) and so exits non-zero on findings.

**Keeping SARIF mode here deliberately.** CodeQL already provides the blocking signal on this repo, and the Security-tab history is worth having where it comes free on a public repo. The tradeoff is that zizmor is a reporter here rather than a gate, which is worth knowing when reading a green tick.

## Unchanged

The TypeScript major `ignore` rule from #217 is preserved.