### PR TITLE
feat(export): self-serve workspace data export (Owner-gated)

### DIFF
--- a/backend/migrations/2026-08-27-000001_workspace_export_jobs/down.sql
+++ b/backend/migrations/2026-08-27-000001_workspace_export_jobs/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS workspace_export_jobs;

--- a/backend/migrations/2026-08-27-000001_workspace_export_jobs/up.sql
+++ b/backend/migrations/2026-08-27-000001_workspace_export_jobs/up.sql
@@ -1,0 +1,48 @@
+-- Self-serve workspace data export: the Art 28(3)(g) "return" path a customer
+-- uses to take their data before an account deletion erases it (account-erasure
+-- Phase 3 prerequisite, on the control plane). One row per export request; the
+-- artifact is a storage-backed ZIP (see services::workspace_export) and this row
+-- tracks the job plus a bounded download window (expires_at, set from
+-- completion). Owner-gated and self-serve, unlike the platform-admin export.
+CREATE TABLE workspace_export_jobs (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    workspace_id integer NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+    requested_by uuid,
+    status varchar(20) NOT NULL DEFAULT 'pending'
+        CHECK (status IN ('pending', 'processing', 'completed', 'failed')),
+    file_path text,
+    file_size bigint,
+    error_message text,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    completed_at timestamptz,
+    -- Download window; NULL until completion, then completed_at + TTL. The
+    -- retention sweep deletes the artifact + row once past this.
+    expires_at timestamptz
+);
+
+CREATE INDEX idx_workspace_export_jobs_workspace
+    ON workspace_export_jobs (workspace_id, created_at DESC);
+-- Supports the "at most one active job per workspace" + "one completed per day"
+-- rate-limit checks.
+CREATE INDEX idx_workspace_export_jobs_active
+    ON workspace_export_jobs (workspace_id) WHERE status IN ('pending', 'processing');
+CREATE INDEX idx_workspace_export_jobs_expiry
+    ON workspace_export_jobs (expires_at) WHERE expires_at IS NOT NULL;
+
+-- New-table ownership + runtime grants. A new table must set these explicitly
+-- (see workspace_notification_defaults): nosdesk_admin must OWN it so the
+-- BYPASSRLS export/background role sees it via information_schema and can write
+-- the job row from the background task; nosdesk_app needs DML for the RLS-scoped
+-- tenant reads (enqueue / status / download).
+ALTER TABLE public.workspace_export_jobs OWNER TO nosdesk_admin;
+GRANT SELECT, INSERT, DELETE, UPDATE ON TABLE public.workspace_export_jobs TO nosdesk_app;
+
+-- Workspace isolation for the RLS-enforced runtime role (mirrors
+-- workspace_notification_defaults). Background writes run under the BYPASSRLS
+-- role and are unaffected.
+ALTER TABLE workspace_export_jobs ENABLE ROW LEVEL SECURITY;
+ALTER TABLE workspace_export_jobs FORCE ROW LEVEL SECURITY;
+CREATE POLICY workspace_export_jobs_workspace_isolation
+    ON workspace_export_jobs
+    USING (workspace_id = (NULLIF(current_setting('app.workspace_id', true), ''))::integer)
+    WITH CHECK (workspace_id = (NULLIF(current_setting('app.workspace_id', true), ''))::integer);

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -80,6 +80,7 @@ pub mod users;
 pub mod webhooks;
 pub mod well_known;
 pub mod workflow_states;
+pub mod workspace_data_export;
 pub mod workspace_email;
 pub mod workspace_export;
 pub mod workspace_members;

--- a/backend/src/handlers/workspace_data_export.rs
+++ b/backend/src/handlers/workspace_data_export.rs
@@ -1,0 +1,306 @@
+//! Self-serve workspace data export (Owner-gated). The Art 28(3)(g) "return"
+//! path: a workspace Owner exports all of their workspace's data (tickets,
+//! comments, attachments, requesters, orgs, documents, ...) as a single ZIP,
+//! before an account deletion erases it.
+//!
+//! Reuses the platform-admin export service (`services::workspace_export`), but:
+//! - gated to the workspace Owner (not a cross-tenant platform admin), and the
+//!   workspace comes from `WorkspaceContext`, NEVER a path param;
+//! - runs as a background job that writes a storage-backed artifact with a
+//!   bounded download window (`expires_at`), instead of a synchronous stream;
+//! - strips sensitive auth fields (`include_sensitive = false`) since a data
+//!   export never needs password hashes; an optional password only SEALS the zip.
+
+use actix_web::http::header;
+use actix_web::{web, HttpMessage, HttpRequest, HttpResponse, Responder};
+use chrono::{Duration, Utc};
+use serde::Deserialize;
+use serde_json::json;
+use uuid::Uuid;
+
+use crate::db::Pool;
+use crate::extractors::{TenantConn, WorkspaceContext};
+use crate::handlers::errors;
+use crate::models::{
+    Claims, NewWorkspaceExportJob, WorkspaceExportJob, WorkspaceExportJobUpdate, WorkspaceRole,
+};
+use crate::repository::workspace_export_jobs as export_repo;
+use crate::services::workspace_export::{assemble_workspace_archive, collect_workspace_rows};
+use crate::sync::actor::ActorContext;
+use crate::sync::session::with_actor_bypass_context;
+use crate::utils::rbac::require_workspace_role;
+use crate::utils::storage::{process_storage, WorkspaceScopedStorage};
+
+/// Cap on the in-memory archive (row dumps + files). A larger workspace is
+/// refused with a clear message rather than risking an OOM of the instance.
+const MAX_EXPORT_BYTES: usize = 1024 * 1024 * 1024; // 1 GiB
+/// How long a completed export stays downloadable, from completion.
+const EXPORT_TTL_DAYS: i64 = 7;
+/// Minimum spacing between completed exports per workspace.
+const MIN_HOURS_BETWEEN_EXPORTS: i64 = 24;
+
+pub fn config(cfg: &mut web::ServiceConfig) {
+    cfg.route("/workspace/export", web::post().to(request_export))
+        .route("/workspace/export/{id}", web::get().to(get_export_status))
+        .route(
+            "/workspace/export/{id}/download",
+            web::get().to(download_export),
+        );
+}
+
+#[derive(Debug, Deserialize)]
+pub struct RequestExportBody {
+    /// Optional: when present, the archive is sealed with AES-256-GCM.
+    #[serde(default)]
+    pub password: Option<String>,
+}
+
+fn job_view(job: &WorkspaceExportJob) -> serde_json::Value {
+    let now = Utc::now().naive_utc();
+    let download_available =
+        job.status == "completed" && job.expires_at.map(|e| e > now).unwrap_or(false);
+    json!({
+        "id": job.id,
+        "status": job.status,
+        "file_size": job.file_size,
+        "error_message": job.error_message,
+        "created_at": job.created_at,
+        "completed_at": job.completed_at,
+        "expires_at": job.expires_at,
+        "download_available": download_available,
+    })
+}
+
+/// POST /api/workspace/export — request a self-serve export of THIS workspace.
+/// Owner-only. Returns 202 with the job to poll.
+pub async fn request_export(
+    pool: web::Data<Pool>,
+    mut tc: TenantConn,
+    ws: WorkspaceContext,
+    req: HttpRequest,
+    body: web::Json<RequestExportBody>,
+) -> impl Responder {
+    if let Err(resp) = require_workspace_role(&req, WorkspaceRole::Owner) {
+        return resp;
+    }
+    let workspace_id = ws.workspace_id;
+    let requested_by = req
+        .extensions()
+        .get::<Claims>()
+        .and_then(|c| Uuid::parse_str(&c.sub).ok());
+    let password = body.into_inner().password.filter(|p| !p.is_empty());
+
+    // Rate limit 1: at most one in-flight export.
+    match tc.run(|conn| export_repo::has_active(conn, workspace_id)) {
+        Ok(true) => return errors::conflict("An export is already in progress."),
+        Ok(false) => {}
+        Err(e) => return errors::internal(format!("export check: {e}")),
+    }
+    // Rate limit 2: one completed export per day (a completed export can be
+    // re-downloaded within its window, so this bounds the work, not access).
+    let since = (Utc::now() - Duration::hours(MIN_HOURS_BETWEEN_EXPORTS)).naive_utc();
+    match tc.run(|conn| export_repo::last_completed_at(conn, workspace_id)) {
+        Ok(Some(last)) if last > since => {
+            return errors::too_many_requests(
+                "You can request one export per day. Download your latest export, or try again later.",
+                MIN_HOURS_BETWEEN_EXPORTS as u64 * 3600,
+            );
+        }
+        Ok(_) => {}
+        Err(e) => return errors::internal(format!("export rate check: {e}")),
+    }
+
+    let new_job = NewWorkspaceExportJob {
+        workspace_id,
+        requested_by,
+        status: "processing".to_string(),
+    };
+    let job = match tc.run(|conn| export_repo::create(conn, new_job)) {
+        Ok(j) => j,
+        Err(e) => return errors::internal(format!("create export job: {e}")),
+    };
+    let job_id = job.id;
+
+    // Background: the export must read across RLS, so it runs under the BYPASSRLS
+    // role with the workspace_id captured from the (Owner-gated) request context.
+    let pool_clone = pool.clone();
+    tokio::spawn(async move {
+        run_export(pool_clone, job_id, workspace_id, password).await;
+    });
+
+    HttpResponse::Accepted().json(job_view(&job))
+}
+
+/// GET /api/workspace/export/{id} — poll job status. Owner-only, workspace-scoped.
+pub async fn get_export_status(
+    mut tc: TenantConn,
+    ws: WorkspaceContext,
+    req: HttpRequest,
+    path: web::Path<Uuid>,
+) -> impl Responder {
+    if let Err(resp) = require_workspace_role(&req, WorkspaceRole::Owner) {
+        return resp;
+    }
+    let id = path.into_inner();
+    match tc.run(|conn| export_repo::get_owned(conn, id, ws.workspace_id)) {
+        Ok(Some(job)) => HttpResponse::Ok().json(job_view(&job)),
+        Ok(None) => errors::not_found("export"),
+        Err(e) => errors::internal(format!("export status: {e}")),
+    }
+}
+
+/// GET /api/workspace/export/{id}/download — stream the artifact. Owner-only,
+/// workspace-scoped. 410 once the download window has passed.
+pub async fn download_export(
+    mut tc: TenantConn,
+    ws: WorkspaceContext,
+    req: HttpRequest,
+    path: web::Path<Uuid>,
+) -> impl Responder {
+    if let Err(resp) = require_workspace_role(&req, WorkspaceRole::Owner) {
+        return resp;
+    }
+    let id = path.into_inner();
+    let job = match tc.run(|conn| export_repo::get_owned(conn, id, ws.workspace_id)) {
+        Ok(Some(j)) => j,
+        Ok(None) => return errors::not_found("export"),
+        Err(e) => return errors::internal(format!("export lookup: {e}")),
+    };
+    if job.status != "completed" {
+        return errors::not_found("export");
+    }
+    let now = Utc::now().naive_utc();
+    if job.expires_at.map(|e| e < now).unwrap_or(true) {
+        return errors::gone("This export has expired. Request a new one.");
+    }
+    let Some(key) = job.file_path else {
+        return errors::not_found("export");
+    };
+
+    let scoped = WorkspaceScopedStorage::arc(process_storage(), ws.workspace_id);
+    let bytes = match scoped.get_file(&key).await {
+        Ok(b) => b,
+        Err(e) => return errors::internal(format!("read export artifact: {e:?}")),
+    };
+    // The artifact is the whole tenant's data: no-store, no CORS wildcard, and an
+    // attachment disposition (NOT the generic file proxy, which sets public
+    // caching + ACAO:*).
+    HttpResponse::Ok()
+        .content_type("application/octet-stream")
+        .insert_header((
+            header::CONTENT_DISPOSITION,
+            format!(
+                "attachment; filename=\"workspace-{}.nosdesk\"",
+                ws.workspace_id
+            ),
+        ))
+        .insert_header((header::CACHE_CONTROL, "no-store"))
+        .body(bytes)
+}
+
+/// Run the export end to end and record the terminal status. Never panics the
+/// worker: any failure is logged and written as `failed` so the poller sees it.
+async fn run_export(
+    pool: web::Data<Pool>,
+    job_id: Uuid,
+    workspace_id: i32,
+    password: Option<String>,
+) {
+    let outcome = run_export_inner(&pool, job_id, workspace_id, password).await;
+
+    let mut conn = match pool.get() {
+        Ok(c) => c,
+        Err(e) => {
+            log::error!("workspace export {job_id}: cannot get conn to record status: {e}");
+            return;
+        }
+    };
+    let actor = ActorContext::system("background:workspace_export");
+    let upd = match outcome {
+        Ok((file_path, file_size)) => {
+            let now = Utc::now().naive_utc();
+            WorkspaceExportJobUpdate {
+                status: Some("completed".to_string()),
+                file_path: Some(file_path),
+                file_size: Some(file_size),
+                completed_at: Some(now),
+                expires_at: Some(now + Duration::days(EXPORT_TTL_DAYS)),
+                ..Default::default()
+            }
+        }
+        Err(msg) => {
+            log::error!("workspace export {job_id} failed: {msg}");
+            WorkspaceExportJobUpdate {
+                status: Some("failed".to_string()),
+                error_message: Some(msg),
+                ..Default::default()
+            }
+        }
+    };
+    let _ = with_actor_bypass_context(&mut conn, &actor, |conn| {
+        export_repo::update(conn, job_id, upd).map(|_| ())
+    });
+}
+
+/// The export work. Returns `(storage_key, byte_size)` on success, or a
+/// human-readable failure message. Bounds peak memory: the row dumps and the
+/// files are summed against `MAX_EXPORT_BYTES` and a large workspace is refused
+/// before it can OOM the instance.
+async fn run_export_inner(
+    pool: &web::Data<Pool>,
+    job_id: Uuid,
+    workspace_id: i32,
+    password: Option<String>,
+) -> Result<(String, i64), String> {
+    // 1. Row dumps (sync, BYPASSRLS). include_sensitive = false: a data export
+    //    never needs auth secrets.
+    let mut conn = pool.get().map_err(|e| format!("pool: {e}"))?;
+    let actor = ActorContext::system("background:workspace_export");
+    let (dumps, meta) = with_actor_bypass_context(&mut conn, &actor, |conn| {
+        collect_workspace_rows(conn, workspace_id, false)
+            .map_err(|e| diesel::result::Error::QueryBuilderError(e.to_string().into()))
+    })
+    .map_err(|e| format!("collect rows: {e}"))?;
+    drop(conn);
+
+    let mut total: usize = dumps.iter().map(|d| d.json.len()).sum();
+    if total > MAX_EXPORT_BYTES {
+        return Err(too_large());
+    }
+
+    // 2. Files, read with a cumulative cap.
+    let scoped = WorkspaceScopedStorage::arc(process_storage(), workspace_id);
+    let paths = scoped
+        .list_prefix("")
+        .await
+        .map_err(|e| format!("list files: {e:?}"))?;
+    let mut files: Vec<(String, Vec<u8>)> = Vec::with_capacity(paths.len());
+    for p in paths {
+        let bytes = scoped
+            .get_file(&p)
+            .await
+            .map_err(|e| format!("read file {p}: {e:?}"))?;
+        total += bytes.len();
+        if total > MAX_EXPORT_BYTES {
+            return Err(too_large());
+        }
+        files.push((p, bytes));
+    }
+
+    // 3. Assemble (sync CPU). 4. Store under the workspace-scoped prefix.
+    let archive =
+        assemble_workspace_archive(&dumps, &meta, workspace_id, &files, password.as_deref())
+            .map_err(|e| format!("assemble archive: {e}"))?;
+    let file_size = archive.len() as i64;
+    let key = format!("exports/{job_id}.nosdesk");
+    scoped
+        .put_file(&archive, &key, "application/octet-stream")
+        .await
+        .map_err(|e| format!("store artifact: {e:?}"))?;
+    Ok((key, file_size))
+}
+
+fn too_large() -> String {
+    "This workspace is too large for a self-serve export. Contact support to arrange one."
+        .to_string()
+}

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -4536,6 +4536,44 @@ pub struct BackupJobUpdate {
     pub completed_at: Option<NaiveDateTime>,
 }
 
+// ── Self-serve workspace export (Owner-gated; account-erasure Phase 3) ──
+
+#[derive(Debug, Serialize, Deserialize, Identifiable, Queryable)]
+#[diesel(table_name = crate::schema::workspace_export_jobs)]
+pub struct WorkspaceExportJob {
+    pub id: Uuid,
+    pub workspace_id: i32,
+    pub requested_by: Option<Uuid>,
+    pub status: String,
+    pub file_path: Option<String>,
+    pub file_size: Option<i64>,
+    pub error_message: Option<String>,
+    pub created_at: NaiveDateTime,
+    pub completed_at: Option<NaiveDateTime>,
+    pub expires_at: Option<NaiveDateTime>,
+}
+
+#[derive(Debug, Insertable)]
+#[diesel(table_name = crate::schema::workspace_export_jobs)]
+pub struct NewWorkspaceExportJob {
+    pub workspace_id: i32,
+    pub requested_by: Option<Uuid>,
+    pub status: String,
+}
+
+/// Partial update: a `None` field is left unchanged (cannot NULL a column, which
+/// this flow never needs to).
+#[derive(Debug, Default, AsChangeset)]
+#[diesel(table_name = crate::schema::workspace_export_jobs)]
+pub struct WorkspaceExportJobUpdate {
+    pub status: Option<String>,
+    pub file_path: Option<String>,
+    pub file_size: Option<i64>,
+    pub error_message: Option<String>,
+    pub completed_at: Option<NaiveDateTime>,
+    pub expires_at: Option<NaiveDateTime>,
+}
+
 /// CSV import job. Two-phase: rows go through dry-run (parse +
 /// validate, write `summary`) before the admin commits. The
 /// audit row outlives the request that triggered the upload so

--- a/backend/src/repository/mod.rs
+++ b/backend/src/repository/mod.rs
@@ -76,6 +76,7 @@ pub mod site_settings;
 
 // Per-workspace outbound email identity
 pub mod workspace_email_settings;
+pub mod workspace_export_jobs;
 pub mod workspace_ldap_settings;
 
 // Backup and restore

--- a/backend/src/repository/workspace_export_jobs.rs
+++ b/backend/src/repository/workspace_export_jobs.rs
@@ -1,0 +1,105 @@
+//! Self-serve workspace export jobs (Owner-gated). Tracks one export request,
+//! its storage-backed artifact, and a bounded download window. All access is
+//! isolated by `workspace_id` (RLS for the tenant-facing reads; an explicit
+//! predicate on `get_owned` so a guessed id from another tenant is a clean miss).
+
+use crate::db::DbConnection;
+use crate::models::{NewWorkspaceExportJob, WorkspaceExportJob, WorkspaceExportJobUpdate};
+use crate::schema::workspace_export_jobs;
+use chrono::NaiveDateTime;
+use diesel::prelude::*;
+use uuid::Uuid;
+
+// sync-audit-only: Operational / bespoke tables
+/// Create an export job (status defaults to `pending`).
+pub fn create(
+    conn: &mut DbConnection,
+    new: NewWorkspaceExportJob,
+) -> QueryResult<WorkspaceExportJob> {
+    diesel::insert_into(workspace_export_jobs::table)
+        .values(&new)
+        .get_result(conn)
+}
+
+/// Fetch a job by id, scoped to a workspace. The `workspace_id` predicate is the
+/// isolation for reads that run through the BYPASSRLS role.
+pub fn get_owned(
+    conn: &mut DbConnection,
+    id: Uuid,
+    workspace_id: i32,
+) -> QueryResult<Option<WorkspaceExportJob>> {
+    workspace_export_jobs::table
+        .filter(workspace_export_jobs::id.eq(id))
+        .filter(workspace_export_jobs::workspace_id.eq(workspace_id))
+        .first(conn)
+        .optional()
+}
+
+/// Whether the workspace has an in-flight (pending/processing) export.
+pub fn has_active(conn: &mut DbConnection, workspace_id: i32) -> QueryResult<bool> {
+    diesel::select(diesel::dsl::exists(
+        workspace_export_jobs::table
+            .filter(workspace_export_jobs::workspace_id.eq(workspace_id))
+            .filter(workspace_export_jobs::status.eq_any(vec!["pending", "processing"])),
+    ))
+    .get_result(conn)
+}
+
+/// The most recent completed export's `created_at` (drives the per-day limit).
+pub fn last_completed_at(
+    conn: &mut DbConnection,
+    workspace_id: i32,
+) -> QueryResult<Option<NaiveDateTime>> {
+    workspace_export_jobs::table
+        .filter(workspace_export_jobs::workspace_id.eq(workspace_id))
+        .filter(workspace_export_jobs::status.eq("completed"))
+        .order(workspace_export_jobs::created_at.desc())
+        .select(workspace_export_jobs::created_at)
+        .first(conn)
+        .optional()
+}
+
+// sync-audit-only: Operational / bespoke tables
+/// Apply a partial update.
+pub fn update(
+    conn: &mut DbConnection,
+    id: Uuid,
+    upd: WorkspaceExportJobUpdate,
+) -> QueryResult<WorkspaceExportJob> {
+    diesel::update(workspace_export_jobs::table.find(id))
+        .set(&upd)
+        .get_result(conn)
+}
+
+/// Completed jobs whose download window has passed (for artifact cleanup).
+pub fn list_expired(
+    conn: &mut DbConnection,
+    now: NaiveDateTime,
+) -> QueryResult<Vec<WorkspaceExportJob>> {
+    workspace_export_jobs::table
+        .filter(workspace_export_jobs::status.eq("completed"))
+        .filter(workspace_export_jobs::expires_at.lt(now))
+        .load(conn)
+}
+
+// sync-audit-only: Operational / bespoke tables
+/// Fail pending/processing jobs older than `cutoff` (crash / stuck recovery), so
+/// the poller sees a terminal state rather than a job stranded at `processing`.
+pub fn fail_stale(conn: &mut DbConnection, cutoff: NaiveDateTime) -> QueryResult<usize> {
+    diesel::update(
+        workspace_export_jobs::table
+            .filter(workspace_export_jobs::status.eq_any(vec!["pending", "processing"]))
+            .filter(workspace_export_jobs::created_at.lt(cutoff)),
+    )
+    .set((
+        workspace_export_jobs::status.eq("failed"),
+        workspace_export_jobs::error_message.eq(Some("Export timed out".to_string())),
+    ))
+    .execute(conn)
+}
+
+// sync-audit-only: Operational / bespoke tables
+/// Delete a job row (after its artifact is removed from storage).
+pub fn delete(conn: &mut DbConnection, id: Uuid) -> QueryResult<usize> {
+    diesel::delete(workspace_export_jobs::table.find(id)).execute(conn)
+}

--- a/backend/src/route_registration_tests.rs
+++ b/backend/src/route_registration_tests.rs
@@ -32,6 +32,19 @@ async fn sse_config_routes_registered() {
 }
 
 #[actix_web::test]
+async fn workspace_data_export_config_routes_registered() {
+    assert_config_registers(
+        crate::handlers::workspace_data_export::config,
+        &[
+            ("POST", "/workspace/export"),
+            ("GET", "/workspace/export/{id}"),
+            ("GET", "/workspace/export/{id}/download"),
+        ],
+    )
+    .await;
+}
+
+#[actix_web::test]
 async fn search_config_routes_registered() {
     assert_config_registers(
         crate::handlers::search::config,

--- a/backend/src/schema.rs
+++ b/backend/src/schema.rs
@@ -2110,6 +2110,22 @@ diesel::table! {
 }
 
 diesel::table! {
+    workspace_export_jobs (id) {
+        id -> Uuid,
+        workspace_id -> Int4,
+        requested_by -> Nullable<Uuid>,
+        #[max_length = 20]
+        status -> Varchar,
+        file_path -> Nullable<Text>,
+        file_size -> Nullable<Int8>,
+        error_message -> Nullable<Text>,
+        created_at -> Timestamptz,
+        completed_at -> Nullable<Timestamptz>,
+        expires_at -> Nullable<Timestamptz>,
+    }
+}
+
+diesel::table! {
     workspace_ldap_settings (workspace_id) {
         workspace_id -> Int4,
         enabled -> Bool,
@@ -2445,6 +2461,7 @@ diesel::joinable!(working_calendar_holidays -> workspaces (workspace_id));
 diesel::joinable!(working_calendars -> users (created_by));
 diesel::joinable!(working_calendars -> workspaces (workspace_id));
 diesel::joinable!(workspace_email_settings -> workspaces (workspace_id));
+diesel::joinable!(workspace_export_jobs -> workspaces (workspace_id));
 diesel::joinable!(workspace_ldap_settings -> workspaces (workspace_id));
 diesel::joinable!(workspace_ldap_sync_state -> workspaces (workspace_id));
 diesel::joinable!(workspace_members -> users (user_uuid));
@@ -2569,6 +2586,7 @@ diesel::allow_tables_to_appear_in_same_query!(
     working_calendar_holidays,
     working_calendars,
     workspace_email_settings,
+    workspace_export_jobs,
     workspace_ldap_settings,
     workspace_ldap_sync_state,
     workspace_members,

--- a/backend/src/services/scheduled_jobs.rs
+++ b/backend/src/services/scheduled_jobs.rs
@@ -407,6 +407,61 @@ pub async fn prune_csp_reports(pool: Pool) -> Result<()> {
     Ok(())
 }
 
+/// Retention for self-serve workspace exports: fail jobs stuck in
+/// pending/processing (a crashed background task, since the spawn is
+/// fire-and-forget with no lease), then delete completed artifacts whose download
+/// window has passed (storage file + row). Cross-tenant, so it runs under
+/// background_run (BYPASSRLS) like the other sweeps.
+pub async fn cleanup_expired_workspace_exports(pool: Pool) -> Result<()> {
+    let now = chrono::Utc::now().naive_utc();
+    let stale_cutoff = (chrono::Utc::now() - chrono::Duration::hours(1)).naive_utc();
+
+    let failed =
+        // cross-tenant: recover exports stranded by a crashed background task.
+        crate::sync::session::background_run(&pool, "scheduler:workspace_export_stale", |conn| {
+            crate::repository::workspace_export_jobs::fail_stale(conn, stale_cutoff)
+        })
+        .map_err(|e| anyhow::anyhow!("fail stale workspace exports: {e}"))?;
+    if failed > 0 {
+        info!(count = failed, "scheduler: stale workspace exports failed");
+    }
+
+    let expired =
+        // cross-tenant: expired-artifact cleanup across every workspace.
+        crate::sync::session::background_run(&pool, "scheduler:workspace_export_expired", |conn| {
+            crate::repository::workspace_export_jobs::list_expired(conn, now)
+        })
+        .map_err(|e| anyhow::anyhow!("list expired workspace exports: {e}"))?;
+
+    let mut purged = 0usize;
+    for job in expired {
+        if let Some(key) = job.file_path.as_deref() {
+            let scoped = crate::utils::storage::WorkspaceScopedStorage::arc(
+                crate::utils::storage::process_storage(),
+                job.workspace_id,
+            );
+            if let Err(e) = scoped.delete_file(key).await {
+                // Leave the row so we retry next sweep rather than orphaning the file.
+                warn!(job_id = %job.id, error = ?e, "scheduler: export artifact delete failed; will retry");
+                continue;
+            }
+        }
+        let _ =
+            // cross-tenant: delete the expired export's row after its file is gone.
+            crate::sync::session::background_run(&pool, "scheduler:workspace_export_delete", |conn| {
+                crate::repository::workspace_export_jobs::delete(conn, job.id)
+            });
+        purged += 1;
+    }
+    if purged > 0 {
+        info!(
+            count = purged,
+            "scheduler: expired workspace exports purged"
+        );
+    }
+    Ok(())
+}
+
 /// Auto-archive stale notifications so the bell/inbox self-prunes instead of
 /// growing without bound. Read notifications older than
 /// `NOTIFICATION_READ_RETENTION_DAYS` (default 30) are archived; anything older

--- a/backend/src/services/workspace_export.rs
+++ b/backend/src/services/workspace_export.rs
@@ -60,7 +60,10 @@ const WORKSPACE_EXPORT_FORMAT_VERSION: u32 = 1;
 /// high-churn tables. They carry `workspace_id` but are the audit trail and the
 /// sync outbox, not core tenant data, and their partitioned shape complicates a
 /// scoped dump (matching the whole-DB backup's parent-only handling).
-const EXCLUDE_FROM_WORKSPACE_EXPORT: &[&str] = &["audit_log", "sync_actions"];
+// `workspace_export_jobs` carries a workspace_id but is operational metadata (job
+// status + storage keys), not tenant content, so it is excluded like audit_log.
+const EXCLUDE_FROM_WORKSPACE_EXPORT: &[&str] =
+    &["audit_log", "sync_actions", "workspace_export_jobs"];
 
 /// The export package manifest. Carries everything the Phase 2 import needs:
 /// the workspace identity, the member user uuids referenced by tenant rows, and

--- a/backend/src/startup.rs
+++ b/backend/src/startup.rs
@@ -857,6 +857,8 @@ pub fn configure_app(
                     // requires ?confirm=<slug> matching the row.
                     .configure(crate::handlers::admin_workspaces::config)
                     .configure(crate::handlers::workspace_export::config)
+                    // Self-serve, Owner-gated workspace data export (DSAR return).
+                    .configure(crate::handlers::workspace_data_export::config)
 
                     // Guest access controls (admin only)
                     .configure(crate::handlers::guest_settings::config)

--- a/backend/src/workers.rs
+++ b/backend/src/workers.rs
@@ -51,6 +51,17 @@ pub fn spawn_scheduled_jobs(
             move || jobs::cleanup_expired_refresh_tokens(p.clone()),
         );
 
+        // Hourly: fail stranded self-serve workspace exports and delete expired
+        // export artifacts (storage file + row) past their download window.
+        let p = pool.clone();
+        spawn_periodic(
+            "workspace_exports.cleanup",
+            Duration::from_secs(60 * 60),
+            scheduler_shutdown.clone(),
+            scheduler_status.clone(),
+            move || jobs::cleanup_expired_workspace_exports(p.clone()),
+        );
+
         // Daily: send notification email digests (batches the notifications a
         // user set to email=digest into one summary). Single-machine via lock.
         let p = pool.clone();


### PR DESCRIPTION
## What

A self-serve, Owner-gated **"export my data"** for a workspace: the Art 28(3)(g) "return" path a customer uses to take all of their workspace data (tickets, comments, attachments, requesters, orgs, documents, ...) before an account deletion erases it. This is a prerequisite for the control-plane account-erasure work (auto-erase-after-grace can only ship once customers can export first).

## Approach

Reuses the existing platform-admin export service (`collect_workspace_rows` + `assemble_workspace_archive`), but delivered as a self-serve background job rather than a synchronous platform-admin stream:

- **`workspace_export_jobs`** table (proper RLS tenant table; `workspace_id` comes from `WorkspaceContext`, never a path param) tracks one export + a bounded download window.
- **`POST /api/workspace/export`** (Owner-gated) refuses a concurrent export and rate-limits to one completed export per day, then runs the export under the BYPASSRLS role in a `tokio::spawn`. It strips sensitive auth fields (`include_sensitive = false` — a data export never needs password hashes); an optional password only AES-256-GCM-seals the archive.
- **Memory is bounded:** the row dumps + attachments are summed against a 1 GiB cap and a larger workspace is refused rather than risking an OOM (the existing export holds the whole archive in memory).
- **`GET /api/workspace/export/{id}`** polls status; **`GET .../download`** streams the artifact with `Cache-Control: no-store` and no CORS wildcard (not the generic file proxy), returning 410 once the 7-day window passes.
- **Hourly retention sweep** deletes expired artifacts (storage file + row) and fails jobs stranded by a crashed background task (the spawn is fire-and-forget, no lease).
- Excludes `workspace_export_jobs` from the workspace export itself (it carries a `workspace_id`).

## Validation

Migration reverses cleanly (down + up); `cargo check` + `cargo check --tests` clean; the four enforced lints (sync-emit, direct-write, tenant-read, audit-context) pass; the route-registration test passes; and the live routes reject unauthenticated calls (403/401, not 404).

## Follow-up

The Owner-facing frontend action (request + poll + download) lands in a follow-up PR.