### PR TITLE
Make the iOS swipe-back preview fall back to the theme colour, not white

### DIFF
--- a/mobile/src-tauri/src/lib.rs
+++ b/mobile/src-tauri/src/lib.rs
@@ -52,40 +52,40 @@ pub fn run() {
             let wk = pw.inner() as *mut AnyObject;
             let _: () = msg_send![wk, setAllowsBackForwardNavigationGestures: true];
 
-            // Paint the webview with the appearance-aware `LaunchBackground`
-            // colour (light #f3f4f6 / dark #08090a, the same colorset the
-            // launch storyboard uses) and make it non-opaque, so that
-            // colour shows before the web content paints instead of the
-            // default white backing. This is what removes the white launch
-            // flash; the scroll view is painted too so overscroll doesn't
-            // expose white. Colour resolved from the asset catalog by name.
+            // Paint every layer (webview, scroll view, superview, window) with
+            // the appearance-aware `LaunchBackground` colour (light / dark) so
+            // nothing white shows before the content paints or in a region it
+            // doesn't cover (launch flash, safe-area sliver). Keep the webview
+            // opaque so its back/forward snapshots carry a background colour.
             let name: *mut AnyObject = msg_send![
               class!(NSString),
               stringWithUTF8String: b"LaunchBackground\0".as_ptr() as *const std::os::raw::c_char
             ];
             let color: *mut AnyObject = msg_send![class!(UIColor), colorNamed: name];
             if !color.is_null() {
-              let _: () = msg_send![wk, setOpaque: false];
+              let _: () = msg_send![wk, setOpaque: true];
               let _: () = msg_send![wk, setBackgroundColor: color];
+              // `underPageBackgroundColor` (iOS 15+) is what the interactive
+              // swipe-back paints when the previous view's snapshot surface has
+              // been reclaimed (common on a heavy page). Without it that
+              // fallback is hard-coded white; with it, an evicted preview
+              // degrades to the theme colour. Guarded for the iOS 14 floor.
+              let responds: bool = msg_send![
+                wk,
+                respondsToSelector: objc2::sel!(setUnderPageBackgroundColor:)
+              ];
+              if responds {
+                let _: () = msg_send![wk, setUnderPageBackgroundColor: color];
+              }
               let scroll: *mut AnyObject = msg_send![wk, scrollView];
               if !scroll.is_null() {
                 let _: () = msg_send![scroll, setBackgroundColor: color];
-                // Stop iOS auto-adjusting the scroll view's content inset
-                // to the safe area. With the default `.automatic`, the
-                // native layer pads a strip at the bottom (home-indicator
-                // area) that our full-bleed CSS (viewport-fit=cover +
-                // env() padding) doesn't fill, so that strip shows the
-                // window background as a white sliver. `.never` (raw value
-                // 2) makes the web content full-bleed, so CSS owns all the
-                // inset padding and there is no uncovered strip.
+                // `.never` (raw 2): full-bleed content so CSS owns the
+                // safe-area inset; `.automatic` leaves an uncovered bottom
+                // strip that shows through as a white sliver.
                 let _: () = msg_send![scroll, setContentInsetAdjustmentBehavior: 2_i64];
               }
-              // Paint the layers BEHIND the webview too: the host view
-              // controller's view (webview superview) and the window.
-              // A non-opaque webview reveals these in any region it
-              // doesn't fully cover (the bottom safe-area / home-
-              // indicator strip), which is where the white bottom
-              // sliver came from.
+              // Base colour behind the webview, for rotation / first layout.
               let superview: *mut AnyObject = msg_send![wk, superview];
               if !superview.is_null() {
                 let _: () = msg_send![superview, setBackgroundColor: color];


### PR DESCRIPTION
## What

On iOS the native swipe-back gesture's interactive preview (the bitmap of the previous view revealed during the drag) intermittently flashed **white**. The navigation itself was always correct; only the drag preview was affected.

## Why

The swipe-back preview is a WebKit **view snapshot** of the previous view, held in a volatile IOSurface. On a heavy page (e.g. a large collaborative notes doc) WebKit reclaims that surface, and `ViewGestureControllerIOS` then paints a hard-coded **white** fallback for the duration of the drag. It was white specifically because our `WKWebView` was non-opaque, so the snapshot recorded no valid background colour. This made it intermittent and content-dependent (a heavy ticket evicted the previous view's snapshot; a light one did not).

## Fix

In `mobile/src-tauri/src/lib.rs`:
- Set the webview **opaque** so its back/forward snapshots carry a background colour.
- Set **`underPageBackgroundColor`** to the appearance-aware `LaunchBackground` colour, which is the colour WebKit uses for that fallback (iOS 15+, guarded by `respondsToSelector` for the iOS 14 deployment floor).

An evicted preview now degrades to the app background colour (light or dark) instead of a white flash. One file, no frontend changes, no feature loss.

## Not in scope (optional follow-ups)

- Preventing the eviction itself so the *real* previous view shows during the drag (would mean trimming the collab page's memory/graphics footprint).
- Matching the exact current theme background rather than the light/dark launch colour (the launch colour already tracks appearance).