### PR TITLE
deny: drop the stale diesel sqlite advisory ignore

### DIFF
--- a/backend/deny.toml
+++ b/backend/deny.toml
@@ -33,13 +33,6 @@ ignore = [
     # primitives we exercise are unaffected. Revisit when rsa ships a
     # fix or openidconnect migrates away.
     { id = "RUSTSEC-2023-0071", reason = "signature verify only, not decrypt" },
-    # RUSTSEC-2026-0172 — diesel 2.3.9 possible use-after-free in
-    # SqliteConnection::deserialize_readonly_database. We depend on
-    # diesel with the `postgres` backend only (no `sqlite` feature), so
-    # the SQLite backend — and this function — is never compiled or
-    # called. Crate-level lockfile match only. Revisit if the sqlite
-    # feature is ever enabled.
-    { id = "RUSTSEC-2026-0172", reason = "diesel sqlite backend not enabled; vulnerable fn not compiled" },
 ]
 
 [bans]


### PR DESCRIPTION
The cargo-minor-patch group (#201) carried diesel to 2.3.12, past the 2.3.9 that RUSTSEC-2026-0172 affected. The suppression no longer matches anything, and `cargo deny` now warns `advisory-not-detected` on every run.

A suppression that matches nothing is worse than none: it reads as a known-accepted risk when it is actually dead configuration, and it trains people to skim past the ignore list.

## No SECURITY.md change

`deny.toml`'s header says each ignore mirrors a row in the Acknowledged advisories table. This one was never added there, so there is nothing to remove. RUSTSEC-2023-0071 (rsa, transitive via openidconnect) stays and does have its row.

## Verification

`cargo deny check` reports `advisories ok, bans ok, licenses ok, sources ok`, with zero `advisory-not-detected` warnings.