### PR TITLE
Remove the placeholder comment-attachment endpoint

### DIFF
--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -920,13 +920,6 @@ pub async fn delete_comment(
     }
 }
 
-pub async fn add_attachment_to_comment(
-    _: web::Path<i32>,
-    _: web::Data<crate::db::Pool>,
-) -> impl Responder {
-    HttpResponse::Ok().json(json!({"message": "Add attachment to comment handler placeholder"}))
-}
-
 /// Serve the raw RFC-822 source for an email-derived comment as
 /// `text/plain` so agents can fall back to the unparsed message
 /// when the quote splitter misfires or they need to inspect

--- a/backend/src/handlers/tickets.rs
+++ b/backend/src/handlers/tickets.rs
@@ -187,10 +187,6 @@ pub fn config(cfg: &mut web::ServiceConfig) {
             web::get().to(crate::handlers::image_proxy::proxy_image),
         )
         .route(
-            "/comments/{comment_id}/attachments",
-            web::post().to(crate::handlers::add_attachment_to_comment),
-        )
-        .route(
             "/attachments/{id}",
             web::delete().to(crate::handlers::delete_attachment),
         );

--- a/backend/src/route_registration_tests.rs
+++ b/backend/src/route_registration_tests.rs
@@ -123,7 +123,6 @@ async fn tickets_config_routes_registered() {
             ("DELETE", "/comments/1"),
             ("GET", "/comments/1/raw.eml"),
             ("GET", "/image-proxy/1/1"),
-            ("POST", "/comments/1/attachments"),
             ("DELETE", "/attachments/1"),
         ],
     )

--- a/packages/core/src/services/ticketService.ts
+++ b/packages/core/src/services/ticketService.ts
@@ -266,20 +266,6 @@ export const addCommentToTicket = async (
   }
 };
 
-// Add an attachment to a comment
-export const addAttachmentToComment = async (commentId: number, url: string, name: string): Promise<Attachment> => {
-  try {
-    const response = await apiClient.post(`/comments/${commentId}/attachments`, {
-      url,
-      name,
-    });
-    return response.data;
-  } catch (error) {
-    logger.error('Failed to add attachment to comment', { error, commentId });
-    throw error;
-  }
-};
-
 // Delete a comment
 export const deleteComment = async (commentId: number): Promise<void> => {
   try {
@@ -420,7 +406,6 @@ export default {
   linkTicket,
   unlinkTicket,
   addCommentToTicket,
-  addAttachmentToComment,
   deleteComment,
   deleteAttachment,
   getCommentsByTicketId,


### PR DESCRIPTION
## Why

`POST /comments/{comment_id}/attachments` was registered and reachable, but the handler was a stub:

```rust
pub async fn add_attachment_to_comment(
    _: web::Path<i32>,
    _: web::Data<crate::db::Pool>,
) -> impl Responder {
    HttpResponse::Ok().json(json!({"message": "Add attachment to comment handler placeholder"}))
}
```

It ignores both arguments and returns **200**. That is the worst possible shape: any caller, including an API-token integration exploring the surface, is told the attachment was recorded when nothing happened. `ticketService.addAttachmentToComment` in the client mirrored the route and had **zero call sites**.

Real attachment binding already happens inside `add_comment_to_ticket`, which moves the object from `temp/` to `tickets/{ticket_id}/` and sets `comment_id` on the `attachments` row. Nothing depended on this path.

## What changed

Removed the route, the handler, its route-registration assertion, and the unused client method.

## Worth a second opinion

This deletes an endpoint from a public API. I think removing beats keeping, because it never worked and a 200 is actively misleading, but implementing it instead is a legitimate alternative — that would be product work rather than cleanup, since you would need to settle reparenting and ownership semantics. Happy to restore it if you would rather go that way.

## Verification

`cargo check --all-targets` clean, 47 route-registration tests pass, `vue-tsc` and lint clean, 33 frontend tests pass.