### PR TITLE
Redesign the documentation index as a library ledger

### DIFF
--- a/frontend/src/components/documentationComponents/CollectionBrowser.vue
+++ b/frontend/src/components/documentationComponents/CollectionBrowser.vue
@@ -1,15 +1,23 @@
 <script setup lang="ts">
+/**
+ * The documentation index's library: one ledger row per collection with its
+ * top pages inline, so a known page is one click from the index instead of
+ * a click into each collection. Collection metadata (visibility, counts)
+ * comes from the REST endpoint as before; each row's top pages and
+ * last-updated derive live from the sync pool.
+ */
 import { computed, ref, onMounted } from 'vue'
 import { RouterLink } from 'vue-router'
 import { useFluent } from 'fluent-vue'
 import { getCollections, reorderCollections } from '@nosdesk/core/services/collectionService'
 import type { CollectionWithDetails } from '@nosdesk/core/services/collectionService'
+import { useSyncDocsStore, isActivePage, type DocPageRow } from '@nosdesk/core/sync/stores/documentation'
+import { docUrl } from '@nosdesk/core/utils/docUrl'
+import { formatRelativeTime } from '@nosdesk/core/utils/dateUtils'
 import { useAuthStore } from '@/stores/auth'
 import Skeleton from '@/components/common/Skeleton.vue'
 import SkeletonBar from '@/components/common/SkeletonBar.vue'
-import Button from '@/components/common/Button.vue'
 import Icon from '@/components/common/Icon.vue'
-import AvatarStack from '@/components/common/AvatarStack.vue'
 import CollectionIcon from '@/components/documentationComponents/CollectionIcon.vue'
 
 const emit = defineEmits<{
@@ -20,6 +28,7 @@ const fluent = useFluent()
 const t = (key: string, args?: Record<string, string | number>) => fluent.$t(key, args)
 
 const authStore = useAuthStore()
+const docs = useSyncDocsStore()
 const collections = ref<CollectionWithDetails[]>([])
 const loading = ref(true)
 
@@ -33,8 +42,44 @@ const skeletonCount = computed(() =>
   collections.value.length > 0 ? Math.min(collections.value.length, 6) : 3,
 )
 
-function memberUuids(collection: CollectionWithDetails): string[] {
-  return collection.visible_to_users.map((u) => u.uuid)
+/** How many page links a ledger row carries before "N more". */
+const TOP_PAGES = 3
+
+interface LedgerDerived {
+  topPages: DocPageRow[]
+  moreCount: number
+  updatedAt: string | null
+}
+
+/** Active pages per collection from the sync pool, newest first. */
+const derivedByCollection = computed<Map<number, LedgerDerived>>(() => {
+  const byCollection = new Map<number, DocPageRow[]>()
+  for (const page of docs.allPages) {
+    if (page.collection_id == null || !isActivePage(page)) continue
+    const rows = byCollection.get(page.collection_id)
+    if (rows) rows.push(page)
+    else byCollection.set(page.collection_id, [page])
+  }
+  const out = new Map<number, LedgerDerived>()
+  for (const [id, rows] of byCollection) {
+    rows.sort((a, b) => (b.updated_at ?? '').localeCompare(a.updated_at ?? ''))
+    out.set(id, {
+      topPages: rows.slice(0, TOP_PAGES),
+      moreCount: Math.max(rows.length - TOP_PAGES, 0),
+      updatedAt: rows[0]?.updated_at ?? null,
+    })
+  }
+  return out
+})
+
+function derived(collection: CollectionWithDetails): LedgerDerived {
+  return (
+    derivedByCollection.value.get(collection.id) ?? {
+      topPages: [],
+      moreCount: 0,
+      updatedAt: null,
+    }
+  )
 }
 
 function audienceLabel(collection: CollectionWithDetails): string {
@@ -57,10 +102,6 @@ function audienceLabel(collection: CollectionWithDetails): string {
     return t('docs-collection-browser-members-count', { count: users })
   }
   return t('docs-collection-browser-audience-mixed', { groups, users })
-}
-
-function pageCountLabel(count: number): string {
-  return t('docs-collection-browser-pages', { count })
 }
 
 const loadCollections = async () => {
@@ -124,175 +165,130 @@ onMounted(loadCollections)
 </script>
 
 <template>
-  <section class="flex flex-col gap-3">
-    <header class="flex items-center justify-between gap-3 min-h-8">
-      <div class="flex items-center gap-2 min-w-0">
-        <h2 class="text-sm font-semibold text-primary tracking-tight truncate">
-          {{ $t('docs-collection-browser-heading') }}
-        </h2>
-        <span
-          v-if="collections.length > 0"
-          class="shrink-0 inline-flex items-center h-5 px-1.5 rounded-md bg-surface-alt border border-subtle text-[11px] text-tertiary tabular-nums"
-        >
-          {{ collections.length }}
-        </span>
-      </div>
-      <Button
-        size="sm"
-        variant="ghost"
-        icon="add"
-        class="shrink-0 -mr-2"
+  <!-- @container: row extras (description, freshness) key off the card's own
+       width, so the ledger degrades gracefully in a narrow main column. -->
+  <section class="@container bg-surface rounded-xl border border-default overflow-hidden">
+    <header class="flex items-center gap-2 px-3 h-9 border-b border-default bg-surface-alt">
+      <h2 class="text-[13px] font-semibold text-primary tracking-tight truncate flex-1">
+        {{ $t('docs-index-library-heading') }}
+      </h2>
+      <span v-if="collections.length > 0" class="text-[11px] text-tertiary tabular-nums">
+        {{ $t('docs-index-library-count', { count: collections.length }) }}
+      </span>
+      <button
+        type="button"
+        class="text-[11px] font-medium text-accent hover:underline whitespace-nowrap"
         @click="emit('create')"
       >
         {{ $t('docs-collection-browser-new') }}
-      </Button>
+      </button>
     </header>
 
     <Skeleton
       v-if="showSkeleton"
       :label="$t('docs-collection-browser-loading-label')"
-      class="docs-collection-grid"
+      class="flex flex-col"
     >
       <div
         v-for="i in skeletonCount"
         :key="i"
-        class="flex flex-col gap-2 p-2.5 rounded-xl bg-surface border border-default"
+        class="flex items-start gap-3.5 px-4 py-3.5 border-b border-subtle last:border-b-0"
       >
-        <div class="flex items-start gap-2">
-          <SkeletonBar class="w-5 h-5 rounded shrink-0" />
-          <div class="flex-1 flex flex-col gap-1.5 min-w-0">
-            <div class="flex items-center gap-2">
-              <SkeletonBar class="h-3 flex-1" />
-              <SkeletonBar class="h-4 w-7 rounded shrink-0" />
-            </div>
-            <SkeletonBar class="h-2.5 w-full" />
-          </div>
+        <SkeletonBar class="w-8 h-8 rounded-lg shrink-0" />
+        <div class="flex-1 flex flex-col gap-2 min-w-0">
+          <SkeletonBar class="h-3.5 w-2/5" />
+          <SkeletonBar class="h-3 w-4/5" />
         </div>
-        <div class="flex items-center gap-2 pl-7">
-          <SkeletonBar class="h-4 w-4 rounded-full shrink-0" />
-          <SkeletonBar class="h-2.5 w-20" />
-        </div>
+        <SkeletonBar class="h-3 w-16 shrink-0" />
       </div>
     </Skeleton>
 
-    <ul
-      v-else-if="collections.length > 0"
-      class="docs-collection-grid"
-    >
-      <li v-for="(collection, index) in collections" :key="collection.id">
-        <RouterLink
-          :to="`/documentation/collections/${collection.slug}`"
-          :draggable="canReorder"
-          @dragstart="canReorder && onDragStart(index, $event)"
-          @dragover="canReorder && onDragOver(index, $event)"
-          @dragleave="canReorder && onDragLeave()"
-          @drop.prevent="canReorder && onDrop(index)"
-          @dragend="canReorder && onDragEnd()"
-          class="group flex flex-col gap-1.5 p-2.5 h-full rounded-xl bg-surface border border-default hover:border-accent/50 hover:shadow-sm transition-[border-color,box-shadow,background-color]"
-          :class="{
-            'opacity-50': dragIndex === index,
-            'ring-2 ring-inset ring-accent/40': dropIndex === index,
-            'cursor-grab': canReorder,
-          }"
-        >
-          <div class="flex items-start gap-2 min-w-0">
-            <CollectionIcon
-              :icon="collection.icon"
-              :color="collection.color"
-              size="md"
-            />
-            <div class="min-w-0 flex-1">
-              <div class="flex items-start gap-2 min-w-0">
-                <h3 class="text-[13px] font-medium text-primary truncate leading-snug flex-1 min-w-0 group-hover:text-accent transition-colors">
-                  {{ collection.name }}
-                </h3>
-                <span
-                  class="shrink-0 inline-flex items-center gap-0.5 h-5 px-1.5 rounded-md bg-surface-alt border border-subtle text-[11px] font-medium text-secondary tabular-nums"
-                  :title="pageCountLabel(collection.page_count)"
-                >
-                  <Icon name="document" size="xs" class="opacity-60" aria-hidden="true" />
-                  {{ collection.page_count }}
-                </span>
-              </div>
-              <p
-                v-if="collection.description"
-                class="text-[11px] text-tertiary mt-0.5 line-clamp-1 leading-snug"
-              >
-                {{ collection.description }}
-              </p>
-            </div>
-          </div>
+    <ul v-else-if="collections.length > 0" class="flex flex-col">
+      <li
+        v-for="(collection, index) in collections"
+        :key="collection.id"
+        :draggable="canReorder"
+        class="group flex items-start gap-3.5 px-4 py-3.5 border-b border-subtle last:border-b-0 hover:bg-surface-hover/50 transition-colors"
+        :class="{
+          'opacity-50': dragIndex === index,
+          'ring-2 ring-inset ring-accent/40': dropIndex === index,
+          'cursor-grab': canReorder,
+        }"
+        @dragstart="canReorder && onDragStart(index, $event)"
+        @dragover="canReorder && onDragOver(index, $event)"
+        @dragleave="canReorder && onDragLeave()"
+        @drop.prevent="canReorder && onDrop(index)"
+        @dragend="canReorder && onDragEnd()"
+      >
+        <CollectionIcon :icon="collection.icon" :color="collection.color" size="md" />
 
-          <div class="flex items-center gap-1.5 min-w-0 pl-7 text-[11px] leading-none">
-            <template v-if="collection.is_public">
-              <Icon name="team" size="xs" class="shrink-0 text-tertiary opacity-70" aria-hidden="true" />
-              <span class="truncate text-tertiary">{{ $t('collection-badge-public') }}</span>
-            </template>
-            <template v-else>
-              <AvatarStack
-                v-if="memberUuids(collection).length > 0"
-                :uuids="memberUuids(collection)"
-                :max="3"
-                size="xxs"
-              />
-              <Icon
-                v-else-if="collection.visible_to_groups.length > 0"
-                name="team"
-                size="xs"
-                class="shrink-0 text-tertiary opacity-70"
-                aria-hidden="true"
-              />
-              <Icon
-                v-else
-                name="lock"
-                size="xs"
-                class="shrink-0 text-status-warning/80"
-                aria-hidden="true"
-              />
-              <span class="truncate min-w-0 text-tertiary">{{ audienceLabel(collection) }}</span>
-            </template>
-
-            <span
-              v-if="collection.is_system"
-              class="shrink-0 ml-auto px-1.5 py-0.5 rounded bg-surface-hover text-tertiary"
+        <div class="flex flex-col gap-1 min-w-0 flex-1">
+          <div class="flex items-baseline gap-2 min-w-0">
+            <RouterLink
+              :to="`/documentation/collections/${collection.slug}`"
+              class="text-sm font-semibold text-primary tracking-tight hover:text-accent transition-colors shrink-0 max-w-full truncate"
             >
-              {{ $t('docs-collection-browser-system-badge') }}
+              {{ collection.name }}
+            </RouterLink>
+            <span
+              v-if="!collection.is_public"
+              class="shrink-0 inline-flex items-center gap-1 self-center text-[11px] text-tertiary border border-subtle rounded-md px-1.5 py-px bg-surface-alt"
+            >
+              <Icon name="lock" size="xs" class="text-status-warning/80" aria-hidden="true" />
+              {{ audienceLabel(collection) }}
+            </span>
+            <span
+              v-if="collection.description"
+              class="hidden @2xl:inline text-xs text-tertiary truncate min-w-0"
+            >
+              {{ collection.description }}
             </span>
           </div>
-        </RouterLink>
+
+          <div
+            v-if="derived(collection).topPages.length > 0"
+            class="flex items-center gap-x-1.5 gap-y-0.5 flex-wrap text-xs"
+          >
+            <!-- Separator rides inside each item so a wrap never strands a
+                 lone dot at a line edge. -->
+            <span
+              v-for="(page, i) in derived(collection).topPages"
+              :key="page.id"
+              class="flex items-center gap-1.5 min-w-0"
+            >
+              <span v-if="i > 0" class="text-strong" aria-hidden="true">·</span>
+              <RouterLink
+                :to="docUrl(page)"
+                class="text-secondary hover:text-accent transition-colors truncate max-w-[16rem]"
+              >
+                {{ page.title }}
+              </RouterLink>
+            </span>
+            <span v-if="derived(collection).moreCount > 0" class="flex items-center gap-1.5">
+              <span class="text-strong" aria-hidden="true">·</span>
+              <RouterLink
+                :to="`/documentation/collections/${collection.slug}`"
+                class="text-tertiary hover:text-accent transition-colors whitespace-nowrap"
+              >
+                {{ $t('docs-index-library-more-pages', { count: derived(collection).moreCount }) }}
+              </RouterLink>
+            </span>
+          </div>
+        </div>
+
+        <div class="flex flex-col items-end gap-1 shrink-0 text-[11px] text-tertiary whitespace-nowrap">
+          <span class="font-medium text-secondary tabular-nums">
+            {{ $t('docs-collection-browser-pages', { count: collection.page_count }) }}
+          </span>
+          <span v-if="derived(collection).updatedAt" class="hidden @xl:inline">
+            {{ $t('docs-index-library-updated', { time: formatRelativeTime(derived(collection).updatedAt!, { addSuffix: true }) }) }}
+          </span>
+        </div>
       </li>
     </ul>
 
-    <p v-else class="text-[13px] text-tertiary py-2">
+    <p v-else class="text-[13px] text-tertiary px-4 py-3">
       {{ $t('docs-collection-browser-empty') }}
     </p>
   </section>
 </template>
-
-<style scoped>
-.docs-collection-grid {
-  display: grid;
-  gap: 0.75rem;
-  grid-template-columns: 1fr;
-}
-
-@media (min-width: 480px) {
-  .docs-collection-grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 0.875rem;
-  }
-}
-
-@media (min-width: 768px) {
-  .docs-collection-grid {
-    grid-template-columns: repeat(auto-fill, minmax(14rem, 1fr));
-  }
-}
-
-@media (min-width: 1280px) {
-  .docs-collection-grid {
-    grid-template-columns: repeat(auto-fill, minmax(16rem, 1fr));
-    gap: 1rem;
-  }
-}
-</style>

--- a/frontend/src/components/documentationComponents/DocumentationHubRow.vue
+++ b/frontend/src/components/documentationComponents/DocumentationHubRow.vue
@@ -24,6 +24,9 @@ const props = defineProps<{
   updatedAt?: string | null
   /** Plain inline meta — verification labels, child counts, etc. */
   meta?: string
+  /** Rail mode: avatar + compact time only, no author name. Keeps the
+   *  title readable inside a narrow column regardless of viewport. */
+  compact?: boolean
 }>()
 
 const destination = computed(() => {
@@ -78,25 +81,29 @@ const fullTime = computed(() =>
         :clickable="false"
       />
       <template v-if="author?.name">
-        <span class="sr-only sm:hidden">{{ author.name }}</span>
-        <span class="hidden sm:inline truncate max-w-[8rem] text-[11px] leading-none text-tertiary">
+        <span class="sr-only" :class="{ 'sm:hidden': !compact }">{{ author.name }}</span>
+        <span
+          v-if="!compact"
+          class="hidden sm:inline truncate max-w-[8rem] text-[11px] leading-none text-tertiary"
+        >
           {{ author.name }}
         </span>
       </template>
       <span
-        v-if="author?.name && fullTime"
+        v-if="!compact && author?.name && fullTime"
         class="hidden sm:inline text-[11px] text-tertiary/60 shrink-0"
         aria-hidden="true"
       >·</span>
       <span
         v-if="compactTime"
-        class="sm:hidden text-[11px] leading-none text-tertiary whitespace-nowrap tabular-nums shrink-0"
+        class="text-[11px] leading-none text-tertiary whitespace-nowrap tabular-nums shrink-0"
+        :class="{ 'sm:hidden': !compact }"
         :title="fullTime"
       >
         {{ compactTime }}
       </span>
       <span
-        v-if="fullTime"
+        v-if="!compact && fullTime"
         class="hidden sm:inline text-[11px] leading-none text-tertiary whitespace-nowrap tabular-nums shrink-0"
       >
         {{ fullTime }}

--- a/frontend/src/components/documentationComponents/DocumentationIndexToolbar.vue
+++ b/frontend/src/components/documentationComponents/DocumentationIndexToolbar.vue
@@ -10,7 +10,7 @@ import { useRouter } from 'vue-router'
 import { useFluent } from 'fluent-vue'
 import { useAuthStore } from '@/stores/auth'
 import { usePublicSettingsStore } from '@nosdesk/core/stores/publicSettings'
-import { useSyncDocsStore } from '@nosdesk/core/sync/stores/documentation'
+import { useSyncDocsStore, isActivePage } from '@nosdesk/core/sync/stores/documentation'
 import { useGlobalSearch } from '@/composables/useGlobalSearch'
 import { useDetectClustersMutation } from '@/composables/useKnowledgeGaps'
 import { useToastStore } from '@nosdesk/core/stores/toast'
@@ -45,6 +45,11 @@ const archivedCount = computed(
 const trashCount = computed(
   () => docs.allPages.filter((p) => p.status === 'deleted').length,
 )
+
+// Header stats: active pages + collection count, so the index states its
+// scope up front instead of leaving the reader to infer it.
+const activePageCount = computed(() => docs.allPages.filter(isActivePage).length)
+const collectionCount = computed(() => docs.allCollections.length)
 
 const publicDocsEnabled = computed(
   () => publicSettings.settings?.guest_public_docs_enabled === true,
@@ -181,17 +186,22 @@ onMounted(() => {
 
 <template>
   <div class="flex items-center justify-between gap-4 w-full min-w-0">
-    <div class="flex items-center gap-2 min-w-0">
-      <Button
-        size="sm"
-        variant="secondary"
-        icon="search"
-        class="shrink-0"
+    <p class="hidden @3xl:block text-xs text-tertiary truncate min-w-0">
+      {{ $t('docs-index-toolbar-stats', { pages: activePageCount, collections: collectionCount }) }}
+    </p>
+
+    <div class="flex items-center gap-2 min-w-0 flex-1 @3xl:flex-none @3xl:ml-auto">
+      <!-- Search leads: styled as the field it opens, not a button. -->
+      <button
+        type="button"
+        class="flex items-center gap-2.5 h-8 px-3 flex-1 @3xl:flex-none @3xl:w-[360px] min-w-0 rounded-lg bg-surface-alt border border-default text-tertiary hover:border-strong hover:text-secondary transition-colors"
         :aria-label="$t('docs-index-toolbar-search')"
         @click="openDocSearch"
       >
-        {{ $t('docs-index-toolbar-search') }}
-      </Button>
+        <Icon name="search" size="sm" aria-hidden="true" />
+        <span class="text-[13px] truncate flex-1 text-left">{{ $t('docs-index-toolbar-search-placeholder') }}</span>
+        <kbd class="hidden sm:inline-flex items-center text-[11px] px-1.5 py-px rounded border border-default bg-surface text-tertiary">⌘K</kbd>
+      </button>
 
       <Button
         size="sm"

--- a/frontend/src/views/DocumentationIndexView.vue
+++ b/frontend/src/views/DocumentationIndexView.vue
@@ -38,7 +38,7 @@ const titleManager = useTitleManager()
 const scrollEl = ref<HTMLElement | null>(null)
 
 const { createNewPage } = useDocumentation()
-const { allTree: pages, drafts: uncollectedPages } = useDocPages()
+const { allTree: pages } = useDocPages()
 const docs = useSyncDocsStore()
 const { gaps, isLoading: gapsLoading } = useKnowledgeGaps()
 
@@ -73,18 +73,14 @@ const recentlyUpdated = computed<Page[]>(() => {
   return flat
     .filter((p) => p.updated_at && p.status !== 'archived')
     .sort((a, b) => (b.updated_at ?? '').localeCompare(a.updated_at ?? ''))
-    .slice(0, 12)
+    .slice(0, 6)
 })
 
-const visibleStarred = computed(() => starredPages.value.slice(0, 10))
+const visibleStarred = computed(() => starredPages.value.slice(0, 8))
 
-const visibleGaps = computed(() => gaps.value.slice(0, 6))
-
-const visibleUncollected = computed<Page[]>(() =>
-  [...uncollectedPages.value]
-    .sort((a, b) => (b.updated_at ?? '').localeCompare(a.updated_at ?? ''))
-    .slice(0, 12),
-)
+/** The attention rail keeps each queue short; the full lists live behind
+ *  the footer links. */
+const visibleGaps = computed(() => gaps.value.slice(0, 3))
 
 /** Collection ids whose pages require verification. Used to gate the
  *  never-verified case so unverified pages in neutral collections
@@ -110,10 +106,12 @@ const verificationAttention = computed<Page[]>(() => {
     }
     return (b.updated_at ?? '').localeCompare(a.updated_at ?? '')
   })
-  return rows.slice(0, 10).map((r) => toPage(r))
+  return rows.slice(0, 3).map((r) => toPage(r))
 })
 
 const verificationCount = computed(() => docs.allPages.filter(pageNeedsAttention).length)
+
+const attentionCount = computed(() => gapCount.value + verificationCount.value)
 
 const totalPages = computed(() => flattenTree(pages.value).length)
 
@@ -124,17 +122,6 @@ function onCollectionCreated() {
 
 function pageAuthor(page: Page) {
   return page.last_edited_by ?? page.created_by
-}
-
-function gapMeta(gap: KnowledgeGap): string {
-  const parts: string[] = []
-  if (gap.evidence_count > 0) {
-    parts.push(t('docs-index-gap-evidence', { count: gap.evidence_count }))
-  }
-  if (gap.last_evidence_at) {
-    parts.push(formatRelativeTime(gap.last_evidence_at))
-  }
-  return parts.join(' · ')
 }
 
 function isSearchGap(title: string): boolean {
@@ -149,11 +136,9 @@ function gapImpactLabel(gap: KnowledgeGap): string {
 
 function verificationMeta(page: Page): string {
   if (!page.verified_at) {
-    return t('doc-detail-needs-verification')
+    return t('docs-index-verification-never')
   }
-  return t('docs-index-verification-stale-meta', {
-    time: formatRelativeTime(page.verified_at),
-  })
+  return formatRelativeTime(page.verified_at, { addSuffix: true })
 }
 
 onMounted(() => {
@@ -167,7 +152,7 @@ usePageCreateAction(handleCreatePage)
   <div class="flex-1 flex flex-col min-h-0">
     <PullToRefresh :target="scrollEl" />
     <header class="shrink-0 border-b border-subtle bg-surface">
-      <div class="px-4 sm:px-6 py-2.5 mx-auto w-full max-w-8xl">
+      <div class="@container px-4 sm:px-6 py-2.5 mx-auto w-full max-w-8xl">
         <DocumentationIndexToolbar @create-collection="showCreateCollectionModal = true" />
       </div>
     </header>
@@ -179,243 +164,186 @@ usePageCreateAction(handleCreatePage)
       @created="onCollectionCreated"
     />
 
-    <div ref="scrollEl" class="flex-1 min-h-0 overflow-auto">
-      <div class="flex flex-col gap-4 sm:gap-5 px-4 sm:px-6 py-4 mx-auto w-full max-w-8xl">
-        <CollectionBrowser
-          ref="collectionBrowserRef"
-          @create="showCreateCollectionModal = true"
-        />
+    <!-- @container: the two-column split keys off THIS panel's width, not the
+         viewport, so the layout stays correct whatever the nav sidebar does
+         (same convention as the gantt). -->
+    <div ref="scrollEl" class="@container flex-1 min-h-0 overflow-auto">
+      <div class="docs-index-layout px-4 sm:px-6 py-4 mx-auto w-full max-w-8xl">
+        <!-- Main column: the library leads; drafts collapse to one strip. -->
+        <div class="flex flex-col gap-4 sm:gap-5 min-w-0">
+          <CollectionBrowser
+            ref="collectionBrowserRef"
+            @create="showCreateCollectionModal = true"
+          />
 
-        <EmptyState
-          v-if="totalPages === 0"
-          variant="compact"
-          icon="document"
-          :title="$t('empty-documentation-index-title')"
-          :description="$t('empty-documentation-index-description')"
-          :action-label="$t('docs-index-new-page')"
-          @action="handleCreatePage"
-        />
+          <EmptyState
+            v-if="totalPages === 0"
+            variant="compact"
+            icon="document"
+            :title="$t('empty-documentation-index-title')"
+            :description="$t('empty-documentation-index-description')"
+            :action-label="$t('docs-index-new-page')"
+            @action="handleCreatePage"
+          />
 
-        <template v-if="totalPages > 0">
-          <div class="docs-index-pages-grid">
-            <SectionCard content-padding="p-1">
-              <template #title>{{ $t('docs-index-recently-updated') }}</template>
-              <template #headerActions>
-                <span
-                  v-if="recentlyUpdated.length > 0"
-                  class="text-[11px] text-tertiary tabular-nums font-normal"
-                >
-                  {{ $t('docs-index-recently-updated-count', { count: recentlyUpdated.length }) }}
-                </span>
-              </template>
-              <ul v-if="recentlyUpdated.length > 0" class="flex flex-col">
-                <li v-for="page in recentlyUpdated" :key="page.id">
-                  <DocumentationHubRow
-                    :page="page"
-                    :author="pageAuthor(page)"
-                    :updated-at="page.updated_at"
-                  />
-                </li>
-              </ul>
-              <p v-else class="px-2 py-2 text-[13px] text-tertiary">
-                {{ $t('docs-index-no-recent-activity') }}
-              </p>
-            </SectionCard>
-
-            <SectionCard content-padding="p-1">
-              <template #title>{{ $t('docs-index-starred') }}</template>
-              <template #headerActions>
-                <span
-                  v-if="visibleStarred.length > 0"
-                  class="text-[11px] text-tertiary tabular-nums font-normal"
-                >
-                  {{ starredPages.length }}
-                </span>
-              </template>
-              <ul v-if="visibleStarred.length > 0" class="flex flex-col">
-                <li v-for="sp in visibleStarred" :key="sp.page_id">
-                  <DocumentationHubRow
-                    :href="docUrl({ slug: sp.slug, id: sp.page_id })"
-                    :title="sp.title"
-                    :icon="sp.icon"
-                  />
-                </li>
-              </ul>
-              <p v-else class="px-2 py-2 text-[13px] text-tertiary">
-                {{ $t('docs-index-starred-hint') }}
-              </p>
-            </SectionCard>
-          </div>
-
-          <div class="docs-index-queue-grid">
-            <SectionCard
-              content-padding="p-1"
-              action-to="/documentation/gaps"
-              :action-label="$t('docs-index-gaps-view-all')"
-            >
-              <template #title>{{ $t('docs-index-gaps-heading') }}</template>
-              <template #headerActions>
-                <span
-                  v-if="gapCount > 0"
-                  class="text-[11px] text-tertiary tabular-nums font-normal"
-                >
-                  {{ gapCount }}
-                </span>
-              </template>
-              <p v-if="gapsLoading" class="px-2 py-2 text-[13px] text-tertiary">
-                {{ $t('docs-index-gaps-loading') }}
-              </p>
-              <ul v-else-if="visibleGaps.length > 0" class="flex flex-col">
-                <li v-for="gap in visibleGaps" :key="gap.id">
-                  <RouterLink
-                    :to="`/documentation/gaps/${gap.id}`"
-                    class="group flex items-center gap-2 py-1.5 min-h-7 px-2 -mx-2 rounded hover:bg-surface-hover transition-colors"
-                  >
-                    <Icon name="warning" size="xs" class="shrink-0 text-amber-500" aria-hidden="true" />
-                    <div class="flex items-center gap-1.5 min-w-0 flex-1">
-                      <span class="truncate text-[13px] leading-snug text-primary group-hover:text-accent transition-colors">
-                        {{ gap.title }}
-                      </span>
-                      <template v-if="gapMeta(gap)">
-                        <span class="shrink-0 text-[11px] text-tertiary/60" aria-hidden="true">·</span>
-                        <span class="shrink-0 text-[11px] text-tertiary whitespace-nowrap">
-                          {{ gapMeta(gap) }}
-                        </span>
-                      </template>
-                    </div>
-                    <span
-                      class="shrink-0 text-[10px] px-1.5 py-0.5 rounded bg-surface-alt text-tertiary tabular-nums"
-                    >
-                      {{ gapImpactLabel(gap) }}
-                    </span>
-                  </RouterLink>
-                </li>
-              </ul>
-              <p v-else class="px-2 py-2 text-[13px] text-tertiary">
-                {{ $t('docs-index-gaps-empty') }}
-              </p>
-            </SectionCard>
-
-            <SectionCard content-padding="p-1">
-              <template #title>{{ $t('docs-index-verification-heading') }}</template>
-              <template #headerActions>
-                <span
-                  v-if="verificationCount > 0"
-                  class="text-[11px] text-tertiary tabular-nums font-normal"
-                >
-                  {{ verificationCount }}
-                </span>
-              </template>
-              <ul v-if="verificationAttention.length > 0" class="flex flex-col">
-                <li v-for="page in verificationAttention" :key="page.id">
-                  <DocumentationHubRow
-                    :page="page"
-                    :meta="verificationMeta(page)"
-                  />
-                </li>
-              </ul>
-              <p v-else class="px-2 py-2 text-[13px] text-tertiary">
-                {{ $t('docs-index-verification-empty') }}
-              </p>
-            </SectionCard>
-          </div>
-
-          <SectionCard
-            content-padding="p-1"
-            action-to="/documentation/drafts"
-            :action-label="$t('docs-index-uncollected-view-all')"
+          <RouterLink
+            v-if="uncollectedCount > 0"
+            to="/documentation/drafts"
+            class="group flex items-center gap-2.5 px-4 py-2.5 bg-surface rounded-xl border border-default hover:border-strong transition-colors text-xs text-secondary"
           >
-            <template #title>{{ $t('docs-index-uncollected-heading') }}</template>
+            <Icon name="documentEdit" size="sm" class="text-tertiary shrink-0" aria-hidden="true" />
+            <span>
+              <span class="font-medium text-primary">{{ $t('docs-index-drafts-strip-count', { count: uncollectedCount }) }}</span>
+              {{ $t('docs-index-drafts-strip-suffix') }}
+            </span>
+            <span class="ml-auto text-[11px] font-medium text-accent group-hover:underline whitespace-nowrap">
+              {{ $t('docs-index-drafts-strip-review') }}
+            </span>
+          </RouterLink>
+        </div>
+
+        <!-- Rail: attention first, then activity, then personal. -->
+        <div v-if="totalPages > 0" class="flex flex-col gap-4 sm:gap-5 min-w-0">
+          <SectionCard content-padding="p-0" :clip-content="true">
+            <template #title>{{ $t('docs-index-attention-heading') }}</template>
             <template #headerActions>
-              <span class="text-[11px] text-tertiary tabular-nums font-normal">
-                {{ uncollectedCount }}
+              <span
+                v-if="attentionCount > 0"
+                class="inline-flex items-center h-[18px] px-1.5 rounded-full bg-status-warning-muted text-amber-700 text-[11px] font-semibold tabular-nums"
+              >
+                {{ attentionCount }}
               </span>
             </template>
-            <ul v-if="visibleUncollected.length > 0" class="docs-index-uncollected-grid">
-              <li v-for="page in visibleUncollected" :key="page.id">
+
+            <p v-if="gapsLoading && attentionCount === 0" class="px-3 py-2.5 text-[13px] text-tertiary">
+              {{ $t('docs-index-gaps-loading') }}
+            </p>
+            <p v-else-if="attentionCount === 0" class="px-3 py-2.5 text-[13px] text-tertiary">
+              {{ $t('docs-index-attention-empty') }}
+            </p>
+
+            <template v-else>
+              <template v-if="visibleGaps.length > 0">
+                <p class="px-3 pt-2 pb-1 text-[11px] font-semibold text-tertiary uppercase tracking-wide">
+                  {{ $t('docs-index-gaps-heading') }}
+                </p>
+                <ul class="flex flex-col px-1.5">
+                  <li v-for="gap in visibleGaps" :key="gap.id">
+                    <RouterLink
+                      :to="`/documentation/gaps/${gap.id}`"
+                      class="group flex items-center gap-2 py-1.5 px-1.5 rounded hover:bg-surface-hover transition-colors"
+                    >
+                      <Icon name="warning" size="xs" class="shrink-0 text-status-warning" aria-hidden="true" />
+                      <span class="truncate min-w-0 flex-1 text-[13px] leading-snug text-primary group-hover:text-accent transition-colors">
+                        {{ gap.title }}
+                      </span>
+                      <span class="shrink-0 text-[10px] px-1.5 py-0.5 rounded bg-surface-alt text-tertiary tabular-nums whitespace-nowrap">
+                        {{ gapImpactLabel(gap) }}
+                      </span>
+                    </RouterLink>
+                  </li>
+                </ul>
+              </template>
+
+              <template v-if="verificationAttention.length > 0">
+                <p
+                  class="px-3 pt-2 pb-1 text-[11px] font-semibold text-tertiary uppercase tracking-wide"
+                  :class="{ 'border-t border-subtle mt-1': visibleGaps.length > 0 }"
+                >
+                  {{ $t('docs-index-attention-verification') }}
+                </p>
+                <ul class="flex flex-col px-1.5 pb-1.5">
+                  <li v-for="page in verificationAttention" :key="page.id">
+                    <RouterLink
+                      :to="docUrl(page)"
+                      class="group flex items-center gap-2 py-1.5 px-1.5 rounded hover:bg-surface-hover transition-colors"
+                    >
+                      <span class="shrink-0 w-4 text-center text-sm leading-none opacity-80" aria-hidden="true">
+                        {{ page.icon || '📄' }}
+                      </span>
+                      <span class="truncate min-w-0 flex-1 text-[13px] leading-snug text-primary group-hover:text-accent transition-colors">
+                        {{ page.title }}
+                      </span>
+                      <span class="shrink-0 text-[11px] text-amber-700 whitespace-nowrap">
+                        {{ verificationMeta(page) }}
+                      </span>
+                    </RouterLink>
+                  </li>
+                </ul>
+              </template>
+
+              <div class="flex items-center justify-between px-3 py-2 border-t border-default bg-surface-alt/50">
+                <RouterLink to="/documentation/gaps" class="text-[11px] font-medium text-accent hover:underline">
+                  {{ $t('docs-index-attention-gaps-link') }}
+                </RouterLink>
+                <span class="text-[11px] text-tertiary tabular-nums">
+                  {{ $t('docs-index-attention-totals', { gaps: gapCount, stale: verificationCount }) }}
+                </span>
+              </div>
+            </template>
+          </SectionCard>
+
+          <SectionCard content-padding="p-1.5">
+            <template #title>{{ $t('docs-index-recently-updated') }}</template>
+            <ul v-if="recentlyUpdated.length > 0" class="flex flex-col">
+              <li v-for="page in recentlyUpdated" :key="page.id">
                 <DocumentationHubRow
                   :page="page"
-                  :meta="page.children?.length
-                    ? $t('docs-index-page-children', { count: page.children.length })
-                    : undefined"
-                  :author="page.children?.length ? undefined : pageAuthor(page)"
-                  :updated-at="page.children?.length ? undefined : page.updated_at"
+                  :author="pageAuthor(page)"
+                  :updated-at="page.updated_at"
+                  compact
                 />
               </li>
             </ul>
-            <p v-else class="px-2 py-2 text-[13px] text-tertiary">
-              {{ $t('docs-index-uncollected-empty') }}
+            <p v-else class="px-2 py-1.5 text-[13px] text-tertiary">
+              {{ $t('docs-index-no-recent-activity') }}
             </p>
           </SectionCard>
-        </template>
+
+          <SectionCard content-padding="p-1.5">
+            <template #title>{{ $t('docs-index-starred') }}</template>
+            <template #headerActions>
+              <span
+                v-if="visibleStarred.length > 0"
+                class="text-[11px] text-tertiary tabular-nums font-normal"
+              >
+                {{ starredPages.length }}
+              </span>
+            </template>
+            <ul v-if="visibleStarred.length > 0" class="flex flex-col">
+              <li v-for="sp in visibleStarred" :key="sp.page_id">
+                <DocumentationHubRow
+                  :href="docUrl({ slug: sp.slug, id: sp.page_id })"
+                  :title="sp.title"
+                  :icon="sp.icon"
+                  compact
+                />
+              </li>
+            </ul>
+            <p v-else class="px-2 py-1.5 text-[13px] text-tertiary">
+              {{ $t('docs-index-starred-hint') }}
+            </p>
+          </SectionCard>
+        </div>
       </div>
     </div>
   </div>
 </template>
 
 <style scoped>
-.docs-index-queue-grid {
+.docs-index-layout {
   display: grid;
   gap: 1rem;
   grid-template-columns: 1fr;
+  align-items: start;
 }
 
-@media (min-width: 1024px) {
-  .docs-index-queue-grid {
+/* Rail splits off only when the content panel itself is wide enough for a
+   useful main column beside the fixed 21.75rem rail. */
+@container (min-width: 60rem) {
+  .docs-index-layout {
     gap: 1.25rem;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-}
-
-.docs-index-pages-grid {
-  display: grid;
-  gap: 1rem;
-  grid-template-columns: 1fr;
-}
-
-@media (min-width: 1024px) {
-  .docs-index-pages-grid {
-    gap: 1.25rem;
-    grid-template-columns: repeat(12, minmax(0, 1fr));
-  }
-
-  .docs-index-pages-grid > * {
-    grid-column: span 6;
-  }
-}
-
-@media (min-width: 1280px) {
-  .docs-index-pages-grid > :first-child {
-    grid-column: span 7;
-  }
-
-  .docs-index-pages-grid > :nth-child(2) {
-    grid-column: span 5;
-  }
-}
-
-.docs-index-uncollected-grid {
-  display: grid;
-  gap: 0;
-  grid-template-columns: 1fr;
-}
-
-@media (min-width: 640px) {
-  .docs-index-uncollected-grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    column-gap: 0.5rem;
-  }
-}
-
-@media (min-width: 1024px) {
-  .docs-index-uncollected-grid {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-  }
-}
-
-@media (min-width: 1536px) {
-  .docs-index-uncollected-grid {
-    grid-template-columns: repeat(auto-fill, minmax(16rem, 1fr));
+    grid-template-columns: minmax(0, 1fr) 21.75rem;
   }
 }
 </style>

--- a/i18n/locales/en-US/main.ftl
+++ b/i18n/locales/en-US/main.ftl
@@ -2887,6 +2887,36 @@ docs-index-new-page = New page
 
 # Docs: documentation index toolbar (DocumentationIndexToolbar)
 docs-index-toolbar-search = Search documentation
+docs-index-toolbar-search-placeholder = Search documentation…
+docs-index-toolbar-stats = { $pages ->
+    [one] { $pages } page
+   *[other] { $pages } pages
+  } across { $collections ->
+    [one] { $collections } collection
+   *[other] { $collections } collections
+  }
+# Library ledger (CollectionBrowser)
+docs-index-library-heading = Library
+docs-index-library-count = { $count ->
+    [one] { $count } collection
+   *[other] { $count } collections
+  }
+docs-index-library-more-pages = { $count } more
+docs-index-library-updated = updated { $time }
+# Needs-attention rail card
+docs-index-attention-heading = Needs attention
+docs-index-attention-verification = Verification due
+docs-index-attention-empty = Nothing needs attention right now.
+docs-index-attention-gaps-link = View all gaps
+docs-index-attention-totals = { $gaps } gaps · { $stale } due
+docs-index-verification-never = never verified
+# Drafts strip
+docs-index-drafts-strip-count = { $count ->
+    [one] { $count } draft
+   *[other] { $count } drafts
+  }
+docs-index-drafts-strip-suffix = aren't in a collection yet
+docs-index-drafts-strip-review = Review drafts →
 docs-index-toolbar-search-shortcut = ⌘K
 docs-index-toolbar-new-collection = New collection
 docs-index-toolbar-more = More

--- a/i18n/locales/fr-FR/main.ftl
+++ b/i18n/locales/fr-FR/main.ftl
@@ -2735,6 +2735,34 @@ docs-index-new-page = Nouvelle page
 
 # Docs : barre d'outils de l'index (DocumentationIndexToolbar)
 docs-index-toolbar-search = Rechercher dans la documentation
+# MACHINE TRANSLATION, pending native review
+docs-index-toolbar-search-placeholder = Rechercher dans la documentation…
+docs-index-toolbar-stats = { $pages ->
+    [one] { $pages } page
+   *[other] { $pages } pages
+  } dans { $collections ->
+    [one] { $collections } collection
+   *[other] { $collections } collections
+  }
+docs-index-library-heading = Bibliothèque
+docs-index-library-count = { $count ->
+    [one] { $count } collection
+   *[other] { $count } collections
+  }
+docs-index-library-more-pages = { $count } de plus
+docs-index-library-updated = mise à jour { $time }
+docs-index-attention-heading = À traiter
+docs-index-attention-verification = Vérification à faire
+docs-index-attention-empty = Rien à traiter pour le moment.
+docs-index-attention-gaps-link = Toutes les lacunes
+docs-index-attention-totals = { $gaps } lacunes · { $stale } à vérifier
+docs-index-verification-never = jamais vérifiée
+docs-index-drafts-strip-count = { $count ->
+    [one] { $count } brouillon
+   *[other] { $count } brouillons
+  }
+docs-index-drafts-strip-suffix = ne sont pas encore dans une collection
+docs-index-drafts-strip-review = Passer en revue →
 docs-index-toolbar-search-shortcut = ⌘K
 docs-index-toolbar-new-collection = Nouvelle collection
 docs-index-toolbar-more = Plus

--- a/i18n/locales/nl-NL/main.ftl
+++ b/i18n/locales/nl-NL/main.ftl
@@ -2732,6 +2732,34 @@ docs-index-new-page = Nieuwe pagina
 
 # Docs: indexwerkbalk (DocumentationIndexToolbar)
 docs-index-toolbar-search = Documentatie doorzoeken
+# MACHINE TRANSLATION, pending native review
+docs-index-toolbar-search-placeholder = Documentatie doorzoeken…
+docs-index-toolbar-stats = { $pages ->
+    [one] { $pages } pagina
+   *[other] { $pages } pagina's
+  } in { $collections ->
+    [one] { $collections } collectie
+   *[other] { $collections } collecties
+  }
+docs-index-library-heading = Bibliotheek
+docs-index-library-count = { $count ->
+    [one] { $count } collectie
+   *[other] { $count } collecties
+  }
+docs-index-library-more-pages = { $count } meer
+docs-index-library-updated = bijgewerkt { $time }
+docs-index-attention-heading = Aandacht nodig
+docs-index-attention-verification = Verificatie nodig
+docs-index-attention-empty = Er is momenteel niets dat aandacht nodig heeft.
+docs-index-attention-gaps-link = Alle kennishiaten
+docs-index-attention-totals = { $gaps } hiaten · { $stale } te verifiëren
+docs-index-verification-never = nooit geverifieerd
+docs-index-drafts-strip-count = { $count ->
+    [one] { $count } concept
+   *[other] { $count } concepten
+  }
+docs-index-drafts-strip-suffix = zitten nog niet in een collectie
+docs-index-drafts-strip-review = Concepten bekijken →
 docs-index-toolbar-search-shortcut = ⌘K
 docs-index-toolbar-new-collection = Nieuwe collectie
 docs-index-toolbar-more = Meer


### PR DESCRIPTION
Rebuilds the documentation index around the "Library ledger" direction chosen from a three-way design exploration (design canvas: audit of the old layout, three directions with motivations and tradeoffs, final on the front page).

**What changes**
- **Library ledger**: CollectionBrowser becomes one row per collection with its three most-recently-updated pages inline (derived live from the sync pool), an "N more" link, a lock chip only on restricted collections, and a right meta column (page count, freshness). A known page is one click from the index. Agent drag-to-reorder preserved.
- **Main-plus-rail layout**: the rail stacks a merged **Needs attention** card (knowledge gaps with impact badges, verification-due with amber ages, count badge, footer totals and link; one quiet line when clear), Recently updated, and Starred. The uncollected queue collapses to a one-line drafts strip that hides at zero; the giant empty-queue cards are gone.
- **Toolbar**: search leads as a field-styled affordance with a ⌘K hint; a stats line states the scope ("N pages across M collections"). "New page" stays with the global header's Create document button rather than duplicating.
- **DocumentationHubRow** gains a `compact` mode (avatar + compact time, no name) for the narrow rail.

**Responsive by container, not viewport**: the two-column split keys off the content panel's width (same convention as the gantt), so a laptop with the sidebar open gets a full-width single column instead of a starved main column. Row extras yield by the card's own width (inline description first, freshness second), and page-link separators wrap as one unit with their link so no dot ever strands at a line edge.

Verified against the dev stack at 390/768/1024/1280/1900 widths with zero horizontal overflow, including the empty-attention state, drafts strip, and live counts. vue-tsc clean; frontend unit suite 59/59. i18n: en-US plus machine fr/nl pending native review.