### PR TITLE
compose: pin the dev build to the development stage

### DIFF
--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -48,6 +48,13 @@ services:
     build:
       context: .
       dockerfile: backend/Dockerfile.dev
+      # Compose merges `build` key by key, so the base file's
+      # `target: runtime` survives swapping the dockerfile and resolves
+      # against Dockerfile.dev, which only defines `development`. Without
+      # this override every build fails with
+      # `target stage "runtime" could not be found`, which takes out
+      # `make dev` and `docker compose watch` and therefore all source sync.
+      target: development
     # Empty default = host arch. Override with BACKEND_PLATFORM=linux/amd64
     # (or linux/arm64) to test the other architecture.
     platform: ${BACKEND_PLATFORM:-}


### PR DESCRIPTION
## Why

`docker compose` merges the `build` block key by key. `compose.yaml` pins `target: runtime`; `compose.dev.yaml` overrides `dockerfile` to `backend/Dockerfile.dev` but not `target`. That file defines only a `development` stage, so the merged config resolves a target that does not exist:

```
failed to solve: target stage "runtime" could not be found
```

Anything that builds hits it: `make dev` (`up --watch --build`) and `docker compose watch`. Because the `develop.watch` sync only runs while a watcher is alive, losing the watcher also silently stops host edits reaching the container. The stack keeps serving the last successful compile, so nothing looks broken.

The container in my working copy was running source dated **2026-07-04**, six weeks stale, which is what this failure mode looks like in practice.

## The fix

`target: development` in the dev override, with a comment recording the merge behaviour so it does not regress.

## Verification

- `docker compose -f compose.yaml -f compose.dev.yaml build nosdesk` → **Image nosdesk-nosdesk Built** (previously the error above)
- `docker compose watch` → **Watch enabled** → **Syncing service "nosdesk" after 1 changes were detected**
- Touched `backend/src/main.rs`; the container copy's mtime followed
- Stack healthy afterwards, data intact (11 users, 719 tickets, seeded docs page present)

Source sync was then used for real for the rest of the session, so this is exercised rather than just smoke-tested.