### PR TITLE
Render revisions in a detached overlay instead of re-stating the live editor

### DIFF
--- a/frontend/src/components/CollaborativeEditor.vue
+++ b/frontend/src/components/CollaborativeEditor.vue
@@ -35,6 +35,7 @@ import {
     type LinkTooltipState,
 } from "./editor/linkTooltipPlugin";
 import { createTicketLinkPlugin, setTicketNavigationHandler } from "./editor/ticketLinkPlugin";
+import { mountRevisionView, decodeRevisionBytes, type RevisionViewHandle } from "./editor/revisionView";
 import { createEmbeddedDocumentPlugin, setDocumentNavigationHandler } from "./editor/embeddedDocumentPlugin";
 import DocumentPicker from "./editor/DocumentPicker.vue";
 import apiClient from "@nosdesk/core/apiClient";
@@ -722,6 +723,10 @@ const initEditor = async () => {
         }
 
         editorView = new EditorView(editorElement.value, {
+            // The revision overlay hides this view but leaves it mounted and
+            // syncing. Editing it while it cannot be seen would be an invisible
+            // change to the live document, so gate it for as long as it is covered.
+            editable: () => !isViewingRevision.value,
             state: EditorState.create({
                 doc: doc,
                 schema,
@@ -1753,6 +1758,12 @@ onBeforeUnmount(() => {
     // Sync embeddings before unmounting (fire-and-forget)
     syncEmbeddings();
 
+    // Tear down the revision overlay first: it owns a detached EditorView and a
+    // scratch Y.Doc, and the ydoc outlives this component via the refcounted
+    // collab session store.
+    revisionHandle?.destroy();
+    revisionHandle = null;
+
     cleanup();
     document.removeEventListener("mousedown", handleClickOutside);
     document.removeEventListener("keydown", handleKeydown);
@@ -1781,130 +1792,69 @@ onBeforeUnmount(() => {
     document.removeEventListener("visibilitychange", handleVisibilityChange);
 });
 
-// Store original state when viewing revisions
-let originalYXmlFragment: Y.XmlFragment | null = null;
-let originalEditorState: EditorState | null = null;
+// The detached revision viewer. The live editor is never re-stated, so there
+// is no "original state" to stash and restore; see editor/revisionView.ts for
+// why the previous approach lost remote edits.
+const revisionOverlayEl = ref<HTMLElement | null>(null);
+const revisionOverlayHost = ref<HTMLElement | null>(null);
+let revisionHandle: RevisionViewHandle | null = null;
 
-// Revision viewing methods
-function viewSnapshot(snapshotData: { revision_number: number; yjs_document_content: string }) {
-    if (!editorView || !ydoc || !yXmlFragment) {
-        log.error("Cannot view snapshot: editor not initialized");
+// Revision viewing. Renders the revision in a detached overlay; the live
+// editor keeps its state, its Yjs binding and its incoming updates throughout.
+async function viewSnapshot(snapshotData: { revision_number: number; yjs_document_content: string }) {
+    // Show the overlay host first so the ref resolves, then mount into it.
+    isViewingRevision.value = true;
+    currentRevisionNumber.value = snapshotData.revision_number;
+    await nextTick();
+
+    const mount = revisionOverlayEl.value;
+    if (!mount) {
+        isViewingRevision.value = false;
+        currentRevisionNumber.value = null;
+        log.error("Cannot view revision: overlay host not mounted");
         return;
     }
 
     try {
-        log.info(`Viewing revision ${snapshotData.revision_number}`);
-
-        // Store the original state for restoring later
-        if (!isViewingRevision.value) {
-            originalYXmlFragment = yXmlFragment;
-            originalEditorState = editorView.state;
-        }
-
-        // Decode the full document content for this revision
-        log.info(`Base64 yjs_document_content length: ${snapshotData.yjs_document_content.length}`);
-        const documentBytes = Uint8Array.from(atob(snapshotData.yjs_document_content), c => c.charCodeAt(0));
-        log.info(`Decoded bytes length: ${documentBytes.length}`);
-        log.info(`First 20 bytes: ${Array.from(documentBytes.slice(0, 20))}`);
-
-        // Create a temporary Yjs document for viewing this revision
-        // Disable GC to ensure all historical data is preserved
-        const tempDoc = new Y.Doc({ gc: false });
-
-        // Apply the revision's content to the temporary document FIRST
-        log.info(`Applying update to temp doc...`);
-        try {
-            Y.applyUpdate(tempDoc, documentBytes);
-            log.info(`Update applied successfully.`);
-        } catch (err) {
-            log.error(`Error applying update:`, err);
-            throw err;
-        }
-
-        // NOW get the fragment after the update has been applied
-        const tempFragment = tempDoc.getXmlFragment("prosemirror");
-        log.info(`Got fragment after update. Children: ${tempFragment.length}`);
-
-        // Debug: Log the Yjs fragment content
-        log.info(`Temp doc state after applying update: ${tempDoc.store.clients.size} clients`);
-        log.info(`Temp fragment children: ${tempFragment.length}`);
-        log.info(`Temp fragment content: ${tempFragment.toString()}`);
-
-        // Create a read-only ProseMirror state from this revision
-        const { doc } = initProseMirrorDoc(tempFragment, schema);
-
-        // Debug: Log the ProseMirror doc content
-        log.info(`ProseMirror doc from revision: ${doc.textContent}`);
-
-        // Create a read-only state with the revision content. The
-        // doc has no Yjs binding here (intentional — edits would be
-        // discarded on exit), but ProseMirror would still accept
-        // keystrokes into the local state if `editable` weren't
-        // overridden, which presents a confusing "looks like I'm
-        // typing, then it disappears" experience when the user
-        // exits the revision view.
-        const readOnlyState = EditorState.create({
-            doc,
+        revisionHandle?.destroy();
+        revisionHandle = mountRevisionView({
+            mount,
             schema,
+            updateBytes: decodeRevisionBytes(snapshotData.yjs_document_content),
+            // Node views only, so historical mentions, ticket cards and embeds
+            // render as they did when written. Nothing here dispatches.
             plugins: [
-                // Minimal plugins for read-only viewing
-                keymap(baseKeymap),
-                dropCursor(),
+                createTicketLinkPlugin(),
+                createEmbeddedDocumentPlugin(),
+                syntaxHighlightPlugin,
+                createMentionViewPlugin(),
                 twemojiPlugin,
             ],
         });
-
-        // Update the editor view to show this read-only state and
-        // mark it non-editable so dispatched transactions are
-        // rejected at the prop boundary, matching the user's
-        // expectation that historical revisions are immutable.
-        editorView.updateState(readOnlyState);
-        editorView.setProps({ editable: () => false });
-
-        // Mark as viewing revision
-        isViewingRevision.value = true;
-        currentRevisionNumber.value = snapshotData.revision_number;
-
-        log.info(`Successfully loaded revision ${snapshotData.revision_number} (read-only view)`);
+        // Focus the region: it is what Escape listens on, and it is where a
+        // screen reader should land now that it covers the document.
+        editorView?.setProps({});
+        revisionOverlayHost.value?.focus();
+        log.info(`Viewing revision ${snapshotData.revision_number} (read-only)`);
     } catch (error) {
-        log.error("Failed to view snapshot:", error);
-        // If viewing fails, make sure to clear the viewing state
+        revisionHandle = null;
         isViewingRevision.value = false;
         currentRevisionNumber.value = null;
+        log.error("Failed to view revision:", error);
         throw error;
     }
 }
 
 function exitRevisionView() {
-    if (!editorView || !originalEditorState || !originalYXmlFragment) {
-        log.error("Cannot exit revision view: no original state stored");
-        return;
-    }
-
-    try {
-        log.info("Exiting revision view, returning to live document");
-
-        // Restore the original editor state (connected to live Yjs
-        // doc) and flip the editable prop back on. The revision
-        // view setter installed `editable: () => false`; without
-        // this clear, the live doc would inherit the read-only
-        // gate and silently refuse the next keystroke.
-        editorView.updateState(originalEditorState);
-        editorView.setProps({ editable: () => true });
-
-        // Clear stored state
-        originalYXmlFragment = null;
-        originalEditorState = null;
-
-        // Mark as no longer viewing revision
-        isViewingRevision.value = false;
-        currentRevisionNumber.value = null;
-
-        log.info("Successfully returned to live editing");
-    } catch (error) {
-        log.error("Failed to exit revision view:", error);
-        throw error;
-    }
+    revisionHandle?.destroy();
+    revisionHandle = null;
+    isViewingRevision.value = false;
+    currentRevisionNumber.value = null;
+    // `editable` is a prop function; ProseMirror re-reads it on updateState.
+    editorView?.setProps({});
+    // The live view was never re-stated, so its selection survived and
+    // ProseMirror has been mapping it through remote edits the whole time.
+    nextTick(() => editorView?.focus());
 }
 
 // Handle revision selection from RevisionList.
@@ -1990,8 +1940,9 @@ defineExpose({
 
 <template>
     <div class="collaborative-editor">
-        <!-- Toolbar -->
-        <div class="toolbar">
+        <!-- Toolbar. Inert while a revision is on screen: its commands dispatch
+             straight to the live view, which is hidden under the overlay. -->
+        <div class="toolbar" :inert="isViewingRevision" :class="{ 'toolbar-inert': isViewingRevision }">
             <!-- Type Dropdown -->
             <div class="relative">
                 <button
@@ -2412,6 +2363,35 @@ defineExpose({
                 class="editor-container"
             ></div>
 
+            <!-- Revision overlay. Covers the live editor rather than replacing
+                 its state, so the document underneath keeps syncing. The bar is
+                 the only way out of a read-only revision, so it stays in view
+                 while the revision scrolls under it. -->
+            <div
+                v-if="isViewingRevision"
+                ref="revisionOverlayHost"
+                class="revision-overlay"
+                role="region"
+                tabindex="-1"
+                :aria-label="$t('editor-revision-view-aria', { revision: currentRevisionNumber ?? 0 })"
+                @keydown.esc="exitRevisionView"
+            >
+                <div class="revision-overlay-bar">
+                    <span class="revision-overlay-label">
+                        {{ $t('editor-revision-viewing-label', { revision: currentRevisionNumber ?? 0 }) }}
+                    </span>
+                    <button
+                        type="button"
+                        class="revision-overlay-exit"
+                        @click="exitRevisionView"
+                    >
+                        {{ $t('editor-revision-back-to-current') }}
+                    </button>
+                </div>
+                <!-- Mount target kept separate: the detached EditorView appends
+                     into this node, never into the bar. -->
+                <div ref="revisionOverlayEl"></div>
+            </div>
         </div>
 
         <!-- Mention Dropdown (teleported to body for proper positioning) -->
@@ -2690,6 +2670,61 @@ defineExpose({
     display: flex;
     flex-direction: column;
     min-height: 0;
+}
+
+/* Sits over the live editor. Opaque, because the live document is still
+   mounted and rendering underneath. */
+.revision-overlay {
+    position: absolute;
+    inset: 0;
+    z-index: 10;
+    overflow: auto;
+    background-color: var(--color-surface);
+}
+
+.toolbar-inert {
+    opacity: 0.5;
+}
+
+.revision-overlay:focus {
+    outline: none;
+}
+
+.revision-overlay-bar {
+    position: sticky;
+    top: 0;
+    z-index: 1;
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.5rem 0.75rem;
+    background-color: var(--color-surface-alt);
+    border-bottom: 1px solid var(--color-default);
+}
+
+.revision-overlay-label {
+    font-size: 0.8125rem;
+    color: var(--color-secondary);
+}
+
+.revision-overlay-exit {
+    margin-left: auto;
+    padding: 0.25rem 0.625rem;
+    font-size: 0.8125rem;
+    color: var(--color-primary);
+    background-color: var(--color-surface);
+    border: 1px solid var(--color-default);
+    border-radius: 0.375rem;
+    cursor: pointer;
+}
+
+.revision-overlay-exit:hover {
+    background-color: var(--color-surface-hover);
+}
+
+.revision-overlay .revision-view-content {
+    padding: 1rem;
+    outline: none;
 }
 
 .mention-dropdown {

--- a/frontend/src/components/editor/RevisionHistory.vue
+++ b/frontend/src/components/editor/RevisionHistory.vue
@@ -23,6 +23,7 @@ interface Props {
   ticketId?: number
   documentId?: number
   type?: 'ticket' | 'documentation'
+  activeRevisionNumber?: number | null
 }
 
 withDefaults(defineProps<Props>(), {
@@ -48,6 +49,7 @@ const emit = defineEmits<{
       :ticket-id="ticketId"
       :document-id="documentId"
       :type="type"
+      :active-revision-number="activeRevisionNumber"
       @select-revision="(n) => emit('selectRevision', n)"
       @restored="(n) => emit('restored', n)"
     />

--- a/frontend/src/components/editor/RevisionList.vue
+++ b/frontend/src/components/editor/RevisionList.vue
@@ -39,6 +39,12 @@ interface Props {
   ticketId?: number
   documentId?: number
   type?: 'ticket' | 'documentation'
+  /**
+   * Revision currently on screen in the editor, or null when the live document
+   * is showing. The editor owns this: a revision can be exited from the overlay
+   * as well as from this list, and the highlight has to follow either.
+   */
+  activeRevisionNumber?: number | null
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -160,6 +166,15 @@ const getUserName = (uuid: string): string | undefined => {
 }
 
 const selectedRevision = ref<ArticleRevision | null>(null)
+
+// The editor exited the revision view (overlay button, Escape, or a restore),
+// so drop the highlight this list set when the row was clicked.
+watch(
+  () => props.activeRevisionNumber,
+  (active) => {
+    if (active === null || active === undefined) selectedRevision.value = null
+  },
+)
 const showRestoreConfirm = ref(false)
 const revisionToRestore = ref<number | null>(null)
 

--- a/frontend/src/components/editor/revisionView.spec.ts
+++ b/frontend/src/components/editor/revisionView.spec.ts
@@ -1,0 +1,199 @@
+/**
+ * The non-destructiveness invariant for revision viewing.
+ *
+ * These tests exist because the previous implementation lost data. It called
+ * `editorView.updateState()` on the LIVE editor with a plugin list that omitted
+ * `ySyncPlugin`, which made ProseMirror destroy the plugin view and detach the
+ * Yjs binding. Remote edits arriving while a revision was open never reached the
+ * document, and exiting restored a pre-edit state that then overwrote the
+ * collaborators' work.
+ *
+ * The assertions below are written against that failure mode specifically: they
+ * pass with the detached overlay and fail if anyone re-states the live view.
+ */
+import { beforeEach, describe, expect, it } from 'vitest'
+import { EditorState } from 'prosemirror-state'
+import { EditorView } from 'prosemirror-view'
+import * as Y from 'yjs'
+import { initProseMirrorDoc, ySyncPlugin } from 'y-prosemirror'
+
+import { schema } from './schema'
+import { decodeRevisionBytes, mountRevisionView } from './revisionView'
+
+/** Base64-encode bytes the way the revision endpoints do. */
+function toBase64(bytes: Uint8Array): string {
+  let binary = ''
+  for (const b of bytes) binary += String.fromCharCode(b)
+  return btoa(binary)
+}
+
+/** A live editor: Y.Doc + bound EditorView, as the app builds it. */
+function makeLiveEditor() {
+  const ydoc = new Y.Doc({ gc: false })
+  const fragment = ydoc.getXmlFragment('prosemirror')
+  const mount = document.createElement('div')
+  document.body.appendChild(mount)
+
+  const { doc, mapping } = initProseMirrorDoc(fragment, schema)
+  const view = new EditorView(mount, {
+    state: EditorState.create({ doc, schema, plugins: [ySyncPlugin(fragment, { mapping })] }),
+  })
+  return { ydoc, fragment, view, mount }
+}
+
+/** Type `text` as a new paragraph, the way an edit would arrive locally. */
+function appendParagraph(view: EditorView, text: string) {
+  const { state } = view
+  const node = state.schema.nodes.paragraph.create(null, state.schema.text(text))
+  view.dispatch(state.tr.insert(state.doc.content.size, node))
+}
+
+/**
+ * A second peer editing the same logical document. Updates are exchanged by
+ * hand so a test can control exactly when a "remote" edit lands.
+ */
+function makePeer(from: Y.Doc) {
+  const peer = new Y.Doc({ gc: false })
+  Y.applyUpdate(peer, Y.encodeStateAsUpdate(from))
+  return {
+    peer,
+    editAndSyncTo(target: Y.Doc, text: string) {
+      const frag = peer.getXmlFragment('prosemirror')
+      const p = new Y.XmlElement('paragraph')
+      p.insert(0, [new Y.XmlText(text)])
+      frag.insert(frag.length, [p])
+      Y.applyUpdate(target, Y.encodeStateAsUpdate(peer))
+    },
+  }
+}
+
+describe('mountRevisionView', () => {
+  let host: HTMLElement
+
+  beforeEach(() => {
+    document.body.innerHTML = ''
+    host = document.createElement('div')
+    document.body.appendChild(host)
+  })
+
+  it('renders the revision content', () => {
+    const source = new Y.Doc({ gc: false })
+    const frag = source.getXmlFragment('prosemirror')
+    const p = new Y.XmlElement('paragraph')
+    p.insert(0, [new Y.XmlText('content as it was')])
+    frag.insert(0, [p])
+
+    const handle = mountRevisionView({
+      mount: host,
+      schema,
+      updateBytes: Y.encodeStateAsUpdate(source),
+    })
+
+    expect(handle.text()).toContain('content as it was')
+    handle.destroy()
+  })
+
+  it('is non-editable', () => {
+    const source = new Y.Doc({ gc: false })
+    const frag = source.getXmlFragment('prosemirror')
+    const p = new Y.XmlElement('paragraph')
+    p.insert(0, [new Y.XmlText('historical')])
+    frag.insert(0, [p])
+
+    const handle = mountRevisionView({ mount: host, schema, updateBytes: Y.encodeStateAsUpdate(source) })
+    expect(handle.view.editable).toBe(false)
+    handle.destroy()
+  })
+
+  // The core invariant. Under the old implementation this failed: the binding
+  // was detached, so the remote paragraph never reached the ProseMirror doc, and
+  // exiting reverted it in Yjs.
+  it('lets remote edits reach the live document while a revision is open', () => {
+    const live = makeLiveEditor()
+    appendParagraph(live.view, 'original paragraph')
+    const revisionBytes = Y.encodeStateAsUpdate(live.ydoc)
+
+    const remote = makePeer(live.ydoc)
+
+    const handle = mountRevisionView({ mount: host, schema, updateBytes: revisionBytes })
+
+    // A collaborator edits while the revision is on screen.
+    remote.editAndSyncTo(live.ydoc, 'arrived during revision view')
+
+    expect(live.view.state.doc.textContent).toContain('arrived during revision view')
+
+    handle.destroy()
+
+    // ...and it is still there after exiting.
+    expect(live.view.state.doc.textContent).toContain('arrived during revision view')
+    expect(live.fragment.toString()).toContain('arrived during revision view')
+
+    live.view.destroy()
+  })
+
+  it('leaves the live document byte-identical across mount and destroy', () => {
+    const live = makeLiveEditor()
+    appendParagraph(live.view, 'untouched')
+    const before = Y.encodeStateAsUpdate(live.ydoc)
+
+    const handle = mountRevisionView({ mount: host, schema, updateBytes: before })
+    handle.destroy()
+
+    const after = Y.encodeStateAsUpdate(live.ydoc)
+    expect(Array.from(after)).toEqual(Array.from(before))
+
+    live.view.destroy()
+  })
+
+  it('leaves the live editor state and selection untouched', () => {
+    const live = makeLiveEditor()
+    appendParagraph(live.view, 'keep my place')
+    const stateBefore = live.view.state
+    const selectionBefore = live.view.state.selection.from
+
+    const handle = mountRevisionView({
+      mount: host,
+      schema,
+      updateBytes: Y.encodeStateAsUpdate(live.ydoc),
+    })
+    handle.destroy()
+
+    // Identity, not equality: the live view must not have been re-stated at all.
+    expect(live.view.state).toBe(stateBefore)
+    expect(live.view.state.selection.from).toBe(selectionBefore)
+    expect(live.view.editable).toBe(true)
+
+    live.view.destroy()
+  })
+
+  it('destroy is idempotent', () => {
+    const source = new Y.Doc({ gc: false })
+    source.getXmlFragment('prosemirror')
+    const handle = mountRevisionView({ mount: host, schema, updateBytes: Y.encodeStateAsUpdate(source) })
+    handle.destroy()
+    expect(() => handle.destroy()).not.toThrow()
+  })
+
+  it('cleans up and rethrows when the update cannot be decoded', () => {
+    const before = document.body.innerHTML
+    expect(() =>
+      mountRevisionView({ mount: host, schema, updateBytes: new Uint8Array([9, 9, 9, 9, 9]) }),
+    ).toThrow()
+    expect(document.body.innerHTML).toBe(before)
+  })
+})
+
+describe('decodeRevisionBytes', () => {
+  it('round-trips the wire encoding the revision endpoints use', () => {
+    const source = new Y.Doc({ gc: false })
+    const frag = source.getXmlFragment('prosemirror')
+    const p = new Y.XmlElement('paragraph')
+    p.insert(0, [new Y.XmlText('wire format')])
+    frag.insert(0, [p])
+
+    const bytes = Y.encodeStateAsUpdate(source)
+    const decoded = decodeRevisionBytes(toBase64(bytes))
+
+    expect(Array.from(decoded)).toEqual(Array.from(bytes))
+  })
+})

--- a/frontend/src/components/editor/revisionView.ts
+++ b/frontend/src/components/editor/revisionView.ts
@@ -1,0 +1,126 @@
+/**
+ * Detached read-only viewer for a stored revision.
+ *
+ * ## Why this exists
+ *
+ * Revision viewing used to work by calling `editorView.updateState()` on the
+ * LIVE editor with a plugin list that omitted `ySyncPlugin`. That is a data-loss
+ * bug, not a style problem:
+ *
+ *   1. ProseMirror's `updatePluginViews` destroys every plugin view whenever
+ *      `prevState.plugins != this.state.plugins` (prosemirror-view/dist/index.js).
+ *      Swapping the plugin list therefore ran `ySyncPlugin`'s `destroy`, which
+ *      calls `binding.destroy()` -> `prosemirrorView = null` and
+ *      `type.unobserveDeep(...)`.
+ *   2. With the binding unobserved, every remote edit arriving while a revision
+ *      was on screen never reached the ProseMirror document.
+ *   3. Exiting restored an `EditorState` captured BEFORE those edits. The binding
+ *      re-initialised against the stale document, and the next change ran
+ *      `updateYFragment`, which diffed stale ProseMirror against the advanced Yjs
+ *      fragment, deleted the collaborators' work and broadcast the deletion.
+ *
+ * So: never touch the live view. This mounts a second, throwaway `EditorView`
+ * over a scratch `Y.Doc` and renders it in an overlay. The live editor stays
+ * mounted, bound and receiving updates the whole time, and exiting is just a
+ * teardown of things nobody else references.
+ *
+ * The scratch doc is deliberately provider-free. y-prosemirror's node-building
+ * catch block deletes the offending item from whatever doc it is rendering and
+ * lets that deletion propagate; keeping every doc we touch here detached means a
+ * render failure can only damage something we are about to throw away.
+ */
+import { EditorState, type Plugin } from 'prosemirror-state';
+import { EditorView } from 'prosemirror-view';
+import type { Schema } from 'prosemirror-model';
+import * as Y from 'yjs';
+import { initProseMirrorDoc } from 'y-prosemirror';
+
+/** The Yjs root a Nosdesk collaborative document lives under. */
+const ROOT_FRAGMENT = 'prosemirror';
+
+export interface RevisionViewHandle {
+  /** The detached view, exposed for tests and for reading text out. */
+  readonly view: EditorView;
+  /** Plain text of the revision, for copy-out and assertions. */
+  text(): string;
+  /** Idempotent. */
+  destroy(): void;
+}
+
+/**
+ * Decode the base64 payload the revision endpoints return.
+ *
+ * Both `GET /collaboration/tickets/{id}/revisions/{n}` and the `/docs/` sibling
+ * return the column base64-encoded under `yjs_document_content`, and both store a
+ * full v1 document update despite the documentation column being named
+ * `yjs_document_snapshot`.
+ */
+export function decodeRevisionBytes(base64: string): Uint8Array {
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return bytes;
+}
+
+/**
+ * Render a stored revision into `mount`, detached from the live document.
+ *
+ * Throws if the update cannot be decoded, having cleaned up after itself, so the
+ * caller can surface the failure without leaving a half-built view behind.
+ */
+export function mountRevisionView(opts: {
+  mount: HTMLElement;
+  schema: Schema;
+  /** Full Yjs v1 document update for the revision. */
+  updateBytes: Uint8Array;
+  /**
+   * Plugins for the detached view. Supplied by the caller rather than imported
+   * here, for two reasons: the node-view plugins reach the router, which would
+   * drag every view into anything importing this module, and the fidelity of a
+   * historical render is the caller's decision.
+   *
+   * Pass only what renders. Anything that can dispatch a transaction (keymaps,
+   * input rules, drop cursor, image upload, or any Yjs plugin) does not belong
+   * on a static document.
+   */
+  plugins?: readonly Plugin[];
+}): RevisionViewHandle {
+  const { mount, schema, updateBytes, plugins = [] } = opts;
+
+  // gc:false mirrors the live document and the server (`skip_gc: true`), so a
+  // revision carrying tombstones decodes with its history intact.
+  const scratchDoc = new Y.Doc({ gc: false });
+  let view: EditorView | null = null;
+
+  try {
+    Y.applyUpdate(scratchDoc, updateBytes);
+    const fragment = scratchDoc.getXmlFragment(ROOT_FRAGMENT);
+    const { doc } = initProseMirrorDoc(fragment, schema);
+
+    view = new EditorView(mount, {
+      state: EditorState.create({ doc, schema, plugins: [...plugins] }),
+      // Set as a direct prop rather than relying on a plugin, so the view is
+      // non-editable from its very first render.
+      editable: () => false,
+      attributes: { class: 'revision-view-content', 'aria-readonly': 'true' },
+    });
+  } catch (error) {
+    view?.destroy();
+    scratchDoc.destroy();
+    throw error;
+  }
+
+  const liveView = view;
+  let destroyed = false;
+
+  return {
+    view: liveView,
+    text: () => liveView.state.doc.textBetween(0, liveView.state.doc.content.size, '\n', '\n'),
+    destroy() {
+      if (destroyed) return;
+      destroyed = true;
+      liveView.destroy();
+      scratchDoc.destroy();
+    },
+  };
+}

--- a/frontend/src/components/ticketComponents/CollaborativeTicketArticle.vue
+++ b/frontend/src/components/ticketComponents/CollaborativeTicketArticle.vue
@@ -1,6 +1,6 @@
 <!-- CollaborativeTicketArticle.vue -->
 <script setup lang="ts">
-import { ref, onMounted, nextTick } from 'vue';
+import { ref, computed, onMounted, nextTick } from 'vue';
 import { useRouter } from 'vue-router';
 import { useFluent } from 'fluent-vue';
 import CollaborativeEditor from '@/components/CollaborativeEditor.vue';
@@ -103,6 +103,10 @@ const handleSelectRevision = async (revisionNumber: number | null) => {
     console.error('Failed to fetch revision:', error);
   }
 };
+
+// The editor owns which revision is on screen, so the list highlight follows it
+// whether the exit came from the list or from the overlay's own button.
+const activeRevisionNumber = computed(() => editorRef.value?.currentRevisionNumber ?? null);
 
 const toggleRevisionHistory = () => {
   // Closing: also exit any in-progress revision preview so the
@@ -209,6 +213,7 @@ const confirmPromote = async () => {
       >
         <RevisionList
           :ticket-id="ticketId"
+          :active-revision-number="activeRevisionNumber"
           @select-revision="handleSelectRevision"
         />
       </aside>

--- a/frontend/src/views/DocumentView.vue
+++ b/frontend/src/views/DocumentView.vue
@@ -238,6 +238,10 @@ const toggleRevisionHistory = () => {
   showRevisionHistory.value ? docPanel.close() : docPanel.open('history')
 }
 
+// The editor owns which revision is on screen, so the panel highlight follows
+// it whether the exit came from the list or from the overlay's own button.
+const activeRevisionNumber = computed(() => editorRef.value?.currentRevisionNumber ?? null)
+
 const handleSelectRevision = async (revisionNumber: number | null) => {
   if (!editorRef.value) return
 
@@ -832,6 +836,7 @@ watch(documentObj, (newDocument) => {
           :open="showRevisionHistory"
           type="documentation"
           :document-id="Number(currentPageId)"
+          :active-revision-number="activeRevisionNumber"
           class="flex-shrink-0"
           @close="handleCloseRevisionHistory"
           @select-revision="handleSelectRevision"

--- a/i18n/locales/en-AU/main.ftl
+++ b/i18n/locales/en-AU/main.ftl
@@ -5197,3 +5197,6 @@ editor-image-upload-invalid = Image cannot be added
 editor-image-upload-invalid-detail = { $name } is not a supported image, or is larger than 10MB.
 editor-image-upload-anchor-lost = Image could not be placed
 editor-image-upload-anchor-lost-detail = { $name } uploaded, but the spot you pasted it into was edited away. Paste it again.
+editor-revision-view-aria = Viewing revision { $revision }, read only
+editor-revision-viewing-label = Viewing revision { $revision }
+editor-revision-back-to-current = Back to current version

--- a/i18n/locales/en-GB/main.ftl
+++ b/i18n/locales/en-GB/main.ftl
@@ -5185,3 +5185,6 @@ editor-image-upload-invalid = Image cannot be added
 editor-image-upload-invalid-detail = { $name } is not a supported image, or is larger than 10MB.
 editor-image-upload-anchor-lost = Image could not be placed
 editor-image-upload-anchor-lost-detail = { $name } uploaded, but the spot you pasted it into was edited away. Paste it again.
+editor-revision-view-aria = Viewing revision { $revision }, read only
+editor-revision-viewing-label = Viewing revision { $revision }
+editor-revision-back-to-current = Back to current version

--- a/i18n/locales/en-US/main.ftl
+++ b/i18n/locales/en-US/main.ftl
@@ -6716,3 +6716,6 @@ editor-image-upload-invalid = Image cannot be added
 editor-image-upload-invalid-detail = { $name } is not a supported image, or is larger than 10MB.
 editor-image-upload-anchor-lost = Image could not be placed
 editor-image-upload-anchor-lost-detail = { $name } uploaded, but the spot you pasted it into was edited away. Paste it again.
+editor-revision-view-aria = Viewing revision { $revision }, read only
+editor-revision-viewing-label = Viewing revision { $revision }
+editor-revision-back-to-current = Back to current version

--- a/i18n/locales/fr-FR/main.ftl
+++ b/i18n/locales/fr-FR/main.ftl
@@ -6638,3 +6638,6 @@ editor-image-upload-invalid = Impossible d'ajouter l'image
 editor-image-upload-invalid-detail = { $name } n'est pas une image prise en charge, ou dépasse 10 Mo.
 editor-image-upload-anchor-lost = Impossible de placer l'image
 editor-image-upload-anchor-lost-detail = { $name } a bien été téléversé, mais l'endroit où vous l'avez collé a été modifié. Collez-la de nouveau.
+editor-revision-view-aria = Révision { $revision } affichée, lecture seule
+editor-revision-viewing-label = Révision { $revision } affichée
+editor-revision-back-to-current = Revenir à la version actuelle

--- a/i18n/locales/nl-NL/main.ftl
+++ b/i18n/locales/nl-NL/main.ftl
@@ -6630,3 +6630,6 @@ editor-image-upload-invalid = Afbeelding kan niet worden toegevoegd
 editor-image-upload-invalid-detail = { $name } is geen ondersteunde afbeelding, of is groter dan 10 MB.
 editor-image-upload-anchor-lost = Afbeelding kon niet worden geplaatst
 editor-image-upload-anchor-lost-detail = { $name } is geüpload, maar de plek waar je hem plakte is inmiddels gewijzigd. Plak hem opnieuw.
+editor-revision-view-aria = Revisie { $revision } wordt getoond, alleen-lezen
+editor-revision-viewing-label = Revisie { $revision } wordt getoond
+editor-revision-back-to-current = Terug naar huidige versie


### PR DESCRIPTION
## The bug

`viewSnapshot` called `updateState()` on the **live** `EditorView` with a plugin list
omitting `ySyncPlugin`. ProseMirror destroys plugin views whenever `state.plugins`
changes, so `ySyncPlugin`'s `destroy` ran `binding.destroy()` and `unobserveDeep()`.

Consequences, in order:

1. Remote edits arriving while a revision was open never reached the ProseMirror document.
2. Exiting restored an `EditorState` captured *before* those edits.
3. The next change ran `updateYFragment`, diffing the stale ProseMirror doc against the
   advanced Yjs fragment, deleting the collaborators' work and broadcasting the deletion.

Silent data loss, on both the documentation and ticket surfaces.

## The fix

`revisionView.ts` mounts a second, throwaway `EditorView` over a scratch `Y.Doc` and
renders it in an overlay above the still-mounted live editor. The live view keeps its
state, its binding and its incoming updates for the whole time a revision is on screen,
and exiting is teardown of things nothing else references.

The scratch doc is deliberately provider-free: y-prosemirror's node-building catch block
deletes the offending item from whatever doc it is rendering and lets that deletion
propagate, so a render failure can only damage something already being thrown away.

## Three problems verification turned up

- **No way out.** The overlay had no exit affordance, and `RevisionList`'s "Current
  Version" is a static header, not a button, so closing the panel was the only escape.
  Added a sticky bar (revision number + "Back to current version") and Escape, with the
  overlay taking focus so the handler fires and screen readers land on the region.
- **Invisible edits.** With the live view covered rather than replaced, it stayed
  editable underneath, so a toolbar click would have dispatched into a hidden document.
  The live view is now `editable: () => !isViewingRevision.value` and the toolbar is
  `inert`. Neither blocks Yjs sync.
- **Stale highlight.** `RevisionList` owned its selection locally, so exiting from the
  overlay left a row highlighted. The highlight now derives from the editor's
  `currentRevisionNumber` through a new `activeRevisionNumber` prop.

## Verification

`vue-tsc`, `npm run lint`, 47 tests (8 new). The unit tests target this exact failure
mode: `expect(live.view.state).toBe(stateBefore)` (identity, not equality) and a
byte-identical document check, so they fail if anyone re-states the live view again.

Two-session browser test, both surfaces:

```
A received the edit      : true     <- false before the fix
B still has its own edit : true     <- false before the fix
live editable DURING     : false      toolbar inert DURING  : true
panel highlight          : 1 -> 0     Escape closed overlay : true
```

The full inline diff view remains deferred; this is the correctness fix underneath it.