### PR TITLE
deps: patch quick-xml via plist for RUSTSEC-2026-0194/0195, and scan every lockfile on PRs

### DIFF
--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -15,9 +15,15 @@ on:
   push:
     branches: [main]
   pull_request:
+    # Globbed, not an explicit list. The scan below is recursive, so it already
+    # covers every lockfile in the repo; naming two of them here meant a PR
+    # touching any other one (mobile/src-tauri/Cargo.lock, a future workspace)
+    # got no scan at all and had to wait for the push or weekly run. That is how
+    # RUSTSEC-2026-0194/0195 sat on the mobile lockfile without a PR ever
+    # flagging them.
     paths:
-      - 'backend/Cargo.lock'
-      - 'pnpm-lock.yaml'
+      - '**/Cargo.lock'
+      - '**/pnpm-lock.yaml'
       - '.github/workflows/osv-scanner.yml'
   schedule:
     # Weekly. Most findings arrive because the world changed, not because the

--- a/mobile/src-tauri/Cargo.lock
+++ b/mobile/src-tauri/Cargo.lock
@@ -2799,9 +2799,9 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plist"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "092791278e026273c1b65bbdcfbba3a300f2994c896bd01ab01da613c29c46f1"
+checksum = "7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.14.0",
@@ -2980,9 +2980,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.39.4"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]


### PR DESCRIPTION
Closes the last two high-severity code-scanning alerts (#42, #43), and fixes the reason they were never raised on a pull request.

## The advisories

`mobile/src-tauri` pulled `quick-xml 0.39.4` through `plist 1.9.0`:

- **RUSTSEC-2026-0194** — quadratic run time when checking a start tag for duplicate attribute names
- **RUSTSEC-2026-0195** — unbounded namespace-declaration allocation in `NsReader`, enabling memory exhaustion

Both denial-of-service.

## Why the obvious answer was wrong

`quick-xml 0.39.4` **is** the newest `0.39.x`, and the next release is `0.41.0`, a semver-major jump. Looking only at `quick-xml`, there is nothing in range and the situation reads as "acknowledge and wait".

The parent had already moved:

| | requires |
|---|---|
| `plist 1.9.0` | `quick-xml ^0.39.2` |
| **`plist 1.10.0`** | **`quick-xml ^0.41.0`** |

`tauri` asks only for `plist = "^1"`, so `cargo update -p plist` resolves both advisories with a four-line lockfile change. OSV lists `0.41.0` as the `fixed` version for each, so this genuinely resolves them rather than just moving version numbers. No dependency substitution and no fork.

Worth noting the exposure was narrower than the alerts imply: `plist` reaches `tauri` under `cfg(target_os = "macos")`, so it is not compiled into iOS builds at all.

## Why a PR never flagged this

The OSV workflow's scan is recursive, and its own comment says so:

> "Recursive discovery rather than naming lockfiles explicitly: it picks up `backend/Cargo.lock` and `pnpm-lock.yaml` today, and any workspace added under `packages/` or `plugins/` later without an edit here."

But the `pull_request` trigger named only those two lockfiles. A PR touching `mobile/src-tauri/Cargo.lock` ran **no scan at all**, so these advisories could only surface via the push-to-`main` or weekly cron run, never on the change that introduced them.

The path filter is now globbed to `**/Cargo.lock` and `**/pnpm-lock.yaml`, matching what the scan already does. This PR should trigger the scan on itself, which is a reasonable smoke test of the change.

## Checked and clean

- `backend/Cargo.lock` — already on `quick-xml 0.41.0` (direct dependency)
- `mobile/tauri-plugin-secure-store/Cargo.lock` — was on 0.39.4, but it is gitignored (`.gitignore:13`), the normal convention for a library crate, so it is never in CI and correctly never alerted. The app lockfile governs what ships.
- `mobile/tauri-plugin-push` has no lockfile

## Verification

`cargo check` on `mobile/src-tauri` builds clean with the new versions. Workflow YAML parses, and the filter resolves to `['**/Cargo.lock', '**/pnpm-lock.yaml', '.github/workflows/osv-scanner.yml']`.