### PR TITLE
feat(export): self-serve workspace export UI (Owner-gated)

### DIFF
--- a/backend/src/handlers/workspace_data_export.rs
+++ b/backend/src/handlers/workspace_data_export.rs
@@ -41,6 +41,7 @@ const MIN_HOURS_BETWEEN_EXPORTS: i64 = 24;
 
 pub fn config(cfg: &mut web::ServiceConfig) {
     cfg.route("/workspace/export", web::post().to(request_export))
+        .route("/workspace/export", web::get().to(list_latest_export))
         .route("/workspace/export/{id}", web::get().to(get_export_status))
         .route(
             "/workspace/export/{id}/download",
@@ -129,6 +130,24 @@ pub async fn request_export(
     });
 
     HttpResponse::Accepted().json(job_view(&job))
+}
+
+/// GET /api/workspace/export — the workspace's most recent export (or `null`),
+/// so the UI can resume an in-flight export or offer a ready download after a
+/// reload. Owner-only.
+pub async fn list_latest_export(
+    mut tc: TenantConn,
+    ws: WorkspaceContext,
+    req: HttpRequest,
+) -> impl Responder {
+    if let Err(resp) = require_workspace_role(&req, WorkspaceRole::Owner) {
+        return resp;
+    }
+    match tc.run(|conn| export_repo::latest_for_workspace(conn, ws.workspace_id)) {
+        Ok(Some(job)) => HttpResponse::Ok().json(job_view(&job)),
+        Ok(None) => HttpResponse::Ok().json(serde_json::Value::Null),
+        Err(e) => errors::internal(format!("latest export: {e}")),
+    }
 }
 
 /// GET /api/workspace/export/{id} — poll job status. Owner-only, workspace-scoped.

--- a/backend/src/repository/workspace_export_jobs.rs
+++ b/backend/src/repository/workspace_export_jobs.rs
@@ -45,6 +45,19 @@ pub fn has_active(conn: &mut DbConnection, workspace_id: i32) -> QueryResult<boo
     .get_result(conn)
 }
 
+/// The most recent export job for a workspace (any status), so the UI can show
+/// an in-flight or ready export after a reload rather than losing track of it.
+pub fn latest_for_workspace(
+    conn: &mut DbConnection,
+    workspace_id: i32,
+) -> QueryResult<Option<WorkspaceExportJob>> {
+    workspace_export_jobs::table
+        .filter(workspace_export_jobs::workspace_id.eq(workspace_id))
+        .order(workspace_export_jobs::created_at.desc())
+        .first(conn)
+        .optional()
+}
+
 /// The most recent completed export's `created_at` (drives the per-day limit).
 pub fn last_completed_at(
     conn: &mut DbConnection,

--- a/backend/src/route_registration_tests.rs
+++ b/backend/src/route_registration_tests.rs
@@ -37,6 +37,7 @@ async fn workspace_data_export_config_routes_registered() {
         crate::handlers::workspace_data_export::config,
         &[
             ("POST", "/workspace/export"),
+            ("GET", "/workspace/export"),
             ("GET", "/workspace/export/{id}"),
             ("GET", "/workspace/export/{id}/download"),
         ],

--- a/frontend/src/components/settings/WorkspaceDataExportCard.vue
+++ b/frontend/src/components/settings/WorkspaceDataExportCard.vue
@@ -1,0 +1,224 @@
+<template>
+  <div class="bg-surface border border-default rounded-xl hover:border-strong transition-colors">
+    <div class="p-4 flex flex-col gap-3">
+      <div class="flex items-center gap-3">
+        <div
+          class="flex-shrink-0 h-9 w-9 rounded-lg bg-accent/20 flex items-center justify-center text-accent"
+        >
+          <Icon name="archive" size="md" />
+        </div>
+
+        <div class="flex-1 min-w-0">
+          <span class="font-medium text-primary">{{ t('settings-export-title') }}</span>
+        </div>
+
+        <Button
+          variant="secondary"
+          size="sm"
+          icon="download"
+          :loading="busy"
+          :disabled="!canRequest"
+          @click="requestExport"
+        >
+          {{ busy ? t('settings-export-preparing') : requestLabel }}
+        </Button>
+      </div>
+
+      <p class="text-secondary text-sm">
+        {{ t('settings-export-description') }}
+      </p>
+
+      <!-- Optional password, only offered when starting a fresh export -->
+      <div v-if="showPasswordField" class="max-w-sm">
+        <FormInput
+          v-model="password"
+          type="password"
+          size="sm"
+          autocomplete="new-password"
+          :label="t('settings-export-password-label')"
+          :description="t('settings-export-password-hint')"
+          :disabled="busy"
+        />
+      </div>
+
+      <p v-else-if="rateLimited" class="text-tertiary text-xs flex items-center gap-1.5">
+        <Icon name="clock" size="sm" />
+        {{ t('settings-export-rate-limited') }}
+      </p>
+    </div>
+
+    <!-- Status panel -->
+    <div
+      v-if="statusPanel"
+      class="border-t border-default p-4 bg-surface-alt rounded-b-xl flex flex-col gap-3"
+    >
+      <!-- Processing -->
+      <div v-if="isProcessing" class="flex items-center gap-2 text-sm text-secondary">
+        <Spinner size="sm" />
+        <span>{{ t('settings-export-status-processing') }}</span>
+      </div>
+
+      <!-- Ready -->
+      <template v-else-if="isReady">
+        <div class="flex items-start gap-2">
+          <Icon name="checkCircle" size="sm" class="text-status-success mt-0.5 flex-shrink-0" />
+          <div class="flex flex-col gap-0.5 min-w-0">
+            <span class="text-sm text-status-success font-medium">
+              {{ t('settings-export-status-ready') }}
+            </span>
+            <span class="text-xs text-tertiary">
+              {{ readyMeta }}
+            </span>
+          </div>
+        </div>
+        <div>
+          <Button variant="primary" size="sm" icon="download" @click="download">
+            {{ t('settings-export-download') }}
+          </Button>
+        </div>
+      </template>
+
+      <!-- Expired -->
+      <div v-else-if="isExpired" class="flex items-center gap-2 text-sm text-secondary">
+        <Icon name="clock" size="sm" class="text-tertiary flex-shrink-0" />
+        <span>{{ t('settings-export-status-expired') }}</span>
+      </div>
+
+      <!-- Failed -->
+      <div v-else-if="isFailed" class="flex items-start gap-2">
+        <Icon name="warning" size="sm" class="text-status-error mt-0.5 flex-shrink-0" />
+        <span class="text-sm text-status-error">
+          {{ job?.error_message || t('settings-export-status-failed') }}
+        </span>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onMounted } from 'vue';
+import { useFluent } from 'fluent-vue';
+import { useToastStore } from '@nosdesk/core/stores/toast';
+import Button from '@/components/common/Button.vue';
+import Icon from '@/components/common/Icon.vue';
+import FormInput from '@/components/common/FormInput.vue';
+import Spinner from '@/components/common/Spinner.vue';
+import {
+  workspaceExportService,
+  type WorkspaceExportJob,
+} from '@/services/workspaceExportService';
+
+const fluent = useFluent();
+const t = (key: string, args?: Record<string, string | number>) => fluent.$t(key, args);
+const toast = useToastStore();
+
+const job = ref<WorkspaceExportJob | null>(null);
+const busy = ref(false);
+const password = ref('');
+
+const isProcessing = computed(
+  () => job.value?.status === 'processing' || job.value?.status === 'pending'
+);
+const isReady = computed(() => job.value?.status === 'completed' && job.value.download_available);
+const isExpired = computed(
+  () => job.value?.status === 'completed' && !job.value.download_available
+);
+const isFailed = computed(() => job.value?.status === 'failed');
+const statusPanel = computed(
+  () => busy.value || isProcessing.value || isReady.value || isExpired.value || isFailed.value
+);
+
+// One completed export per 24h; disable the request while inside that window so
+// the user gets a hint instead of a rejected request. The server is the real gate.
+const rateLimited = computed(() => {
+  if (job.value?.status !== 'completed') return false;
+  const created = new Date(job.value.created_at).getTime();
+  return Number.isFinite(created) && Date.now() - created < 24 * 60 * 60 * 1000;
+});
+const canRequest = computed(() => !busy.value && !isProcessing.value && !rateLimited.value);
+const showPasswordField = computed(() => canRequest.value && !isReady.value);
+const requestLabel = computed(() =>
+  job.value ? t('settings-export-action-new') : t('settings-export-action')
+);
+
+const readyMeta = computed(() => {
+  const parts: string[] = [];
+  if (job.value?.file_size) parts.push(formatBytes(job.value.file_size));
+  if (job.value?.expires_at) {
+    parts.push(t('settings-export-status-ready-until', { date: formatDate(job.value.expires_at) }));
+  }
+  return parts.join(' · ');
+});
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  const units = ['KB', 'MB', 'GB'];
+  let value = bytes / 1024;
+  let unit = 0;
+  while (value >= 1024 && unit < units.length - 1) {
+    value /= 1024;
+    unit += 1;
+  }
+  return `${value.toFixed(value >= 10 ? 0 : 1)} ${units[unit]}`;
+}
+
+function formatDate(iso: string): string {
+  const d = new Date(iso);
+  return Number.isNaN(d.getTime())
+    ? iso
+    : d.toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' });
+}
+
+async function requestExport() {
+  if (!canRequest.value) return;
+  busy.value = true;
+  try {
+    const started = await workspaceExportService.requestExport(password.value);
+    password.value = '';
+    job.value = started;
+    const finished = await workspaceExportService.pollExport(started.id);
+    job.value = finished;
+    if (finished.status === 'completed') {
+      toast.success(t('settings-export-success'));
+    } else {
+      toast.error(finished.error_message || t('settings-export-status-failed'));
+    }
+  } catch (e) {
+    const status = (e as { response?: { status?: number } })?.response?.status;
+    if (status === 429) {
+      toast.error(t('settings-export-rate-limited'));
+    } else if (status === 409) {
+      toast.error(t('settings-export-in-progress'));
+      await refresh();
+    } else {
+      toast.error(t('settings-export-error'));
+    }
+  } finally {
+    busy.value = false;
+  }
+}
+
+function download() {
+  if (job.value?.id) workspaceExportService.downloadExport(job.value.id);
+}
+
+async function refresh() {
+  try {
+    const latest = await workspaceExportService.getLatest();
+    job.value = latest;
+    // Resume tracking an export that is still running (e.g. after a reload).
+    if (latest && (latest.status === 'processing' || latest.status === 'pending')) {
+      busy.value = true;
+      try {
+        job.value = await workspaceExportService.pollExport(latest.id);
+      } finally {
+        busy.value = false;
+      }
+    }
+  } catch {
+    // Non-fatal: the card simply starts in its idle state.
+  }
+}
+
+onMounted(refresh);
+</script>

--- a/frontend/src/services/workspaceExportService.ts
+++ b/frontend/src/services/workspaceExportService.ts
@@ -1,0 +1,57 @@
+import apiClient from '@nosdesk/core/apiClient';
+
+/** A self-serve workspace data export job (mirrors the backend `job_view`). */
+export interface WorkspaceExportJob {
+  id: string;
+  status: 'pending' | 'processing' | 'completed' | 'failed';
+  file_size: number | null;
+  error_message: string | null;
+  created_at: string;
+  completed_at: string | null;
+  expires_at: string | null;
+  download_available: boolean;
+}
+
+export const workspaceExportService = {
+  /** Start an export of the current workspace. Owner-only (enforced server-side). */
+  async requestExport(password?: string): Promise<WorkspaceExportJob> {
+    const res = await apiClient.post<WorkspaceExportJob>('/workspace/export', {
+      password: password || undefined,
+    });
+    return res.data;
+  },
+
+  /** The workspace's most recent export, or `null` if there is none. */
+  async getLatest(): Promise<WorkspaceExportJob | null> {
+    const res = await apiClient.get<WorkspaceExportJob | null>('/workspace/export');
+    return res.data ?? null;
+  },
+
+  /** Fetch one export job's status. */
+  async getExport(id: string): Promise<WorkspaceExportJob> {
+    const res = await apiClient.get<WorkspaceExportJob>(`/workspace/export/${id}`);
+    return res.data;
+  },
+
+  /** Poll until the export completes or fails. */
+  async pollExport(id: string, intervalMs = 2500, maxAttempts = 160): Promise<WorkspaceExportJob> {
+    for (let i = 0; i < maxAttempts; i++) {
+      const job = await this.getExport(id);
+      if (job.status === 'completed' || job.status === 'failed') return job;
+      await new Promise((resolve) => setTimeout(resolve, intervalMs));
+    }
+    throw new Error('Export polling timed out');
+  },
+
+  /** Trigger the browser download of a completed export's artifact. */
+  downloadExport(id: string): void {
+    const link = document.createElement('a');
+    link.href = `/api/workspace/export/${id}/download`;
+    link.download = '';
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+  },
+};
+
+export default workspaceExportService;

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -78,6 +78,9 @@ export const useAuthStore = defineStore('auth', () => {
       user.value?.workspace_role === 'owner' ||
       user.value?.workspace_role === 'admin'
   );
+  // Strict workspace owner (not admin). Gates owner-only actions like the
+  // workspace data export; the backend enforces the same.
+  const isOwner = computed(() => user.value?.workspace_role === 'owner');
   const isTechnician = computed(() => isAdmin.value || user.value?.workspace_role === 'agent');
   // Standalone read-only audit role (Item C/D4). Distinct from admin:
   // an audit reviewer can reach only the audit surface, not the rest
@@ -588,6 +591,7 @@ export const useAuthStore = defineStore('auth', () => {
     mfaUserUuid,
     isAuthenticated,
     isAdmin,
+    isOwner,
     isTechnician,
     isAuditReviewer,
     isPlatformAdmin,

--- a/frontend/src/views/SystemSettingsView.vue
+++ b/frontend/src/views/SystemSettingsView.vue
@@ -8,6 +8,9 @@
       <!-- System Information Section -->
       <SystemInfoCard />
 
+      <!-- Workspace data export (owner-only, self-serve DSAR return) -->
+      <WorkspaceDataExportCard v-if="authStore.isOwner" />
+
       <!-- Storage Management Section -->
       <div class="bg-surface border border-default rounded-xl hover:border-strong transition-colors">
         <div class="p-4 flex flex-col gap-3">
@@ -149,6 +152,7 @@ import { useRouter } from 'vue-router'
 import { useFluent } from 'fluent-vue'
 
 import SystemInfoCard from '@/components/admin/SystemInfoCard.vue'
+import WorkspaceDataExportCard from '@/components/settings/WorkspaceDataExportCard.vue'
 import ConfirmModal from '@/components/common/ConfirmModal.vue'
 import Icon from '@/components/common/Icon.vue'
 import Button from '@/components/common/Button.vue'

--- a/i18n/locales/en-US/main.ftl
+++ b/i18n/locales/en-US/main.ftl
@@ -6765,3 +6765,22 @@ editor-image-upload-anchor-lost-detail = { $name } uploaded, but the spot you pa
 editor-revision-view-aria = Viewing revision { $revision }, read only
 editor-revision-viewing-label = Viewing revision { $revision }
 editor-revision-back-to-current = Back to current version
+
+# Settings: workspace data export (WorkspaceDataExportCard).
+settings-export-title = Export workspace data
+settings-export-description = Download a complete archive of this workspace's data: tickets, comments, attachments, contacts, and more. Useful before closing the account, or for your own records.
+settings-export-action = Request export
+settings-export-action-new = Request new export
+settings-export-preparing = Preparing…
+settings-export-password-label = Password (optional)
+settings-export-password-hint = Encrypt the archive with a password. You will need it to open the file.
+settings-export-status-processing = Preparing your export. This can take a few minutes for a large workspace.
+settings-export-status-ready = Your export is ready.
+settings-export-status-ready-until = Available until { $date }.
+settings-export-download = Download
+settings-export-status-expired = Your last export has expired. Request a new one.
+settings-export-status-failed = The export could not be completed. Please try again.
+settings-export-rate-limited = You can request one export per day. Please try again later.
+settings-export-in-progress = An export is already in progress.
+settings-export-success = Your export is ready to download.
+settings-export-error = Could not start the export. Please try again.

--- a/i18n/locales/fr-FR/main.ftl
+++ b/i18n/locales/fr-FR/main.ftl
@@ -6688,3 +6688,22 @@ editor-image-upload-anchor-lost-detail = { $name } a bien été téléversé, ma
 editor-revision-view-aria = Révision { $revision } affichée, lecture seule
 editor-revision-viewing-label = Révision { $revision } affichée
 editor-revision-back-to-current = Revenir à la version actuelle
+
+# Settings: workspace data export (WorkspaceDataExportCard). Machine-translated, pending native review.
+settings-export-title = Exporter les données de l'espace de travail
+settings-export-description = Téléchargez une archive complète des données de cet espace de travail : tickets, commentaires, pièces jointes, contacts, et plus encore. Utile avant de fermer le compte ou pour vos propres archives.
+settings-export-action = Demander un export
+settings-export-action-new = Demander un nouvel export
+settings-export-preparing = Préparation…
+settings-export-password-label = Mot de passe (facultatif)
+settings-export-password-hint = Chiffrez l'archive avec un mot de passe. Vous en aurez besoin pour ouvrir le fichier.
+settings-export-status-processing = Préparation de votre export. Cela peut prendre quelques minutes pour un espace de travail volumineux.
+settings-export-status-ready = Votre export est prêt.
+settings-export-status-ready-until = Disponible jusqu'au { $date }.
+settings-export-download = Télécharger
+settings-export-status-expired = Votre dernier export a expiré. Demandez-en un nouveau.
+settings-export-status-failed = L'export n'a pas pu être terminé. Veuillez réessayer.
+settings-export-rate-limited = Vous pouvez demander un export par jour. Veuillez réessayer plus tard.
+settings-export-in-progress = Un export est déjà en cours.
+settings-export-success = Votre export est prêt à être téléchargé.
+settings-export-error = Impossible de démarrer l'export. Veuillez réessayer.

--- a/i18n/locales/nl-NL/main.ftl
+++ b/i18n/locales/nl-NL/main.ftl
@@ -6680,3 +6680,22 @@ editor-image-upload-anchor-lost-detail = { $name } is geüpload, maar de plek wa
 editor-revision-view-aria = Revisie { $revision } wordt getoond, alleen-lezen
 editor-revision-viewing-label = Revisie { $revision } wordt getoond
 editor-revision-back-to-current = Terug naar huidige versie
+
+# Settings: workspace data export (WorkspaceDataExportCard). Machine-translated, pending native review.
+settings-export-title = Werkruimtegegevens exporteren
+settings-export-description = Download een volledig archief van de gegevens van deze werkruimte: tickets, reacties, bijlagen, contacten en meer. Handig voordat je het account sluit of voor je eigen administratie.
+settings-export-action = Export aanvragen
+settings-export-action-new = Nieuwe export aanvragen
+settings-export-preparing = Voorbereiden…
+settings-export-password-label = Wachtwoord (optioneel)
+settings-export-password-hint = Versleutel het archief met een wachtwoord. Je hebt het nodig om het bestand te openen.
+settings-export-status-processing = Je export wordt voorbereid. Dit kan enkele minuten duren voor een grote werkruimte.
+settings-export-status-ready = Je export is klaar.
+settings-export-status-ready-until = Beschikbaar tot { $date }.
+settings-export-download = Downloaden
+settings-export-status-expired = Je laatste export is verlopen. Vraag een nieuwe aan.
+settings-export-status-failed = De export kon niet worden voltooid. Probeer het opnieuw.
+settings-export-rate-limited = Je kunt één export per dag aanvragen. Probeer het later opnieuw.
+settings-export-in-progress = Er is al een export bezig.
+settings-export-success = Je export is klaar om te downloaden.
+settings-export-error = Kan de export niet starten. Probeer het opnieuw.


### PR DESCRIPTION
## What

The Owner-facing UI for the self-serve workspace data export (the API landed in #272). A card in **System Settings** (owner-only) lets a workspace Owner request, track, and download a full export of their workspace's data before an account deletion erases it.

Follows the erasure-track legal research: this is the customer-facing half of the Art 28(3)(g) "return" path.

## Included

- **`GET /api/workspace/export`** (new, Owner-gated): returns the workspace's most recent export job (or `null`). Without it, a page reload would lose track of an in-flight or ready export and the 1/day rate-limit would then strand the user; now the card recovers state and resumes polling / offers the ready download.
- **`WorkspaceDataExportCard.vue`**: polished, native-styled card with clear states, idle, preparing (spinner + "may take a few minutes"), ready (download button + archive size + "available until <date>"), expired, and failed. An optional archive password (AES-256-GCM seal), toast feedback, and graceful handling of the rate-limit (429) and in-progress (409) responses. The request button disables inside the per-day window with a hint instead of a rejected call.
- **`isOwner`** auth getter (strict workspace owner, matching the server gate); a polling **export service** (mirrors `backupService`); and **`settings-export-*`** Fluent strings in en-US plus machine-translated fr-FR / nl-NL (flagged pending native review).

## Placement

Owner-only card in `SystemSettingsView` (`v-if="authStore.isOwner"`); no new route or nav needed. The export is workspace-scoped (all tickets/contacts/etc.), so it lives in workspace/system settings rather than personal profile.

## Validation

`cargo check`; route-registration test (4 routes, no path shadowing); `vue-tsc` type-check; eslint (changed files); and the vite build all pass. The live routes reject unauthenticated calls (401).