### PR TITLE
Editor images: one collab-document upload path for docs, collections and tickets

### DIFF
--- a/backend/src/handlers/collab_images.rs
+++ b/backend/src/handlers/collab_images.rs
@@ -1,0 +1,356 @@
+//! Images pasted or dropped into a collaborative document.
+//!
+//! Generic over the three collab resource kinds, keyed on the
+//! workspace-namespaced doc_id the editor already holds
+//! (`ws-{workspace_uuid}_{kind}-{resource_uuid}`). Documentation pages and
+//! collection descriptions previously had no upload route at all: their
+//! editor fell through to `POST /api/upload`, which stages into `temp/` and
+//! reports a `/uploads/...` URL that `reject_legacy_upload_path` 404s. That
+//! staging folder was also the wrong home, because `authorize_temp_file_access`
+//! gates on workspace membership alone with no per-document check.
+//!
+//! The gate here is `can_access_document`, the same primitive the collab
+//! WebSocket upgrade and the REST article read use, so "who may see this
+//! image" cannot drift from "who may open this document".
+
+use actix_web::{web, HttpResponse};
+
+use actix_multipart::Multipart;
+use futures::{StreamExt, TryStreamExt};
+use serde_json::json;
+use std::sync::Arc;
+use tracing::{debug, error, info, warn};
+use uuid::Uuid;
+
+use crate::db::Pool;
+use crate::extractors::{AuthContext, ScopedStorage, TenantConn};
+use crate::handlers::collaboration::{
+    can_access_document, DocAccessor, DocKind, DocumentType, ParsedDocId,
+};
+use crate::handlers::errors;
+use crate::handlers::files::serve_or_not_found;
+use crate::sync::actor::ActorContext;
+use crate::sync::session;
+use crate::utils::file_validation::FileValidator;
+use crate::utils::storage::{Storage, WorkspaceScopedStorage};
+
+/// Editor images are capped well below the generic attachment limit: they are
+/// inline document content, not file attachments.
+const MAX_IMAGE_SIZE: usize = 10 * 1024 * 1024;
+
+pub fn config(cfg: &mut web::ServiceConfig) {
+    cfg.route(
+        "/documents/{doc_id}/images",
+        web::post().to(upload_collab_document_image),
+    );
+}
+
+/// Storage folder for a document's images. The URL suffix after
+/// `/api/files/collab/` is byte-identical to this logical key, so the serve
+/// route reconstructs exactly what the upload wrote. Change one and you must
+/// change the other.
+fn image_folder(kind: DocKind, resource_uuid: Uuid) -> String {
+    format!("collab/{}/{resource_uuid}", kind.url_token())
+}
+
+/// `POST /api/documents/{doc_id}/images`
+///
+/// Runs on `TenantConn`: this request goes through the axios client, so the
+/// workspace selection header is present. The response carries the final
+/// `/api/files/collab/...` URL. It must NOT return `stored_file.url`, which is
+/// the logical `/uploads/...` form that `reject_legacy_upload_path` 404s.
+/// Handing the editor an unreachable src is the exact bug this route fixes.
+pub async fn upload_collab_document_image(
+    path: web::Path<String>,
+    mut payload: Multipart,
+    mut tc: TenantConn,
+    auth: AuthContext,
+    storage: ScopedStorage,
+) -> Result<HttpResponse, actix_web::Error> {
+    let doc_id = path.into_inner();
+
+    let parsed: ParsedDocId = match DocumentType::from_namespaced_doc_id(&doc_id) {
+        Ok(p) => p,
+        Err(e) => {
+            warn!(doc_id = %doc_id, error = ?e, "Invalid document ID format on image upload");
+            return Ok(errors::bad_request(
+                "doc_id must be in the workspace-namespaced format ws-{uuid}_{kind}-{uuid}",
+            ));
+        }
+    };
+
+    // Gate BEFORE reading the body so an unauthorized caller cannot make us
+    // buffer 10MB. `resolve` runs RLS-scoped, so a doc_id naming another
+    // workspace's resource simply does not resolve: that is the cross-workspace
+    // guard, and it lands on 404 rather than the 403 an explicit uuid
+    // comparison would give.
+    let accessor = DocAccessor::from_auth(&auth);
+    let gate = tc.run(|conn| {
+        let Some(doc_type) = parsed.resolve(conn)? else {
+            return Ok(None);
+        };
+        Ok(Some(can_access_document(conn, &accessor, &doc_type)?))
+    });
+    match gate {
+        Ok(Some(true)) => {}
+        Ok(Some(false)) | Ok(None) => {
+            return Err(actix_web::error::ErrorNotFound("Document not found"));
+        }
+        Err(e) => {
+            error!(doc_id = %doc_id, error = ?e, "Document access check failed on image upload");
+            return Err(actix_web::error::ErrorInternalServerError(
+                "Failed to check document access",
+            ));
+        }
+    }
+
+    let folder = image_folder(parsed.kind, parsed.resource_uuid);
+    let mut uploaded_files = Vec::new();
+
+    while let Some(mut field) = payload.try_next().await? {
+        if field.name() != "files" {
+            debug!(field_name = %field.name(), "Skipping non-file field");
+            continue;
+        }
+
+        let original_filename = field
+            .content_disposition()
+            .get_filename()
+            .ok_or_else(|| actix_web::error::ErrorBadRequest("Filename is required"))?
+            .to_string();
+
+        let sanitized_filename = FileValidator::sanitize_filename(&original_filename)
+            .map_err(|e| {
+                warn!(error = ?e, original_filename = %original_filename, "Filename sanitization failed");
+                actix_web::error::ErrorBadRequest(format!("Invalid filename: {e}"))
+            })?;
+
+        let mut file_data = Vec::new();
+        let mut total_size = 0usize;
+        while let Some(chunk) = field.next().await {
+            let data = chunk.map_err(|e| {
+                error!(error = ?e, "Error reading chunk");
+                actix_web::error::ErrorInternalServerError("Error reading chunk")
+            })?;
+            if total_size + data.len() > MAX_IMAGE_SIZE {
+                return Err(actix_web::error::ErrorBadRequest(
+                    "File too large (max 10MB)",
+                ));
+            }
+            total_size += data.len();
+            file_data.extend_from_slice(&data);
+        }
+
+        let detected_mime = FileValidator::validate_file(&file_data, Some(&sanitized_filename))
+            .map_err(|e| {
+                warn!(error = ?e, filename = %sanitized_filename, "File validation failed");
+                actix_web::error::ErrorBadRequest(format!("Invalid file: {e}"))
+            })?;
+
+        if !detected_mime.starts_with("image/") {
+            return Err(actix_web::error::ErrorBadRequest(
+                "Only image files are allowed",
+            ));
+        }
+
+        let stored = storage
+            .0
+            .store_file(&file_data, &sanitized_filename, &detected_mime, &folder)
+            .await
+            .map_err(|e| {
+                error!(error = ?e, filename = %sanitized_filename, "Failed to store file");
+                actix_web::error::ErrorInternalServerError("Failed to store file")
+            })?;
+
+        // `stored.id` is the unique `{uuid7}_{filename}` basename, which is the
+        // last segment of the logical path the serve route reconstructs.
+        let url = format!(
+            "/api/files/collab/{}/{}/{}",
+            parsed.kind.url_token(),
+            parsed.resource_uuid,
+            stored.id
+        );
+        info!(url = %url, filename = %sanitized_filename, "Stored collab document image");
+
+        uploaded_files.push(json!({
+            "url": url,
+            "name": sanitized_filename,
+            "size": total_size,
+        }));
+    }
+
+    Ok(HttpResponse::Ok().json(uploaded_files))
+}
+
+/// `GET /api/files/collab/{kind}/{resource_uuid}/{filename}`
+///
+/// The browser loads this straight from an `<img>` tag, which bypasses the
+/// axios interceptor carrying `X-Nosdesk-Workspace`, so this route cannot take
+/// a `TenantConn` (it would 400 with "No workspace selected" under hosted
+/// selection). The workspace is derived from the resource instead, exactly
+/// like `authorize_ticket_file_access`.
+///
+/// The path segments are taken as plain strings so a malformed uuid or an
+/// unknown kind answers 404 like everything else in this scope, rather than
+/// leaking a 400 that tells a prober its guess was well formed.
+pub async fn serve_collab_document_image(
+    path: web::Path<(String, String, String)>,
+    req: actix_web::HttpRequest,
+    pool: web::Data<Pool>,
+    auth: AuthContext,
+    base_storage: web::Data<Arc<dyn Storage>>,
+) -> Result<HttpResponse, actix_web::Error> {
+    let (kind_token, uuid_str, filename) = path.into_inner();
+
+    let kind = DocKind::from_url_token(&kind_token)
+        .ok_or_else(|| actix_web::error::ErrorNotFound("File not found"))?;
+    let resource_uuid = Uuid::parse_str(&uuid_str)
+        .map_err(|_| actix_web::error::ErrorNotFound("File not found"))?;
+
+    let workspace_id = authorize_collab_file_access(&pool, &auth, kind, resource_uuid)?;
+    let storage = WorkspaceScopedStorage::arc(base_storage.get_ref().clone(), workspace_id);
+
+    let file_path = format!("{}/{filename}", image_folder(kind, resource_uuid));
+    // `serve_file_from_storage` runs `is_safe_storage_path` first, so the
+    // greedy `{filename:.*}` tail cannot traverse out of the folder.
+    serve_or_not_found(storage, &file_path, &req).await
+}
+
+/// Authorize access to a collaborative document's images, deriving the
+/// workspace from the resource rather than from the request's selection.
+///
+/// The direct `<img>` load carries no `X-Nosdesk-Workspace`, so we look the
+/// owning workspace up unscoped (the only cross-tenant step, and it reveals
+/// only a workspace id), then gate on the caller's membership plus the
+/// per-document ACL IN THAT WORKSPACE under RLS. Same shape as
+/// `authorize_ticket_file_access`, generalised over the three collab kinds.
+///
+/// Security is unchanged from the selection path: "having selected the
+/// workspace" was never a control, membership and the document gate are, and
+/// both still apply. Every denial is a 404, never a 403, so a probe cannot
+/// tell a missing image from one it may not see.
+fn authorize_collab_file_access(
+    pool: &Pool,
+    auth: &AuthContext,
+    kind: DocKind,
+    resource_uuid: Uuid,
+) -> Result<i32, actix_web::Error> {
+    let mut conn = pool.get().map_err(|e| {
+        error!(error = ?e, "collab file access: pool acquire failed");
+        actix_web::error::ErrorInternalServerError("Database error")
+    })?;
+
+    // Which workspace owns this resource? Unscoped read (BYPASSRLS); reveals
+    // only the workspace id, access is gated below.
+    let lookup_actor = ActorContext::system("collab_file_access");
+    let workspace_id =
+        session::with_actor_bypass_context(&mut conn, &lookup_actor, |c| match kind {
+            DocKind::Ticket => crate::repository::tickets::workspace_id_by_uuid(c, resource_uuid),
+            DocKind::Documentation => {
+                crate::repository::documentation::page_workspace_id_by_uuid(c, resource_uuid)
+            }
+            DocKind::Collection => {
+                crate::repository::documentation_collections::collection_workspace_id_by_uuid(
+                    c,
+                    resource_uuid,
+                )
+            }
+        })
+        .map_err(|e| {
+            error!(error = ?e, %resource_uuid, "collab file access: workspace lookup failed");
+            actix_web::error::ErrorInternalServerError("Authorization check failed")
+        })?
+        .ok_or_else(|| actix_web::error::ErrorNotFound("File not found"))?;
+
+    // Pinned to the resource's workspace: membership (None = non-member) plus
+    // the caller's role *there* drives the document gate.
+    let actor = ActorContext::user_at_workspace(auth.user_uuid, workspace_id);
+    let allowed = session::with_actor_context(&mut conn, &actor, |c| {
+        let Some(accessor) =
+            DocAccessor::at_pinned_workspace(c, auth.user_uuid, auth.platform_role)
+        else {
+            return Ok(false);
+        };
+
+        // Re-resolve the UUID under the pin. Not redundant with the lookup
+        // above: it re-proves under RLS that the resource really is in the
+        // workspace we pinned to, so a bug in the unscoped read cannot widen
+        // access, and it fails closed if the row vanished between the two.
+        let doc_type = match kind {
+            DocKind::Ticket => {
+                crate::repository::tickets::id_by_uuid(c, resource_uuid)?.map(DocumentType::Ticket)
+            }
+            DocKind::Documentation => {
+                crate::repository::documentation::page_id_by_uuid(c, resource_uuid)?
+                    .map(DocumentType::Documentation)
+            }
+            DocKind::Collection => {
+                crate::repository::documentation_collections::collection_id_by_uuid(
+                    c,
+                    resource_uuid,
+                )?
+                .map(DocumentType::Collection)
+            }
+        };
+        let Some(doc_type) = doc_type else {
+            return Ok(false);
+        };
+
+        can_access_document(c, &accessor, &doc_type)
+    })
+    .map_err(|e| {
+        error!(error = ?e, %resource_uuid, "collab file access: authorization lookup failed");
+        actix_web::error::ErrorInternalServerError("Authorization check failed")
+    })?;
+
+    if !allowed {
+        return Err(actix_web::error::ErrorNotFound("File not found"));
+    }
+    Ok(workspace_id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The URL token is the hinge between three surfaces: the collab doc_id,
+    /// the image URL and the storage folder. A one-sided rename would leave
+    /// already-stored images unreachable, so lock the round trip down.
+    #[test]
+    fn url_tokens_round_trip() {
+        for kind in [DocKind::Ticket, DocKind::Documentation, DocKind::Collection] {
+            assert_eq!(DocKind::from_url_token(kind.url_token()), Some(kind));
+        }
+    }
+
+    #[test]
+    fn unknown_url_token_is_rejected() {
+        assert_eq!(DocKind::from_url_token("widget"), None);
+        assert_eq!(DocKind::from_url_token(""), None);
+        // The doc_id spells documentation pages "doc", not "documentation".
+        assert_eq!(DocKind::from_url_token("documentation"), None);
+    }
+
+    /// The path segment after `/api/files/collab/` must be byte-identical to
+    /// the logical storage key, so the serve route reconstructs exactly what
+    /// the upload wrote.
+    #[test]
+    fn served_url_suffix_matches_storage_key() {
+        let uuid = Uuid::parse_str("019eb4e2-dbaa-75e5-9eb2-aa3dc7d8a7cb").expect("valid uuid");
+        let folder = image_folder(DocKind::Documentation, uuid);
+        assert_eq!(folder, "collab/doc/019eb4e2-dbaa-75e5-9eb2-aa3dc7d8a7cb");
+
+        let stored_name = "019ec111-2222-7333-8444-555566667777_paste.png";
+        let url = format!(
+            "/api/files/{}/{}/{}",
+            "collab",
+            format_args!("{}/{}", DocKind::Documentation.url_token(), uuid),
+            stored_name
+        );
+        assert_eq!(
+            url.strip_prefix("/api/files/")
+                .expect("served under /api/files"),
+            format!("{folder}/{stored_name}")
+        );
+    }
+}

--- a/backend/src/handlers/collaboration.rs
+++ b/backend/src/handlers/collaboration.rs
@@ -378,7 +378,7 @@ const EMPTY_ROOM_EVICT_DELAY: Duration = Duration::from_secs(60);
 // collections own their overview content directly instead of
 // pointing at a sentinel "main page".
 #[derive(Debug, Clone, Copy, PartialEq)]
-enum DocumentType {
+pub(crate) enum DocumentType {
     Ticket(i32),
     Documentation(i32),
     Collection(i32),
@@ -388,10 +388,35 @@ enum DocumentType {
 /// carries the resource's immutable UUID; the integer id used by the
 /// persistence layer is resolved from it (see [`ParsedDocId::resolve`]).
 #[derive(Debug, Clone, Copy, PartialEq)]
-enum DocKind {
+pub(crate) enum DocKind {
     Ticket,
     Documentation,
     Collection,
+}
+
+impl DocKind {
+    /// The URL token for this kind. One token set spans three surfaces:
+    /// the collab doc_id (`ws-{uuid}_doc-{uuid}`), the image URL
+    /// (`/api/files/collab/doc/{uuid}/...`) and the storage folder
+    /// (`collab/doc/{uuid}/`). Deriving all three from one function is what
+    /// stops a rename from silently orphaning stored objects.
+    pub(crate) fn url_token(self) -> &'static str {
+        match self {
+            Self::Ticket => "ticket",
+            Self::Documentation => "doc",
+            Self::Collection => "collection",
+        }
+    }
+
+    /// Inverse of [`DocKind::url_token`]. `None` for an unrecognised token.
+    pub(crate) fn from_url_token(token: &str) -> Option<Self> {
+        match token {
+            "ticket" => Some(Self::Ticket),
+            "doc" => Some(Self::Documentation),
+            "collection" => Some(Self::Collection),
+            _ => None,
+        }
+    }
 }
 
 /// Result of parsing a workspace-namespaced doc_id
@@ -403,10 +428,10 @@ enum DocKind {
 /// UUID never recycles, so the resulting doc identity is stable across
 /// an integer-id reset.
 #[derive(Debug, Clone)]
-struct ParsedDocId {
-    workspace_uuid: Uuid,
-    kind: DocKind,
-    resource_uuid: Uuid,
+pub(crate) struct ParsedDocId {
+    pub(crate) workspace_uuid: Uuid,
+    pub(crate) kind: DocKind,
+    pub(crate) resource_uuid: Uuid,
 }
 
 impl ParsedDocId {
@@ -415,7 +440,7 @@ impl ParsedDocId {
     /// Returns `Ok(None)` when no live row has that UUID (resource
     /// deleted, or a stale client holding a recycled-but-different
     /// doc), which the WS handler turns into a clean rejection.
-    fn resolve(
+    pub(crate) fn resolve(
         &self,
         conn: &mut crate::db::DbConnection,
     ) -> diesel::QueryResult<Option<DocumentType>> {
@@ -441,7 +466,7 @@ impl ParsedDocId {
 /// variant maps cleanly to the operator-facing log line + the
 /// HTTP status the caller should return.
 #[derive(Debug, Clone, Copy, PartialEq)]
-enum DocIdParseError {
+pub(crate) enum DocIdParseError {
     /// The doc_id didn't start with the `ws-{uuid}_` namespace
     /// prefix. The legacy bare-id form (`ticket-N`) lands here so
     /// stale clients failing to upgrade are surfaced loudly.
@@ -465,7 +490,7 @@ impl DocumentType {
     /// recreated, so the new docId doesn't collide with the old
     /// cache), AND the server-side guard the ws_handler uses to
     /// reject a client requesting another workspace's docId.
-    fn from_namespaced_doc_id(doc_id: &str) -> Result<ParsedDocId, DocIdParseError> {
+    pub(crate) fn from_namespaced_doc_id(doc_id: &str) -> Result<ParsedDocId, DocIdParseError> {
         let after_ws = doc_id
             .strip_prefix("ws-")
             .ok_or(DocIdParseError::MissingNamespace)?;
@@ -482,15 +507,12 @@ impl DocumentType {
         // `rest` starts with the `_`; drop it before parsing the
         // `{kind}-{resource_uuid}` handle.
         let resource = &rest[1..];
-        let (kind, uuid_str) = if let Some(rest) = resource.strip_prefix("ticket-") {
-            (DocKind::Ticket, rest)
-        } else if let Some(rest) = resource.strip_prefix("doc-") {
-            (DocKind::Documentation, rest)
-        } else if let Some(rest) = resource.strip_prefix("collection-") {
-            (DocKind::Collection, rest)
-        } else {
-            return Err(DocIdParseError::InvalidResource);
-        };
+        // Split on the FIRST `-` only: the resource UUID contains its own
+        // hyphens, so a greedy split would swallow part of it.
+        let (kind_token, uuid_str) = resource
+            .split_once('-')
+            .ok_or(DocIdParseError::InvalidResource)?;
+        let kind = DocKind::from_url_token(kind_token).ok_or(DocIdParseError::InvalidResource)?;
         let resource_uuid =
             Uuid::parse_str(uuid_str).map_err(|_| DocIdParseError::InvalidResource)?;
         Ok(ParsedDocId {
@@ -571,7 +593,7 @@ mod doc_id_tests {
 /// workspace-admin override. Reuses the same primitives as the REST
 /// ticket/documentation read paths and the SSE topic gate so the
 /// three can't drift. See security-audit-2026-06.
-struct DocAccessor {
+pub(crate) struct DocAccessor {
     vis: crate::repository::ticket_visibility::VisibilityContext,
     is_workspace_admin: bool,
 }
@@ -579,11 +601,48 @@ struct DocAccessor {
 impl DocAccessor {
     /// Build from the `AuthContext` extractor the REST handlers
     /// already destructure (uses the request-resolved workspace role).
-    fn from_auth(auth: &AuthContext) -> Self {
+    pub(crate) fn from_auth(auth: &AuthContext) -> Self {
         Self {
             vis: crate::repository::ticket_visibility::VisibilityContext::from_auth(auth),
             is_workspace_admin: auth.is_workspace_admin(),
         }
+    }
+
+    /// Build from a connection ALREADY PINNED to the resource's workspace.
+    ///
+    /// [`DocAccessor::from_auth`] reads the request-resolved workspace role,
+    /// which is wrong on the resource-derived file routes: a browser `<img>`
+    /// load carries no `X-Nosdesk-Workspace`, so the request resolved to no
+    /// workspace (or a different one). This resolves the role under the pin
+    /// instead, so the membership check and the document gate agree on one
+    /// workspace.
+    ///
+    /// `None` means "not a member of the pinned workspace", which callers
+    /// MUST turn into a 404, never a 403. That differs from
+    /// [`DocAccessor::from_claims`], which returns `Some` with a `None` role
+    /// because the WebSocket handshake gates membership separately. Do not
+    /// unify the two.
+    ///
+    /// Must be called inside `with_actor_context`: `workspace_members` is
+    /// RLS scoped, so on an unpinned connection a real member reads as a
+    /// non-member and this fails closed.
+    pub(crate) fn at_pinned_workspace(
+        conn: &mut crate::db::DbConnection,
+        user_uuid: Uuid,
+        platform_role: crate::models::PlatformRole,
+    ) -> Option<Self> {
+        let workspace_role = crate::repository::user_helpers::workspace_role(conn, user_uuid)?;
+        let vis = crate::repository::ticket_visibility::VisibilityContext::new(
+            user_uuid,
+            platform_role,
+            Some(workspace_role),
+        );
+        let is_workspace_admin = platform_role.is_platform_admin()
+            || workspace_role.meets(crate::models::WorkspaceRole::Admin);
+        Some(Self {
+            vis,
+            is_workspace_admin,
+        })
     }
 
     /// Build from JWT claims when no `AuthContext` is in scope (the
@@ -614,7 +673,7 @@ impl DocAccessor {
 /// True when `accessor` may read/edit `document`. The error type is
 /// Diesel's so callers can map a DB failure to a 500 and a `false`
 /// to a 404 (never 403: a 403 leaks existence, per OWASP IDOR).
-fn can_access_document(
+pub(crate) fn can_access_document(
     conn: &mut crate::db::DbConnection,
     accessor: &DocAccessor,
     document: &DocumentType,

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -23,6 +23,7 @@ pub mod bug_reports;
 pub mod canned_responses;
 pub mod categories;
 pub mod channels;
+pub mod collab_images;
 pub mod collaboration;
 pub mod csp_reports;
 pub mod cycles;

--- a/backend/src/middleware/token_scope.rs
+++ b/backend/src/middleware/token_scope.rs
@@ -599,6 +599,15 @@ mod enforcement_tests {
             .await,
             StatusCode::FORBIDDEN
         );
+        assert_eq!(
+            status_for(
+                Some("*:read"),
+                Method::GET,
+                "/api/files/collab/doc/019eb4e2-dbaa-75e5-9eb2-aa3dc7d8a7cb/x.png"
+            )
+            .await,
+            StatusCode::FORBIDDEN
+        );
         // A full credential (cookie session / un-narrowed token) still reaches
         // the file handler.
         assert_eq!(

--- a/backend/src/repository/documentation.rs
+++ b/backend/src/repository/documentation.rs
@@ -135,6 +135,23 @@ pub fn page_id_by_uuid(conn: &mut DbConnection, uuid: uuid::Uuid) -> QueryResult
         .optional()
 }
 
+/// The workspace that owns the resource with this UUID, or `None` when no row
+/// has it. Backs the collab image serve route, which derives the workspace
+/// from the resource because a direct browser file load carries no workspace
+/// selection header. Intended to be called elevated (BYPASSRLS): it reveals
+/// only a workspace id, and the caller gates on membership plus the document
+/// ACL under that workspace's pin.
+pub fn page_workspace_id_by_uuid(
+    conn: &mut DbConnection,
+    uuid: uuid::Uuid,
+) -> QueryResult<Option<i32>> {
+    documentation_pages::table
+        .filter(documentation_pages::uuid.eq(uuid))
+        .select(documentation_pages::workspace_id)
+        .first::<i32>(conn)
+        .optional()
+}
+
 /// Inverse of [`page_id_by_uuid`]: the immutable UUID for an integer
 /// page id, or `None` if no live page has it. Used when building a
 /// UUID-keyed collab doc_id from an integer id (revision restore).

--- a/backend/src/repository/documentation_collections.rs
+++ b/backend/src/repository/documentation_collections.rs
@@ -24,6 +24,23 @@ pub fn collection_id_by_uuid(conn: &mut DbConnection, uuid: Uuid) -> QueryResult
         .optional()
 }
 
+/// The workspace that owns the resource with this UUID, or `None` when no row
+/// has it. Backs the collab image serve route, which derives the workspace
+/// from the resource because a direct browser file load carries no workspace
+/// selection header. Intended to be called elevated (BYPASSRLS): it reveals
+/// only a workspace id, and the caller gates on membership plus the document
+/// ACL under that workspace's pin.
+pub fn collection_workspace_id_by_uuid(
+    conn: &mut DbConnection,
+    uuid: Uuid,
+) -> QueryResult<Option<i32>> {
+    documentation_collections::table
+        .filter(documentation_collections::uuid.eq(uuid))
+        .select(documentation_collections::workspace_id)
+        .first::<i32>(conn)
+        .optional()
+}
+
 /// Sync-event payload for a documentation collection. Excludes the
 /// Yjs binary columns (`description_yjs` / `description_state_vector`).
 /// The rich description body flows through the collaborative-editor

--- a/backend/src/repository/tickets.rs
+++ b/backend/src/repository/tickets.rs
@@ -24,6 +24,20 @@ pub fn id_by_uuid(conn: &mut DbConnection, uuid: Uuid) -> QueryResult<Option<i32
         .optional()
 }
 
+/// The workspace that owns the resource with this UUID, or `None` when no row
+/// has it. Backs the collab image serve route, which derives the workspace
+/// from the resource because a direct browser file load carries no workspace
+/// selection header. Intended to be called elevated (BYPASSRLS): it reveals
+/// only a workspace id, and the caller gates on membership plus the document
+/// ACL under that workspace's pin.
+pub fn workspace_id_by_uuid(conn: &mut DbConnection, uuid: Uuid) -> QueryResult<Option<i32>> {
+    tickets::table
+        .filter(tickets::uuid.eq(uuid))
+        .select(tickets::workspace_id)
+        .first::<i32>(conn)
+        .optional()
+}
+
 /// Inverse of [`id_by_uuid`]: the immutable UUID for an integer id, or
 /// `None` if no live ticket has it. Used when building a UUID-keyed
 /// collab doc_id from an integer id (e.g. revision restore).

--- a/backend/src/route_registration_tests.rs
+++ b/backend/src/route_registration_tests.rs
@@ -14,6 +14,19 @@
 use crate::test_helpers::assert_config_registers;
 
 #[actix_web::test]
+async fn collab_images_config_routes_registered() {
+    // Namespaced doc_id shape the editor builds: ws-{workspace_uuid}_doc-{page_uuid}.
+    assert_config_registers(
+        crate::handlers::collab_images::config,
+        &[(
+            "POST",
+            "/documents/ws-3f8e9d4c-1234-5678-9abc-def012345678_doc-019eb4e2-dbaa-75e5-9eb2-aa3dc7d8a7cb/images",
+        )],
+    )
+    .await;
+}
+
+#[actix_web::test]
 async fn sse_config_routes_registered() {
     assert_config_registers(crate::handlers::sse::config, &[("POST", "/events/token")]).await;
 }

--- a/backend/src/startup.rs
+++ b/backend/src/startup.rs
@@ -720,6 +720,12 @@ pub fn configure_app(
                     .wrap(actix_web::middleware::from_fn(crate::middleware::dual_auth_middleware))
                     .route("/tickets/{ticket_id}/notes/{filename:.*}", web::get().to(crate::handlers::serve_ticket_note_image))
                     .route("/tickets/{filename:.*}", web::get().to(crate::handlers::serve_ticket_file))
+                    // Collab-document images (documentation pages, collection
+                    // descriptions, ticket notes). Same "most specific first"
+                    // discipline as the ticket pair above: every route here has a
+                    // distinct literal first segment, so nothing can be swallowed by
+                    // a sibling's `{filename:.*}` tail.
+                    .route("/collab/{kind}/{resource_uuid}/{filename:.*}", web::get().to(crate::handlers::collab_images::serve_collab_document_image))
                     .route("/assets/{asset_id}/media/{filename:.*}", web::get().to(crate::handlers::asset_media::serve_asset_media_file))
                     .route("/temp/{filename:.*}", web::get().to(crate::handlers::serve_temp_file))
             )
@@ -961,6 +967,12 @@ pub fn configure_app(
 
                     // File upload endpoint
                     .configure(crate::handlers::files::config)
+
+                    // Collab-document image upload. Deliberately here rather
+                    // than under /api/collaboration: that scope carries
+                    // neither the rate limiter nor token-scope enforcement,
+                    // and a 10MB multipart write needs both.
+                    .configure(crate::handlers::collab_images::config)
 
                     // ===== SSE / SEARCH / NOTIFICATIONS / BUG REPORTS =====
                     .configure(crate::handlers::sse::config)

--- a/frontend/src/components/CollaborativeEditor.vue
+++ b/frontend/src/components/CollaborativeEditor.vue
@@ -74,6 +74,8 @@ import {
     ellipsis,
 } from "prosemirror-inputrules";
 import { createImageUploadPlugin } from "./editor/imageUploadPlugin";
+import { EditorImageUploadError } from "@/services/editorImageService";
+import { useToastStore } from "@nosdesk/core/stores/toast";
 import { syntaxHighlightPlugin } from "./editor/syntaxHighlightPlugin";
 import { twemojiPlugin } from "@/plugins/prosemirror-twemoji";
 import { createTicketDropIndicatorPlugin } from "./editor/ticketDropIndicatorPlugin";
@@ -111,6 +113,25 @@ const authStore = useAuthStore();
 
 const fluent = useFluent();
 const t = (key: string, args?: Record<string, string | number>) => fluent.$t(key, args);
+
+const toast = useToastStore();
+
+// A failed paste used to vanish silently: the plugin calls preventDefault and
+// then only logged. Each failure mode gets its own message because they have
+// different fixes (save the page, pick a smaller image, retry).
+const handleImageUploadError = (error: unknown, file: { name: string }) => {
+    log.error("Image upload failed:", error);
+    const code = error instanceof EditorImageUploadError ? error.code : "upload-failed";
+    if (code === "no-target") {
+        toast.error(t("editor-image-upload-no-target"), t("editor-image-upload-no-target-detail"));
+    } else if (code === "anchor-lost") {
+        toast.error(t("editor-image-upload-anchor-lost"), t("editor-image-upload-anchor-lost-detail", { name: file.name }));
+    } else if (code === "invalid-file") {
+        toast.error(t("editor-image-upload-invalid"), t("editor-image-upload-invalid-detail", { name: file.name }));
+    } else {
+        toast.error(t("editor-image-upload-failed"), t("editor-image-upload-failed-detail", { name: file.name }));
+    }
+};
 
 // Set up Vue Router navigation for ticket link cards
 const router = useRouter();
@@ -871,10 +892,11 @@ const initEditor = async () => {
                     createTicketDropIndicatorPlugin(), // Shows drop indicator for ticket cards
                     // NOTE: gapCursor() removed - causes null reference errors with empty Yjs documents
                     createImageUploadPlugin({
-                        ticketId: props.ticketId,
+                        docId: props.docId,
+                        uploadingLabel: (filename: string) => t('editor-image-uploading', { name: filename }),
                         onUploadStart: () => log.debug('Image upload started'),
                         onUploadEnd: () => log.debug('Image upload completed'),
-                        onUploadError: (error) => log.error('Image upload failed:', error)
+                        onUploadError: handleImageUploadError,
                     }),
                     syntaxHighlightPlugin,
                     createMentionViewPlugin(),

--- a/frontend/src/components/editor/imageUploadPlugin.ts
+++ b/frontend/src/components/editor/imageUploadPlugin.ts
@@ -1,299 +1,424 @@
 /**
  * ProseMirror Image Upload Plugin
  *
- * Intercepts paste and drop events containing images, uploads them to the server,
- * and inserts URL references instead of base64 dataURIs.
+ * Intercepts paste and drop events containing images, uploads them, and
+ * inserts a URL reference instead of a base64 dataURI. Large binary data in
+ * the Yjs document is the failure mode this exists to prevent.
  *
- * This prevents Yjs/WebSocket sync issues caused by large binary data in the document.
+ * ## Why the position is anchored twice
+ *
+ * The upload is async, so the insertion point must survive whatever happens to
+ * the document while it is in flight. The usual ProseMirror recipe is a widget
+ * decoration mapped through `tr.mapping`, and that handles local edits. It is
+ * not enough here.
+ *
+ * y-prosemirror applies every REMOTE update as a single whole-document
+ * `replace(0, doc.content.size, ...)` (see `ProsemirrorBinding._typeChanged` in
+ * y-prosemirror/src/plugins/sync-plugin.js). Its step map reports every
+ * interior position as deleted, and `WidgetType.map` returns null for a deleted
+ * position, so a mapping-only placeholder is destroyed the moment any
+ * collaborator types anywhere in the document.
+ *
+ * y-prosemirror solves the same problem for the local caret by anchoring it in
+ * the CRDT: `getRelativeSelection` before the replace, `restoreRelativeSelection`
+ * after. `yCursorPlugin` does the same for remote carets. We copy that: each
+ * pending upload carries a Yjs relative position used to rebuild the widget on
+ * y-sync transactions, and falls back to `tr.mapping` for local ones. Neither
+ * alone is correct, because on a local edit the ProseMirror document changes
+ * before ySyncPlugin pushes it into Yjs, leaving the relative position briefly
+ * stale.
  */
 
-import { Plugin, PluginKey } from 'prosemirror-state';
-import { EditorView } from 'prosemirror-view';
-import { Slice } from 'prosemirror-model';
+import { Plugin, PluginKey, type EditorState } from 'prosemirror-state';
+import { Decoration, DecorationSet, type EditorView } from 'prosemirror-view';
+import { Fragment, Slice, type Node as PMNode } from 'prosemirror-model';
+import {
+  ySyncPluginKey,
+  absolutePositionToRelativePosition,
+  relativePositionToAbsolutePosition,
+} from 'y-prosemirror';
 import {
   uploadEditorImage,
   dataURLToFile,
   isDataURL,
-  generateImageFilename
+  generateImageFilename,
+  EditorImageUploadError,
+  type EditorImageUploadResult,
 } from '@/services/editorImageService';
 
-export const imageUploadPluginKey = new PluginKey('imageUpload');
+/** Yjs relative position. Opaque here; only y-prosemirror interprets it. */
+type RelativePosition = unknown;
+
+interface PendingUpload {
+  id: string;
+  /** Text shown next to the spinner while the upload runs. */
+  label: string;
+  /** CRDT anchor, or null when the editor has no y-sync binding. */
+  relPos: RelativePosition | null;
+}
 
 export interface ImageUploadPluginState {
-  uploading: boolean;
-  uploadCount: number;
+  pending: PendingUpload[];
+  decos: DecorationSet;
 }
 
-interface ImageUploadPluginOptions {
-  ticketId?: number;
+type ImageUploadMeta =
+  | { kind: 'add'; id: string; pos: number; label: string; relPos: RelativePosition | null }
+  | { kind: 'remove'; id: string };
+
+export const imageUploadPluginKey = new PluginKey<ImageUploadPluginState>('imageUpload');
+
+export interface ImageUploadPluginOptions {
+  /** Collab doc id; the upload target is derived from it. */
+  docId: string;
+  /** Pre-translated placeholder label. The plugin is framework free, so the component translates. */
+  uploadingLabel: (filename: string) => string;
   onUploadStart?: () => void;
   onUploadEnd?: () => void;
-  onUploadError?: (error: Error) => void;
+  onUploadError?: (error: unknown, file: { name: string }) => void;
 }
 
-/**
- * Handle image files - upload and insert
- */
-async function handleImageFiles(
+function placeholderWidget(pos: number, pending: PendingUpload): Decoration {
+  return Decoration.widget(
+    pos,
+    () => {
+      const el = document.createElement('span');
+      el.className = 'image-upload-placeholder';
+      const spinner = document.createElement('span');
+      spinner.className = 'image-upload-spinner';
+      const label = document.createElement('span');
+      label.textContent = pending.label;
+      el.append(spinner, label);
+      return el;
+    },
+    // `key` lets ProseMirror reuse the DOM across redraws so the spinner does
+    // not restart. `side: 1` puts an insert at the same position before the
+    // widget, which is what keeps a batch of images in paste order.
+    { uploadId: pending.id, key: `image-upload-${pending.id}`, side: 1, ignoreSelection: true }
+  );
+}
+
+/** Snapshot a position as a Yjs relative position, when a y-sync binding exists. */
+function captureRelPos(state: EditorState, pos: number): RelativePosition | null {
+  const ystate = ySyncPluginKey.getState(state);
+  if (!ystate?.binding) return null;
+  try {
+    return absolutePositionToRelativePosition(pos, ystate.type, ystate.binding.mapping);
+  } catch {
+    // lib.js can throw on unusual trees; degrade to mapping-only anchoring.
+    return null;
+  }
+}
+
+/** Current position of a pending placeholder, or null when it is gone. */
+function placeholderPos(state: EditorState, id: string): number | null {
+  const found = imageUploadPluginKey
+    .getState(state)
+    ?.decos.find(undefined, undefined, (spec) => spec.uploadId === id);
+  return found?.length ? found[0].from : null;
+}
+
+function newUploadId(): string {
+  return (
+    globalThis.crypto?.randomUUID?.() ??
+    `up-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+  );
+}
+
+/** Add a placeholder at `pos` and start the upload. Returns a settled outcome. */
+function startUpload(
   view: EditorView,
-  files: File[],
+  file: File,
+  alt: string,
   pos: number,
   options: ImageUploadPluginOptions
-): Promise<void> {
-  const { schema } = view.state;
-  const imageType = schema.nodes.image;
+): PendingUploadHandle {
+  const id = newUploadId();
+  const relPos = captureRelPos(view.state, pos);
 
-  if (!imageType) {
-    console.error('[ImageUpload] Image node type not found in schema');
+  view.dispatch(
+    view.state.tr.setMeta(imageUploadPluginKey, {
+      kind: 'add',
+      id,
+      pos,
+      label: options.uploadingLabel(file.name),
+      relPos,
+    } satisfies ImageUploadMeta)
+  );
+
+  // Settle the promise here so a rejection never escapes as unhandled while
+  // this entry waits its turn to be inserted.
+  const settled = uploadEditorImage(file, { docId: options.docId }).then(
+    (value) => ({ value }),
+    (error: unknown) => ({ error })
+  );
+
+  return { id, file, alt, settled };
+}
+
+interface PendingUploadHandle {
+  id: string;
+  file: File;
+  alt: string;
+  settled: Promise<{ value?: EditorImageUploadResult; error?: unknown }>;
+}
+
+/** Insert one finished upload at wherever its placeholder ended up. */
+function finishUpload(
+  view: EditorView,
+  handle: PendingUploadHandle,
+  outcome: { value?: EditorImageUploadResult; error?: unknown },
+  options: ImageUploadPluginOptions
+): void {
+  // The editor can unmount while an upload is in flight (paste, then navigate
+  // away). Dispatching into a destroyed view throws, which would swallow the
+  // error callback below.
+  if (view.isDestroyed) return;
+
+  const clearPlaceholder = () =>
+    view.dispatch(
+      view.state.tr.setMeta(imageUploadPluginKey, {
+        kind: 'remove',
+        id: handle.id,
+      } satisfies ImageUploadMeta)
+    );
+
+  if (outcome.error !== undefined || !outcome.value) {
+    clearPlaceholder();
+    options.onUploadError?.(outcome.error, { name: handle.file.name });
     return;
   }
 
+  const at = placeholderPos(view.state, handle.id);
+  if (at === null) {
+    // The anchor was deleted locally or by a collaborator while we uploaded.
+    // Dropping the result beats guessing a position, but the upload DID happen,
+    // so tell the user rather than leaving them with a silently missing image.
+    clearPlaceholder();
+    options.onUploadError?.(
+      new EditorImageUploadError(
+        'anchor-lost',
+        `Anchor for ${handle.file.name} was removed during upload`
+      ),
+      { name: handle.file.name }
+    );
+    return;
+  }
+
+  const imageType = view.state.schema.nodes.image;
+  if (!imageType) {
+    clearPlaceholder();
+    return;
+  }
+
+  view.dispatch(
+    view.state.tr
+      .insert(at, imageType.create({ src: outcome.value.url, alt: handle.alt, title: handle.alt }))
+      .setMeta(imageUploadPluginKey, { kind: 'remove', id: handle.id } satisfies ImageUploadMeta)
+  );
+}
+
+/**
+ * Upload a batch at one position.
+ *
+ * Every placeholder is dispatched up front so each upload has an anchor before
+ * any of them resolves, and the uploads themselves run concurrently. Insertion
+ * is then serialised in paste order: all the widgets share a position, so
+ * inserting one maps the rest to after it, and whichever image is inserted
+ * first ends up first. Awaiting them in order is what keeps a multi-image paste
+ * in the order the user pasted rather than the order the network happened to
+ * finish.
+ */
+async function uploadBatch(
+  view: EditorView,
+  files: { file: File; alt: string }[],
+  pos: number,
+  options: ImageUploadPluginOptions
+): Promise<void> {
+  if (!files.length) return;
   options.onUploadStart?.();
-
-  for (const file of files) {
-    if (!file.type.startsWith('image/')) {
-      continue;
+  try {
+    const handles = files.map(({ file, alt }) => startUpload(view, file, alt, pos, options));
+    for (const handle of handles) {
+      finishUpload(view, handle, await handle.settled, options);
     }
-
-
-    try {
-      // Upload the image with ticket context if available
-      const result = await uploadEditorImage(file, { ticketId: options.ticketId });
-
-      // Create the image node with the URL
-      const imageNode = imageType.create({
-        src: result.url,
-        alt: file.name,
-        title: file.name
-      });
-
-      // Insert the image at the position
-      const tr = view.state.tr.insert(pos, imageNode);
-      view.dispatch(tr);
-
-      // Update position for next image
-      pos += imageNode.nodeSize;
-    } catch (error) {
-      console.error('[ImageUpload] Failed to upload image:', error);
-      options.onUploadError?.(error instanceof Error ? error : new Error(String(error)));
-    }
+  } finally {
+    options.onUploadEnd?.();
   }
+}
 
-  options.onUploadEnd?.();
+function imageFilesFrom(list: FileList | null | undefined): File[] {
+  const out: File[] = [];
+  for (let i = 0; i < (list?.length ?? 0); i++) {
+    const file = list![i];
+    if (file.type.startsWith('image/')) out.push(file);
+  }
+  return out;
+}
+
+/** dataURL `<img>` tags in pasted HTML, e.g. a copied rich-text region. */
+function dataURLImagesFrom(html: string): { src: string; alt: string }[] {
+  const doc = new DOMParser().parseFromString(html, 'text/html');
+  const out: { src: string; alt: string }[] = [];
+  doc.querySelectorAll('img').forEach((img) => {
+    if (isDataURL(img.src)) out.push({ src: img.src, alt: img.alt || 'pasted-image' });
+  });
+  return out;
 }
 
 /**
- * Handle pasted content - check for images in HTML or as files
+ * Convert pasted dataURL images to files, dropping any that are not base64.
+ * Runs synchronously inside handlePaste, so it must not throw: see the note on
+ * `dataURLToFile`. Anything dropped here falls through to the default paste,
+ * where `transformPasted` strips it before it can reach the document.
  */
-async function handlePaste(
-  view: EditorView,
-  event: ClipboardEvent,
-  options: ImageUploadPluginOptions
-): Promise<boolean> {
-  const { clipboardData } = event;
-  if (!clipboardData) return false;
-
-  // Check for image files first (e.g., screenshot paste)
-  const imageFiles: File[] = [];
-  for (let i = 0; i < clipboardData.files.length; i++) {
-    const file = clipboardData.files[i];
-    if (file.type.startsWith('image/')) {
-      imageFiles.push(file);
-    }
+function toFiles(dataURLImages: { src: string; alt: string }[]): { file: File; alt: string }[] {
+  const out: { file: File; alt: string }[] = [];
+  for (const { src, alt } of dataURLImages) {
+    const mime = src.match(/data:([^;]+)[;,]/)?.[1] ?? 'image/png';
+    const file = dataURLToFile(src, generateImageFilename(mime));
+    if (file) out.push({ file, alt });
   }
+  return out;
+}
 
-  if (imageFiles.length > 0) {
-    event.preventDefault();
-    const pos = view.state.selection.from;
-    await handleImageFiles(view, imageFiles, pos, options);
-    return true;
-  }
+/** Strip dataURL image nodes out of a slice so base64 can never reach the document. */
+function stripDataURLImages(slice: Slice, state: EditorState): Slice {
+  const imageType = state.schema.nodes.image;
+  if (!imageType) return slice;
 
-  // Check for HTML content with images
-  const html = clipboardData.getData('text/html');
-  if (html) {
-    const parser = new DOMParser();
-    const doc = parser.parseFromString(html, 'text/html');
-    const images = doc.querySelectorAll('img');
-
-    const dataURLImages: { src: string; alt: string }[] = [];
-    images.forEach(img => {
-      if (isDataURL(img.src)) {
-        dataURLImages.push({
-          src: img.src,
-          alt: img.alt || 'pasted-image'
-        });
+  let found = false;
+  const scrub = (fragment: Fragment): Fragment => {
+    const kept: PMNode[] = [];
+    fragment.forEach((node) => {
+      if (node.type === imageType && isDataURL(node.attrs.src)) {
+        found = true;
+        return;
       }
+      kept.push(node.childCount ? node.copy(scrub(node.content)) : node);
     });
+    return Fragment.fromArray(kept);
+  };
 
-    if (dataURLImages.length > 0) {
-      event.preventDefault();
-
-      options.onUploadStart?.();
-      const { schema } = view.state;
-      const imageType = schema.nodes.image;
-      let pos = view.state.selection.from;
-
-      for (const imgData of dataURLImages) {
-        try {
-          // Convert dataURL to file
-          const mimeMatch = imgData.src.match(/data:([^;]+);/);
-          const mime = mimeMatch ? mimeMatch[1] : 'image/png';
-          const filename = generateImageFilename(mime);
-          const file = dataURLToFile(imgData.src, filename);
-
-          // Upload the image with ticket context if available
-          const result = await uploadEditorImage(file, { ticketId: options.ticketId });
-
-          // Create and insert the image node
-          const imageNode = imageType.create({
-            src: result.url,
-            alt: imgData.alt,
-            title: imgData.alt
-          });
-
-          const tr = view.state.tr.insert(pos, imageNode);
-          view.dispatch(tr);
-          pos += imageNode.nodeSize;
-        } catch (error) {
-          console.error('Failed to upload pasted image:', error);
-          options.onUploadError?.(error instanceof Error ? error : new Error(String(error)));
-        }
-      }
-
-      options.onUploadEnd?.();
-      return true;
-    }
-  }
-
-  return false;
+  const content = scrub(slice.content);
+  return found ? new Slice(content, slice.openStart, slice.openEnd) : slice;
 }
 
-/**
- * Handle dropped files
- */
-async function handleDrop(
-  view: EditorView,
-  event: DragEvent,
-  options: ImageUploadPluginOptions
-): Promise<boolean> {
-  const { dataTransfer } = event;
-  if (!dataTransfer) return false;
-
-  const imageFiles: File[] = [];
-  for (let i = 0; i < dataTransfer.files.length; i++) {
-    const file = dataTransfer.files[i];
-    if (file.type.startsWith('image/')) {
-      imageFiles.push(file);
-    }
-  }
-
-  if (imageFiles.length === 0) return false;
-
-  event.preventDefault();
-
-  // Get the drop position
-  const pos = view.posAtCoords({ left: event.clientX, top: event.clientY });
-  if (!pos) return false;
-
-  await handleImageFiles(view, imageFiles, pos.pos, options);
-  return true;
-}
-
-/**
- * Create the image upload plugin
- */
-export function createImageUploadPlugin(options: ImageUploadPluginOptions = {}): Plugin {
-  return new Plugin({
+export function createImageUploadPlugin(options: ImageUploadPluginOptions): Plugin {
+  return new Plugin<ImageUploadPluginState>({
     key: imageUploadPluginKey,
 
     state: {
       init(): ImageUploadPluginState {
-        return { uploading: false, uploadCount: 0 };
+        return { pending: [], decos: DecorationSet.empty };
       },
-      apply(tr, state): ImageUploadPluginState {
-        return state;
-      }
+
+      // The 4th argument is the new EditorState, which is where the y-sync
+      // binding is read from. Map or rebuild FIRST, then apply the meta: the
+      // completion transaction inserts the image and removes the placeholder
+      // together, so the insert step must be mapped through before the removal.
+      apply(tr, value, _oldState, newState): ImageUploadPluginState {
+        const meta = tr.getMeta(imageUploadPluginKey) as ImageUploadMeta | undefined;
+        const ystate = ySyncPluginKey.getState(newState);
+        const fromYSync = tr.getMeta(ySyncPluginKey) !== undefined;
+
+        let pending = value.pending;
+        let decos = value.decos;
+
+        if (pending.length && fromYSync && ystate?.binding) {
+          // Whole-document replace: tr.mapping reports every interior position
+          // as deleted, so re-derive from the CRDT anchor instead.
+          const kept: PendingUpload[] = [];
+          const widgets: Decoration[] = [];
+          for (const p of pending) {
+            const pos = p.relPos
+              ? relativePositionToAbsolutePosition(
+                  ystate.doc,
+                  ystate.type,
+                  p.relPos,
+                  ystate.binding.mapping
+                )
+              : null;
+            if (pos === null) continue;
+            kept.push(p);
+            widgets.push(placeholderWidget(Math.min(pos, tr.doc.content.size), p));
+          }
+          pending = kept;
+          decos = DecorationSet.create(tr.doc, widgets);
+        } else if (tr.docChanged) {
+          decos = decos.map(tr.mapping, tr.doc);
+          if (pending.length) {
+            // A pending entry whose widget did not survive the map is
+            // unrecoverable, so drop it rather than leaking the entry.
+            const live = new Set(decos.find().map((d) => d.spec.uploadId as string));
+            pending = pending.filter((p) => live.has(p.id));
+          }
+        }
+
+        if (meta?.kind === 'add') {
+          const entry: PendingUpload = { id: meta.id, label: meta.label, relPos: meta.relPos };
+          pending = [...pending, entry];
+          decos = decos.add(tr.doc, [placeholderWidget(meta.pos, entry)]);
+        } else if (meta?.kind === 'remove') {
+          const { id } = meta;
+          pending = pending.filter((p) => p.id !== id);
+          const gone = decos.find(undefined, undefined, (spec) => spec.uploadId === id);
+          if (gone.length) decos = decos.remove(gone);
+        }
+
+        return { pending, decos };
+      },
     },
 
     props: {
+      decorations(state) {
+        return imageUploadPluginKey.getState(state)?.decos ?? DecorationSet.empty;
+      },
+
       handlePaste(view: EditorView, event: ClipboardEvent): boolean {
-        // Handle async - return true to prevent default when handling images
         const clipboardData = event.clipboardData;
         if (!clipboardData) return false;
 
-        // Check if there are image files or dataURL images
-        let hasImages = false;
-        for (let i = 0; i < clipboardData.files.length; i++) {
-          if (clipboardData.files[i].type.startsWith('image/')) {
-            hasImages = true;
-            break;
-          }
-        }
+        const imageFiles = imageFilesFrom(clipboardData.files);
+        const html = imageFiles.length ? '' : clipboardData.getData('text/html');
+        const batch = imageFiles.length
+          ? imageFiles.map((file) => ({ file, alt: file.name }))
+          : html.includes('data:image')
+            ? toFiles(dataURLImagesFrom(html))
+            : [];
 
-        if (!hasImages) {
-          const html = clipboardData.getData('text/html');
-          if (html && html.includes('data:image')) {
-            hasImages = true;
-          }
-        }
+        if (!batch.length) return false;
 
-        if (hasImages) {
-          // Prevent default and handle async
-          handlePaste(view, event, options);
-          return true;
-        }
-
-        return false;
+        // Positions must be read synchronously, before any await.
+        event.preventDefault();
+        void uploadBatch(view, batch, view.state.selection.from, options);
+        return true;
       },
 
       handleDrop(view: EditorView, event: DragEvent, _slice: Slice, _moved: boolean): boolean {
-        const { dataTransfer } = event;
-        if (!dataTransfer) return false;
+        const imageFiles = imageFilesFrom(event.dataTransfer?.files);
+        if (!imageFiles.length) return false;
 
-        // Check if there are image files
-        let hasImages = false;
-        for (let i = 0; i < dataTransfer.files.length; i++) {
-          if (dataTransfer.files[i].type.startsWith('image/')) {
-            hasImages = true;
-            break;
-          }
-        }
+        const at = view.posAtCoords({ left: event.clientX, top: event.clientY });
+        if (!at) return false;
 
-        if (hasImages) {
-          // Prevent default and handle async
-          handleDrop(view, event, options);
-          return true;
-        }
-
-        return false;
+        event.preventDefault();
+        void uploadBatch(
+          view,
+          imageFiles.map((file) => ({ file, alt: file.name })),
+          at.pos,
+          options
+        );
+        return true;
       },
 
-      // Transform pasted content to convert any remaining dataURL images
-      // This catches images that slip through other handlers
+      // Safety net for a mixed paste that reaches the default handler: strip
+      // dataURL images so base64 can never enter the Yjs document. handlePaste
+      // uploads them properly when it recognises the paste.
       transformPasted(slice: Slice, view: EditorView): Slice {
-        const { schema } = view.state;
-
-        // Walk through the slice and look for image nodes with dataURL sources
-        let hasDataURLImages = false;
-
-        slice.content.descendants((node) => {
-          if (node.type === schema.nodes.image && isDataURL(node.attrs.src)) {
-            hasDataURLImages = true;
-            return false; // Stop iteration
-          }
-          return true;
-        });
-
-        if (hasDataURLImages) {
-          // Return an empty slice to prevent the paste
-          // The handlePaste will handle the upload
-          console.warn('Blocked paste with dataURL images - uploading instead');
-        }
-
-        return slice;
-      }
-    }
+        return stripDataURLImages(slice, view.state);
+      },
+    },
   });
 }
 

--- a/frontend/src/services/editorImageService.ts
+++ b/frontend/src/services/editorImageService.ts
@@ -1,138 +1,161 @@
 /**
  * Editor Image Upload Service
  *
- * Handles image uploads for the collaborative editor, converting
- * pasted/dropped images to URL references instead of storing
- * base64 dataURIs in the Yjs document.
+ * Uploads images pasted or dropped into a collaborative editor and returns a
+ * URL reference for the `image` node. The node's payload stays a short URL:
+ * base64 dataURIs in the Yjs document are the failure mode this whole
+ * subsystem exists to avoid.
  *
- * This prevents Yjs/WebSocket sync issues with large binary data.
+ * The upload target is derived from the collab docId the editor is already
+ * bound to (`ws-{workspace_uuid}_{kind}-{resource_uuid}`), so documentation
+ * pages and collection descriptions work the same way tickets do. There is no
+ * fallback to the generic `/upload` staging endpoint: that stored into `temp/`
+ * and handed back an unreachable `/uploads/...` URL, which is what made pasted
+ * images look broken on documentation pages.
  */
 
+import apiClient from '@nosdesk/core/apiClient';
+import { parseCollabDocId } from '@nosdesk/core/utils/collabDocId';
 import uploadService from '@/services/uploadService';
 import { logger } from '@nosdesk/core/utils/logger';
+
+export type EditorImageErrorCode =
+  | 'no-target'
+  | 'invalid-file'
+  | 'upload-failed'
+  /** Uploaded fine, but the spot it was pasted at no longer exists. */
+  | 'anchor-lost';
+
+/**
+ * Typed so the editor can pick the right message per failure mode instead of
+ * swallowing every failure into one console line.
+ */
+export class EditorImageUploadError extends Error {
+  constructor(
+    readonly code: EditorImageErrorCode,
+    message: string,
+    readonly cause?: unknown
+  ) {
+    super(message);
+    this.name = 'EditorImageUploadError';
+  }
+}
 
 export interface EditorImageUploadResult {
   url: string;
   name: string;
-  id?: number;
   size?: number;
 }
 
 export interface EditorImageUploadOptions {
-  ticketId?: number;
+  /** Workspace-namespaced collab doc id the editor is bound to. */
+  docId: string;
   onProgress?: (message: string) => void;
 }
 
+interface UploadedEditorImage {
+  url: string;
+  name: string;
+  size?: number;
+}
+
 /**
- * Upload an image file for use in the collaborative editor
- * Returns a URL that can be used as the image src
- *
- * @param file - The image file to upload
- * @param options - Upload options including ticketId for ticket-specific storage
+ * Upload an image for use in the collaborative editor. Resolves to the final
+ * servable URL, already in `/api/files/collab/...` form; callers insert it as
+ * the image node's `src` verbatim.
  */
 export async function uploadEditorImage(
   file: File,
-  options: EditorImageUploadOptions = {}
+  options: EditorImageUploadOptions
 ): Promise<EditorImageUploadResult> {
-  const { ticketId, onProgress } = options;
+  const { docId, onProgress } = options;
 
-  // Validate the file
-  const validation = uploadService.validateFile(file, {
-    maxSizeMB: 10, // 10MB limit for editor images
-    allowedTypes: ['image/*']
-  });
-
-  if (!validation.valid) {
-    throw new Error(validation.error || 'Invalid file');
+  // A docId that does not parse means there is no document to attach to: the
+  // brand-new-page wizard's `documentation-new` sentinel, a legacy bare id, or
+  // an unresolved workspace. Fail loudly rather than staging the file
+  // somewhere it can never be served from.
+  if (!parseCollabDocId(docId)) {
+    throw new EditorImageUploadError(
+      'no-target',
+      `Cannot upload an image for an unsaved or unparseable document (got "${docId}")`
+    );
   }
 
-  // Convert HEIC to WebP if needed
+  const validation = uploadService.validateFile(file, {
+    maxSizeMB: 10,
+    allowedTypes: ['image/*'],
+  });
+  if (!validation.valid) {
+    throw new EditorImageUploadError('invalid-file', validation.error || 'Invalid file');
+  }
+
   const processedFile = await uploadService.convertHeicToJpeg(file, onProgress);
 
-  // Create form data for upload
   const formData = new FormData();
-  // Explicitly pass filename as third argument
+  // Explicit filename third argument: HEIC conversion renames the file.
   formData.append('files', processedFile, processedFile.name);
 
-  if (onProgress) {
-    onProgress('Uploading image...');
-  }
-
-  // Get CSRF token from cookie for the request
-  const csrfMatch = document.cookie.match(/csrf_token=([^;]+)/);
-  const csrfToken = csrfMatch ? csrfMatch[1] : '';
-
-  // Use ticket-specific endpoint if ticketId is provided
-  const uploadUrl = ticketId
-    ? `/api/tickets/${ticketId}/notes/images`
-    : '/api/upload';
-
-  logger.debug(`[EditorImage] Uploading to ${uploadUrl}`);
+  onProgress?.('Uploading image...');
 
   try {
-    // Use native fetch for FormData uploads - axios has issues with multipart boundary
-    // when Content-Type is set in default headers
-    const response = await fetch(uploadUrl, {
-      method: 'POST',
-      body: formData,
-      credentials: 'same-origin',
-      headers: {
-        'X-CSRF-Token': csrfToken
-      }
-      // Don't set Content-Type - browser will set it correctly with boundary for FormData
-    });
+    // Through the shared axios client, not raw fetch: the interceptor carries
+    // the workspace selection header and the active auth strategy (cookie CSRF
+    // on web, bearer in the Tauri webview). The per-request Content-Type
+    // override stops axios serialising the FormData as JSON; the browser then
+    // replaces it with a boundary-carrying multipart header.
+    const { data } = await apiClient.post<UploadedEditorImage[]>(
+      `/documents/${docId}/images`,
+      formData,
+      { headers: { 'Content-Type': 'multipart/form-data' } }
+    );
 
-    if (!response.ok) {
-      const errorText = await response.text();
-      throw new Error(`Upload failed: ${response.status} ${errorText}`);
+    const uploaded = data?.[0];
+    if (!uploaded) {
+      throw new EditorImageUploadError('upload-failed', 'No file returned from upload');
     }
 
-    const data = await response.json();
+    onProgress?.('Upload complete');
+    logger.debug(`[EditorImage] Upload complete, URL: ${uploaded.url}`);
 
-    if (data && data.length > 0) {
-      const uploadedFile = data[0];
-
-      if (onProgress) {
-        onProgress('Upload complete');
-      }
-
-      // The URL returned from the ticket-specific endpoint is in format:
-      // /uploads/tickets/{ticketId}/notes/{uuid}_{filename}
-      // Convert to the API file serving endpoint:
-      // /api/files/tickets/{ticketId}/notes/{uuid}_{filename}
-      let finalUrl = uploadedFile.url;
-      if (ticketId && finalUrl.startsWith('/uploads/')) {
-        finalUrl = '/api/files/' + finalUrl.substring('/uploads/'.length);
-      }
-
-      logger.debug(`[EditorImage] Upload complete, URL: ${finalUrl}`);
-
-      return {
-        url: finalUrl,
-        name: uploadedFile.name,
-        id: uploadedFile.id,
-        size: uploadedFile.size
-      };
-    }
-
-    throw new Error('No file returned from upload');
+    return { url: uploaded.url, name: uploaded.name, size: uploaded.size };
   } catch (error) {
+    if (error instanceof EditorImageUploadError) {
+      throw error;
+    }
     logger.error('Failed to upload editor image:', error);
-    throw error;
+    throw new EditorImageUploadError('upload-failed', 'Image upload failed', error);
   }
 }
 
 /**
- * Convert a dataURL to a File object
+ * Convert a dataURL to a File, or null when it is not base64 encoded.
+ *
+ * Returns null rather than throwing: the caller runs inside ProseMirror's
+ * synchronous paste handler, and prosemirror-view calls
+ * `event.preventDefault()` only AFTER that handler returns (see `doPaste` in
+ * prosemirror-view/src/input.ts). An exception there would skip preventDefault
+ * entirely, letting the browser paste the raw base64 img into the contentEditable
+ * where the DOM observer reads it straight into the Yjs document.
+ *
+ * Percent-encoded data URLs are the common case that used to throw:
+ * `data:image/svg+xml,<svg .../>` has no base64 payload, so `atob` rejects it.
  */
-export function dataURLToFile(dataURL: string, filename: string): File {
-  const arr = dataURL.split(',');
-  const mimeMatch = arr[0].match(/:(.*?);/);
+export function dataURLToFile(dataURL: string, filename: string): File | null {
+  const [header, payload] = dataURL.split(',');
+  if (!header?.includes(';base64') || !payload) return null;
+
+  const mimeMatch = header.match(/:(.*?);/);
   const mime = mimeMatch ? mimeMatch[1] : 'image/png';
-  const bstr = atob(arr[1]);
+
+  let bstr: string;
+  try {
+    bstr = atob(payload);
+  } catch {
+    return null;
+  }
+
   let n = bstr.length;
   const u8arr = new Uint8Array(n);
-
   while (n--) {
     u8arr[n] = bstr.charCodeAt(n);
   }

--- a/i18n/locales/en-AU/main.ftl
+++ b/i18n/locales/en-AU/main.ftl
@@ -5186,3 +5186,14 @@ gantt-tickets-of-total-in-view =
     }
 saved-view-name-this = Name this view
 saved-view-copy-suffix = { $name } copy
+
+# Editor: image upload (imageUploadPlugin / CollaborativeEditor)
+editor-image-uploading = Uploading { $name }
+editor-image-upload-failed = Image upload failed
+editor-image-upload-failed-detail = { $name } could not be uploaded. Please try again.
+editor-image-upload-no-target = Save this page before adding images
+editor-image-upload-no-target-detail = Images attach to a saved page. Save this page, then paste the image again.
+editor-image-upload-invalid = Image cannot be added
+editor-image-upload-invalid-detail = { $name } is not a supported image, or is larger than 10MB.
+editor-image-upload-anchor-lost = Image could not be placed
+editor-image-upload-anchor-lost-detail = { $name } uploaded, but the spot you pasted it into was edited away. Paste it again.

--- a/i18n/locales/en-GB/main.ftl
+++ b/i18n/locales/en-GB/main.ftl
@@ -5174,3 +5174,14 @@ gantt-tickets-of-total-in-view =
     }
 saved-view-name-this = Name this view
 saved-view-copy-suffix = { $name } copy
+
+# Editor: image upload (imageUploadPlugin / CollaborativeEditor)
+editor-image-uploading = Uploading { $name }
+editor-image-upload-failed = Image upload failed
+editor-image-upload-failed-detail = { $name } could not be uploaded. Please try again.
+editor-image-upload-no-target = Save this page before adding images
+editor-image-upload-no-target-detail = Images attach to a saved page. Save this page, then paste the image again.
+editor-image-upload-invalid = Image cannot be added
+editor-image-upload-invalid-detail = { $name } is not a supported image, or is larger than 10MB.
+editor-image-upload-anchor-lost = Image could not be placed
+editor-image-upload-anchor-lost-detail = { $name } uploaded, but the spot you pasted it into was edited away. Paste it again.

--- a/i18n/locales/en-US/main.ftl
+++ b/i18n/locales/en-US/main.ftl
@@ -6705,3 +6705,14 @@ asset-catalog-col-type = Type
 asset-catalog-col-part-number = Part number
 asset-catalog-filter-all = All
 asset-catalog-manage-manufacturers = Manufacturers
+
+# Editor: image upload (imageUploadPlugin / CollaborativeEditor)
+editor-image-uploading = Uploading { $name }
+editor-image-upload-failed = Image upload failed
+editor-image-upload-failed-detail = { $name } could not be uploaded. Please try again.
+editor-image-upload-no-target = Save this page before adding images
+editor-image-upload-no-target-detail = Images attach to a saved page. Save this page, then paste the image again.
+editor-image-upload-invalid = Image cannot be added
+editor-image-upload-invalid-detail = { $name } is not a supported image, or is larger than 10MB.
+editor-image-upload-anchor-lost = Image could not be placed
+editor-image-upload-anchor-lost-detail = { $name } uploaded, but the spot you pasted it into was edited away. Paste it again.

--- a/i18n/locales/fr-FR/main.ftl
+++ b/i18n/locales/fr-FR/main.ftl
@@ -6627,3 +6627,14 @@ admin-asset-groups-filter-active = Actifs
 admin-asset-groups-filter-archived = Archivés
 admin-asset-groups-filter-empty = Aucun groupe ne correspond à ce filtre.
 admin-asset-groups-col-members = Actifs
+
+# Editor: image upload (imageUploadPlugin / CollaborativeEditor)
+editor-image-uploading = Téléversement de { $name }
+editor-image-upload-failed = Échec du téléversement de l'image
+editor-image-upload-failed-detail = { $name } n'a pas pu être téléversé. Veuillez réessayer.
+editor-image-upload-no-target = Enregistrez cette page avant d'ajouter des images
+editor-image-upload-no-target-detail = Les images sont rattachées à une page enregistrée. Enregistrez cette page, puis collez de nouveau l'image.
+editor-image-upload-invalid = Impossible d'ajouter l'image
+editor-image-upload-invalid-detail = { $name } n'est pas une image prise en charge, ou dépasse 10 Mo.
+editor-image-upload-anchor-lost = Impossible de placer l'image
+editor-image-upload-anchor-lost-detail = { $name } a bien été téléversé, mais l'endroit où vous l'avez collé a été modifié. Collez-la de nouveau.

--- a/i18n/locales/nl-NL/main.ftl
+++ b/i18n/locales/nl-NL/main.ftl
@@ -6619,3 +6619,14 @@ admin-asset-groups-filter-active = Actief
 admin-asset-groups-filter-archived = Gearchiveerd
 admin-asset-groups-filter-empty = Geen groepen komen overeen met dit filter.
 admin-asset-groups-col-members = Activa
+
+# Editor: image upload (imageUploadPlugin / CollaborativeEditor)
+editor-image-uploading = { $name } wordt geüpload
+editor-image-upload-failed = Uploaden van afbeelding mislukt
+editor-image-upload-failed-detail = { $name } kon niet worden geüpload. Probeer het opnieuw.
+editor-image-upload-no-target = Sla deze pagina op voordat je afbeeldingen toevoegt
+editor-image-upload-no-target-detail = Afbeeldingen horen bij een opgeslagen pagina. Sla deze pagina op en plak de afbeelding opnieuw.
+editor-image-upload-invalid = Afbeelding kan niet worden toegevoegd
+editor-image-upload-invalid-detail = { $name } is geen ondersteunde afbeelding, of is groter dan 10 MB.
+editor-image-upload-anchor-lost = Afbeelding kon niet worden geplaatst
+editor-image-upload-anchor-lost-detail = { $name } is geüpload, maar de plek waar je hem plakte is inmiddels gewijzigd. Plak hem opnieuw.


### PR DESCRIPTION
## Why

Pasting an image into a documentation page produced a broken image, while the same paste into a ticket worked. Both surfaces mount the *same* editor with the same plugin list, so the difference was not Yjs, ProseMirror or the schema. It was a missing upload route.

`DocumentView` and `CollectionView` mount `CollaborativeEditor` without a `ticketId`, so `editorImageService` fell through to `POST /api/upload`, which stages into `temp/` and returns `/uploads/temp/...`. The `/uploads/` to `/api/files/` rewrite was itself gated on `ticketId`, so it never ran, and every unmatched `/uploads/*` routes to `reject_legacy_upload_path`. The upload succeeded and the `src` 404ed.

`temp/` was also the wrong home: its read gate is workspace membership alone with no per-document check, and the rows it created kept `comment_id = NULL` forever.

## What changed

Two endpoints keyed on the workspace-namespaced collab docId the editor already holds:

| | |
|---|---|
| `POST /api/documents/{doc_id}/images` | upload |
| `GET /api/files/collab/{kind}/{uuid}/{filename}` | serve |

Both gate on `can_access_document`, the same primitive the collaboration WebSocket and the REST article read use, so image visibility cannot drift from document visibility. All three collab kinds (`doc`, `collection`, `ticket`) go through them; ticket note images already embedded keep resolving through `/api/files/tickets/{id}/notes/...`, which stays registered.

Three placement decisions worth reviewing:

- The upload sits in the main `/api` scope, not `/api/collaboration`, which carries neither the rate limiter nor token-scope enforcement.
- The serve route derives the workspace from the resource, because a browser `<img>` load carries no `X-Nosdesk-Workspace`, so a `TenantConn` there would 400 under hosted selection.
- Neither route creates an `attachments` row, matching `upload_ticket_note_image`, which keeps it off the sync-emit surface.

### The fiddly part

The standard ProseMirror upload-placeholder recipe is wrong under y-prosemirror. `ProsemirrorBinding._typeChanged` applies every **remote** update as a single whole-document `replace(0, size, ...)`, so `tr.mapping` reports interior positions as deleted and `WidgetType.map` returns null. A mapping-only placeholder is destroyed the moment any collaborator types anywhere. Local edits map fine, so it looks correct until you test with two clients.

In-flight uploads are now anchored with Yjs relative positions, re-derived from the CRDT on y-sync transactions and falling back to `tr.mapping` locally, matching how `restoreRelativeSelection` and `yCursorPlugin` anchor carets.

### Also in this change

- Batch insertion is serialised, so a multi-image paste lands in paste order rather than upload completion order.
- `dataURLToFile` returns null instead of throwing. It runs inside the synchronous paste handler, where prosemirror-view calls `preventDefault()` only *after* the handler returns, so a percent-encoded data URL such as `data:image/svg+xml,<svg/>` would skip `preventDefault` and let the browser paste raw base64 into the document. `transformPasted` now strips dataURL image nodes instead of only warning.
- Uploads go through the shared axios client instead of raw `fetch`, so the workspace selection header and the active auth strategy apply.
- Inline placeholder while uploading, and a toast on failure covering `no-target`, `invalid-file`, `upload-failed` and `anchor-lost`. Keys added to all five locales.

## Verification

`cargo test` 1866 passed, `fmt` and `clippy` clean, all four convention lints pass. `vue-tsc`, `npm run lint`, 33 frontend tests.

Driven against the dev stack:

- Round trip for doc, collection and ticket kinds: upload 200, serve 200, bytes identical.
- Denials: unauthenticated 401; unknown kind, bad uuid, path traversal and nonexistent page all 404; non-image 400; legacy bare doc_id 400; missing CSRF 403.
- Visibility gate proven, not assumed: as an end user, a ticket they requested returned 200 and one they did not returned 404.
- Storage is workspace-prefixed on disk (`ws/1/collab/doc/{uuid}/`) while the URL stays prefix-free.
- Two live browser sessions: with A's upload held open, B typing at the top of the page did not displace A's image, which landed at the paste point.
- Three images with the first upload held 6s and the rest at 300ms land in paste order.
- Percent-encoded SVG data URL paste: no page errors, zero `data:` images in the document.

## Notes for review

- `authorize_collab_file_access` does an unscoped workspace lookup and then re-resolves the uuid under the pin. The second resolve is deliberate defence in depth, not redundancy: it re-proves under RLS that the resource is in the workspace we pinned to.
- The `anchor-lost` toast is the one path not exercised empirically; deleting the anchoring block locally did not lose the placeholder.
- Out of scope, recorded: public knowledge base pages return `yjs_document` to guests but no guest surface renders bodies today, so a guest-readable image route is only needed when that ships. Documents already pasted into keep their broken `/uploads/temp/...` srcs. Deleting a page leaves its image objects, matching ticket notes.



---

Supersedes #238, which GitHub closed rather than auto-retargeted when the base branch of the stacked #239 was deleted on merge. Same branch, same commit content, now based directly on `main`.