### PR TITLE
docs(mobile): condense the mobile README; add the slot-tester plugin

### DIFF
--- a/mobile/README.md
+++ b/mobile/README.md
@@ -1,58 +1,74 @@
 # @nosdesk/mobile
 
-The Tauri host for the mobile app. It runs the **existing** `frontend` Vue app
-(already mobile-first, bottom nav + safe-area insets) in a Tauri 2 shell and
-wires the headless `@nosdesk/core` seams to the native platform (bearer auth +
-native HTTP, vs the web's cookies + localStorage). There is no separate mobile
-UI; `@nosdesk/core` is what lets the one UI run in both hosts.
+The Tauri 2 host for the mobile app. There is no separate mobile UI: this runs
+the existing `frontend` Vue app and rebinds the headless `@nosdesk/core` seams
+to native (bearer auth and native HTTP, where web uses cookies and localStorage).
 
 ## Layout
 
-- `src-tauri/` — the Tauri 2 Rust shell. `tauri.conf.json` builds the frontend
-  (`frontendDist: ../../frontend/dist`, `beforeBuildCommand` runs the frontend
-  build) and serves its dev server in `tauri dev`. Registers `tauri-plugin-http`.
-- `src/` — the TS host layer the frontend loads when running under Tauri:
-  - `bootstrap.ts` / `index.ts` — `bootstrapMobile()` + `setSession`/`clearSession`.
-  - `transport.ts` — the `bearerAuthStrategy` (Authorization: Bearer + `X-Auth-Mode`).
-  - `apiClient.ts` — clears the web interceptors and installs the bearer ones +
-    the native-HTTP adapter on core's axios instance.
-  - `tauriHttpAdapter.ts` — axios adapter over `@tauri-apps/plugin-http` (the
-    `tauri://` origin can't reach the API cross-origin from the webview).
-  - `storageSetup.ts` / `loggerSetup.ts` — the general-KV + logger seams.
-  - `serverConfig.ts` — the server picker: persist the chosen origin (cloud or
-    self-hosted), derive the base URLs, and `validateServer()` (HTTPS + probes
-    `/api/auth/setup/status` to confirm it's a Nosdesk instance).
-  - `secureStore.ts` — the keychain `SecureStore` contract + an in-memory impl.
+`src-tauri/` is the Rust shell. `tauri.conf.json` points `frontendDist` at
+`../../frontend/dist` and rebuilds it via `beforeBuildCommand`.
 
-The frontend chooses the host at startup in `frontend/src/platform/index.ts`
-(`isTauriRuntime()` → `bootstrapMobile(...)`, else the web setup); the Tauri
-branch is a lazy chunk, so the web bundle stays Tauri-free.
+`src/` is the TS host layer the frontend loads under Tauri:
 
-## Verified
+| | |
+|---|---|
+| `bootstrap.ts`, `index.ts` | `bootstrapMobile()`, `setSession`, `clearSession` |
+| `transport.ts` | bearer auth strategy (`Authorization`, `X-Auth-Mode`) |
+| `apiClient.ts` | swaps core's web interceptors for the bearer ones |
+| `tauriHttpAdapter.ts` | axios adapter over `@tauri-apps/plugin-http` |
+| `serverConfig.ts` | server picker, base URLs, `validateServer()` |
+| `secureStore.ts` | `SecureStore` contract (iOS Keychain / Android Keystore) |
+| `storageSetup.ts`, `loggerSetup.ts` | general KV and logger seams |
 
-- `pnpm --filter @nosdesk/mobile run type-check` and `pnpm -C frontend run type-check` green.
-- `pnpm -C frontend run build-only` green; Tauri code is code-split out of the web entry chunk.
-- `cd src-tauri && cargo check` compiles the Rust shell.
+`frontend/src/platform/index.ts` picks the host at startup. The Tauri branch is
+a lazy chunk, so the web bundle stays Tauri-free.
 
-## NOT done (needs the mobile SDKs / a device)
+## Device builds
 
-- **Init the mobile targets** (Tauri CLI present, SDKs are not):
-  `pnpm --filter @nosdesk/mobile tauri ios init` / `tauri android init`
-  (iOS needs Xcode; Android needs the SDK + the `aarch64-*` Rust targets).
-  `pnpm --filter @nosdesk/mobile tauri dev` runs the desktop shell.
-- **Keychain `SecureStore`** (`secureStore.ts`): only `memorySecureStore` ships
-  (no cold-start persistence). Pick a non-biometric-gated keychain plugin
-  on-device, NOT Stronghold (deprecated) or the plaintext store plugin.
-- **Connect screen (Vue UI)** — the plumbing is here (`validateServer` /
-  `setServer` / `getStoredServer` / `DEFAULT_SERVER`); the actual first-run
-  "choose your Nosdesk server" screen + a settings entry to switch servers is
-  frontend work. Cloud is the default until then. To support arbitrary
-  self-hosted servers the `http` capability allows any `https://**` and the CSP
-  `connect-src` allows `https:`/`wss:` (still HTTPS-only, only the server the
-  user picks).
-- **Backend** must allowlist the Tauri origin for SSE (EventSource) + collab WS
-  per server (the http plugin handles REST natively, but SSE/WS go through the
-  webview).
-- App icons (placeholders), signing, store metadata; native enhancements (push,
-  biometric unlock, deep links, native passkeys); on-device smoke test
-  (login → `/me` → ticket list).
+```bash
+pnpm --filter @nosdesk/mobile exec tauri ios build --debug --export-method debugging
+xcrun devicectl device install app --device <UUID> src-tauri/gen/apple/build/arm64/Nosdesk.ipa
+```
+
+`--export-method debugging` produces a standalone app. `tauri ios dev` instead
+tethers the webview to the laptop's vite server, so the app stops working as
+soon as the laptop does.
+
+Gotchas:
+
+- The bundled UI comes from `frontend/dist`, so the app always ships a
+  production frontend build rather than whatever the dev stack has in
+  `backend/public`.
+- Touch `src-tauri/src/lib.rs` after a frontend-only change. The Rust side embeds
+  the assets and silently ships the previous bundle if it has no reason to
+  recompile.
+- Unlock the login keychain first or `CodeSign` fails at the end of an otherwise
+  clean build: `security -v unlock-keychain ~/Library/Keychains/login.keychain-db`.
+- Target the device by UUID (`xcrun devicectl list devices`). Device names often
+  contain a curly apostrophe, so passing a name with a straight quote
+  (`--device "Sam's iPhone"`) will not match.
+
+## Simulator
+
+`tauri ios build --target aarch64-sim` fails with `failed to rename app ...
+Directory not empty` when a device archive exists. Xcode still built the app, so
+skip Tauri's packaging and install its output:
+
+```bash
+xcrun simctl boot <SIM-UUID> && open -a Simulator
+xcrun simctl install <SIM-UUID> \
+  ~/Library/Developer/Xcode/DerivedData/app-*/Build/Products/debug-iphonesimulator/Nosdesk.app
+xcrun simctl launch <SIM-UUID> com.nosdesk.app
+```
+
+`simctl` installs, launches and screenshots but cannot tap or swipe. Driving the
+Simulator over AppleScript needs Accessibility permission and otherwise hangs
+until `AppleEvent timed out (-1712)`. Gesture testing needs a real device.
+
+## Open
+
+- Backend must allowlist the Tauri origin per server for SSE and collab WS. The
+  http plugin covers REST natively, but those two go through the webview.
+- App icons are placeholders. Signing and store metadata are not set up.
+- Native work not started: biometric unlock, native passkeys.

--- a/spikes/slot-tester/README.md
+++ b/spikes/slot-tester/README.md
@@ -1,0 +1,18 @@
+# slot-tester
+
+A dev plugin that renders a distinct panel on every UI extension point, so slot
+regressions show up without a real integration. One `mount` switches on
+`context.component.slot`.
+
+Covers the ordinary slots (ticket sidebar, asset info, settings page, dashboard
+widget, header action, bulk action, nav item) and the awkward cases: a panel
+that renders nothing, one whose mount never settles, one that fills in late, and
+one that declares `chrome: "none"` and draws its own frame.
+
+```bash
+# debug builds only, needs NOSDESK_DEV_MODE=1 in .env
+nosdesk-plugin sign --dev --in . --out ../../plugins/slot-tester-1.0.0.zip
+```
+
+The backend provisions `plugins/*.zip` on startup. Zips there are gitignored;
+rebuild from this directory rather than committing one.

--- a/spikes/slot-tester/bundle.js
+++ b/spikes/slot-tester/bundle.js
@@ -1,0 +1,248 @@
+// Slot Tester — a dev-only plugin bundle that renders a distinct, obviously
+// working panel on every UI slot. One `mount` switches on the slot the host is
+// rendering (context.component.slot) and exercises the host API + the context
+// each surface provides.
+//
+// Framework-free on purpose: the sandbox runtime calls `default.mount(root, api,
+// context)` with a Comlink-proxied host API (every call is an async round-trip).
+
+function el(tag, props, children) {
+  const node = document.createElement(tag);
+  if (props) {
+    for (const [k, v] of Object.entries(props)) {
+      if (k === 'style') node.setAttribute('style', v);
+      else if (k === 'text') node.textContent = v;
+      else node.setAttribute(k, v);
+    }
+  }
+  for (const c of children || []) node.appendChild(typeof c === 'string' ? document.createTextNode(c) : c);
+  return node;
+}
+
+// No FONT constant any more: the runtime's injected kit already sets the host
+// font, size and line-height on `body`, so restating them here only risked
+// drifting from the app.
+
+// The panel body. Deliberately draws NO outer frame: on a `card`-chrome slot
+// the host wraps this document in the app's own SectionCard (border, radius,
+// surface, header pill, 12px body padding), so a border here would render a
+// card inside a card. Content starts flush at the top-left and inherits the
+// kit's typography.
+//
+// `fullBleedPanel` below is the counter-example: it declares `chrome: "none"`
+// and therefore does draw its own frame.
+function panel(accent, title) {
+  const root = el('div', { style: 'color: inherit;' });
+  // A slot label, kept because this is a test vehicle and the point is to see
+  // WHICH slot rendered. A real plugin would let the host header carry it.
+  root.appendChild(
+    el('div', {
+      style: `font-weight: 600; color: ${accent}; margin-bottom: var(--nd-space-xs, 4px);`,
+      text: title,
+    }),
+  );
+  return root;
+}
+
+function line(label, value) {
+  return el('div', { style: 'margin: 2px 0;' }, [
+    el('span', { style: 'opacity: 0.6;', text: `${label}: ` }),
+    el('span', { style: 'font-weight: 500;', text: String(value) }),
+  ]);
+}
+
+// Run an async host call and render its result / error into `slot`.
+async function probe(slot, label, fn) {
+  const row = el('div', { style: 'margin-top: 6px; font-family: ui-monospace, monospace; font-size: 12px;' });
+  row.textContent = `${label}: …`;
+  slot.appendChild(row);
+  try {
+    row.textContent = `${label}: ${await fn()}`;
+  } catch (e) {
+    row.textContent = `${label}: ERROR ${e && e.code ? `(${e.code})` : ''} ${e && e.message ? e.message : e}`;
+    row.setAttribute('style', row.getAttribute('style') + '; color: #dc2626;');
+  }
+}
+
+export default {
+  async mount(root, api, context) {
+    const slot = context.component.slot;
+    const name = context.component.name;
+
+    // --- Host-chrome test vehicles -----------------------------------------
+    // These three exist to exercise the host chrome, not the plugin API.
+
+    // Renders nothing, ever. The host should collapse the whole contribution,
+    // chrome included, leaving no empty card and no stray flex gap.
+    if (name === 'emptyPanel') return;
+
+    // Renders nothing at first, then fills in. This is the recovery path: the
+    // host hides an empty contribution with `display: none`, which suspends
+    // layout in here, so the runtime has to signal "I have content now" for the
+    // host to restore layout and pick up the real height. If this one never
+    // appears, that path is broken.
+    if (name === 'latePanel') {
+      setTimeout(() => {
+        const late = panel('#0d9488', 'latePanel (filled in after 1.5s)');
+        late.appendChild(line('info', 'If you can read this, empty -> filled recovery works.'));
+        root.appendChild(late);
+      }, 1500);
+      return;
+    }
+
+    // Never settles. A plugin that awaits something that never resolves must
+    // not disable height reporting: the runtime observes anyway after its
+    // settle timeout, so this should collapse like any other empty panel
+    // rather than sit at the iframe's default height forever.
+    if (name === 'hangPanel') {
+      await new Promise(() => {});
+      return;
+    }
+
+    // Declares `chrome: "none"`, so the host mounts it bare and it owns its
+    // frame. Edge-to-edge on purpose: nothing should inset it.
+    if (name === 'fullBleedPanel') {
+      const bleed = el('div', {
+        style:
+          'background: linear-gradient(90deg, #0891b2, #7c3aed); color: #fff; padding: 12px; border-radius: var(--nd-radius-lg, 12px); font-weight: 600;',
+      });
+      bleed.textContent = 'fullBleedPanel — chrome: "none", draws its own frame';
+      root.appendChild(bleed);
+      return;
+    }
+
+    const ACCENTS = {
+      'ticket.sidebar.panel': '#2563eb',
+      'asset.info.panel': '#0891b2',
+      'settings.integrations.page': '#7c3aed',
+      'dashboard.widget': '#059669',
+      'ticket.header.action': '#d97706',
+      'ticket.bulk.action': '#db2777',
+      'nav.item': '#4f46e5',
+    };
+    const accent = ACCENTS[slot] || '#64748b';
+    const box = panel(accent, `${slot}`);
+
+    // Responsive signals, echoed so a human (and the verification script) can
+    // see the panel's own bucket and the app's breakpoint side by side.
+    const de = document.documentElement;
+    const showLayout = () => {
+      layoutRow.textContent =
+        `container=${de.getAttribute('data-nd-container')} ` +
+        `(${getComputedStyle(de).getPropertyValue('--nd-container-width').trim()}) ` +
+        `app=${de.getAttribute('data-nd-app-breakpoint')} ` +
+        `pointer=${de.getAttribute('data-nd-pointer')}`;
+    };
+    const layoutRow = el('div', {
+      class: 'nd-layout-probe',
+      style: 'margin: 2px 0; font-family: ui-monospace, monospace; font-size: 12px;',
+    });
+    box.appendChild(layoutRow);
+    showLayout();
+    // The container bucket changes without a context push, so watch for it.
+    new ResizeObserver(showLayout).observe(de);
+
+    // `api` is a Comlink proxy: even plain data properties resolve as promises,
+    // so these cannot be concatenated directly (that threw a TypeError out of
+    // `mount`). Filled in asynchronously rather than awaited, because `mount`
+    // must settle promptly: the runtime defers height/emptiness observation
+    // until it does, so a mount that blocks here reports no height at all and
+    // the panel sits at the iframe's default size.
+    const apiRow = line('runtime api', '...');
+    box.appendChild(apiRow);
+    Promise.all([api.version, api.plugin])
+      .then(([v, meta]) => {
+        apiRow.textContent = `api v${v} — ${meta && meta.name} v${meta && meta.version}`;
+      })
+      .catch((e) => {
+        apiRow.textContent = `api: ERROR ${e && e.message ? e.message : e}`;
+      });
+
+    if (slot === 'ticket.sidebar.panel' || slot === 'ticket.header.action') {
+      const t = context.ticket;
+      box.appendChild(line('ticket (from context)', t ? `#${t.id} — ${t.title}` : 'none'));
+      if (t) {
+        await probe(box, 'api.tickets.get(id).title', async () => {
+          const fetched = await api.tickets.get(t.id);
+          return fetched ? fetched.title : 'null';
+        });
+      }
+      // storage round-trip
+      await probe(box, 'storage round-trip', async () => {
+        await api.storage.set('probe', { at: 'ticket', n: (context.ticket && context.ticket.id) || 0 });
+        const got = await api.storage.get('probe');
+        return JSON.stringify(got);
+      });
+    }
+
+    if (slot === 'asset.info.panel') {
+      const a = context.asset;
+      box.appendChild(line('asset (from context)', a ? `#${a.id} — ${a.name}` : 'none'));
+      if (a) {
+        await probe(box, 'api.assets.get(id).name', async () => {
+          const fetched = await api.assets.get(a.id);
+          return fetched ? fetched.name : 'null';
+        });
+      }
+    }
+
+    if (slot === 'ticket.bulk.action') {
+      const ids = context.ticketIds || [];
+      box.appendChild(line('selected ticket ids', ids.length ? ids.join(', ') : '(none)'));
+      box.appendChild(line('selection size', ids.length));
+    }
+
+    if (slot === 'dashboard.widget') {
+      await probe(box, 'api.tickets.list().length', async () => (await api.tickets.list()).length);
+      await probe(box, 'api.users.me().name', async () => {
+        const me = await api.users.me();
+        return me ? me.name : 'null';
+      });
+    }
+
+    if (slot === 'settings.integrations.page') {
+      box.appendChild(line('info', 'This is the plugin-rendered config page.'));
+      await probe(box, 'api.settings.get(greeting)', async () => {
+        const v = await api.settings.get('greeting');
+        return JSON.stringify(v);
+      });
+    }
+
+    if (slot === 'nav.item') {
+      box.appendChild(line('info', 'Full-page plugin surface (a nav.item route).'));
+      await probe(box, 'api.tickets.list().length', async () => (await api.tickets.list()).length);
+    }
+
+    // A live control to prove the bundle is interactive, not a static render.
+    // Uses the kit's `.nd-btn` rather than a hand-rolled button, so it also
+    // proves the injected UI kit matches the host's button styling.
+    let clicks = 0;
+    const btn = el('button', {
+      class: 'nd-btn',
+      style: 'margin-top: var(--nd-space-sm, 8px);',
+      text: 'Click me (0)',
+    });
+    btn.addEventListener('click', () => {
+      clicks += 1;
+      btn.textContent = `Click me (${clicks})`;
+    });
+    box.appendChild(btn);
+
+    root.appendChild(box);
+
+    // React to context updates without a full re-mount (e.g. the ticket the
+    // sidebar shows changing, or the action counter bumping).
+    return {
+      update(next) {
+        if (next.actionActivated !== undefined && next.actionActivated !== context.actionActivated) {
+          const bump = el('div', {
+            style: `margin-top: 6px; color: ${accent}; font-weight: 600;`,
+            text: `actionActivated -> ${next.actionActivated}`,
+          });
+          box.appendChild(bump);
+        }
+        context = next;
+      },
+    };
+  },
+};

--- a/spikes/slot-tester/manifest.json
+++ b/spikes/slot-tester/manifest.json
@@ -1,0 +1,99 @@
+{
+  "manifest_version": 1,
+  "name": "slot-tester",
+  "displayName": "Slot Tester",
+  "version": "1.0.0",
+  "description": "Dev-only plugin that renders a distinct panel on every UI slot, for exercising the plugin extension points end to end.",
+  "license": "MIT",
+  "author": "Nosdesk Dev",
+  "engines": {
+    "nosdesk": ">=1.0.0",
+    "plugin_api": "1"
+  },
+  "permissions": [
+    "ticket:read",
+    "asset:read",
+    "user:read",
+    "storage:plugin"
+  ],
+  "settings": [
+    {
+      "key": "greeting",
+      "type": "string",
+      "label": "Greeting text",
+      "description": "Shown by the settings page panel to prove settings round-trip.",
+      "default": "hello"
+    }
+  ],
+  "components": {
+    "ticketSidebar": {
+      "slot": "ticket.sidebar.panel",
+      "entry": "ticketSidebar",
+      "context": ["ticket"],
+      "label": "Slot Tester"
+    },
+    "assetPanel": {
+      "slot": "asset.info.panel",
+      "entry": "assetPanel",
+      "context": ["asset"],
+      "label": "Slot Tester"
+    },
+    "emptyPanel": {
+      "slot": "ticket.sidebar.panel",
+      "entry": "emptyPanel",
+      "context": [],
+      "label": "Slot Tester (renders nothing)"
+    },
+    "hangPanel": {
+      "slot": "ticket.sidebar.panel",
+      "entry": "hangPanel",
+      "context": [],
+      "label": "Slot Tester (mount never settles)"
+    },
+    "latePanel": {
+      "slot": "ticket.sidebar.panel",
+      "entry": "latePanel",
+      "context": [],
+      "label": "Slot Tester (fills in late)"
+    },
+    "fullBleedPanel": {
+      "slot": "asset.info.panel",
+      "entry": "fullBleedPanel",
+      "context": [],
+      "label": "Slot Tester (full bleed)",
+      "chrome": "none"
+    },
+    "settingsPage": {
+      "slot": "settings.integrations.page",
+      "entry": "settingsPage",
+      "context": [],
+      "label": "Slot Tester Config"
+    },
+    "dashboardWidget": {
+      "slot": "dashboard.widget",
+      "entry": "dashboardWidget",
+      "context": [],
+      "label": "Slot Tester Widget"
+    },
+    "headerAction": {
+      "slot": "ticket.header.action",
+      "entry": "headerAction",
+      "context": ["ticket"],
+      "label": "Slot Tester",
+      "action": { "label": "Slot Tester: header action" }
+    },
+    "bulkAction": {
+      "slot": "ticket.bulk.action",
+      "entry": "bulkAction",
+      "context": ["ticket"],
+      "label": "Slot Tester (bulk)"
+    },
+    "navItem": {
+      "slot": "nav.item",
+      "entry": "navItem",
+      "context": [],
+      "label": "Slot Tester",
+      "icon": "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2'%3E%3Crect x='3' y='3' width='7' height='7' rx='1'/%3E%3Crect x='14' y='3' width='7' height='7' rx='1'/%3E%3Crect x='3' y='14' width='7' height='7' rx='1'/%3E%3Crect x='14' y='14' width='7' height='7' rx='1'/%3E%3C/svg%3E"
+    }
+  }
+}


### PR DESCRIPTION
Two docs/dev-tooling changes.

**mobile/README.md** trimmed from 95 to 74 lines. Dropped the `Verified` section (PR content, not README) and the trim-history blockquote. Module list is now a table. Kept the device-build commands, the four build gotchas (`frontend/dist` vs `backend/public`, touching `lib.rs` after a frontend-only change, keychain unlock before `CodeSign`, targeting by UUID) and the simulator workaround, since none of that is inferable from the tree.

The `Open` list no longer mentions push or deep links: both have shipped (`mobile/tauri-plugin-push`, Universal Links config in `tauri.conf.json`).

**spikes/slot-tester/** is the dev plugin that renders a panel on every UI extension point, moved out of `plugins/` (a runtime drop directory bind-mounted read-only into the backend container) and into `spikes/`, next to `plugin-bridge` and `plugin-sandbox`. It covers the awkward cases as well as the ordinary slots: a panel that renders nothing, one whose mount never settles, one that fills in late, and one declaring `chrome: "none"`.

The signed zip stays gitignored and rebuilds from the source directory with `nosdesk-plugin sign --dev`.