### PR TITLE
Security: gate mention avatars on the image-origin allowlist, fix YAML frontmatter escaping

### DIFF
--- a/frontend/src/components/ticketComponents/CannedResponsePicker.vue
+++ b/frontend/src/components/ticketComponents/CannedResponsePicker.vue
@@ -274,7 +274,9 @@ const highlightPreview = (text: string): string => highlightTerms(text, searchTe
 watch(searchQuery, () => {
   activeIndex.value = 0;
 });
-const uid = Math.random().toString(36).slice(2, 8);
+// Unique suffix for the aria-activedescendant ids. Not security bearing,
+// but crypto.randomUUID avoids the weak-RNG lint and is no more code.
+const uid = crypto.randomUUID().slice(0, 8);
 const optionId = (i: number) => `canned-response-opt-${uid}-${i}`;
 const activeOptionId = computed(() =>
   filteredResponses.value.length > 0 ? optionId(activeIndex.value) : undefined,

--- a/frontend/src/plugins/prosemirror-mention-view.ts
+++ b/frontend/src/plugins/prosemirror-mention-view.ts
@@ -7,6 +7,7 @@
 import { Plugin } from 'prosemirror-state';
 import type { Node as PMNode } from 'prosemirror-model';
 import type { EditorView, NodeView } from 'prosemirror-view';
+import { isAllowedImageSrc } from '@/composables/useSanitise';
 
 // Navigation handler for mention clicks
 let mentionNavigationHandler: ((uuid: string) => void) | null = null;
@@ -64,26 +65,31 @@ function createMentionContent(uuid: string, name: string, avatarUrl: string | nu
   const avatar = document.createElement('span');
   avatar.className = 'mention-avatar';
 
-  if (avatarUrl) {
+  const appendFallback = () => {
+    const fallback = document.createElement('span');
+    fallback.className = 'mention-avatar-fallback';
+    fallback.textContent = getInitials(name);
+    fallback.style.backgroundColor = stringToColor(uuid);
+    avatar.appendChild(fallback);
+  };
+
+  // The avatar URL rides in the mention node's attrs, so it comes out of the
+  // collaborative document and any collaborator can set it. An off-origin
+  // src would make every viewer's browser fetch an attacker-chosen URL,
+  // leaking their IP and a read-receipt timestamp. Same allowlist the
+  // markdown/comment paths use.
+  if (avatarUrl && isAllowedImageSrc(avatarUrl)) {
     const img = document.createElement('img');
     img.src = avatarUrl;
     img.alt = name;
     img.className = 'mention-avatar-img';
     img.onerror = () => {
       img.style.display = 'none';
-      const fallback = document.createElement('span');
-      fallback.className = 'mention-avatar-fallback';
-      fallback.textContent = getInitials(name);
-      fallback.style.backgroundColor = stringToColor(uuid);
-      avatar.appendChild(fallback);
+      appendFallback();
     };
     avatar.appendChild(img);
   } else {
-    const fallback = document.createElement('span');
-    fallback.className = 'mention-avatar-fallback';
-    fallback.textContent = getInitials(name);
-    fallback.style.backgroundColor = stringToColor(uuid);
-    avatar.appendChild(fallback);
+    appendFallback();
   }
 
   // Create name element

--- a/frontend/src/services/markdownExportService.spec.ts
+++ b/frontend/src/services/markdownExportService.spec.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import { yamlString } from './markdownExportService'
+
+describe('yamlString', () => {
+  it('quotes a plain value', () => {
+    expect(yamlString('Getting started')).toBe('"Getting started"')
+  })
+
+  it('escapes double quotes', () => {
+    expect(yamlString('a "b" c')).toBe('"a \\"b\\" c"')
+  })
+
+  // The original bug: quotes were escaped but backslashes were not, so the
+  // escape character itself leaked through into the frontmatter.
+  it('escapes backslashes before quotes', () => {
+    expect(yamlString('a\\b')).toBe('"a\\\\b"')
+    expect(yamlString('a\\"b')).toBe('"a\\\\\\"b"')
+  })
+
+  it('does not leave a trailing backslash unterminated', () => {
+    const out = yamlString('ends with\\')
+    expect(out).toBe('"ends with\\\\"')
+    // An odd number of trailing backslashes would swallow the closing quote.
+    expect(out.match(/\\*"$/)?.[0].length ?? 0).toBe(3)
+  })
+
+  it('drops control characters rather than emitting invalid escapes', () => {
+    expect(yamlString(`a${String.fromCharCode(1)}b${String.fromCharCode(127)}c`)).toBe('"abc"')
+  })
+
+  it('tolerates empty and nullish input', () => {
+    expect(yamlString('')).toBe('""')
+    expect(yamlString(undefined as unknown as string)).toBe('""')
+  })
+})

--- a/frontend/src/services/markdownExportService.ts
+++ b/frontend/src/services/markdownExportService.ts
@@ -283,18 +283,34 @@ const buildFolderStructure = (pages: DocumentationPageExport[]): Map<number, str
 /**
  * Create frontmatter for a markdown file
  */
+/**
+ * Quote a value as a YAML double-quoted scalar.
+ *
+ * Backslashes must be escaped BEFORE quotes, or the escape character itself
+ * is left unescaped: a title of `a\\` previously emitted `"a\\"`, an
+ * unterminated string, and any interior backslash produced an invalid YAML
+ * escape sequence. Control characters are dropped rather than escaped since
+ * they have no place in a title or slug.
+ */
+export const yamlString = (value: string): string =>
+  `"${String(value ?? '')
+     
+    .replace(/[\u0000-\u001f\u007f]/g, '')
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"')}"`;
+
 const createFrontmatter = (page: DocumentationPageExport): string => {
   const frontmatter = [
     '---',
-    `title: "${page.title.replace(/"/g, '\\"')}"`,
-    `slug: "${page.slug}"`,
+    `title: ${yamlString(page.title)}`,
+    `slug: ${yamlString(page.slug)}`,
   ];
 
   if (page.icon) {
-    frontmatter.push(`icon: "${page.icon}"`);
+    frontmatter.push(`icon: ${yamlString(page.icon)}`);
   }
 
-  frontmatter.push(`status: "${page.status}"`);
+  frontmatter.push(`status: ${yamlString(page.status)}`);
   frontmatter.push(`created: ${page.created_at}`);
   frontmatter.push(`updated: ${page.updated_at}`);
   frontmatter.push('---');


### PR DESCRIPTION
Addresses three of the eight open high-severity code-scanning alerts. The other five are triaged below rather than silently left.

## 1. Off-origin mention avatars (`js/xss-through-dom`, alert #53)

`prosemirror-mention-view.ts` assigned an avatar URL straight to `img.src`:

```ts
const avatarUrl = element.getAttribute('data-avatar-url') || null;
img.src = avatarUrl;
```

That URL rides in the mention node's attrs, so it comes out of the **collaborative document** and any collaborator can set it. It cannot execute script (`javascript:` in `img.src` is inert), but an off-origin value makes every viewer's browser fetch an attacker-chosen URL, leaking their IP and a precise read-receipt timestamp.

This is the exact threat `isAllowedImageSrc` already exists for. Its own comment says so: *"An off-origin `<img src>` is a tracking pixel… leaking their IP, approximate location, and a precise read-receipt timestamp."* It was wired into the markdown and comment paths but not this one. Now it is, falling back to the initials avatar when the URL fails the check.

## 2. YAML frontmatter escaping (`js/incomplete-sanitization`, alert #55)

```ts
`title: "${page.title.replace(/"/g, '\\"')}"`
```

Quotes were escaped, backslashes were not, so the escape character leaked through. A title ending in a backslash emitted an unterminated YAML string; an interior one produced an invalid escape sequence. `slug`, `icon` and `status` were interpolated with **no** escaping at all.

All four now go through a `yamlString` helper: strip control characters, escape backslashes, then escape quotes, in that order. Ordering is the whole bug, so there is a spec covering it plus the trailing-backslash case.

## 3. Weak RNG for DOM ids (`js/insecure-randomness`, alert #57)

`Math.random()` generated the `aria-activedescendant` id suffix in `CannedResponsePicker`. Not security bearing, but there is no reason to use a weak source, so it now uses `crypto.randomUUID()`. Fixed rather than dismissed.

## The other five, for the record

- **#56 `js/insecure-randomness`** — dismissed, false positive. Traces to `getSessionId()`, which uses `crypto.randomUUID()`; the `Math.random` branch is a documented fallback for non-secure contexts and the value is a trace-correlation hint, not a token.
- **#54 `js/incomplete-multi-character-sanitization`** — dismissed, false positive. A build-time lint script reading this repo's own sources; ships in no bundle, processes no untrusted input.
- **#61 `js/remote-property-injection`** in the plugin sandbox runtime — **left open deliberately.** Whether it matters depends on the plugin trust model, and it deserves review against the standing plugin audit rather than a snap judgement.
- **#42 / #43 `quick-xml` 0.39.4 DoS advisories** (mobile) — no in-range fix. 0.39.4 is the newest 0.39.x and the next release is 0.41.0, a semver-major jump. It arrives via `plist`, with no direct use in `src-tauri/src`. Same shape as the h2 0.3 line in #239.

Two further alerts, `CVE-2026-25800` x2, were fixed outright by merging #241/#242.

## Verification

`vue-tsc`, `npm run lint`, and 39 tests (6 new) pass.