### PR TITLE
One back affordance per screen

### DIFF
--- a/frontend/src/components/SiteHeader.vue
+++ b/frontend/src/components/SiteHeader.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, ref } from "vue";
 import { RouterLink, useRoute } from "vue-router";
-import { useBackNavigation } from '@/router/navigation';
+import { backFallback, useBackNavigation } from '@/router/navigation';
 import { useFluent } from 'fluent-vue';
 import type { FluentVariable } from '@fluent/bundle';
 import UserAvatar from "./UserAvatar.vue";
@@ -29,7 +29,12 @@ const { isMobile } = useMobileDetection('sm')
 const route = useRoute();
 const { canGoBack, goBack } = useBackNavigation();
 const showBackArrow = computed(
-  () => isMobile.value && (canGoBack.value || !!route.meta.parent),
+  () =>
+    isMobile.value &&
+    // A view-declared target counts: on a cold start there is no in-app history
+    // to pop and often no `meta.parent`, and the view no longer draws its own
+    // control, so without this a deep link would offer no way back.
+    (canGoBack.value || !!route.meta.parent || !!backFallback.value),
 );
 
 const authStore = useAuthStore();
@@ -200,7 +205,7 @@ const handleCreateClick = () => {
         type="button"
         aria-label="Go back"
         class="flex-shrink-0 -ml-1 p-1.5 min-h-[44px] min-w-[44px] sm:min-h-0 sm:min-w-0 inline-flex items-center justify-center text-secondary hover:text-primary rounded"
-        @click="goBack()"
+        @click="goBack(backFallback)"
       >
         <Icon name="chevronLeft" size="md" />
       </button>

--- a/frontend/src/components/common/BackButton.vue
+++ b/frontend/src/components/common/BackButton.vue
@@ -11,6 +11,10 @@ const props = defineProps<{
   label?: string;
   // Compact mode - smaller text, tighter spacing
   compact?: boolean;
+  // Icon-only: a square chevron with no visible text, for headers whose title
+  // sits immediately beside it and has no room for a label. `label` is still
+  // required in that case and becomes the accessible name.
+  iconOnly?: boolean;
 }>();
 
 // One intelligent back action: pop the in-app stack when there is a real
@@ -34,7 +38,18 @@ const { isMobile } = useMobileDetection('sm');
     children, which is how flexbox is meant to be used.
   -->
   <button
-    v-if="!isMobile"
+    v-if="!isMobile && iconOnly"
+    type="button"
+    @click="handleBack"
+    :title="label || 'Go back'"
+    :aria-label="label || 'Go back'"
+    class="p-1.5 -ml-1.5 rounded-md text-tertiary hover:text-primary hover:bg-surface-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-accent transition-colors shrink-0"
+  >
+    <Icon name="chevronLeft" size="md" />
+  </button>
+
+  <button
+    v-else-if="!isMobile"
     @click="handleBack"
     class="text-secondary hover:text-primary inline-flex items-center gap-1 group px-1 rounded"
     :class="compact ? 'h-6 text-xs' : 'h-8 text-sm'"

--- a/frontend/src/router/navigation.ts
+++ b/frontend/src/router/navigation.ts
@@ -15,7 +15,14 @@
 // RETURNING a location (replace-style), so the login/workspace chain never
 // inflates the depth. Depth 0 == the entry point (nothing in-app to go back to).
 
-import { computed, ref } from 'vue'
+import {
+  computed,
+  onUnmounted,
+  ref,
+  toValue,
+  watchEffect,
+  type MaybeRefOrGetter,
+} from 'vue'
 import {
   useRoute,
   useRouter,
@@ -125,6 +132,37 @@ export function performBack(
  * `meta.parent` / derived parent (used only when there's no in-app history) —
  * the migration path for views that currently pass an explicit `fallbackRoute`.
  */
+/**
+ * A back target contributed by the view currently on screen.
+ *
+ * `meta.parent` covers hierarchies the route can express. Some cannot: a cycle
+ * lives under its project, but the project id is not in `/cycles/:uuid`, so the
+ * parent is only knowable once the cycle has loaded.
+ *
+ * Without this the mobile header has nothing to offer on a cold start (no
+ * in-app history to pop, no `meta.parent`), so a deep link would render no back
+ * affordance at all once the view stops drawing its own.
+ */
+const viewBackFallback = ref<string | undefined>(undefined)
+
+/** Read-only view of the current view's back target, for the header. */
+export const backFallback = computed(() => viewBackFallback.value)
+
+/**
+ * Declare this view's back target for as long as it is mounted. Reactive, so a
+ * target that resolves after data loads is picked up when it arrives.
+ */
+export function useViewBackFallback(
+  target: MaybeRefOrGetter<string | undefined>,
+): void {
+  watchEffect(() => {
+    viewBackFallback.value = toValue(target)
+  })
+  onUnmounted(() => {
+    viewBackFallback.value = undefined
+  })
+}
+
 export function useBackNavigation(): {
   canGoBack: typeof canGoBackInApp
   goBack: (fallback?: string) => void

--- a/frontend/src/views/AdminIndexView.vue
+++ b/frontend/src/views/AdminIndexView.vue
@@ -31,14 +31,6 @@ const filteredGroups = computed(() =>
     <div class="flex-1 flex flex-col gap-4 px-4 sm:px-6 py-4 mx-auto w-full max-w-4xl">
       <!-- Header -->
       <div class="mb-2">
-        <!-- Phone/small tablet: back link (hidden at md+ where there's enough context) -->
-        <RouterLink
-          to="/"
-          class="md:hidden flex items-center gap-2 text-sm text-secondary hover:text-primary transition-colors mb-3"
-        >
-          <Icon name="chevronLeft" />
-          {{ $t('admin-back-to-dashboard') }}
-        </RouterLink>
         <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-3">
           <div>
             <h1 class="text-xl lg:text-2xl font-bold text-primary">{{ $t('admin-heading') }}</h1>

--- a/frontend/src/views/CycleDetailView.vue
+++ b/frontend/src/views/CycleDetailView.vue
@@ -15,6 +15,8 @@
  * the same way it works on project detail.
  */
 import { computed, ref, watch } from 'vue'
+import BackButton from '@/components/common/BackButton.vue'
+import { useViewBackFallback } from '@/router/navigation'
 import { useRouter } from 'vue-router'
 import { useFluent } from 'fluent-vue'
 import { subscribe } from '@/sync/lifecycle'
@@ -171,13 +173,19 @@ function openCard(cardId: number): void {
   router.push(`/tickets/${cardId}`)
 }
 
-function backToCycles(): void {
-  // Cycles live under their project; return to that project's Cycles
-  // tab (fall back to history if the cycle hasn't loaded yet).
+// Cycles live under their project, so a deep link with no in-app history should
+// land on that project's Cycles tab rather than a generic parent. `BackButton`
+// pops the in-app stack first and only consults this when there is nothing to
+// pop, which is the case the old hand-rolled handler approximated with
+// `router.back()`.
+const cyclesFallback = computed<string | undefined>(() => {
   const projectId = cycle.value?.project_id
-  if (projectId != null) router.push(`/projects/${projectId}/cycles`)
-  else router.back()
-}
+  return projectId != null ? `/projects/${projectId}/cycles` : undefined
+})
+
+// Give the mobile header the same target the desktop button uses, so a deep
+// link to a cycle still has a way back to its project.
+useViewBackFallback(cyclesFallback)
 
 const stateLabel = computed<string>(() => {
   if (!cycle.value) return ''
@@ -204,15 +212,7 @@ const groupByOptions = computed(() => [
   <div class="flex flex-col h-full min-h-0 overflow-hidden">
     <header class="flex items-center justify-between px-6 py-4 border-b border-subtle bg-app">
       <div class="flex items-center gap-3 min-w-0">
-        <button
-          type="button"
-          class="p-1.5 -ml-1.5 rounded-md text-tertiary hover:text-primary hover:bg-surface-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-accent transition-colors shrink-0"
-          :title="$t('cycle-detail-back')"
-          :aria-label="$t('cycle-detail-back')"
-          @click="backToCycles"
-        >
-          <Icon name="chevronLeft" size="md" />
-        </button>
+        <BackButton icon-only :label="$t('cycle-detail-back')" :fallback-route="cyclesFallback" />
         <div class="min-w-0">
           <h1 class="text-xl font-semibold text-primary truncate">
             {{ cycle?.name ?? $t('cycle-detail-loading-name') }}

--- a/frontend/src/views/PDFViewerView.vue
+++ b/frontend/src/views/PDFViewerView.vue
@@ -89,13 +89,7 @@ watch(filename, (newFilename) => {
     <div class="bg-surface border-b border-default px-4 py-2">
       <div class="flex items-center justify-between max-w-5xl mx-auto">
         <!-- Back button -->
-        <button
-          @click="goBack"
-          class="flex items-center gap-2 px-3 py-1.5 text-secondary hover:text-primary hover:bg-surface-hover rounded-lg transition-colors"
-        >
-          <Icon name="chevronLeft" size="md" />
-          <span class="text-sm font-medium">{{ $t('pdf-viewer-back') }}</span>
-        </button>
+        <BackButton :label="$t('pdf-viewer-back')" />
 
         <!-- Share button -->
         <button

--- a/frontend/src/views/RuleActivityView.vue
+++ b/frontend/src/views/RuleActivityView.vue
@@ -26,6 +26,13 @@ import Icon from '@/components/common/Icon.vue';
 import Skeleton from '@/components/common/Skeleton.vue';
 import SkeletonBar from '@/components/common/SkeletonBar.vue';
 import rulesService from '@nosdesk/core/services/rulesService';
+import { useMobileDetection } from '@/composables/useMobileDetection';
+
+// Desktop only: on mobile the leading back-arrow in SiteHeader is the single
+// back affordance, so this inline control hides to avoid two per screen. Same
+// contract BackButton encodes; kept inline here because this toolbar's
+// secondary-button styling is deliberate.
+const { isMobile } = useMobileDetection('sm');
 import type { RuleApplication, RuleApplicationStatus } from '@nosdesk/core/types/rule';
 
 const fluent = useFluent();
@@ -131,7 +138,7 @@ function back(): void {
 <template>
   <div class="flex flex-col gap-6">
     <div class="flex flex-wrap items-center gap-3">
-      <Button variant="secondary" size="sm" @click="back">
+      <Button v-if="!isMobile" variant="secondary" size="sm" @click="back">
         <Icon name="chevronLeft" class="w-4 h-4" />
         <span>{{ t('admin-rules-activity-back') }}</span>
       </Button>

--- a/frontend/src/views/RuleEditView.vue
+++ b/frontend/src/views/RuleEditView.vue
@@ -28,6 +28,13 @@ import Icon from '@/components/common/Icon.vue';
 import rulesService from '@nosdesk/core/services/rulesService';
 import { extractErrorMessage } from '@/utils/errors';
 import { useToastStore } from '@nosdesk/core/stores/toast';
+import { useMobileDetection } from '@/composables/useMobileDetection';
+
+// Desktop only: on mobile the leading back-arrow in SiteHeader is the single
+// back affordance, so this inline control hides to avoid two per screen. Same
+// contract BackButton encodes; kept inline here because this toolbar's
+// secondary-button styling is deliberate.
+const { isMobile } = useMobileDetection('sm');
 import type {
   CreateRuleRequest,
   Rule,
@@ -236,7 +243,7 @@ const priorityOptions = [
 <template>
   <div class="flex flex-col gap-6 max-w-3xl">
     <div class="flex items-center gap-3">
-      <Button variant="secondary" size="sm" @click="back">
+      <Button v-if="!isMobile" variant="secondary" size="sm" @click="back">
         <Icon name="chevronLeft" class="w-4 h-4" />
         <span>{{ t('admin-rule-editor-back') }}</span>
       </Button>


### PR DESCRIPTION
The cycles view showed **two** back arrows on mobile.

## Why

`SiteHeader` draws a back arrow on mobile and is mobile-only *precisely* to avoid
a second one:

> instead, so this stays mobile-only to avoid two back controls per screen

`BackButton` encodes the other half (`v-if="!isMobile"`). `CycleDetailView`
predated that component, hand-rolled its own control, and had no guard, so the two
stacked. Desktop was correct; only mobile doubled up.

## The fix, and the regression it nearly shipped

Migrated to `BackButton`, which needed an **icon-only** variant: the cycle name
sits immediately beside the control, so forcing the component's label in would
crowd that header.

Migrating alone left **zero** back controls on a deep link. On a cold start there
is no in-app history to pop, the cycle route has no `meta.parent`, and the view no
longer draws its own. I only caught this by measuring at mobile width; the diff
looked clean.

`meta.parent` cannot express this hierarchy. A cycle lives under its project, but
the project id is not in `/cycles/:uuid`, so the parent is only knowable once the
cycle has loaded, and the derived fallback (`/cycles`) is not a real route. Added
`useViewBackFallback()` so a view contributes its target reactively; `SiteHeader`
now shows the arrow when one exists and passes it to `goBack`.

## Audit of the other seven hand-rolled chevrons

They were not all the same problem:

| View | Action |
|---|---|
| `PDFViewerView` | Migrated. Already used the shared `performBack`, only lacked the guard. Its second back button is a recovery action inside an error panel, not chrome, so it stays. |
| `RuleActivityView`, `RuleEditView` | Guarded, not migrated. Their `Button variant="secondary"` matches the admin toolbar; converting it would be unrelated redesign. |
| `AdminIndexView` | Removed. The inverse case: its link was `md:hidden`, so it rendered **only** on mobile, exactly where the header already does. |
| `MFASetupView`, `AcceptInvitationView`, `PasswordResetView` | Left alone. Pre-auth flows, may legitimately own their control. |

## Verification

Counted controls by accessible name at both widths, on both entry paths:

```
width  390  ->  1 control: "Go back"    (SiteHeader arrow)
width 1400  ->  1 control: "‹ Cycles"   (BackButton, icon-only)
```

Mobile shows exactly one on a cold start as well as with history, which is the
case the first attempt broke.

`vue-tsc`, ESLint and 55 frontend tests clean.