### PR TITLE
Plugin sandbox: only accept host messages from the embedding frame, pin the origin

### DIFF
--- a/backend/src/handlers/plugin_sandbox/runtime.js
+++ b/backend/src/handlers/plugin_sandbox/runtime.js
@@ -377,6 +377,12 @@ function wrapEvents(remote) {
   });
   return { api, reset };
 }
+function isHostMessage(event, gate) {
+  if (gate.hostWindow === gate.selfWindow) return false;
+  if (event.source !== gate.hostWindow) return false;
+  if (gate.hostOrigin !== null && event.origin !== gate.hostOrigin) return false;
+  return true;
+}
 function connectToHost() {
   return new Promise((resolve, reject) => {
     const listeners = /* @__PURE__ */ new Set();
@@ -390,6 +396,7 @@ function connectToHost() {
     };
     let theme = { tokens: {}, colorScheme: "light", name: "light" };
     let connected = false;
+    let hostOrigin = null;
     const timer = setTimeout(() => {
       if (!connected) {
         window.removeEventListener("message", onMessage);
@@ -397,10 +404,14 @@ function connectToHost() {
       }
     }, CONNECT_TIMEOUT_MS);
     function onMessage(event) {
+      if (!isHostMessage(event, { hostWindow: window.parent, selfWindow: window, hostOrigin })) {
+        return;
+      }
       const data = event.data;
       if (!data || typeof data !== "object") return;
       if (!connected && data.type === "nosdesk-plugin-init" && event.ports[0]) {
         connected = true;
+        hostOrigin = event.origin;
         clearTimeout(timer);
         context = data.context;
         theme = data.theme;
@@ -423,10 +434,10 @@ function connectToHost() {
           },
           resetEvents: reset
         });
-      } else if (data.type === "nosdesk-plugin-context") {
+      } else if (connected && data.type === "nosdesk-plugin-context") {
         context = data.context;
         for (const cb of listeners) cb(context);
-      } else if (data.type === "nosdesk-plugin-theme") {
+      } else if (connected && data.type === "nosdesk-plugin-theme") {
         theme = data.theme;
         for (const cb of themeListeners) cb(theme);
       }

--- a/packages/plugin-runtime/src/hostMessageGate.spec.ts
+++ b/packages/plugin-runtime/src/hostMessageGate.spec.ts
@@ -1,0 +1,57 @@
+/**
+ * The guest-side gate on host messages.
+ *
+ * Lives here rather than in @nosdesk/plugin-sdk because the runtime package is
+ * the one wired up with vitest in CI, and it already depends on the SDK. The
+ * predicate is pure so it can be exercised without a DOM.
+ */
+import { describe, expect, it } from 'vitest'
+import { isHostMessage } from '@nosdesk/plugin-sdk'
+
+// Stand-ins for WindowProxy; the gate only ever compares identity.
+const hostWindow = { id: 'host' }
+const selfWindow = { id: 'self' }
+const otherWindow = { id: 'other' }
+
+const APP = 'https://app.example'
+
+describe('isHostMessage', () => {
+  it('accepts a message from the embedding frame before the handshake', () => {
+    expect(
+      isHostMessage({ source: hostWindow, origin: APP }, { hostWindow, selfWindow, hostOrigin: null }),
+    ).toBe(true)
+  })
+
+  it('rejects a message from any other window', () => {
+    expect(
+      isHostMessage({ source: otherWindow, origin: APP }, { hostWindow, selfWindow, hostOrigin: null }),
+    ).toBe(false)
+  })
+
+  // Not framed: window.parent === window. There is no host, so an opener that
+  // popped the runtime open cannot drive the handshake.
+  it('rejects everything when the runtime is not framed', () => {
+    expect(
+      isHostMessage(
+        { source: selfWindow, origin: APP },
+        { hostWindow: selfWindow, selfWindow, hostOrigin: null },
+      ),
+    ).toBe(false)
+  })
+
+  it('accepts later messages from the origin that completed the handshake', () => {
+    expect(
+      isHostMessage({ source: hostWindow, origin: APP }, { hostWindow, selfWindow, hostOrigin: APP }),
+    ).toBe(true)
+  })
+
+  // The mid-session rewrite this gate exists to stop.
+  it('rejects a later message from a different origin once pinned', () => {
+    expect(
+      isHostMessage(
+        { source: hostWindow, origin: 'https://evil.example' },
+        { hostWindow, selfWindow, hostOrigin: APP },
+      ),
+    ).toBe(false)
+  })
+})

--- a/packages/plugin-sdk/src/connect.ts
+++ b/packages/plugin-sdk/src/connect.ts
@@ -141,6 +141,34 @@ function wrapEvents(remote: Comlink.Remote<HostApi>): {
  * us (only the host can post to this specific `contentWindow` with the port),
  * and communicate only over that port afterwards.
  */
+/**
+ * Should a `message` event be treated as coming from our host?
+ *
+ * The runtime is a static asset compiled into the backend, so it cannot be
+ * templated with the deployment's app origin and has nothing to compare the
+ * first message against. Two config-free checks do the work instead:
+ *
+ *   * Only the frame that embedded us may drive the runtime. A window opened
+ *     directly at the runtime URL has no parent, so there is no host and
+ *     nothing is accepted; that closes the opener-driven handshake.
+ *   * Once a handshake completes, the origin that completed it is pinned, so a
+ *     later message from anywhere else cannot rewrite context or theme
+ *     mid-session.
+ *
+ * Defence in depth: the sandbox CSP already pins `frame-ancestors` to the app
+ * origin, so a third party cannot frame us in the first place. This keeps the
+ * guest side sound on its own if that ever regresses.
+ */
+export function isHostMessage(
+  event: { source: unknown; origin: string },
+  gate: { hostWindow: unknown; selfWindow: unknown; hostOrigin: string | null },
+): boolean {
+  if (gate.hostWindow === gate.selfWindow) return false;
+  if (event.source !== gate.hostWindow) return false;
+  if (gate.hostOrigin !== null && event.origin !== gate.hostOrigin) return false;
+  return true;
+}
+
 export function connectToHost(): Promise<PluginRuntime> {
   return new Promise((resolve, reject) => {
     const listeners = new Set<(ctx: PluginContext) => void>();
@@ -156,6 +184,8 @@ export function connectToHost(): Promise<PluginRuntime> {
     };
     let theme: PluginTheme = { tokens: {}, colorScheme: 'light', name: 'light' };
     let connected = false;
+    // Origin that completed the handshake; every later message must match it.
+    let hostOrigin: string | null = null;
 
     // Fail loudly if the host never connects (dropped port / host disposed before
     // postInit) so `boot()` can render an error instead of hanging on a blank
@@ -168,6 +198,11 @@ export function connectToHost(): Promise<PluginRuntime> {
     }, CONNECT_TIMEOUT_MS);
 
     function onMessage(event: MessageEvent) {
+      if (
+        !isHostMessage(event, { hostWindow: window.parent, selfWindow: window, hostOrigin })
+      ) {
+        return;
+      }
       const data = event.data as
         | HostInitMessage
         | HostContextMessage
@@ -177,6 +212,7 @@ export function connectToHost(): Promise<PluginRuntime> {
 
       if (!connected && data.type === 'nosdesk-plugin-init' && event.ports[0]) {
         connected = true;
+        hostOrigin = event.origin;
         clearTimeout(timer);
         context = data.context;
         theme = data.theme;
@@ -199,10 +235,10 @@ export function connectToHost(): Promise<PluginRuntime> {
           },
           resetEvents: reset,
         });
-      } else if (data.type === 'nosdesk-plugin-context') {
+      } else if (connected && data.type === 'nosdesk-plugin-context') {
         context = data.context;
         for (const cb of listeners) cb(context);
-      } else if (data.type === 'nosdesk-plugin-theme') {
+      } else if (connected && data.type === 'nosdesk-plugin-theme') {
         theme = data.theme;
         for (const cb of themeListeners) cb(theme);
       }

--- a/packages/plugin-sdk/src/index.ts
+++ b/packages/plugin-sdk/src/index.ts
@@ -12,7 +12,7 @@
 //       root.textContent = t ? t.title : 'no ticket';
 //     },
 //   } satisfies PluginModule;
-export { connectToHost, proxy, reportHeight } from './connect';
+export { connectToHost, isHostMessage, proxy, reportHeight } from './connect';
 export type { PluginRuntime } from './connect';
 
 // Host-side bridge (used by the app + the bridge harness, not by plugins).


### PR DESCRIPTION
Defence-in-depth hardening of the guest side of the plugin bridge. Came out of triaging CodeQL alert #61.

## Context: #61 itself is a false positive

The alert points at `parent[path.slice(-1)[0]] = fromWireValue(...)` in `backend/src/handlers/plugin_sandbox/runtime.js`. That line is inside **vendored Comlink 4.4.2**, in a file generated from `@nosdesk/plugin-runtime` and drift-checked by CI ("Do not edit by hand"). `expose()` is only ever called on a `MessagePort`, never on `window`, so the sink is gated by **possession of the port**, not by origin. The surrounding boundary is intact: opaque-origin iframe (`sandbox="allow-scripts"`, no `allow-same-origin`), per-plugin CSP with `default-src 'none'`, `frame-ancestors` pinned to the app origin, token-gated bundle.

Also checked and correct as-is: `postInit` uses `targetOrigin: '*'` because an opaque frame's origin is the literal string `"null"`, so a specific target origin is unusable. The capability is the transferred port plus the host holding that exact `contentWindow`.

## What this PR does fix

While reading that path, the guest listener turned out to accept `nosdesk-plugin-init`, `nosdesk-plugin-context` and `nosdesk-plugin-theme` from **any** window, and the context/theme branches ran with no check that a handshake had happened.

The runtime is compiled into the backend via `include_str!`, so it cannot be templated with the deployment's app origin and has nothing to compare the first message against. Two config-free checks cover it:

```ts
export function isHostMessage(event, gate): boolean {
  if (gate.hostWindow === gate.selfWindow) return false;   // not framed: no host exists
  if (event.source !== gate.hostWindow) return false;       // only the embedder may drive us
  if (gate.hostOrigin !== null && event.origin !== gate.hostOrigin) return false;
  return true;
}
```

1. **Only the embedding frame may drive the runtime.** A window opened directly at the runtime URL has no parent, closing an opener-driven handshake.
2. **The handshake origin is pinned**, so nothing can rewrite `context` or `theme` mid-session.
3. The **`connected` guard** stops the update messages running before a handshake at all.

Not presently exploitable: `frame-ancestors` already stops a third party framing the runtime. This keeps the guest side sound independently of that.

## Testing

`isHostMessage` is pure so it can be tested without a DOM. The spec lives in `@nosdesk/plugin-runtime`, which already runs vitest in CI and depends on the SDK, so **no new CI step** is needed. Five cases, including the mid-session rewrite the pin exists to stop.

`runtime.js` is regenerated, since CI runs the esbuild build and asserts no drift.

## Verification

SDK + runtime type-check, both lints, 15 tests (5 new), backend `cargo check` with the new bundle embedded.

Then exercised against the real installed `slot-tester` plugin with the hardened runtime actually being served, confirming the handshake still completes:

```
RESP 200 /api/plugins/<uuid>/bundle-token
RESP 200 /__plugin-sandbox/runtime.html?t=...
RESP 200 /__plugin-sandbox/runtime.js
RESP 200 /__plugin-sandbox/bundle?t=...
```

The bundle fetch is the proof: `runtime.ts` does `await connectToHost()` *before* importing the bundle, and the runtime's own header notes `connectToHost()` "resolves only once the host posts the init message". If the gate had rejected the init, the bundle would never have been requested. The frame reported `origin: "null"`, `framed: true`, and no connect timeout.

## Unrelated finding worth recording

With `FRONTEND_URL=https://nosdesk.<host>.orb.local`, the sandbox CSP emits `frame-ancestors` for that origin, so browsing the dev stack via `http://localhost:8080` silently breaks **all** plugin rendering: the iframe mounts, the browser blocks the load, and you get `chrome-error://chromewebdata/` with no console message explaining it. Same class as the existing `FRONTEND_URL` / collab-WebSocket gotcha. Not changed here; may be worth a line in `DEVELOPMENT.md`.