### PR TITLE
tickets: render the warm cache on launch instead of gating on bootstrap

### DIFF
--- a/frontend/src/sync/views/TicketsListView.vue
+++ b/frontend/src/sync/views/TicketsListView.vue
@@ -387,7 +387,17 @@ watch(sortedCards, () => {
   if (splitViewActive.value) selection.selectFirstIfNone()
 })
 
-const isInitiallyLoading = computed(() => !bootstrapped.value)
+// Cache-first: the ticket pool is rehydrated from IndexedDB before this view
+// mounts, so a warm start already has rows while this mount re-runs the network
+// bootstrap (`bootstrapped` starts false again). Gating on the flag alone
+// therefore shows a loading state over data we already have. Gate on "no rows
+// yet" as well, so a warm launch paints immediately and the bootstrap
+// reconciles behind it; a genuine cold load (empty pool) still shows it.
+//
+// Same shape as ProjectsView, which has gated this way since it shipped.
+const isInitiallyLoading = computed(
+  () => !bootstrapped.value && allCards.value.length === 0,
+)
 
 function open(cardId: number): void {
   router.push(`/tickets/${cardId}`)


### PR DESCRIPTION
Salvaged from `fix/tickets-cache-first-launch`, a four-week-old branch. This half stands alone and is still wanted; the rest of that branch needs re-siting (see below).

## The problem

The ticket pool is rehydrated from IndexedDB before this view mounts, so a warm start already has rows. But `bootstrapped` starts false again on every mount, so gating the loading state on that flag alone shows a spinner **over data we already have**, for as long as the network bootstrap takes.

## The change

```diff
-const isInitiallyLoading = computed(() => !bootstrapped.value)
+const isInitiallyLoading = computed(
+  () => !bootstrapped.value && allCards.value.length === 0,
+)
```

A warm launch paints immediately and the bootstrap reconciles behind it; a genuine cold load (empty pool) still shows the loading state.

## Why this shape

It is what `ProjectsView` has done since it shipped — `!bootstrapped.value && sortedByName.value.length === 0` at ProjectsView.vue:147. TicketsListView was the odd one out, so this removes an inconsistency rather than introducing a pattern.

Gates on `allCards` (pre-filter) rather than `sortedCards` (post-filter) deliberately: gating on the filtered list would show a **loading** state whenever a filter matched nothing, instead of the empty state.

## Not included

The source branch also carries a delta-first warm-launch change to `lifecycle.ts`. I left it out: main has since grown `bootstrapDeferredGroups()`, which calls `runBootstrap` directly and bypasses `subscribe()` where that logic lives — so on the deferred path (the common mobile cold start) it would silently never run. It needs re-siting at the `runBootstrap` boundary rather than a rebase.

## Verification

`vue-tsc` clean, 33 frontend tests pass.