### PR TITLE
Fix iOS avatar loading and add a photo-fade loading state

### DIFF
--- a/frontend/src/components/UserAvatar.vue
+++ b/frontend/src/components/UserAvatar.vue
@@ -2,6 +2,7 @@
 import { computed, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import { useReference } from '@nosdesk/core/sync/composables'
+import { assetUrl } from '@nosdesk/core/transport'
 import type { User } from '@nosdesk/core/types/user'
 
 interface Props {
@@ -58,7 +59,11 @@ const avatarUrl = computed<string | null>(() => {
   const full = liveUser.value?.avatar_url ?? null
   const primary = prefersFullRes.value ? full : thumb
   const secondary = prefersFullRes.value ? thumb : full
-  return primary ?? secondary ?? props.fallbackAvatar ?? null
+  const resolved = primary ?? secondary ?? props.fallbackAvatar ?? null
+  // Resolve the stored `/uploads/...` path for the current runtime: identity on
+  // web (same origin as the API), the `nosdesk-asset://` proxy scheme on mobile
+  // (the webview's `tauri://localhost` origin can't load a bare API path).
+  return resolved ? assetUrl(resolved) : null
 })
 
 /**
@@ -135,12 +140,23 @@ const navigateToProfile = () => {
   }
 }
 
-// Track image load failure
+// Track image download: `imageLoaded` gates the fade-in over the initials
+// base so there's never a transparent gap while the bytes arrive; `imageFailed`
+// falls back to the initials permanently. Both reset when the URL changes.
+const imageLoaded = ref(false)
 const imageFailed = ref(false)
 
 watch(avatarUrl, () => {
+  imageLoaded.value = false
   imageFailed.value = false
 })
+
+// A cached image can already be `complete` before `@load` binds, which would
+// otherwise strand it at opacity 0. Catch that on mount.
+const onImgMount = (el: unknown) => {
+  const img = el as HTMLImageElement | null
+  if (img?.complete && img.naturalWidth > 0) imageLoaded.value = true
+}
 </script>
 
 <template>
@@ -164,36 +180,41 @@ watch(avatarUrl, () => {
            tone, never a UUID-derived hue, so the resolve doesn't
            flash a different colour into place. -->
       <Transition name="avatar-resolve" mode="out-in">
-        <!-- Loading: skeleton pulse. Same pattern the rest of
-             the app uses (TicketRowSkeleton, etc.). -->
+        <!-- Loading: skeleton pulse while the pool row resolves. Same
+             pattern the rest of the app uses (TicketRowSkeleton, etc.). -->
         <div
           v-if="isLoading"
           key="loading"
           class="w-full h-full rounded-full bg-surface-alt animate-pulse"
           aria-hidden="true"
         />
-        <!-- Resolved + has image. :key on the URL forces element
-             recreation when URL changes, bypassing browser cache. -->
-        <img
-          v-else-if="avatarUrl && !imageFailed"
-          :key="`img:${avatarUrl}`"
-          :src="avatarUrl"
-          :alt="displayName || 'User'"
-          :title="displayName || 'User'"
-          class="w-full h-full rounded-full object-cover"
-          loading="lazy"
-          @error="imageFailed = true"
-        />
-        <!-- Resolved without image: coloured initials fallback. -->
-        <div
-          v-else
-          key="initials"
-          :class="sizeClasses.text"
-          class="w-full h-full rounded-full flex items-center justify-center font-medium text-white"
-          :style="{ backgroundColor: getBackgroundColor(displayName) }"
-          :title="displayName || 'User'"
-        >
-          {{ getInitials(displayName) }}
+        <!-- Resolved: coloured initials are the base layer; the photo (when
+             there is one) fades in over them once it decodes. So the circle is
+             never a transparent gap while the image downloads, and a failed
+             load simply leaves the initials in place. -->
+        <div v-else key="resolved" class="relative w-full h-full">
+          <div
+            class="absolute inset-0 rounded-full flex items-center justify-center font-medium text-white"
+            :class="sizeClasses.text"
+            :style="{ backgroundColor: getBackgroundColor(displayName) }"
+            :title="displayName || 'User'"
+          >
+            {{ getInitials(displayName) }}
+          </div>
+          <!-- :key on the URL forces element recreation when it changes,
+               bypassing the browser cache and re-running the fade. -->
+          <img
+            v-if="avatarUrl && !imageFailed"
+            :key="`img:${avatarUrl}`"
+            :ref="onImgMount"
+            :src="avatarUrl"
+            :alt="displayName || 'User'"
+            class="absolute inset-0 w-full h-full rounded-full object-cover transition-opacity duration-200"
+            :class="imageLoaded ? 'opacity-100' : 'opacity-0'"
+            loading="lazy"
+            @load="imageLoaded = true"
+            @error="imageFailed = true"
+          />
         </div>
       </Transition>
     </div>

--- a/frontend/src/components/common/AssignmentPicker.vue
+++ b/frontend/src/components/common/AssignmentPicker.vue
@@ -3,6 +3,7 @@ import { ref, computed, onBeforeUnmount, nextTick, watch } from 'vue'
 import { useFluent } from 'fluent-vue'
 import { useAssignmentPickerQueries } from '@/composables/useAssignmentPickerQueries'
 import Icon from '@/components/common/Icon.vue'
+import UserAvatar from '@/components/UserAvatar.vue'
 
 const { $t } = useFluent()
 
@@ -216,15 +217,14 @@ onBeforeUnmount(() => {
               @mousedown.prevent="selectUser(user)"
               class="w-full flex items-center gap-3 px-3 py-2.5 min-h-[44px] md:min-h-0 text-left hover:bg-surface-hover transition-colors"
             >
-              <div class="w-5 h-5 rounded-full bg-accent/20 flex items-center justify-center flex-shrink-0 overflow-hidden">
-                <img
-                  v-if="user.avatar_url"
-                  :src="user.avatar_url"
-                  :alt="user.name"
-                  class="w-full h-full object-cover"
-                />
-                <span v-else class="text-[10px] font-medium text-accent">{{ user.name.charAt(0).toUpperCase() }}</span>
-              </div>
+              <UserAvatar
+                size="xs"
+                :fallback-name="user.name"
+                :fallback-avatar="user.avatar_url"
+                :show-name="false"
+                :clickable="false"
+                class="flex-shrink-0"
+              />
               <div class="flex-1 min-w-0">
                 <div class="text-sm text-primary truncate">{{ user.name }}</div>
                 <div class="text-[11px] text-tertiary truncate">{{ user.email }}</div>


### PR DESCRIPTION
## Fix: uploaded avatars didn't load on iOS

Avatars bound the **raw** `avatar_url` (`/uploads/users/avatars/...`) as the `<img src>`, bypassing the mobile `assetUrl` resolver that attachments use. On iOS the webview origin is `tauri://localhost`, so a bare `/uploads/...` path resolved to the app instead of the API host and 404'd. On web it worked only because the document is same-origin with the API.

Now the avatar URL goes through `assetUrl()`: identity on web (unchanged), the `nosdesk-asset://` proxy scheme on mobile (the Rust proxy fetches it from the API host with the bearer, same path attachments already use).

## Polish: no more transparent avatar while the photo downloads

The old three-state crossfade treated "URL resolved" as done and swapped straight to a bare `<img>`, which is transparent while the bytes download. Now the coloured **initials are the base layer** and the photo **fades in over them** on `@load` (200ms). No transparent gap; a failed load leaves the initials; the cached-image case (load event before the handler binds) is guarded on mount.

## Cleanup

`AssignmentPicker` hand-rolled its own avatar `<img>` (the duplication that let this bug exist). It now uses `UserAvatar`, inheriting both the fix and the loading behaviour.

Verified: typecheck + lint clean; web is unchanged by construction (`assetUrl` is only configured on mobile); confirmed on-device that the uploaded avatar loads and fades in over the initials.