### PR TITLE
Redesign the remote collaborator caret

### DIFF
--- a/frontend/src/components/CollaborativeEditor.vue
+++ b/frontend/src/components/CollaborativeEditor.vue
@@ -90,6 +90,12 @@ import {
 } from "@/plugins/prosemirror-mentions";
 import { createMentionViewPlugin } from "@/plugins/prosemirror-mention-view";
 import { useUserMentionSearch } from "@/composables/useUserMentionSearch";
+// Same identity colour the workspace/user marks use, so one person reads as one
+// colour wherever they appear.
+import { monogramColor } from "@/utils/monogram";
+
+/** Fallback caret colour for an awareness state carrying no identity. */
+const NEUTRAL_CARET_COLOR = 'hsl(215, 15%, 45%)';
 
 // Yjs awareness user state structure
 interface AwarenessUser {
@@ -676,7 +682,10 @@ const initEditor = async () => {
         // sessions (per y-protocols/awareness.js).
         provider.awareness.setLocalStateField('user', {
             name: getUserDisplayName(),
-            color: getRandomColor(),
+            // Derived from the uuid rather than randomised per session: the same
+            // person keeps one colour across sessions and across surfaces, and
+            // two people no longer collide by chance out of a palette of eight.
+            color: authStore.user?.uuid ? monogramColor(authStore.user.uuid) : NEUTRAL_CARET_COLOR,
             uuid: authStore.user?.uuid || undefined,
             avatar: authStore.user?.avatar_thumb || authStore.user?.avatar_url || undefined,
         });
@@ -742,14 +751,37 @@ const initEditor = async () => {
                     yCursorPlugin(provider.awareness, {
                         // Custom cursor builder that handles missing users gracefully
                         cursorBuilder: (user: AwarenessUser | undefined, _clientId: number): HTMLElement => {
-                            const cursor = document.createElement('span');
-                            cursor.classList.add('ProseMirror-yjs-cursor');
-                            cursor.setAttribute('style', `border-color: ${user?.color || '#808080'}`);
-                            const userLabel = document.createElement('div');
-                            userLabel.setAttribute('style', `background-color: ${user?.color || '#808080'}`);
-                            userLabel.textContent = user?.name || 'Anonymous';
-                            cursor.appendChild(userLabel);
-                            return cursor;
+                            // Derive from the uuid rather than trusting the colour on the
+                            // wire, so a peer on an older build still renders in its
+                            // owner's colour. `user.color` is the fallback for awareness
+                            // states that carry no uuid.
+                            const color = user?.uuid
+                                ? monogramColor(user.uuid)
+                                : user?.color || NEUTRAL_CARET_COLOR;
+
+                            const caret = document.createElement('span');
+                            caret.classList.add('ProseMirror-yjs-cursor');
+                            // One custom property drives every part. Nothing reads
+                            // `currentColor`, which is what made the label render white
+                            // on white whenever the inline colour went missing.
+                            caret.style.setProperty('--yjs-caret-color', color);
+
+                            // Small permanent tab: enough to see someone is here without
+                            // a name label sitting over the line above.
+                            const flag = document.createElement('span');
+                            flag.className = 'yjs-caret-flag';
+
+                            // y-prosemirror keys this widget per client, so ProseMirror
+                            // rebuilds the element when THIS user's cursor moves and
+                            // reuses it when anyone else's awareness changes. The reveal
+                            // animation therefore replays on movement only, with no
+                            // timers to manage.
+                            const name = document.createElement('span');
+                            name.className = 'yjs-caret-name';
+                            name.textContent = user?.name || 'Anonymous';
+
+                            caret.append(flag, name);
+                            return caret;
                         },
                     }),
                     yUndoPlugin(),
@@ -1177,19 +1209,6 @@ const initEditor = async () => {
 };
 
 // Helper function to get random color for user
-const getRandomColor = () => {
-    const colors = [
-        "#f87171",
-        "#fb923c",
-        "#fbbf24",
-        "#a3e635",
-        "#34d399",
-        "#22d3ee",
-        "#60a5fa",
-        "#a78bfa",
-    ];
-    return colors[Math.floor(Math.random() * colors.length)];
-};
 
 // Helper function to get user display name
 const getUserDisplayName = () => {
@@ -3516,39 +3535,86 @@ defineExpose({
     flex-grow: 1;
 }
 
-/* This gives the remote user caret. The colors are automatically overwritten*/
+/* Remote collaborator caret.
+   Sized in `em` throughout so it tracks the editor's line-height and the
+   reader's zoom; the previous mix of fixed px against em offsets did neither.
+   Colour comes from one custom property set by the cursor builder, so no part
+   of this depends on `currentColor` (which is what let the label render white
+   on white when the inline colour was missing). */
 .ProseMirror-yjs-cursor {
     position: relative;
     margin-left: -1px;
     margin-right: -1px;
-    border-left: 1px solid orange;
-    border-right: 1px solid orange;
-    border-color: orange;
+    border-left: 0.125em solid var(--yjs-caret-color, hsl(215, 15%, 45%));
+    height: 1em;
     word-break: normal;
     pointer-events: none;
-    opacity: 1;
-    height: 1.2em;
 }
 
-/* This renders the username above the caret */
-.ProseMirror-yjs-cursor > div {
+/* Always-on tab at the top of the caret. Small enough that it never occludes
+   text, which is the job the permanent name label used to do badly. */
+.ProseMirror-yjs-cursor > .yjs-caret-flag {
     position: absolute;
-    top: -1.5em;
-    left: -2px;
-    font-size: 12px;
-    background-color: currentColor;
+    top: -0.18em;
+    left: -0.125em;
+    width: 0.45em;
+    height: 0.45em;
+    border-radius: 0.16em 0.16em 0.16em 0;
+    background-color: var(--yjs-caret-color, hsl(215, 15%, 45%));
+    /* The one interactive part: hovering the tab re-reveals the name. Kept off
+       the caret itself so it cannot interfere with selecting text. */
+    pointer-events: auto;
+}
+
+/* The name. Revealed by the rebuild animation when this user's cursor moves,
+   then faded out, so a document with several collaborators is not permanently
+   covered in labels. */
+.ProseMirror-yjs-cursor > .yjs-caret-name {
+    position: absolute;
+    bottom: 1.15em;
+    left: -0.125em;
+    padding: 0.1em 0.4em;
+    border-radius: 0.3em;
+    background-color: var(--yjs-caret-color, hsl(215, 15%, 45%));
+    /* Lightness is fixed where the colour is generated, so white clears 7:1
+       against every hue it can produce. */
+    color: #fff;
     font-family: var(--font-sans, 'Inter', ui-sans-serif, system-ui, sans-serif);
-    font-weight: normal;
-    line-height: normal;
-    user-select: none;
-    color: white;
-    padding: 1px 5px;
+    font-size: 0.75em;
+    font-weight: 500;
+    line-height: 1.4;
     white-space: nowrap;
-    border-radius: 4px;
-    max-width: 150px;
+    max-width: 12em;
     overflow: hidden;
     text-overflow: ellipsis;
+    user-select: none;
     z-index: 10;
+    opacity: 0;
+    animation: yjs-caret-name-reveal 2.4s ease-out forwards;
+}
+
+.ProseMirror-yjs-cursor > .yjs-caret-flag:hover ~ .yjs-caret-name {
+    animation: none;
+    opacity: 1;
+}
+
+@keyframes yjs-caret-name-reveal {
+    0%,
+    70% {
+        opacity: 1;
+    }
+    100% {
+        opacity: 0;
+    }
+}
+
+/* No motion: the name stays hidden and hover is the way to read it, rather
+   than reinstating the permanent label this replaced. */
+@media (prefers-reduced-motion: reduce) {
+    .ProseMirror-yjs-cursor > .yjs-caret-name {
+        animation: none;
+        opacity: 0;
+    }
 }
 
 /* Revision History Sidebar */


### PR DESCRIPTION
Reported as a white background on the presence indicator on mobile, plus the name
label getting in the way of content and not being measured against line-height.
All three trace back to the same block of CSS.

## The white background was structural

```css
.ProseMirror-yjs-cursor > div {
  background-color: currentColor;   /* resolves to the element's color... */
  color: white;                     /* ...which is white */
}
```

The label's **default** background was white. Only the inline `background-color`
from the cursor builder made it readable, so any path where that inline style was
missing or overridden gave white text on a white pill.

One custom property now drives the bar, the flag and the label, with an explicit
fallback:

```css
background-color: var(--yjs-caret-color, hsl(215, 15%, 45%));
```

Nothing reads `currentColor`, so the failure mode no longer exists.

## Colour follows identity, not the session

Derived from the user's uuid via the same `monogramColor` the workspace and user
marks use, so one person reads as one colour wherever they appear.
`getRandomColor()` is deleted.

It picked from eight pastels at connect time, so a person changed colour on every
session and two people collided by roughly the fourth participant. Because the
generator fixes lightness at 38%, white label text now clears about 7:1 against
**every** hue it can produce; on the old `#a3e635` lime it was about 1.6:1, which
is likely as much of the "looks white" report as the bug itself.

The builder derives from the uuid rather than trusting the colour on the wire, so
a peer on an older build still renders in its owner's colour.

## Measured in em

The label mixed fixed px (`12px` font, `1px 5px` padding, `150px` max-width) with
`em` offsets, so it tracked neither line-height nor zoom, and the caret used a
guessed `1.2em` rather than the line's height. Everything is now `em`: `0.125em`
bar, `0.45em` flag, `0.75em` label.

## The name no longer sits on the document

A small always-on flag marks presence; the name reveals on movement and fades.

y-prosemirror keys the cursor widget per client
(`Decoration.widget(head, ..., { key: clientId })`), and ProseMirror reuses widget
DOM when key and position are unchanged. So the element is rebuilt when **that**
user's cursor moves and reused when anyone else's awareness changes: the reveal
animation replays on movement alone, with no timers or awareness bookkeeping.
Hovering the flag brings the name back; `prefers-reduced-motion` keeps it hidden
with hover as the way in.

## Verification

Two live clients on one document, no typing (the caret comes from awareness
selection state, so the document is unmodified). Verified in both states: name up
during the reveal window, flag only after the fade. Computed style confirms the
derived background and white text rather than white on white.

`vue-tsc`, ESLint and 55 frontend tests clean.

Known limitation: during the reveal the label still slightly overlaps the line
above, which is inherent to placing a label above an inline caret in flowing text.
It is transient and small now rather than permanent.