### PR TITLE
Give the workspace switcher a per-workspace mark

### DIFF
--- a/backend/src/handlers/admin_workspaces.rs
+++ b/backend/src/handlers/admin_workspaces.rs
@@ -743,6 +743,10 @@ struct MyWorkspaceEntry {
     role: String,
     invited_at: chrono::DateTime<chrono::Utc>,
     accepted_at: Option<chrono::DateTime<chrono::Utc>>,
+    /// Workspace branding logo, for the switcher's mark. `None` when the
+    /// workspace has not uploaded one, which is the common case: the client
+    /// falls back to a monogram rather than a broken image.
+    logo_url: Option<String>,
 }
 
 pub async fn list_my_workspaces(req: HttpRequest, mut pc: PlatformConn) -> impl Responder {
@@ -757,26 +761,45 @@ pub async fn list_my_workspaces(req: HttpRequest, mut pc: PlatformConn) -> impl 
         }
     };
 
-    match pc.run(|conn| workspaces::list_memberships_for_user(conn, user_uuid)) {
-        Ok(rows) => {
-            let body: Vec<MyWorkspaceEntry> = rows
-                .into_iter()
-                .map(|(m, w)| MyWorkspaceEntry {
-                    workspace_id: w.id,
-                    workspace_uuid: w.uuid,
-                    slug: w.slug,
-                    name: w.name,
-                    custom_domain: w.custom_domain,
-                    role: m.role,
-                    invited_at: m.invited_at,
-                    accepted_at: m.accepted_at,
-                })
-                .collect();
-            HttpResponse::Ok().json(body)
-        }
+    // Memberships first, then branding for exactly those workspaces. The
+    // connection bypasses RLS (cross-workspace by nature), so the membership
+    // list is what constrains the branding read to workspaces the caller
+    // belongs to.
+    let rows = match pc.run(|conn| workspaces::list_memberships_for_user(conn, user_uuid)) {
+        Ok(rows) => rows,
         Err(e) => {
             error!(error = ?e, %user_uuid, "me/workspaces list failed");
-            errors::internal("Failed to load memberships")
+            return errors::internal("Failed to load memberships");
         }
-    }
+    };
+
+    let workspace_ids: Vec<i32> = rows.iter().map(|(_, w)| w.id).collect();
+    // Branding is decoration: if it fails, the switcher falls back to
+    // monograms rather than the whole list failing to load.
+    let logos: std::collections::HashMap<i32, String> = pc
+        .run(|conn| workspaces::logo_urls_for_workspaces(conn, &workspace_ids))
+        .unwrap_or_else(|e| {
+            warn!(error = ?e, %user_uuid, "workspace branding lookup failed");
+            Vec::new()
+        })
+        .into_iter()
+        .filter_map(|(id, url)| url.map(|u| (id, u)))
+        .collect();
+
+    let body: Vec<MyWorkspaceEntry> = rows
+        .into_iter()
+        .map(|(m, w)| MyWorkspaceEntry {
+            workspace_id: w.id,
+            workspace_uuid: w.uuid,
+            slug: w.slug,
+            name: w.name,
+            custom_domain: w.custom_domain,
+            role: m.role,
+            invited_at: m.invited_at,
+            accepted_at: m.accepted_at,
+            logo_url: logos.get(&w.id).cloned(),
+        })
+        .collect();
+
+    HttpResponse::Ok().json(body)
 }

--- a/backend/src/repository/workspaces.rs
+++ b/backend/src/repository/workspaces.rs
@@ -15,7 +15,7 @@ use uuid::Uuid;
 
 use crate::db::DbConnection;
 use crate::models::{NewWorkspace, Workspace, WorkspaceMember};
-use crate::schema::{retired_slugs, workspace_members, workspaces};
+use crate::schema::{retired_slugs, site_settings, workspace_members, workspaces};
 
 /// Staff roles that count toward a workspace's `seat_limit`. Mirrors
 /// [`crate::models::WorkspaceRole::is_staff`]; kept as a literal array for the
@@ -610,6 +610,30 @@ pub fn list_memberships_for_user(
         .load::<(WorkspaceMember, Workspace)>(conn)
 }
 
+/// Branding logo for each of `workspace_ids`, as `(workspace_id, logo_url)`.
+///
+/// Kept separate from [`list_memberships_for_user`] rather than folded into its
+/// join: three other callers depend on that function's shape, and only the
+/// workspace switcher needs branding.
+///
+/// `site_settings` holds one row per workspace (`site_settings_workspace_id_key`),
+/// so this is a single indexed read over the caller's handful of memberships,
+/// not a per-workspace fetch. Rows are absent for a workspace with no settings
+/// row yet, so callers treat a missing entry as "no logo".
+///
+/// Reads across workspaces, so it needs a connection that bypasses RLS. The
+/// caller must have already narrowed `workspace_ids` to the user's own
+/// memberships; this function does no authorization of its own.
+pub fn logo_urls_for_workspaces(
+    conn: &mut DbConnection,
+    workspace_ids: &[i32],
+) -> QueryResult<Vec<(i32, Option<String>)>> {
+    site_settings::table
+        .filter(site_settings::workspace_id.eq_any(workspace_ids))
+        .select((site_settings::workspace_id, site_settings::logo_url))
+        .load(conn)
+}
+
 /// List every membership row for a workspace. Used by the admin
 /// member-management UI.
 pub fn list_workspace_members(
@@ -1067,6 +1091,50 @@ mod tests {
             !slugs.contains(&"memship-archived"),
             "archived workspace must not appear in /me/workspaces switcher list"
         );
+    }
+
+    #[test]
+    fn logo_urls_returns_only_requested_workspaces() {
+        use crate::schema::site_settings;
+
+        let pool = setup_test_pool();
+        let mut conn = pool.get().expect("conn");
+
+        let branded = fresh_workspace(&mut conn, "logo-branded");
+        let plain = fresh_workspace(&mut conn, "logo-plain");
+        let other = fresh_workspace(&mut conn, "logo-other");
+
+        let url = format!("/uploads/branding/{}/logo.png?v=1", branded.uuid);
+        for (ws, logo) in [
+            (&branded, Some(url.clone())),
+            (&other, Some("/other.png".into())),
+        ] {
+            as_admin(&mut conn, |c| {
+                diesel::insert_into(site_settings::table)
+                    .values((
+                        site_settings::workspace_id.eq(ws.id),
+                        site_settings::logo_url.eq(logo.clone()),
+                    ))
+                    .on_conflict(site_settings::workspace_id)
+                    .do_update()
+                    .set(site_settings::logo_url.eq(logo.clone()))
+                    .execute(c)
+            })
+            .expect("seed branding");
+        }
+
+        let rows = as_admin(&mut conn, |c| {
+            logo_urls_for_workspaces(c, &[branded.id, plain.id])
+        })
+        .expect("logo urls");
+
+        let found: std::collections::HashMap<i32, Option<String>> = rows.into_iter().collect();
+        assert_eq!(found.get(&branded.id), Some(&Some(url)));
+        // Present but unset reads as no logo, and the client draws a monogram.
+        assert!(matches!(found.get(&plain.id), None | Some(None)));
+        // A workspace the caller did not ask for is never returned, which is
+        // what keeps this from widening past the caller's memberships.
+        assert!(!found.contains_key(&other.id));
     }
 
     #[test]

--- a/backend/tests/admin_workspace_members.rs
+++ b/backend/tests/admin_workspace_members.rs
@@ -140,6 +140,13 @@ async fn workspace_member_lifecycle_contract() {
     assert_eq!(body.len(), 1, "alice should see exactly 1 workspace");
     assert_eq!(body[0]["slug"], "memship-acme");
     assert_eq!(body[0]["role"], "agent");
+    // The switcher's mark: present in the payload, null until the workspace
+    // uploads a logo, which is what makes the client fall back to a monogram.
+    assert!(
+        body[0].get("logo_url").is_some(),
+        "logo_url must be serialized so the switcher can decide on a mark"
+    );
+    assert!(body[0]["logo_url"].is_null(), "no branding uploaded yet");
 
     // --- 3: re-add alice -> 200 already_member ---
     let mut resp = client

--- a/frontend/src/components/WorkspaceSwitcher.vue
+++ b/frontend/src/components/WorkspaceSwitcher.vue
@@ -7,6 +7,7 @@
 import { computed, ref } from 'vue';
 import { useFluent } from 'fluent-vue';
 import Icon from '@/components/common/Icon.vue';
+import { initialsFrom, monogramColor, monogramDataUri } from '@/utils/monogram';
 import MenuList, { type MenuItem } from '@/components/common/MenuList.vue';
 import ResponsiveMenu from '@/components/common/ResponsiveMenu.vue';
 import Spinner from '@/components/common/Spinner.vue';
@@ -47,6 +48,9 @@ const menuItems = computed<MenuItem[]>(() =>
     id: `ws:${ws.workspace_id}`,
     label: ws.name,
     trailing: roleLabel(ws.role),
+    // `checked` takes the icon gutter for the active row, which is the more
+    // useful signal there; the trigger already shows that workspace's mark.
+    iconUrl: ws.logo_url ?? monogramDataUri(ws.name, ws.workspace_uuid),
     checked: ws.workspace_id === store.activeWorkspaceId,
   })),
 );
@@ -63,6 +67,17 @@ function handleSelect(id: string): void {
   open.value = false;
   void switchWorkspace(entry);
 }
+
+/** Mark for the active workspace: its logo, else a monogram. */
+const activeMark = computed(() => {
+  const active = store.activeWorkspace;
+  if (!active) return null;
+  return {
+    logo: active.logo_url,
+    initials: initialsFrom(active.name),
+    color: monogramColor(active.workspace_uuid),
+  };
+});
 
 const triggerTitle = computed(() => {
   const active = store.activeWorkspace;
@@ -83,13 +98,32 @@ const triggerTitle = computed(() => {
           : 'px-2.5 py-1.5 gap-2 justify-between min-w-0'
       "
       :title="triggerTitle"
-      :aria-label="t('nav-workspace-switcher-label')"
+      :aria-label="
+        store.activeWorkspace
+          ? t('nav-workspace-switcher-current', { name: store.activeWorkspace.name })
+          : t('nav-workspace-switcher-label')
+      "
       :aria-expanded="open"
       aria-haspopup="menu"
       @click="open = !open"
     >
       <div class="flex items-center gap-2 min-w-0" :class="collapsed ? '' : 'flex-1'">
-        <Icon name="folder" class="shrink-0" />
+        <!-- Decorative: the workspace name sits in the label beside it, and in
+             the button's aria-label when the sidebar is collapsed. -->
+        <img
+          v-if="activeMark?.logo"
+          :src="activeMark.logo"
+          alt=""
+          class="h-5 w-5 shrink-0 rounded-[0.3125rem] object-cover"
+        />
+        <span
+          v-else-if="activeMark"
+          class="h-5 w-5 shrink-0 rounded-[0.3125rem] grid place-items-center text-[0.625rem] font-semibold leading-none text-white"
+          :style="{ backgroundColor: activeMark.color }"
+          aria-hidden="true"
+          >{{ activeMark.initials }}</span
+        >
+        <Icon v-else name="folder" class="shrink-0" />
         <template v-if="!collapsed">
           <span v-if="store.isLoading" class="text-sm inline-flex items-center gap-2">
             <Spinner size="xs" :label="$t('nav-workspace-switcher-loading')" />

--- a/frontend/src/stores/branding.ts
+++ b/frontend/src/stores/branding.ts
@@ -12,15 +12,30 @@ import { logger } from '@nosdesk/core/utils/logger'
 import { defineStore } from 'pinia'
 import { ref, computed } from 'vue'
 import brandingService, { type BrandingConfig } from '@nosdesk/core/services/brandingService'
+import { activeWorkspaceSlugRef } from '@/services/activeWorkspace'
 
-const BRANDING_CACHE_KEY = 'nosdesk_branding_cache'
+const BRANDING_CACHE_PREFIX = 'nosdesk_branding_cache'
+
+/**
+ * Cache key for the workspace currently on screen.
+ *
+ * Scoped per workspace because the cache exists to paint branding before the
+ * fetch resolves: with one shared key, switching workspaces paints the previous
+ * tenant's logo and colours until the new config arrives. Falls back to the
+ * bare key when no slug is set, which is host mode and self-hosted, where there
+ * is only ever one workspace.
+ */
+function brandingCacheKey(): string {
+  const slug = activeWorkspaceSlugRef.value
+  return slug ? `${BRANDING_CACHE_PREFIX}:${slug}` : BRANDING_CACHE_PREFIX
+}
 
 /**
  * Load cached branding from localStorage
  */
 function loadCachedBranding(): BrandingConfig | null {
   try {
-    const cached = localStorage.getItem(BRANDING_CACHE_KEY)
+    const cached = localStorage.getItem(brandingCacheKey())
     if (cached) {
       return JSON.parse(cached)
     }
@@ -35,7 +50,7 @@ function loadCachedBranding(): BrandingConfig | null {
  */
 function saveBrandingCache(config: BrandingConfig): void {
   try {
-    localStorage.setItem(BRANDING_CACHE_KEY, JSON.stringify(config))
+    localStorage.setItem(brandingCacheKey(), JSON.stringify(config))
   } catch {
     // Ignore storage errors
   }
@@ -186,7 +201,7 @@ export const useBrandingStore = defineStore('branding', () => {
     }
     // Clear the cache
     try {
-      localStorage.removeItem(BRANDING_CACHE_KEY)
+      localStorage.removeItem(brandingCacheKey())
     } catch {
       // Ignore storage errors
     }

--- a/frontend/src/utils/monogram.spec.ts
+++ b/frontend/src/utils/monogram.spec.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+
+import { initialsFrom, monogramColor, monogramDataUri, monogramHue } from './monogram'
+
+describe('initialsFrom', () => {
+  it('takes up to two initials', () => {
+    expect(initialsFrom('Venus')).toBe('V')
+    expect(initialsFrom('Acme Support')).toBe('AS')
+    expect(initialsFrom('One Two Three')).toBe('OT')
+  })
+
+  it('handles separators and empty input', () => {
+    expect(initialsFrom('north-west')).toBe('NW')
+    expect(initialsFrom('  spaced   out ')).toBe('SO')
+    expect(initialsFrom('')).toBe('?')
+    expect(initialsFrom('   ')).toBe('?')
+  })
+})
+
+describe('monogramHue', () => {
+  it('is stable for the same key', () => {
+    expect(monogramHue('abc')).toBe(monogramHue('abc'))
+  })
+
+  it('is in range', () => {
+    for (const key of ['', 'a', 'workspace', '3f2b1c9d-0000-4000-8000-000000000001']) {
+      const hue = monogramHue(key)
+      expect(hue).toBeGreaterThanOrEqual(0)
+      expect(hue).toBeLessThan(360)
+    }
+  })
+
+  // The reason this is keyed on the uuid rather than the name: uuids share
+  // long prefixes, so a weak hash would put every workspace on one colour.
+  it('separates keys that share a prefix', () => {
+    const a = '3f2b1c9d-0000-4000-8000-000000000001'
+    const b = '3f2b1c9d-0000-4000-8000-000000000002'
+    expect(monogramHue(a)).not.toBe(monogramHue(b))
+  })
+})
+
+describe('monogramDataUri', () => {
+  it('renders the initials into an svg data uri', () => {
+    const uri = monogramDataUri('Venus', 'key-1')
+    expect(uri.startsWith('data:image/svg+xml,')).toBe(true)
+    expect(decodeURIComponent(uri)).toContain('>V<')
+  })
+
+  it('escapes names that would otherwise break the document', () => {
+    const decoded = decodeURIComponent(monogramDataUri('<script>', 'key-1'))
+    expect(decoded).not.toContain('<script>')
+    expect(decoded).toContain('&lt;')
+  })
+
+  it('uses the key, not the name, for colour', () => {
+    // Same first letter, different workspace: the marks must not match.
+    expect(monogramDataUri('Support', 'key-a')).not.toBe(monogramDataUri('Support', 'key-b'))
+    expect(monogramColor('key-a')).not.toBe(monogramColor('key-b'))
+  })
+})

--- a/frontend/src/utils/monogram.ts
+++ b/frontend/src/utils/monogram.ts
@@ -1,0 +1,74 @@
+/**
+ * Monogram marks for entities that may not have an uploaded image.
+ *
+ * Used by the workspace switcher, where most workspaces will never upload a
+ * logo, so the monogram is the ordinary case rather than an error state.
+ *
+ * Colour is derived from a stable key (a uuid), not from the display name.
+ * Keying on the first letter, as `UserAvatar` does, gives every workspace
+ * starting with the same letter an identical colour, which defeats the point
+ * of a mark whose job is telling two workspaces apart at a glance.
+ */
+
+/** Up to two initials, or `?` when there is nothing to take them from. */
+export function initialsFrom(name: string): string {
+  if (!name) return '?';
+  return (
+    name
+      .split(/[\s-]+/)
+      .filter((part) => part.length > 0)
+      .map((word) => word.charAt(0))
+      .join('')
+      .toUpperCase()
+      .slice(0, 2) || '?'
+  );
+}
+
+/**
+ * A stable hue in [0, 360) for `key`.
+ *
+ * FNV-1a over the whole key, so two keys sharing a prefix (uuids often share
+ * their first characters) still land in different places on the wheel.
+ */
+export function monogramHue(key: string): number {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < key.length; i++) {
+    hash ^= key.charCodeAt(i);
+    // FNV prime, via shifts to stay in 32-bit range without Math.imul overflow.
+    hash = (hash + ((hash << 1) + (hash << 4) + (hash << 7) + (hash << 8) + (hash << 24))) >>> 0;
+  }
+  return hash % 360;
+}
+
+/** The `hsl()` background for a monogram. Lightness is fixed so white text
+ *  keeps its contrast in both themes. */
+export function monogramColor(key: string): string {
+  return `hsl(${monogramHue(key)}, 65%, 38%)`;
+}
+
+/** XML-escape text destined for an SVG data URI. */
+function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+/**
+ * The monogram as an SVG data URI, for slots that take an image URL rather
+ * than markup (`MenuItem.iconUrl`). Rendered in an `<img>`, so the SVG is
+ * inert regardless of what the name contains, and escaped anyway so a name
+ * with a quote or an ampersand cannot break the document.
+ */
+export function monogramDataUri(name: string, key: string): string {
+  const initials = escapeXml(initialsFrom(name));
+  const svg =
+    `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">` +
+    `<rect width="32" height="32" rx="7" fill="${monogramColor(key)}"/>` +
+    `<text x="16" y="17" fill="#fff" font-family="system-ui,sans-serif" font-size="14"` +
+    ` font-weight="600" text-anchor="middle" dominant-baseline="central">${initials}</text>` +
+    `</svg>`;
+  return `data:image/svg+xml,${encodeURIComponent(svg)}`;
+}

--- a/i18n/locales/en-AU/main.ftl
+++ b/i18n/locales/en-AU/main.ftl
@@ -226,6 +226,7 @@ nav-documentation = Documentation
 nav-inbox = Inbox
 nav-collapse = Collapse
 nav-workspace-switcher-label = Workspace
+nav-workspace-switcher-current = Workspace: { $name }
 nav-workspace-switcher-loading = Loading workspaces…
 nav-search = Search
 nav-more = More

--- a/i18n/locales/en-GB/main.ftl
+++ b/i18n/locales/en-GB/main.ftl
@@ -216,6 +216,7 @@ nav-documentation = Documentation
 nav-inbox = Inbox
 nav-collapse = Collapse
 nav-workspace-switcher-label = Workspace
+nav-workspace-switcher-current = Workspace: { $name }
 nav-workspace-switcher-loading = Loading workspaces…
 nav-search = Search
 nav-more = More

--- a/i18n/locales/en-US/main.ftl
+++ b/i18n/locales/en-US/main.ftl
@@ -303,6 +303,7 @@ nav-documentation = Documentation
 nav-inbox = Inbox
 nav-collapse = Collapse
 nav-workspace-switcher-label = Workspace
+nav-workspace-switcher-current = Workspace: { $name }
 nav-workspace-switcher-loading = Loading workspaces…
 nav-search = Search
 nav-more = More

--- a/i18n/locales/fr-FR/main.ftl
+++ b/i18n/locales/fr-FR/main.ftl
@@ -254,6 +254,7 @@ nav-documentation = Documentation
 nav-inbox = Boîte de réception
 nav-collapse = Réduire
 nav-workspace-switcher-label = Espace de travail
+nav-workspace-switcher-current = Espace de travail : { $name }
 nav-workspace-switcher-loading = Chargement des espaces de travail…
 nav-search = Rechercher
 nav-more = Plus

--- a/i18n/locales/nl-NL/main.ftl
+++ b/i18n/locales/nl-NL/main.ftl
@@ -251,6 +251,7 @@ nav-documentation = Documentatie
 nav-inbox = Postvak
 nav-collapse = Inklappen
 nav-workspace-switcher-label = Werkruimte
+nav-workspace-switcher-current = Werkruimte: { $name }
 nav-workspace-switcher-loading = Werkruimtes laden…
 nav-search = Zoeken
 nav-more = Meer

--- a/packages/core/src/types/workspace.ts
+++ b/packages/core/src/types/workspace.ts
@@ -67,6 +67,9 @@ export interface MyWorkspaceEntry {
   role: WorkspaceRole;
   invited_at: string;
   accepted_at: string | null;
+  /** Workspace branding logo. `null` for most workspaces, which never upload
+   *  one; surfaces fall back to a monogram rather than a broken image. */
+  logo_url: string | null;
 }
 
 /** Request body for POST /api/admin/workspaces. */


### PR DESCRIPTION
The switcher drew a hardcoded folder glyph (`WorkspaceSwitcher.vue:93`) for every
workspace, so the control whose job is telling you which tenant you are in looked
identical in all of them.

## Backend

`GET /api/me/workspaces` now returns `logo_url` per workspace.

The read (`logo_urls_for_workspaces`) is deliberately **not** folded into
`list_memberships_for_user`'s join: three other callers depend on that function's
shape. `site_settings` holds one row per workspace
(`site_settings_workspace_id_key`), so this is a single indexed read over the
caller's handful of memberships, not a per-workspace fetch.

The connection is already `PlatformConn` (BYPASSRLS, audit-attributed) and
`list_memberships_for_user` already restricts to the caller's own memberships, so
the membership list is what narrows the branding read. No new cross-tenant
mechanism, and nothing is returned for a workspace the caller doesn't belong to.

A failed branding read degrades to monograms rather than failing the whole list.

## Frontend

Real logo when set, deterministic monogram otherwise. Most workspaces never
upload a logo, so the monogram is the ordinary case rather than an error state,
and without it this would ship a broken-image state.

**Colour derives from `workspace_uuid`, not the name.** `UserAvatar` keys its
colour on the first letter, which would give every workspace starting with the
same letter an identical mark, defeating the purpose. Two workspaces both named
"Support" render distinct colours.

Menu rows reuse `MenuItem.iconUrl`, which already accepts a data URI, so
`MenuList` is unchanged. The active row still shows a checkmark in that gutter,
which is the more useful signal there; the trigger carries the active mark.

## Also fixed

The branding cache was a single `nosdesk_branding_cache` localStorage key. It
exists to paint branding before the fetch resolves, so under one shared key a
workspace switch painted the *previous* tenant's logo and colours until the new
config arrived. Now keyed per workspace slug, falling back to the bare key in
host mode where there is only ever one workspace.

## Accessibility

The mark is decorative (`alt=""` / `aria-hidden`), since the workspace name sits
beside it. The collapsed sidebar hides that label, so the trigger's `aria-label`
now carries the name via `nav-workspace-switcher-current`, added to all five
catalogues. That gap predates this change.

## Verification

Backend `fmt` / `clippy --all-targets --all-features` clean, 1757 tests plus
integration, 0 failures. Frontend `vue-tsc`, lint, 55 tests (8 new). Core
type-check clean.

The new tests cover the properties that matter: initials and separators, hue
stability, that uuids sharing a long prefix don't collide, that names are
XML-escaped before going into an SVG data URI, and that colour follows the key
rather than the name. The integration test asserts `logo_url` is serialized and
null before any upload.

The switcher only renders with more than one workspace, so it is not observable
on a single-workspace dev stack; it becomes visible on staging.

Follows #252, which scoped branding storage per workspace and made this possible.