### PR TITLE
Warm launches catch up via delta instead of re-streaming the snapshot

### DIFF
--- a/backend/src/handlers/sync/bootstrap.rs
+++ b/backend/src/handlers/sync/bootstrap.rs
@@ -190,20 +190,12 @@ fn stream_bootstrap_inner(
     // Workspace capability flags. These are simple booleans the
     // frontend uses to gate optional UI surfaces (filter chips,
     // default visible columns, summary segments). Adding a flag
-    // here is the right place when the client should treat a
-    // feature as "exists for this workspace" vs "available
-    // everywhere" — eg. SLA chrome should hide entirely until
-    // an admin sets up at least one policy. Counts (rather than
-    // "any non-archived") are fine for v1: a workspace either
-    // has policies or it doesn't.
-    let sla_enabled: bool = {
-        use diesel::dsl::count_star;
-        let n: i64 = crate::schema::sla_policies::table
-            .select(count_star())
-            .first(conn)
-            .unwrap_or(0);
-        n > 0
-    };
+    // belongs in `capability_flags` (shared with the delta
+    // response) when the client should treat a feature as "exists
+    // for this workspace" vs "available everywhere" — eg. SLA
+    // chrome should hide entirely until an admin sets up at least
+    // one policy.
+    let capabilities = super::capability_flags(conn);
 
     // Header: schema hash, cursor, granted groups, and capability
     // flags. Clients read this once at the start of every
@@ -216,7 +208,7 @@ fn stream_bootstrap_inner(
                 "last_xid8": last_xid8,
                 "last_sync_id": last_sync_id,
                 "groups_granted": granted,
-                "sla_enabled": sla_enabled,
+                "sla_enabled": capabilities.sla_enabled,
             }
         }),
     )?;

--- a/backend/src/handlers/sync/delta.rs
+++ b/backend/src/handlers/sync/delta.rs
@@ -91,6 +91,13 @@ pub struct DeltaResponse {
     /// A false positive costs one re-bootstrap; a false negative leaves the
     /// cache silently wrong, so it errs toward resyncing.
     pub resync_required: bool,
+    /// Current workspace capability flags. Carried on every delta (not just
+    /// the bootstrap `__meta__`) so a warm launch that catches up via delta
+    /// without re-streaming the snapshot still converges on current flags.
+    /// `None` when the probe failed; the client keeps its current flags
+    /// rather than flickering chrome off over a transient error.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub capabilities: Option<super::CapabilityFlags>,
 }
 
 /// Smallest `sync_id` still present in `sync_actions`, or `None` when the
@@ -179,6 +186,16 @@ pub async fn delta(
         }
     };
 
+    // Cheap (count over a tiny table); every response carries current flags.
+    let capabilities =
+        match tc.run(|conn| Ok::<_, diesel::result::Error>(super::capability_flags(conn))) {
+            Ok(c) => Some(c),
+            Err(e) => {
+                error!(error = %e, "delta: capability probe failed; omitting flags");
+                None
+            }
+        };
+
     if granted.is_empty() {
         // No groups in common between request and permission set;
         // return an empty delta rather than an error so clients can
@@ -189,6 +206,7 @@ pub async fn delta(
             last_sync_id: query.from,
             has_more: false,
             resync_required,
+            capabilities,
         });
     }
 
@@ -291,6 +309,7 @@ pub async fn delta(
         last_sync_id,
         has_more,
         resync_required,
+        capabilities,
     })
 }
 

--- a/backend/src/handlers/sync/mod.rs
+++ b/backend/src/handlers/sync/mod.rs
@@ -20,6 +20,29 @@ pub mod delta;
 pub mod push;
 pub mod schema;
 
+/// Workspace capability flags surfaced to the client (feature chrome gates,
+/// e.g. hide all SLA UI until a policy exists). Sent in the bootstrap
+/// `__meta__` header and on every delta response, so a client that skips the
+/// snapshot on a warm launch (delta catch-up) still converges on the current
+/// flags, and a flag flipped by an admin reaches running clients within one
+/// poll interval rather than at their next full bootstrap.
+#[derive(Debug, serde::Serialize)]
+pub struct CapabilityFlags {
+    pub sla_enabled: bool,
+}
+
+pub fn capability_flags(conn: &mut crate::db::DbConnection) -> CapabilityFlags {
+    use diesel::dsl::count_star;
+    use diesel::prelude::*;
+    // A count (rather than "any non-archived") is fine for v1: a workspace
+    // either has SLA policies or it doesn't.
+    let n: i64 = crate::schema::sla_policies::table
+        .select(count_star())
+        .first(conn)
+        .unwrap_or(0);
+    CapabilityFlags { sla_enabled: n > 0 }
+}
+
 /// Sync-engine routes, mounted inside the authenticated `/api` scope in main.rs.
 pub fn config(cfg: &mut actix_web::web::ServiceConfig) {
     use actix_web::web;

--- a/frontend/e2e/warm-delta.spec.ts
+++ b/frontend/e2e/warm-delta.spec.ts
@@ -1,0 +1,51 @@
+import { test, expect } from '@playwright/test'
+
+/**
+ * The warm-launch transport contract (sync/lifecycle.ts).
+ *
+ * First visit in a fresh browser context has an empty IndexedDB, so it must
+ * stream the workspace bootstrap. A reload of the same context has the
+ * snapshot cached and watermarked, so it must catch up with a delta from the
+ * commit-safe cursor and re-stream NO workspace snapshot. Playwright's
+ * storageState carries cookies but never IndexedDB, so every test context
+ * starts cold by construction and the reload is the warm case.
+ *
+ * Asserted at the network layer on purpose: rendering is covered elsewhere,
+ * and this is the machinery that quietly regresses if a refactor makes
+ * subscribe() bootstrap unconditionally again.
+ */
+test('warm relaunch catches up via delta, not a snapshot re-stream', async ({ page }) => {
+  const calls: string[] = []
+  page.on('request', (req) => {
+    const u = new URL(req.url())
+    if (u.pathname.endsWith('/api/sync/bootstrap') || u.pathname.endsWith('/api/sync/delta')) {
+      calls.push(u.pathname + u.search)
+    }
+  })
+  const workspaceBootstraps = () =>
+    calls.filter((c) => c.includes('bootstrap') && c.includes('workspace%3A')).length
+
+  await page.goto('/tickets', { waitUntil: 'domcontentloaded' })
+  // Cold: the workspace snapshot streams.
+  await expect.poll(workspaceBootstraps, { timeout: 15_000 }).toBeGreaterThan(0)
+  // Let the stream finish so the watermark lands before the reload. The
+  // commit-safe cursor (`from_xid8`) only seeds when the bootstrap's end
+  // line is processed, so a delta carrying it proves the launch settled.
+  await expect
+    .poll(() => calls.some((c) => c.includes('delta') && c.includes('from_xid8=')), {
+      timeout: 15_000,
+    })
+    .toBe(true)
+
+  calls.length = 0
+  await page.reload({ waitUntil: 'domcontentloaded' })
+  // Warm: a delta from a real commit-safe cursor...
+  await expect
+    .poll(
+      () => calls.filter((c) => c.includes('delta') && c.includes('from_xid8=')).length,
+      { timeout: 15_000 },
+    )
+    .toBeGreaterThan(0)
+  // ...and no workspace snapshot re-stream.
+  expect(workspaceBootstraps()).toBe(0)
+})

--- a/frontend/src/composables/useWorkspaceCapabilities.ts
+++ b/frontend/src/composables/useWorkspaceCapabilities.ts
@@ -36,9 +36,13 @@ const state: Ref<CapabilityState> = ref({ ...DEFAULT_STATE })
 export function applyWorkspaceCapabilities(meta: {
   sla_enabled?: boolean
 }): void {
-  state.value = {
+  const next: CapabilityState = {
     slaEnabled: meta.sla_enabled ?? false,
   }
+  // Flags now arrive on every delta poll; only swap the ref when a flag
+  // actually changed so watchers don't fire every 10 seconds.
+  if (next.slaEnabled === state.value.slaEnabled) return
+  state.value = next
 }
 
 /** Reset to defaults — used when the user logs out or switches

--- a/frontend/src/sync/idb.ts
+++ b/frontend/src/sync/idb.ts
@@ -40,6 +40,8 @@ const META_KEY_LAST_XID8 = 'last_xid8'
 const META_KEY_SCHEMA_HASH = 'schema_hash'
 const META_KEY_SUBSCRIBED_GROUPS = 'subscribed_groups'
 const META_KEY_INSTANCE_ID = 'instance_id'
+const META_KEY_GROUP_WATERMARKS = 'group_watermarks'
+const META_KEY_MODEL_VERSIONS_TAG = 'model_versions_tag'
 
 export interface IdbHandle {
   db: IDBDatabase
@@ -257,6 +259,48 @@ export function setSubscribedGroups(handle: IdbHandle, groups: string[]): Promis
 
 export function getSubscribedGroups(handle: IdbHandle): Promise<string[] | undefined> {
   return getMeta<string[]>(handle, META_KEY_SUBSCRIBED_GROUPS)
+}
+
+export function getGroupWatermarks(handle: IdbHandle): Promise<Record<string, number> | undefined> {
+  return getMeta<Record<string, number>>(handle, META_KEY_GROUP_WATERMARKS)
+}
+
+/** Record that a full snapshot of each group completed at `xid8`. Presence
+ * of a group's watermark is the signal the warm-launch path reads for "this
+ * group's rows are fully cached; a delta can bring them current" — so it is
+ * only written when a bootstrap stream reached its `__end__` line. Wiping
+ * the database (schema / instance / retention resync) clears these with it. */
+export async function setGroupWatermarks(
+  handle: IdbHandle,
+  groups: string[],
+  xid8: number,
+): Promise<void> {
+  const current = (await getGroupWatermarks(handle)) ?? {}
+  for (const g of groups) current[g] = xid8
+  await putMeta(handle, META_KEY_GROUP_WATERMARKS, current)
+}
+
+/** Overwrite the watermark map wholesale. Used by the torn-cache prune,
+ * which drops watermarks for groups not subscribed when the session first
+ * advances the cursor (their cached rows stop tracking it from then on). */
+export function replaceGroupWatermarks(
+  handle: IdbHandle,
+  marks: Record<string, number>,
+): Promise<void> {
+  return putMeta(handle, META_KEY_GROUP_WATERMARKS, marks)
+}
+
+/** Client-side aggregate schema-version tag (see `SCHEMA_VERSIONS` in
+ * lifecycle.ts). Cached rows written under a different tag may have been
+ * filtered out on rehydrate, so a matching tag is part of the warm-launch
+ * gate: without it a version bump would leave those aggregates empty, since
+ * a delta only replays recent events, not the snapshot. */
+export function setModelVersionsTag(handle: IdbHandle, tag: string): Promise<void> {
+  return putMeta(handle, META_KEY_MODEL_VERSIONS_TAG, tag)
+}
+
+export function getModelVersionsTag(handle: IdbHandle): Promise<string | undefined> {
+  return getMeta<string>(handle, META_KEY_MODEL_VERSIONS_TAG)
 }
 
 export type { ModelRow }

--- a/frontend/src/sync/lifecycle.ts
+++ b/frontend/src/sync/lifecycle.ts
@@ -50,6 +50,14 @@ interface LifecycleState {
    * wipes and reopens, and `IdbHandle` carries only the derived name, so the
    * inputs have to be kept rather than reverse-engineered from it. */
   openArgs: { userUuid: string; workspaceSlug: string | null } | null
+  /** False until this session's first successful catch-up (a delta apply or
+   * a bootstrap end). Until then an SSE frame may apply its rows but must
+   * NOT advance the cursor: the SSE bridge attaches while the launch
+   * catch-up is still in flight, and a frame that jumped the cursor to
+   * "now" would make the catch-up delta skip the whole offline span. The
+   * frame's events are also in `sync_actions`, so the catch-up re-delivers
+   * them; holding the cursor back loses nothing. */
+  caughtUp: boolean
 }
 
 const state: LifecycleState = {
@@ -59,6 +67,7 @@ const state: LifecycleState = {
   memoryOnly: false,
   resyncing: false,
   openArgs: null,
+  caughtUp: false,
 }
 
 /** Memory-only counts as hydrated (it still bootstraps and serves; only
@@ -78,15 +87,88 @@ function canFetchWorkspace(): boolean {
 }
 
 /**
- * Bootstrap every subscribed group. Called after hydrate() and whenever the
- * workspace becomes ready, to drain groups whose fetch subscribe() deferred
- * (it adds the group to the pool's set but defers the fetch when the runtime
- * isn't hydrated or no workspace is selected), so none is left empty until the
- * next tearDown.
+ * Bring every subscribed group current. Called after hydrate() and whenever
+ * the workspace becomes ready, to drain groups whose fetch subscribe()
+ * deferred (it adds the group to the pool's set but defers the fetch when the
+ * runtime isn't hydrated or no workspace is selected), so none is left empty
+ * until the next tearDown. Warm-cached groups catch up via delta; the rest
+ * bootstrap (see bringGroupsCurrent).
  */
 function bootstrapDeferredGroups(): void {
   const groups = Array.from(pool.getSubscribedGroups())
-  if (groups.length > 0) void runBootstrap(groups)
+  if (groups.length > 0) void bringGroupsCurrent(groups)
+}
+
+/**
+ * Split groups into warm (cached snapshot a delta can bring current) and cold
+ * (needs the full bootstrap stream). A group is warm only when ALL of:
+ *
+ *  - persistence is live and the rehydrated pool actually holds rows;
+ *  - the cached cursor is a real xid8 (a 0 cursor means no commit-safe
+ *    baseline to delta from);
+ *  - the cached rows were written under the current client aggregate
+ *    versions (a SCHEMA_VERSIONS bump filters old rows out on rehydrate,
+ *    and only a bootstrap re-fetches them — a delta never re-streams the
+ *    snapshot);
+ *  - the group holds a bootstrap watermark. Watermarks are written when a
+ *    group's snapshot stream completes and pruned when a session advances
+ *    the cursor while the group is unsubscribed (see pruneTornWatermarks),
+ *    so presence means "these cached rows have tracked the cursor
+ *    continuously since their snapshot".
+ */
+async function partitionWarmGroups(
+  groups: string[],
+): Promise<{ warm: string[]; cold: string[] }> {
+  if (!state.handle || pool.getLastXid8() <= 0 || pool.size() === 0) {
+    return { warm: [], cold: groups }
+  }
+  const versionsTag = await idb.getModelVersionsTag(state.handle)
+  if (versionsTag !== MODEL_VERSIONS_TAG) {
+    return { warm: [], cold: groups }
+  }
+  const watermarks = (await idb.getGroupWatermarks(state.handle)) ?? {}
+  const warm: string[] = []
+  const cold: string[] = []
+  for (const g of groups) {
+    ;(watermarks[g] != null ? warm : cold).push(g)
+  }
+  return { warm, cold }
+}
+
+/**
+ * Bring groups current: delta catch-up for warm-cached groups, full
+ * bootstrap for the rest. Delta runs FIRST — a bootstrap's `__end__`
+ * advances the global cursor to now, so catching the warm groups up from
+ * the cached cursor must happen before that or their missed events are
+ * skipped forever.
+ */
+async function bringGroupsCurrent(groups: string[]): Promise<void> {
+  if (groups.length === 0 || !canFetchWorkspace()) return
+  const { warm, cold } = await partitionWarmGroups(groups)
+  if (warm.length > 0) {
+    logger.info('sync warm launch: delta catch-up instead of snapshot re-stream', {
+      groups: warm,
+    })
+    await catchUpViaDelta()
+  }
+  if (cold.length > 0) {
+    await runBootstrap(cold)
+  }
+}
+
+/**
+ * Page through the delta feed until the cursor is current. Bounded so a
+ * pathological backlog can't spin here forever; anything left after the cap
+ * keeps arriving via the normal 10s poll / SSE.
+ */
+const CATCH_UP_MAX_PAGES = 20
+
+async function catchUpViaDelta(): Promise<void> {
+  for (let i = 0; i < CATCH_UP_MAX_PAGES; i++) {
+    const hasMore = await pullDelta()
+    if (!hasMore) return
+  }
+  logger.warn('sync warm launch: catch-up hit the page cap; poll continues the tail')
 }
 
 // Re-fire once a workspace is selected: an early subscribe (or a hydrate that
@@ -164,6 +246,43 @@ const SCHEMA_VERSIONS: Partial<Record<SyncAggregate, number>> = {
   cycle: 1,
   documentation_page: 1,
   documentation_collection: 1,
+}
+
+/**
+ * Tag identifying the client aggregate versions the cache was written under.
+ * Compared in partitionWarmGroups: rows persisted under a different map may
+ * have been filtered out on rehydrate, and only a full bootstrap re-fetches
+ * them, so any mismatch disqualifies the warm path wholesale.
+ */
+const MODEL_VERSIONS_TAG = JSON.stringify(SCHEMA_VERSIONS)
+
+/**
+ * Drop bootstrap watermarks for groups that are NOT subscribed at the moment
+ * this session first advances the cursor. From that advance on, the cursor
+ * moves past events those groups never apply, so their cached rows stop
+ * tracking it: a later launch must snapshot them again, not delta from a
+ * cursor they don't match. Runs once per session, and must complete BEFORE
+ * the first advanced cursor is persisted — a crash that persisted the moved
+ * cursor but kept the stale watermark would revive the torn cache as warm.
+ */
+let watermarksPruned = false
+
+async function pruneTornWatermarks(): Promise<void> {
+  if (watermarksPruned) return
+  watermarksPruned = true
+  if (!state.handle) return
+  const marks = (await idb.getGroupWatermarks(state.handle)) ?? {}
+  const subscribed = pool.getSubscribedGroups()
+  const kept: Record<string, number> = {}
+  for (const [g, xid8] of Object.entries(marks)) {
+    if (subscribed.has(g)) kept[g] = xid8
+  }
+  if (Object.keys(kept).length !== Object.keys(marks).length) {
+    logger.info('sync: pruning watermarks for unsubscribed groups', {
+      dropped: Object.keys(marks).filter((g) => !subscribed.has(g)),
+    })
+    await idb.replaceGroupWatermarks(state.handle, kept)
+  }
 }
 
 /**
@@ -362,9 +481,10 @@ export async function fetchServerIdentity(): Promise<{
 }
 
 /**
- * Subscribe to a sync group. If the group isn't already in the
- * pool, fetches a per-group bootstrap. Idempotent — calling twice
- * with the same group runs no extra work.
+ * Subscribe to a sync group. If the group isn't already in the pool, brings
+ * it current: a delta catch-up when its snapshot is warm-cached from a prior
+ * session, else a full per-group bootstrap. Idempotent — calling twice with
+ * the same group runs no extra work.
  */
 export async function subscribe(group: string): Promise<void> {
   if (pool.getSubscribedGroups().has(group)) return
@@ -376,7 +496,7 @@ export async function subscribe(group: string): Promise<void> {
     logger.warn('subscribe() deferred: runtime not ready', { group })
     return
   }
-  await runBootstrap([group])
+  await bringGroupsCurrent([group])
 }
 
 /**
@@ -436,10 +556,10 @@ async function resyncFromRetentionGap(): Promise<void> {
   }
 }
 
-export async function pullDelta(): Promise<void> {
-  if (!canFetchWorkspace()) return
+export async function pullDelta(): Promise<boolean> {
+  if (!canFetchWorkspace()) return false
   const groups = Array.from(pool.getSubscribedGroups())
-  if (groups.length === 0) return
+  if (groups.length === 0) return false
   const from = pool.getLastSyncId()
   const fromXid8 = pool.getLastXid8()
   // Send the commit-safe `from_xid8` only once a real xid8 has seeded
@@ -452,16 +572,27 @@ export async function pullDelta(): Promise<void> {
     const res = await syncFetch(url)
     if (!res.ok) {
       logger.warn('sync delta failed', { status: res.status })
-      return
+      return false
     }
     const body = (await res.json()) as DeltaResponse
     if (body.resync_required) {
       // Return without applying: this page is a partial view of a span we
       // cannot complete, and the re-bootstrap replaces it wholesale.
       await resyncFromRetentionGap()
-      return
+      return false
+    }
+    // Every delta carries current capability flags (absent only from an
+    // older backend or a failed server-side probe, where keeping the
+    // current flags is right). This is what keeps feature chrome correct
+    // on a warm launch that never re-streams the bootstrap `__meta__`.
+    if (body.capabilities) {
+      applyWorkspaceCapabilities(body.capabilities)
     }
     applyActions(body.actions)
+    // Torn-cache prune must land before the advanced cursor is persisted
+    // (see pruneTornWatermarks).
+    await pruneTornWatermarks()
+    state.caughtUp = true
     pool.setCursor(body.last_xid8, body.last_sync_id)
     if (state.handle) {
       await idb.setLastSyncId(state.handle, body.last_sync_id)
@@ -471,8 +602,10 @@ export async function pullDelta(): Promise<void> {
     // (useSyncActions) stay live even when SSE is wedged and this 10s
     // poll is the delivery path.
     notifySyncActions(body.actions)
+    return body.has_more
   } catch (e) {
     logger.warn('sync delta network error', { error: e })
+    return false
   }
 }
 
@@ -560,12 +693,28 @@ async function runBootstrap(groups: string[]): Promise<void> {
         // advance the cursor.
         await flushPersistBatch()
         if (bootstrapMeta) {
+          // The end line advances the cursor to now, which tears any cached
+          // group not currently subscribed; prune before persisting.
+          await pruneTornWatermarks()
+          state.caughtUp = true
           // Advance the in-memory cursor always; persist it only when IDB is
           // available (memory-only keeps the cursor in the pool for delta polls).
           pool.setCursor(bootstrapMeta.last_xid8, bootstrapMeta.last_sync_id)
           if (state.handle) {
             await idb.setLastSyncId(state.handle, bootstrapMeta.last_sync_id)
             await idb.setLastXid8(state.handle, bootstrapMeta.last_xid8)
+            // Watermark the snapshots the server actually granted (not the
+            // request list: a requested-but-denied group must not gain a
+            // watermark or the next launch would warm-path it into
+            // emptiness) + stamp the aggregate versions they were written
+            // under, so the next launch can bring these groups current
+            // with a delta instead of re-streaming the snapshot.
+            const granted = bootstrapMeta.groups_granted ?? []
+            const completed = groups.filter((g) => granted.includes(g))
+            if (completed.length > 0) {
+              await idb.setGroupWatermarks(state.handle, completed, bootstrapMeta.last_xid8)
+            }
+            await idb.setModelVersionsTag(state.handle, MODEL_VERSIONS_TAG)
           }
         }
       } else if ('__error__' in line) {
@@ -763,10 +912,24 @@ async function fetchMissingCycles(ids: string[]): Promise<void> {
 /** SSE handler: applies actions, advances the cursor, persists. */
 export function applySseFrame(actions: SyncAction[], lastXid8: number, lastSyncId: number): void {
   applyActions(actions)
+  // Until the session's first catch-up completes, a frame's rows apply but
+  // the cursor holds at its cached value: jumping it to the frame's "now"
+  // would make the in-flight catch-up delta skip the whole offline span
+  // (see LifecycleState.caughtUp). The catch-up re-delivers these events.
+  if (!state.caughtUp) {
+    notifySyncActions(actions)
+    return
+  }
   pool.setCursor(lastXid8, lastSyncId)
   if (state.handle) {
-    void idb.setLastSyncId(state.handle, lastSyncId)
-    void idb.setLastXid8(state.handle, lastXid8)
+    const handle = state.handle
+    // Prune-then-persist, sequenced: the advanced cursor must never be
+    // persisted ahead of the torn-watermark prune (see pruneTornWatermarks).
+    void (async () => {
+      await pruneTornWatermarks()
+      await idb.setLastSyncId(handle, lastSyncId)
+      await idb.setLastXid8(handle, lastXid8)
+    })()
   }
   // Notify imperative observers (useSyncActions) after the pool is
   // updated. This is the live SSE path, so observers fire on the
@@ -788,6 +951,8 @@ export async function tearDown(): Promise<void> {
   state.memoryOnly = false
   state.openArgs = null
   state.resyncing = false
+  state.caughtUp = false
+  watermarksPruned = false
   // Re-arm the single-flight bootstrap so the next navigation rebuilds the
   // runtime for the new session / workspace.
   runtimePromise = null

--- a/packages/core/src/sync/types.ts
+++ b/packages/core/src/sync/types.ts
@@ -78,6 +78,14 @@ export interface DeltaResponse {
    * The client must wipe its cache and re-bootstrap. Optional so a client
    * running against an older backend simply never sees it. */
   resync_required?: boolean
+  /** Current workspace capability flags, same shape as the bootstrap
+   * `__meta__` flags. Carried on every delta so a warm launch that catches
+   * up without re-streaming the snapshot still converges on current flags.
+   * Absent (older backend, or a failed probe server-side) means "keep the
+   * flags you have". */
+  capabilities?: {
+    sla_enabled?: boolean
+  }
 }
 
 export interface BootstrapMeta {


### PR DESCRIPTION
Reimplements the goal of the deleted `fix/tickets-cache-first-launch` branch on main's current contracts. That branch predated the server-side `resync_required` signal and compensated with client-side wall-clock heuristics (a hardcoded 45-day retention guess) and a persisted capability mirror; both are unnecessary now, so rather than rebasing ~90 commits of divergence this rebuilds the one surviving idea cleanly.

**What changes:** a warm launch no longer re-streams the full workspace snapshot. Bootstrap completion writes per-group watermarks (granted groups only) plus a client aggregate-versions tag; the launch drain and `subscribe()` send watermarked, version-consistent groups through a paged `pullDelta()` from the cached commit-safe cursor, and bootstrap only the rest, delta first so a snapshot end cannot advance the global cursor past unapplied events. Staleness stays entirely the server's `resync_required` call.

**Two invariants close the subtle holes:**
- Watermarks are pruned for any group not subscribed at the moment a session first advances the cursor, sequenced before that cursor persists. A deep-link-only session (only `ticket:N` subscribed) can no longer silently tear another group's cache into a trusted-but-stale state.
- Until the session's first catch-up completes, SSE frames apply their rows but do not advance the cursor. Without this, a busy workspace's frame arriving before the catch-up delta would jump the cursor past the offline span and its events would be skipped permanently.

**Capabilities:** flags now ride every delta response via a shared `capability_flags()` (absent field = keep current flags), so skipping the snapshot cannot strand feature chrome, and an admin flipping a flag reaches running clients within one poll instead of at their next launch. `applyWorkspaceCapabilities` no-ops on unchanged flags.

**Verification:** cold visit = one bootstrap; warm relaunch = zero bootstraps, one delta from the cached cursor, list painted from cache; a ticket created while the page was closed appears at the top of the warm-launched list; delta body carries `sla_enabled`. A committed Playwright spec (`e2e/warm-delta.spec.ts`) locks in the transport contract. Backend sync tests 78/78; full local suite green except the known `boot_smoke` `/readiness` contention flake, which passes in isolation.