### PR TITLE
dev-build: correct the summary's claim about when migrations run

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -148,7 +148,7 @@ jobs:
             if [ "$DEPLOY" = "true" ]; then
               echo "Deployed to **nosdesk-dev**."
               echo ""
-              echo "The app applies pending migrations on boot, so no separate step is needed."
+              echo "Migrations ran in the release phase (\`/app/backend migrate\`); app machines refuse to boot against a pending schema."
             else
               echo "Not deployed. To ship it:"
               echo ""


### PR DESCRIPTION
The dev deploy's run summary told the reader:

> The app applies pending migrations on boot, so no separate step is needed.

That is not what happens. `nosdesk-dev` sets `NOSDESK_MIGRATE_ON_BOOT=false` and
migrations run in the release phase via `release_command = "/app/backend migrate"`.
App machines then verify the schema and refuse to serve if anything is pending:

> NOSDESK_MIGRATE_ON_BOOT=false but N migration(s) are unapplied. Refusing to
> serve against an incomplete schema.

The stale line matters because it tells someone reading a deploy summary that
migrations are handled implicitly, which is the wrong mental model for diagnosing
a failed release command or a machine that won't boot.

One line, in the workflow's step summary output.