### PR TITLE
Stop internal image drags re-uploading the image

### DIFF
--- a/frontend/src/components/editor/imageUploadPlugin.ts
+++ b/frontend/src/components/editor/imageUploadPlugin.ts
@@ -396,6 +396,13 @@ export function createImageUploadPlugin(options: ImageUploadPluginOptions): Plug
       },
 
       handleDrop(view: EditorView, event: DragEvent, _slice: Slice, _moved: boolean): boolean {
+        // An internal drag is a MOVE, never an upload. ProseMirror stores the
+        // dragged slice in `view.dragging` for drags it initiated and its
+        // default drop handling relocates the node; Chromium additionally
+        // lists a dragged <img> in `dataTransfer.files`, which without this
+        // guard made a simple reposition re-upload the image as a new
+        // server-side copy at the drop point while leaving the original.
+        if (view.dragging) return false;
         const imageFiles = imageFilesFrom(event.dataTransfer?.files);
         if (!imageFiles.length) return false;
 


### PR DESCRIPTION
Dragging an image to a new position in the collaborative editor re-uploaded it: Chromium lists a dragged `<img>` in `dataTransfer.files`, so the upload plugin's `handleDrop` treated every internal reposition as an OS file drop, uploading a fresh server-side copy at the drop point and stranding the original node.

The fix is the discriminator ProseMirror provides for exactly this: `view.dragging` is set only for drags the editor itself initiated (and carries the dragged slice). `handleDrop` now returns early in that case, so ProseMirror's default drop handling performs a true move with zero network.

Verified on the dev stack with a faithful simulation (dragstart on the image so `view.dragging` is set, then a drop whose DataTransfer also lists the image file, exactly as Chromium does): before the fix, one upload POST and a duplicate; after, zero POSTs, exactly one image with the identical src after the move and after reload, surrounding text intact. An external drop (files present, no editor dragstart) still uploads, so the real path is unharmed.