### PR TITLE
Resizable, alignable images in the collaborative editor

### DIFF
--- a/frontend/src/components/CollaborativeEditor.vue
+++ b/frontend/src/components/CollaborativeEditor.vue
@@ -75,6 +75,7 @@ import {
     ellipsis,
 } from "prosemirror-inputrules";
 import { createImageUploadPlugin } from "./editor/imageUploadPlugin";
+import { ImageNodeView } from "./editor/imageNodeView";
 import { parseCollabDocId } from "@nosdesk/core/utils/collabDocId";
 import { EditorImageUploadError } from "@/services/editorImageService";
 import { useToastStore } from "@nosdesk/core/stores/toast";
@@ -947,6 +948,12 @@ const initEditor = async () => {
                     twemojiPlugin,
                 ],
             }),
+            // Live view only: the revision overlay renders images via plain
+            // toDOM (sized, no handles), which is exactly right for read-only.
+            nodeViews: {
+                image: (node, view, getPos) =>
+                    new ImageNodeView(node, view, getPos, { t }),
+            },
         });
 
         // Initial mention users pre-warm via the composable's
@@ -3668,6 +3675,149 @@ defineExpose({
     to {
         transform: rotate(360deg);
     }
+}
+
+/* ============================================
+   RESIZABLE IMAGES (ImageNodeView + plain toDOM)
+   ============================================ */
+
+/* Widths are stored in px; this guard keeps them inside the container on
+   narrower viewports. Applies to the NodeView img AND plain toDOM renders
+   (revision overlay). */
+.ProseMirror img {
+    max-width: 100%;
+    height: auto;
+}
+
+/* Alignment. The NodeView wrapper shrinks to the image (fit-content) so the
+   corner handles always hug it; the margins place the shrunk box. Plain
+   toDOM imgs (revision overlay) get the same treatment directly. */
+.ProseMirror .pm-image[data-align],
+.ProseMirror img[data-align] {
+    display: block;
+    width: fit-content;
+    max-width: 100%;
+}
+.ProseMirror .pm-image[data-align='left'],
+.ProseMirror img[data-align='left'] {
+    margin-right: auto;
+}
+.ProseMirror .pm-image[data-align='center'],
+.ProseMirror img[data-align='center'] {
+    margin-left: auto;
+    margin-right: auto;
+}
+.ProseMirror .pm-image[data-align='right'],
+.ProseMirror img[data-align='right'] {
+    margin-left: auto;
+}
+
+.pm-image {
+    position: relative;
+    display: inline-block;
+    max-width: 100%;
+    line-height: 0;
+}
+
+.pm-image img {
+    max-width: 100%;
+    height: auto;
+}
+
+.pm-image.is-selected img {
+    outline: 2px solid var(--color-accent);
+    outline-offset: 1px;
+    border-radius: 2px;
+}
+
+.pm-image__handle {
+    display: none;
+    position: absolute;
+    width: 10px;
+    height: 10px;
+    background: var(--color-surface);
+    border: 1.5px solid var(--color-accent);
+    border-radius: 50%;
+    touch-action: none;
+    z-index: 2;
+}
+.pm-image.is-selected .pm-image__handle {
+    display: block;
+}
+.pm-image__handle[data-dir='nw'] { top: -5px; left: -5px; cursor: nwse-resize; }
+.pm-image__handle[data-dir='ne'] { top: -5px; right: -5px; cursor: nesw-resize; }
+.pm-image__handle[data-dir='sw'] { bottom: -5px; left: -5px; cursor: nesw-resize; }
+.pm-image__handle[data-dir='se'] { bottom: -5px; right: -5px; cursor: nwse-resize; }
+
+.pm-image__badge {
+    display: none;
+    position: absolute;
+    bottom: 6px;
+    right: 6px;
+    padding: 2px 6px;
+    border-radius: 4px;
+    background: rgba(0, 0, 0, 0.65);
+    color: #fff;
+    font-size: 11px;
+    line-height: 1.2;
+    font-variant-numeric: tabular-nums;
+    pointer-events: none;
+    z-index: 2;
+}
+.pm-image.is-resizing .pm-image__badge {
+    display: block;
+}
+
+.pm-image__toolbar {
+    display: none;
+    position: absolute;
+    top: -38px;
+    left: 50%;
+    transform: translateX(-50%);
+    align-items: center;
+    gap: 2px;
+    padding: 3px;
+    background: var(--color-surface);
+    border: 1px solid var(--color-default);
+    border-radius: 8px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+    line-height: normal;
+    white-space: nowrap;
+    z-index: 3;
+}
+.pm-image.is-selected .pm-image__toolbar {
+    display: inline-flex;
+}
+.pm-image.is-resizing .pm-image__toolbar {
+    display: none;
+}
+
+.pm-image__tool {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 26px;
+    height: 26px;
+    border-radius: 6px;
+    border: none;
+    background: transparent;
+    color: var(--color-secondary);
+    cursor: pointer;
+}
+.pm-image__tool:hover {
+    background: var(--color-surface-hover);
+    color: var(--color-primary);
+}
+.pm-image__tool.is-active {
+    background: var(--color-accent-muted);
+    color: var(--color-accent);
+}
+
+.pm-image__toolsep {
+    width: 1px;
+    height: 16px;
+    margin: 0 3px;
+    background: var(--color-default);
 }
 
 /* ============================================

--- a/frontend/src/components/editor/imageAttrs.spec.ts
+++ b/frontend/src/components/editor/imageAttrs.spec.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest'
+import { DOMParser, DOMSerializer } from 'prosemirror-model'
+import { schema } from './schema'
+
+/**
+ * The resize/adjust state rides on image node attrs and must survive the
+ * toDOM -> parseDOM round trip: the revision overlay renders via plain
+ * toDOM, and copy/paste re-enters through parseDOM.
+ */
+
+const serializer = DOMSerializer.fromSchema(schema)
+const parser = DOMParser.fromSchema(schema)
+
+function serializeImage(attrs: Record<string, unknown>): HTMLElement {
+  const node = schema.nodes.image.create(attrs)
+  return serializer.serializeNode(node) as HTMLElement
+}
+
+function parseImage(el: HTMLElement): Record<string, unknown> {
+  const wrap = document.createElement('p')
+  wrap.appendChild(el)
+  const doc = parser.parse(wrap)
+  let found: Record<string, unknown> | null = null
+  doc.descendants((n) => {
+    if (n.type === schema.nodes.image) found = n.attrs
+  })
+  if (!found) throw new Error('no image node parsed')
+  return found
+}
+
+describe('image resize/adjust attrs', () => {
+  it('serializes width as an inline style and align as data-align', () => {
+    const el = serializeImage({ src: '/x.png', width: 420, align: 'center' })
+    expect(el.tagName).toBe('IMG')
+    expect(el.getAttribute('style')).toContain('width: 420px')
+    expect(el.getAttribute('data-align')).toBe('center')
+  })
+
+  it('omits style and data-align at the defaults', () => {
+    const el = serializeImage({ src: '/x.png' })
+    expect(el.getAttribute('style')).toBeNull()
+    expect(el.getAttribute('data-align')).toBeNull()
+  })
+
+  it('round-trips width and align through parseDOM', () => {
+    const el = serializeImage({ src: '/x.png', width: 313, align: 'right' })
+    const attrs = parseImage(el)
+    expect(attrs.width).toBe(313)
+    expect(attrs.align).toBe('right')
+    expect(attrs.src).toBe('/x.png')
+  })
+
+  it('parses a bare legacy img with null width and align', () => {
+    const el = document.createElement('img')
+    el.setAttribute('src', '/legacy.png')
+    const attrs = parseImage(el)
+    expect(attrs.width).toBeNull()
+    expect(attrs.align).toBeNull()
+  })
+
+  it('reads a numeric width attribute and rejects junk alignment', () => {
+    const el = document.createElement('img')
+    el.setAttribute('src', '/x.png')
+    el.setAttribute('width', '240')
+    el.setAttribute('data-align', 'sideways')
+    const attrs = parseImage(el)
+    expect(attrs.width).toBe(240)
+    expect(attrs.align).toBeNull()
+  })
+})

--- a/frontend/src/components/editor/imageNodeView.ts
+++ b/frontend/src/components/editor/imageNodeView.ts
@@ -1,0 +1,284 @@
+/**
+ * Resizable image NodeView for the collaborative editor.
+ *
+ * Follows the documented ProseMirror pattern for resize handles (marijn,
+ * discuss "Image resize" / "Draggable and NodeViews") and Tiptap's
+ * onResize/onCommit split:
+ *
+ * - Handles and the adjust toolbar are NodeView-internal DOM, visible only
+ *   while the node holds a NodeSelection (`selectNode`/`deselectNode`) and
+ *   the view is editable.
+ * - A drag mutates DOM style only; exactly ONE transaction commits the new
+ *   width on pointerup (one resize = one undo step, no per-pixel churn to
+ *   collaborators).
+ * - `stopEvent` swallows pointer events on our controls so they never start
+ *   ProseMirror's native node drag, but lets every `drag*` event through so
+ *   grabbing the image body still drags the node (the schema keeps
+ *   `draggable: true`).
+ * - y-prosemirror applies remote edits as whole-document replaces, which can
+ *   destroy this NodeView mid-drag. `getPos()` is therefore re-read at
+ *   commit time (bail on undefined), and `destroy()` tears down the
+ *   document-level listeners so an interrupted drag dies cleanly.
+ */
+import type { Node as PMNode } from 'prosemirror-model';
+import { NodeSelection } from 'prosemirror-state';
+import type { EditorView, NodeView } from 'prosemirror-view';
+
+const MIN_WIDTH_PX = 60;
+
+export interface ImageNodeViewOptions {
+  /** Fluent translate, for control labels. */
+  t: (key: string) => string;
+}
+
+type Align = 'left' | 'center' | 'right';
+
+interface DragState {
+  pointerId: number;
+  startX: number;
+  startWidth: number;
+  /** -1 for west handles (drag left grows), +1 for east handles. */
+  sign: 1 | -1;
+  lastWidth: number;
+  onMove: (e: PointerEvent) => void;
+  onUp: (e: PointerEvent) => void;
+}
+
+export class ImageNodeView implements NodeView {
+  dom: HTMLSpanElement;
+  private img: HTMLImageElement;
+  private badge: HTMLSpanElement;
+  private toolbar: HTMLSpanElement;
+  private node: PMNode;
+  private drag: DragState | null = null;
+
+  constructor(
+    node: PMNode,
+    private view: EditorView,
+    private getPos: () => number | undefined,
+    private options: ImageNodeViewOptions,
+  ) {
+    this.node = node;
+
+    this.dom = document.createElement('span');
+    this.dom.className = 'pm-image';
+    this.dom.contentEditable = 'false';
+
+    this.img = document.createElement('img');
+    this.dom.appendChild(this.img);
+
+    for (const dir of ['nw', 'ne', 'sw', 'se'] as const) {
+      const handle = document.createElement('span');
+      handle.className = 'pm-image__handle';
+      handle.dataset.dir = dir;
+      handle.addEventListener('pointerdown', (e) => this.startDrag(e, dir));
+      this.dom.appendChild(handle);
+    }
+
+    this.badge = document.createElement('span');
+    this.badge.className = 'pm-image__badge';
+    this.dom.appendChild(this.badge);
+
+    this.toolbar = this.buildToolbar();
+    this.dom.appendChild(this.toolbar);
+
+    this.syncAttrs(node);
+  }
+
+  private buildToolbar(): HTMLSpanElement {
+    const bar = document.createElement('span');
+    bar.className = 'pm-image__toolbar';
+
+    const button = (label: string, glyph: string, onClick: () => void) => {
+      const b = document.createElement('button');
+      b.type = 'button';
+      b.className = 'pm-image__tool';
+      b.title = label;
+      b.setAttribute('aria-label', label);
+      b.innerHTML = glyph;
+      // pointerdown (not click) so focus never leaves the editor.
+      b.addEventListener('pointerdown', (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        onClick();
+      });
+      bar.appendChild(b);
+      return b;
+    };
+
+    const alignIcon = (dir: Align) => {
+      const x2 = dir === 'left' ? 'M3 12h10M3 18h14' : dir === 'right' ? 'M11 12h10M7 18h14' : 'M7 12h10M5 18h14';
+      return `<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M3 6h18${x2.startsWith('M') ? '' : ''}"></path><path d="${x2}"></path></svg>`;
+    };
+
+    const t = this.options.t;
+    for (const dir of ['left', 'center', 'right'] as const) {
+      const b = button(t(`editor-image-align-${dir}`), alignIcon(dir), () =>
+        this.setAttrsCommitted({ align: this.node.attrs.align === dir ? null : dir }),
+      );
+      b.dataset.align = dir;
+    }
+
+    const sep = document.createElement('span');
+    sep.className = 'pm-image__toolsep';
+    bar.appendChild(sep);
+
+    button(
+      t('editor-image-size-half'),
+      '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="5" width="10" height="14" rx="1"></rect><path d="M17 5h4v14h-4" stroke-dasharray="2 2"></path></svg>',
+      () => this.setAttrsCommitted({ width: Math.round(this.containerWidth() / 2) }),
+    );
+    button(
+      t('editor-image-size-full'),
+      '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><rect x="3" y="5" width="18" height="14" rx="1"></rect></svg>',
+      () => this.setAttrsCommitted({ width: this.containerWidth() }),
+    );
+    button(
+      t('editor-image-size-reset'),
+      '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 12a9 9 0 1 0 3-6.7"></path><path d="M3 4v5h5"></path></svg>',
+      () => this.setAttrsCommitted({ width: null }),
+    );
+
+    return bar;
+  }
+
+  /** Usable content width of the editor, the natural "100%" for an image. */
+  private containerWidth(): number {
+    const editor = this.view.dom as HTMLElement;
+    const styles = window.getComputedStyle(editor);
+    return Math.max(
+      MIN_WIDTH_PX,
+      Math.round(
+        editor.clientWidth - parseFloat(styles.paddingLeft) - parseFloat(styles.paddingRight),
+      ),
+    );
+  }
+
+  private syncAttrs(node: PMNode): void {
+    const { src, alt, title, width, align } = node.attrs as {
+      src: string;
+      alt: string | null;
+      title: string | null;
+      width: number | null;
+      align: Align | null;
+    };
+    if (this.img.getAttribute('src') !== src) this.img.setAttribute('src', src);
+    if (alt) this.img.setAttribute('alt', alt);
+    else this.img.removeAttribute('alt');
+    if (title) this.img.setAttribute('title', title);
+    else this.img.removeAttribute('title');
+
+    // Skip style writes mid-drag: the drag owns the live width.
+    if (!this.drag) {
+      this.img.style.width = width != null ? `${width}px` : '';
+    }
+    if (align) this.dom.setAttribute('data-align', align);
+    else this.dom.removeAttribute('data-align');
+
+    for (const b of this.toolbar.querySelectorAll<HTMLButtonElement>('button[data-align]')) {
+      b.classList.toggle('is-active', b.dataset.align === (align ?? ''));
+    }
+  }
+
+  /** Commit an attr patch as one transaction, keeping the node selected. */
+  private setAttrsCommitted(patch: Partial<{ width: number | null; align: Align | null }>): void {
+    const pos = this.getPos();
+    if (pos == null) return;
+    const attrs = { ...this.node.attrs, ...patch };
+    let tr = this.view.state.tr.setNodeMarkup(pos, undefined, attrs);
+    tr = tr.setSelection(NodeSelection.create(tr.doc, pos));
+    this.view.dispatch(tr);
+    this.view.focus();
+  }
+
+  private startDrag(e: PointerEvent, dir: 'nw' | 'ne' | 'sw' | 'se'): void {
+    if (!this.view.editable || this.drag) return;
+    e.preventDefault();
+    e.stopPropagation();
+
+    const startWidth = this.img.getBoundingClientRect().width;
+    const sign: 1 | -1 = dir === 'ne' || dir === 'se' ? 1 : -1;
+
+    const onMove = (ev: PointerEvent) => {
+      if (!this.drag || ev.pointerId !== this.drag.pointerId) return;
+      const next = Math.round(
+        Math.min(
+          this.containerWidth(),
+          Math.max(MIN_WIDTH_PX, this.drag.startWidth + sign * (ev.clientX - this.drag.startX)),
+        ),
+      );
+      this.drag.lastWidth = next;
+      this.img.style.width = `${next}px`;
+      this.badge.textContent = `${next}px`;
+      this.dom.classList.add('is-resizing');
+    };
+
+    const onUp = (ev: PointerEvent) => {
+      if (!this.drag || ev.pointerId !== this.drag.pointerId) return;
+      const { lastWidth, startWidth: initial } = this.drag;
+      this.teardownDrag();
+      if (Math.abs(lastWidth - initial) >= 1) {
+        this.setAttrsCommitted({ width: lastWidth });
+      } else {
+        // No effective change: restore whatever the document says.
+        this.syncAttrs(this.node);
+      }
+    };
+
+    this.drag = {
+      pointerId: e.pointerId,
+      startX: e.clientX,
+      startWidth,
+      sign,
+      lastWidth: Math.round(startWidth),
+      onMove,
+      onUp,
+    };
+    document.addEventListener('pointermove', onMove);
+    document.addEventListener('pointerup', onUp);
+    document.addEventListener('pointercancel', onUp);
+  }
+
+  private teardownDrag(): void {
+    if (!this.drag) return;
+    document.removeEventListener('pointermove', this.drag.onMove);
+    document.removeEventListener('pointerup', this.drag.onUp);
+    document.removeEventListener('pointercancel', this.drag.onUp);
+    this.drag = null;
+    this.badge.textContent = '';
+    this.dom.classList.remove('is-resizing');
+  }
+
+  update(node: PMNode): boolean {
+    if (node.type !== this.node.type) return false;
+    this.node = node;
+    this.syncAttrs(node);
+    return true;
+  }
+
+  selectNode(): void {
+    if (this.view.editable) this.dom.classList.add('is-selected');
+  }
+
+  deselectNode(): void {
+    this.dom.classList.remove('is-selected');
+  }
+
+  stopEvent(event: Event): boolean {
+    // Native node drag must keep working when grabbing the image body.
+    if (/drag/.test(event.type)) return false;
+    // Everything on our controls is ours; keep ProseMirror out of it.
+    const target = event.target as HTMLElement | null;
+    return !!target && target !== this.img && this.dom.contains(target);
+  }
+
+  ignoreMutation(record: MutationRecord | { type: 'selection' }): boolean {
+    // Leaf view: every DOM mutation here is handle/badge/toolbar churn we
+    // caused ourselves. Only selection reads must reach ProseMirror.
+    return record.type !== 'selection';
+  }
+
+  destroy(): void {
+    this.teardownDrag();
+  }
+}

--- a/frontend/src/components/editor/schema.ts
+++ b/frontend/src/components/editor/schema.ts
@@ -117,33 +117,64 @@ export const nodes: {[key: string]: NodeSpec} = {
     group: 'inline'
   },
   
-  // An inline image (<img>) node
+  // An inline image (<img>) node.
+  //
+  // `width` (px) and `align` are the resize/adjust state, persisted as
+  // defaulted attrs so documents authored before they existed load
+  // unchanged, and remote peers receive them through the normal Yjs attr
+  // sync. Height is never stored: the natural aspect ratio derives it,
+  // and a `max-width: 100%` style guard keeps any stored width inside
+  // the container. The node deliberately stays `inline`/`group: inline`:
+  // changing those against documents already stored in Yjs is a breaking
+  // schema change with no migration path.
   image: {
     inline: true,
     attrs: {
       ychange: { default: null },
       src: {},
       alt: { default: null },
-      title: { default: null }
+      title: { default: null },
+      /** Rendered width in px; null = natural size. */
+      width: { default: null },
+      /** 'left' | 'center' | 'right'; null = inline flow. */
+      align: { default: null }
     },
     group: 'inline',
     draggable: true,
     parseDOM: [{
       tag: 'img[src]',
       getAttrs(dom: HTMLElement) {
+        const styleWidth = /(?:^|;)\s*width:\s*(\d+(?:\.\d+)?)px/.exec(
+          dom.getAttribute('style') ?? ''
+        );
+        const attrWidth = dom.getAttribute('width');
+        const width = styleWidth
+          ? Math.round(Number(styleWidth[1]))
+          : attrWidth && /^\d+$/.test(attrWidth)
+            ? Number(attrWidth)
+            : null;
+        const align = dom.getAttribute('data-align');
         return {
           src: dom.getAttribute('src'),
           title: dom.getAttribute('title'),
-          alt: dom.getAttribute('alt')
+          alt: dom.getAttribute('alt'),
+          width,
+          align: align === 'left' || align === 'center' || align === 'right' ? align : null
         };
       }
     }],
     toDOM(node) {
-      const domAttrs = {
+      const domAttrs: Record<string, string> = {
         src: node.attrs.src,
         title: node.attrs.title,
         alt: node.attrs.alt
       };
+      if (node.attrs.width != null) {
+        domAttrs.style = `width: ${node.attrs.width}px`;
+      }
+      if (node.attrs.align) {
+        domAttrs['data-align'] = node.attrs.align;
+      }
       return ['img', calcYchangeDomAttrs(node.attrs, domAttrs)];
     }
   },

--- a/i18n/locales/en-US/main.ftl
+++ b/i18n/locales/en-US/main.ftl
@@ -6748,6 +6748,12 @@ asset-catalog-manage-manufacturers = Manufacturers
 
 # Editor: image upload (imageUploadPlugin / CollaborativeEditor)
 editor-image-uploading = Uploading { $name }
+editor-image-align-left = Align left
+editor-image-align-center = Align center
+editor-image-align-right = Align right
+editor-image-size-half = Half width
+editor-image-size-full = Full width
+editor-image-size-reset = Reset size
 editor-image-upload-failed = Image upload failed
 editor-image-upload-failed-detail = { $name } could not be uploaded. Please try again.
 editor-image-upload-no-target = Save this page before adding images

--- a/i18n/locales/fr-FR/main.ftl
+++ b/i18n/locales/fr-FR/main.ftl
@@ -6670,6 +6670,13 @@ admin-asset-groups-col-members = Actifs
 
 # Editor: image upload (imageUploadPlugin / CollaborativeEditor)
 editor-image-uploading = Téléversement de { $name }
+# MACHINE TRANSLATION, pending native review
+editor-image-align-left = Aligner à gauche
+editor-image-align-center = Centrer
+editor-image-align-right = Aligner à droite
+editor-image-size-half = Demi-largeur
+editor-image-size-full = Pleine largeur
+editor-image-size-reset = Réinitialiser la taille
 editor-image-upload-failed = Échec du téléversement de l'image
 editor-image-upload-failed-detail = { $name } n'a pas pu être téléversé. Veuillez réessayer.
 editor-image-upload-no-target = Enregistrez cette page avant d'ajouter des images

--- a/i18n/locales/nl-NL/main.ftl
+++ b/i18n/locales/nl-NL/main.ftl
@@ -6662,6 +6662,13 @@ admin-asset-groups-col-members = Activa
 
 # Editor: image upload (imageUploadPlugin / CollaborativeEditor)
 editor-image-uploading = { $name } wordt geüpload
+# MACHINE TRANSLATION, pending native review
+editor-image-align-left = Links uitlijnen
+editor-image-align-center = Centreren
+editor-image-align-right = Rechts uitlijnen
+editor-image-size-half = Halve breedte
+editor-image-size-full = Volledige breedte
+editor-image-size-reset = Grootte herstellen
 editor-image-upload-failed = Uploaden van afbeelding mislukt
 editor-image-upload-failed-detail = { $name } kon niet worden geüpload. Probeer het opnieuw.
 editor-image-upload-no-target = Sla deze pagina op voordat je afbeeldingen toevoegt


### PR DESCRIPTION
Adds image resize and adjustment to the collaborative editor, built to the documented ProseMirror patterns (researched against the reference manual, marijn's discuss answers, y-prosemirror's CAVEATS, and the Tiptap/prosemirror-image-plugin/BlockNote implementations).

**Architecture**
- `width` (px) and `align` are defaulted node attrs on the existing inline image node: old Yjs documents load unchanged, and no inline/group schema change (which would be breaking with no migration path). Height always derives from aspect ratio; a `max-width: 100%` guard keeps stored widths inside the container.
- `ImageNodeView` (first NodeView in the codebase, live view only): corner handles + adjust bubble shown only on NodeSelection in an editable view. Two-phase interaction per the documented pattern: DOM-only mutation during drag with a live px badge, exactly one `setNodeMarkup` transaction on pointerup that re-reads `getPos()` (bails if the node vanished under a concurrent remote edit) and restores the node selection. One gesture = one undo step; no per-pixel transactions broadcast to peers.
- `stopEvent` follows marijn's draggable-node guidance: control events are swallowed, `drag*` events pass through so grabbing the image body still drags the node. `ignoreMutation` shields handle churn; `destroy()` removes document-level listeners so a mid-drag NodeView teardown from y-prosemirror's whole-doc remote replace fails gracefully.
- The revision overlay intentionally has no NodeView: plain `toDOM` renders sized, aligned images read-only for free.
- Bubble controls: align left/center/right (toggle), half width, full width, reset.

**Verified** on the dev stack: paste-insert at natural size, drag-resize commit, single-undo restore, center alignment, persistence across reload via Yjs, and live sync of a resize to a second tab. Aligned wrappers use `fit-content` so handles hug the image in every alignment. Unit spec covers toDOM/parseDOM round-trip, legacy bare imgs, and junk-value rejection. vue-tsc clean; frontend suite 64/64. i18n: en-US plus machine fr/nl pending native review.