### PR TITLE
deps: patch memmap2, event-listener; correct the install-action pin comment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,7 +161,7 @@ jobs:
         run: cargo test --test channels_email_imap_integration -- --ignored --test-threads=1
 
       - name: Install cargo-deny
-        uses: taiki-e/install-action@82cd3e7658a6f96c86c0234aeeda1748937cb0a1 # v2
+        uses: taiki-e/install-action@82cd3e7658a6f96c86c0234aeeda1748937cb0a1 # v2.85.13
         with:
           tool: cargo-deny
 

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -761,7 +761,7 @@ version = "3.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
 dependencies = [
- "event-listener 5.4.1",
+ "event-listener 5.4.2",
  "event-listener-strategy",
  "pin-project-lite",
 ]
@@ -2694,11 +2694,10 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "event-listener"
-version = "5.4.1"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
- "concurrent-queue",
  "parking",
  "pin-project-lite",
 ]
@@ -2709,7 +2708,7 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
- "event-listener 5.4.1",
+ "event-listener 5.4.2",
  "pin-project-lite",
 ]
 
@@ -4300,9 +4299,9 @@ checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "memmap2"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]

--- a/mobile/src-tauri/Cargo.lock
+++ b/mobile/src-tauri/Cargo.lock
@@ -1140,11 +1140,10 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "5.4.1"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
- "concurrent-queue",
  "parking",
  "pin-project-lite",
 ]
@@ -4434,7 +4433,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",


### PR DESCRIPTION
Outcome of triaging the 26 advisories that osv-scanner reports **without a severity rating**. Because they carry no security-severity they sit below both the ruleset threshold and the check-failure default, so they had never been looked at.

## The shape of the 26

| Group | Count | |
|---|---|---|
| Unmaintained notices, no fix exists | 18 | gtk-rs GTK3 bindings (10), `unic-*` (5), `proc-macro-error`, `paste`, `smallstr` |
| Real advisories with a fix | 5 | acted on or recorded below |
| Workflow lint | 1 | zizmor |
| Already accepted | 2 | h2 0.3 line, per `deny.toml` |

The unmaintained group is exactly what `deny.toml`'s `unmaintained = "workspace"` policy already declines to gate for transitive crates, and `paste` and `smallstr` are named in SECURITY.md and `deny.toml` respectively. The GTK ones are Tauri's Linux backend, not compiled for macOS or iOS.

## Fixed here

**RUSTSEC-2026-0186** — unchecked pointer offset in `memmap2`. `0.9.10` → `0.9.11`.

**RUSTSEC-2026-0221** — `event-listener` allows `!Send` tags to cross thread boundaries via `StackSlot`. `5.4.1` → `5.4.2` in both the backend and mobile lockfiles. The backend also carries `event-listener 2.5.3`; the advisory starts at 5.1.0, so that line is unaffected.

**zizmor `ref-version-mismatch`** — the `taiki-e/install-action` pin is the commit for tag **v2.85.13**, but the comment read `# v2`, and the floating `v2` tag has since moved to a different commit. I corrected the comment rather than moving the pin, so the audited commit is unchanged. Bumping the action is a separate decision that deserves its own review.

## Not fixable, recorded rather than left silent

**`lru` 0.16.4** (RUSTSEC-2026-0253, use-after-free from lack of panic safety in `LruCache::pop()`) is fixed in 0.18.2. Both consumers, `aws-sdk-s3` and `tantivy`, require `^0.16.3` — including their newest releases (1.142.0 and 0.26.1). I checked the parents this time rather than only the crate, which is what made `quick-xml` solvable in #248. Here there is genuinely nothing to move to.

**`rkyv` 0.7.46** (RUSTSEC-2026-0235, out-of-bounds reads on archives containing Rc/Arc) is fixed in 0.8.17, a semver-major move. It is an **optional dependency of `rust_decimal` that is not enabled**, so it does not appear in the resolved graph (`cargo tree -i rkyv --target all --edges all` returns nothing) and is not compiled.

Both will be dismissed with these reasons.

## Verification

`cargo check` clean on backend and mobile. `cargo deny check` on backend: `advisories ok, bans ok, licenses ok, sources ok`.