### PR TITLE
Workspace import table allowlist (S2) + shorten URL-borne token TTL (S3)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -102,6 +102,30 @@ strip any client-supplied value. The `TRUSTED_PROXIES` gate
 is the second layer; the private bind is the first. See
 AUD-004 and `utils::client_ip`.
 
+#### Don't log query strings
+
+Two endpoints carry a credential in the URL: the SSE stream
+(`/api/events/stream`) and the collaboration WebSocket. This
+isn't a design preference. `EventSource` and `WebSocket`
+can't set an `Authorization` header, so the connection token
+has to ride a query parameter.
+
+Those tokens are deliberately short-lived (two minutes,
+`CONNECTION_TOKEN_TTL_SECS`), scoped to a single channel, and
+bound to one workspace. They're only accepted at connection
+setup. But most proxies, CDNs, and load balancers log the
+full request line including the query string by default, and
+the collab token is write-capable, so an access log that
+retains them is a store of replayable credentials for the
+length of that TTL.
+
+Configure your proxy to strip or redact query strings for
+those paths, or at minimum keep access logs to the same
+retention and access controls you'd give an auth log. On
+nginx a custom `log_format` using `$uri` rather than
+`$request` is enough. Cloudflare and most CDNs have an
+equivalent redaction setting.
+
 ## Threat model
 
 Nosdesk is a single-tenant helpdesk. There are four user

--- a/backend/src/handlers/collaboration.rs
+++ b/backend/src/handlers/collaboration.rs
@@ -2609,6 +2609,9 @@ pub async fn get_collab_token(req: HttpRequest) -> impl Responder {
         Ok(token) => HttpResponse::Ok().json(json!({
             "token": token,
             "expires_in": crate::utils::jwt::CONNECTION_TOKEN_TTL_SECS,
+            // Served rather than hardcoded client-side: a client buffer larger
+            // than the TTL silently defeats its own cache.
+            "refresh_buffer": crate::utils::jwt::CONNECTION_TOKEN_REFRESH_BUFFER_SECS,
         })),
         Err(_) => errors::internal("Failed to create collab token"),
     }

--- a/backend/src/handlers/sse.rs
+++ b/backend/src/handlers/sse.rs
@@ -978,6 +978,9 @@ pub async fn get_sse_token(
     HttpResponse::Ok().json(json!({
         "sse_token": sse_token,
         "expires_in": crate::utils::jwt::CONNECTION_TOKEN_TTL_SECS,
+        // Served rather than hardcoded client-side: a client buffer larger than
+        // the TTL silently defeats its own cache.
+        "refresh_buffer": crate::utils::jwt::CONNECTION_TOKEN_REFRESH_BUFFER_SECS,
         "user_id": user_info.sub
     }))
 }

--- a/backend/src/services/workspace_export.rs
+++ b/backend/src/services/workspace_export.rs
@@ -107,7 +107,15 @@ struct RowText {
 /// base table carrying a live `workspace_id` column, minus the excluded ones.
 /// Introspected (not hardcoded) so a future migration's tenant table is picked
 /// up automatically, the same pattern the whole-DB backup uses.
-fn discover_workspace_tables(conn: &mut DbConnection) -> Result<Vec<String>, BackupError> {
+///
+/// Also the import's allowlist (`workspace_import::import_workspace`). Sharing
+/// one definition is the point: "what may be exported" and "what may be
+/// written back" are the same set by construction, so a new tenant table cannot
+/// be exportable but not importable, and no table outside the set can be
+/// written by an archive that names it.
+pub(crate) fn discover_workspace_tables(
+    conn: &mut DbConnection,
+) -> Result<Vec<String>, BackupError> {
     #[derive(QueryableByName)]
     struct TableName {
         #[diesel(sql_type = Text)]

--- a/backend/src/services/workspace_import.rs
+++ b/backend/src/services/workspace_import.rs
@@ -306,6 +306,34 @@ pub fn import_workspace(
         // sync::emit.) SET LOCAL is scoped to this transaction.
         sql_query("SET LOCAL nosdesk.in_audit_read = 'true'").execute(conn)?;
 
+        // The archive decides which tables get written, and this runs BYPASSRLS
+        // with the audit triggers suppressed above. `table_exists_in_db` (in the
+        // insert helpers) only asserts a table EXISTS, so without this an
+        // archive naming a global/platform table would have its rows inserted
+        // there, unaudited. Platform-admin gated, so this is not an escalation
+        // path; it matters because the archive itself is an untrusted input
+        // (operators accept export files to perform migrations).
+        //
+        // Checked before anything is written, so a rejected archive leaves no
+        // partial workspace behind. `workspaces` and `users` are handled
+        // separately below and are legitimately present.
+        let allowed = crate::services::workspace_export::discover_workspace_tables(conn)?;
+        let allowed: HashSet<&str> = allowed.iter().map(String::as_str).collect();
+        let mut rejected: Vec<&str> = contents
+            .tables
+            .keys()
+            .map(String::as_str)
+            .filter(|t| *t != "workspaces" && *t != "users")
+            .filter(|t| !allowed.contains(t))
+            .collect();
+        if !rejected.is_empty() {
+            rejected.sort_unstable();
+            return Err(BackupError::CorruptedBackup(format!(
+                "archive names tables that are not workspace-scoped: {}",
+                rejected.join(", ")
+            )));
+        }
+
         let (new_ws_id, slug) = create_target_workspace(conn, contents, opts)?;
         upsert_members(conn, contents)?;
 
@@ -876,5 +904,111 @@ mod tests {
             new_ug, 1,
             "the id-less user_groups junction row was imported into the new workspace"
         );
+    }
+
+    /// An archive naming a table that is not workspace-scoped is refused
+    /// outright, before anything is written.
+    ///
+    /// The insert helpers validate that a table EXISTS (so the dynamic SQL is
+    /// not injectable) but not that it is a TENANT table. Since the import runs
+    /// BYPASSRLS with `nosdesk.in_audit_read` suppressing the audit triggers, a
+    /// crafted archive could otherwise write unaudited rows into a global or
+    /// platform table. Regression test for S2 (docs/security-audit-2026-08.md).
+    #[test]
+    fn archive_naming_a_non_tenant_table_is_refused() {
+        use crate::services::workspace_export::export_workspace;
+        use crate::sync::actor::ActorContext;
+        use crate::sync::session::with_actor_bypass_context;
+        use crate::test_helpers::setup_test_pool;
+        use diesel::sql_types::Integer;
+
+        fn as_diesel<T>(r: Result<T, BackupError>) -> Result<T, diesel::result::Error> {
+            r.map_err(|e| diesel::result::Error::QueryBuilderError(e.to_string().into()))
+        }
+        #[derive(QueryableByName)]
+        struct IdRow {
+            #[diesel(sql_type = Integer)]
+            id: i32,
+        }
+        #[derive(QueryableByName)]
+        struct Cnt {
+            #[diesel(sql_type = diesel::sql_types::BigInt)]
+            n: i64,
+        }
+
+        let pool = setup_test_pool();
+        let mut conn = pool.get().expect("test pool connection");
+        let actor = ActorContext::system("test:workspace_import_allowlist");
+
+        let src: i32 = with_actor_bypass_context(&mut conn, &actor, |c| {
+            let r: IdRow =
+                sql_query("SELECT id FROM workspaces ORDER BY id LIMIT 1").get_result(c)?;
+            Ok::<_, diesel::result::Error>(r.id)
+        })
+        .expect("a workspace exists in the test DB");
+
+        // Start from a genuine export so the manifest and every other table are
+        // exactly what the importer expects, then tamper with one entry. That is
+        // the realistic shape of this attack: a valid archive with an extra
+        // table spliced in, not a hand-built one that fails for other reasons.
+        let archive = with_actor_bypass_context(&mut conn, &actor, |c| {
+            as_diesel(export_workspace(c, src, None))
+        })
+        .expect("export succeeds");
+        let mut contents = read_archive(&archive, None).expect("read archive");
+
+        // `refresh_tokens` exists but carries no `workspace_id`, so it is
+        // outside the exportable/importable set. It is also the sharpest
+        // illustration of why the guard matters: a row forged into it is a
+        // usable session credential, written with the audit triggers suppressed
+        // and outside any tenant.
+        let before: i64 = with_actor_bypass_context(&mut conn, &actor, |c| {
+            let r: Cnt = sql_query("SELECT count(*) AS n FROM refresh_tokens").get_result(c)?;
+            Ok::<_, diesel::result::Error>(r.n)
+        })
+        .expect("count migrations");
+
+        contents.tables.insert(
+            "refresh_tokens".to_string(),
+            vec![json!({
+                "token_hash": "0000000000000000000000000000000000000000000000000000000000000000",
+                "user_uuid": "00000000-0000-0000-0000-000000000001",
+                "expires_at": "2099-01-01T00:00:00Z",
+            })],
+        );
+
+        let unique = std::process::id();
+        let opts = ImportOptions {
+            slug_override: Some(format!("rejected-{unique}")),
+            uuid_override: Some("00000000-0000-0000-0000-0000000000fe".to_string()),
+            regenerate_uuids: true,
+        };
+
+        let err = with_actor_bypass_context(&mut conn, &actor, |c| {
+            Ok::<_, diesel::result::Error>(import_workspace(c, &contents, &opts).err())
+        })
+        .expect("the transaction itself runs")
+        .expect("import must refuse an archive naming a non-tenant table");
+
+        match err {
+            BackupError::CorruptedBackup(msg) => assert!(
+                msg.contains("refresh_tokens"),
+                "the error should name the offending table, got: {msg}"
+            ),
+            other => panic!("expected CorruptedBackup, got {other:?}"),
+        }
+
+        // Refused before any write: the offending table is untouched and no
+        // workspace was created.
+        let (after, leaked): (i64, i64) = with_actor_bypass_context(&mut conn, &actor, |c| {
+            let a: Cnt = sql_query("SELECT count(*) AS n FROM refresh_tokens").get_result(c)?;
+            let w: Cnt = sql_query("SELECT count(*) AS n FROM workspaces WHERE slug = $1")
+                .bind::<Text, _>(format!("rejected-{unique}"))
+                .get_result(c)?;
+            Ok::<_, diesel::result::Error>((a.n, w.n))
+        })
+        .expect("post-check counts");
+        assert_eq!(before, after, "no row was written to the non-tenant table");
+        assert_eq!(leaked, 0, "no partial workspace was left behind");
     }
 }

--- a/backend/src/utils/jwt.rs
+++ b/backend/src/utils/jwt.rs
@@ -21,7 +21,27 @@ lazy_static::lazy_static! {
 /// source of truth: it sets both the JWT `exp` (in `create_connection_token`)
 /// and the `expires_in` the mint endpoints report to the client, so the client's
 /// refresh-before-expiry cache can never disagree with the real expiry.
-pub const CONNECTION_TOKEN_TTL_SECS: usize = 3600;
+///
+/// Deliberately short, because these are the only tokens that travel in a URL.
+/// `EventSource` and `WebSocket` cannot set headers, so both ride a query
+/// parameter, and query strings are logged by default at essentially every
+/// reverse proxy, CDN, and load balancer. That makes an ordinary access log a
+/// store of replayable credentials, and the collab token is write-capable.
+/// These are only ever presented at connection setup (an established stream is
+/// unaffected by expiry), so the useful lifetime is seconds, not an hour: the
+/// window only has to cover mint, navigate, connect, and the client re-mints
+/// through the authenticated session when its cache goes stale.
+///
+/// Kept above the 30s `leeway` in `validate_token` by a comfortable margin, and
+/// above `CONNECTION_TOKEN_REFRESH_BUFFER_SECS` so the client cache is still
+/// worth having. If this ever needs to be raised, prefer making the token
+/// single-use (exchanged for a session on connect) over lengthening it.
+pub const CONNECTION_TOKEN_TTL_SECS: usize = 120;
+
+/// How far before expiry the client should re-mint. Reported to the client so
+/// the two cannot drift; must stay well below [`CONNECTION_TOKEN_TTL_SECS`] or
+/// the client's cache never hits and every connect re-mints.
+pub const CONNECTION_TOKEN_REFRESH_BUFFER_SECS: usize = 30;
 
 /// JWT token creation and validation utilities
 pub struct JwtUtils;
@@ -66,7 +86,8 @@ impl JwtUtils {
         .map_err(JwtError::EncodingError)
     }
 
-    /// Mint a short-lived (1h), sessionless "connection token" for a URL-only
+    /// Mint a short-lived (`CONNECTION_TOKEN_TTL_SECS`), sessionless
+    /// "connection token" for a URL-only
     /// channel that can't send an `Authorization` header (EventSource SSE,
     /// WebSocket collab), so the token rides in the query string instead.
     /// `workspace_uuid` binds the selected workspace (Model C) so the channel
@@ -829,7 +850,48 @@ mod tests {
         }
     }
 
+    /// The URL-borne connection tokens must stay short-lived.
+    ///
+    /// These are the only credentials Nosdesk puts in a query string (EventSource
+    /// and WebSocket cannot set headers), and query strings land in proxy, CDN,
+    /// and load-balancer access logs by default. The collab variant is
+    /// write-capable, so the TTL is the whole exposure window for a token
+    /// recovered from a log. Guard rather than a comment, because "just bump the
+    /// TTL" is the natural fix for an unrelated reconnect bug.
     #[test]
+    fn connection_token_ttl_stays_short_and_above_its_buffer() {
+        assert!(
+            CONNECTION_TOKEN_TTL_SECS <= 300,
+            "connection tokens travel in the URL; a {CONNECTION_TOKEN_TTL_SECS}s TTL is too long \
+             a replay window. Make the token single-use instead of lengthening it."
+        );
+        // Below the 30s validation leeway the token could expire before it is
+        // usable; below the client buffer the cache never hits.
+        assert!(
+            CONNECTION_TOKEN_TTL_SECS > CONNECTION_TOKEN_REFRESH_BUFFER_SECS * 2,
+            "TTL must leave useful room above the refresh buffer, else every connect re-mints"
+        );
+    }
+
+    #[test]
+    fn connection_token_expiry_matches_the_advertised_ttl() {
+        unsafe {
+            std::env::set_var("JWT_SECRET", "test-secret-key-for-testing-only");
+        }
+        let _ = &*JWT_SECRET;
+
+        let token =
+            JwtUtils::create_collab_token(&uuid::Uuid::new_v4().to_string(), "member", None)
+                .expect("mint collab token");
+        let claims = JwtUtils::validate_token(&token).expect("validate");
+        assert_eq!(
+            claims.exp - claims.iat,
+            CONNECTION_TOKEN_TTL_SECS,
+            "the JWT exp must match the expires_in the mint endpoints report, or the client's \
+             refresh cache drifts from the real expiry"
+        );
+    }
+
     /// A crypto backend is compiled in.
     ///
     /// From jsonwebtoken 10 the crate dispatches through a backend trait, and

--- a/frontend/src/services/collabToken.ts
+++ b/frontend/src/services/collabToken.ts
@@ -11,13 +11,19 @@ import apiClient from '@nosdesk/core/apiClient';
 interface CollabTokenResponse {
   token: string;
   expires_in: number;
+  /** Seconds before expiry at which to re-mint. Served by the backend. */
+  refresh_buffer?: number;
 }
 
 let cached: { token: string; expiresAt: number } | null = null;
 
 // Refetch a little before expiry so a long editing session never connects with
-// an about-to-expire token.
-const REFRESH_BUFFER_MS = 5 * 60 * 1000;
+// an about-to-expire token. The backend serves this alongside `expires_in`
+// (both derive from one constant there) because the token TTL is deliberately
+// short: a buffer hardcoded larger than the TTL would mean the cache never hits
+// and every connect re-mints. Falls back to half the TTL if an older backend
+// omits the field.
+const FALLBACK_BUFFER_RATIO = 0.5;
 
 /**
  * Get a collab connection token, cached until near its expiry. Bound to the
@@ -26,11 +32,17 @@ const REFRESH_BUFFER_MS = 5 * 60 * 1000;
  */
 export async function getCollabToken(): Promise<string> {
   const now = Date.now();
-  if (cached && now < cached.expiresAt - REFRESH_BUFFER_MS) {
+  if (cached && now < cached.expiresAt) {
     return cached.token;
   }
   const { data } = await apiClient.post<CollabTokenResponse>('/collaboration/token');
-  cached = { token: data.token, expiresAt: now + data.expires_in * 1000 };
+  const bufferSecs = data.refresh_buffer ?? data.expires_in * FALLBACK_BUFFER_RATIO;
+  // Store the moment we should stop using it, not the raw expiry, so the
+  // buffer is applied once here rather than at every read.
+  cached = {
+    token: data.token,
+    expiresAt: now + Math.max(0, data.expires_in - bufferSecs) * 1000,
+  };
   return cached.token;
 }
 

--- a/frontend/src/services/sseService.ts
+++ b/frontend/src/services/sseService.ts
@@ -78,12 +78,12 @@ class SSEService {
 
   // Get SSE token from backend with caching
   private async getSseToken(): Promise<string> {
-    // Return cached token if still valid (with 5 min buffer)
-    if (
-      this.sseToken &&
-      this.tokenExpiryTime &&
-      Date.now() < this.tokenExpiryTime - 300000
-    ) {
+    // `tokenExpiryTime` already has the refresh buffer subtracted (see below),
+    // so this is a plain comparison. The buffer is served by the backend rather
+    // than hardcoded here: the token TTL is deliberately short because it
+    // travels in the URL, and a buffer larger than the TTL would mean the cache
+    // never hits and every connect re-mints.
+    if (this.sseToken && this.tokenExpiryTime && Date.now() < this.tokenExpiryTime) {
       return this.sseToken;
     }
 
@@ -97,9 +97,13 @@ class SSEService {
       const response = await apiClient.post("/events/token");
       const data = response.data;
 
-      // Cache token and expiry
+      // Cache the token and the moment we should stop using it (expiry minus
+      // the backend-served refresh buffer), falling back to half the TTL if an
+      // older backend omits the field.
       this.sseToken = data.sse_token;
-      this.tokenExpiryTime = Date.now() + data.expires_in * 1000;
+      const bufferSecs = data.refresh_buffer ?? data.expires_in * 0.5;
+      this.tokenExpiryTime =
+        Date.now() + Math.max(0, data.expires_in - bufferSecs) * 1000;
 
       return this.sseToken!;
     } catch (error) {


### PR DESCRIPTION
S2 and S3 from the 2026-08 audit. These were written, verified and pushed a while back, then the branch never got a PR opened and quietly sat unmerged; caught during a branch cleanup.

Rebased onto current main (28 commits), with one real conflict resolved in `utils/jwt.rs` where the jsonwebtoken 11 work (#203) had added a test beside these. All three tests are kept and pass.

## S2 — workspace import rejects non-tenant tables

`insert_row` / `insert_row_returning_id` validated that a table exists in `public` before interpolating its name, so the dynamic SQL was never injectable, but **existence was the only check**. The archive chose which tables got written, and the import runs on a BYPASSRLS connection with `nosdesk.in_audit_read` suppressing both audit triggers, so a crafted archive could write unaudited rows into a global or platform table.

Platform-admin gated, so this is hardening rather than an escalation path. It matters because the archive itself is the untrusted input: "send us your export and we'll import it" is an operator workflow.

**Fix:** intersect the archive's table set with `workspace_export::discover_workspace_tables` and refuse before any row is written. That function moves to `pub(crate)` so **export and import share one definition** of the workspace-scoped set: a new tenant table cannot become exportable but not importable, and nothing outside the set is writable.

`workspaces` and `users` stay permitted; both are handled separately by `create_target_workspace` and `upsert_members`.

**Test** splices a `refresh_tokens` row into a real export and asserts the import refuses it, the table is untouched, and no partial workspace is left behind. `refresh_tokens` chosen deliberately: a forged row there is a usable session credential.

## S3 — URL-borne connection token TTL, 1 hour to 2 minutes

The SSE and collab connection tokens are the only credentials that travel in a query string, because `EventSource` and `WebSocket` cannot set headers. Query strings are logged by default at most proxies, CDNs and load balancers, and **the collab token is write-capable**, so an ordinary access log retained a replayable write credential for an hour. Both are only presented at connection setup, so the lifetime only has to cover mint, navigate, connect.

`CONNECTION_TOKEN_TTL_SECS` 3600 → **120**.

**The catch:** both clients hardcoded a *5 minute* refresh buffer. At a 120s TTL that is never satisfied, so the cache would miss on every call and each connect would re-mint. So `CONNECTION_TOKEN_REFRESH_BUFFER_SECS` (30s) is now reported from both mint endpoints alongside `expires_in`, and each client subtracts it once when caching rather than at every read. Clients fall back to half the TTL if an older backend omits the field.

**Guards:** the TTL stays at or below 300s and above twice its buffer, and a minted token's `exp - iat` matches the advertised `expires_in`.

SECURITY.md gains a reverse-proxy note on stripping or redacting query strings for those two paths, which is where the residual exposure now sits.

## Verification (post-rebase)

- 1743 lib + 1856 integration tests pass
- `cargo fmt --check` clean, `cargo deny check` clean
- frontend `vue-tsc` clean
- the three reconciled `utils/jwt.rs` tests all pass