### PR TITLE
Redesign the user profile layout and its detail cards

### DIFF
--- a/frontend/src/components/settings/UserDevicesCard.vue
+++ b/frontend/src/components/settings/UserDevicesCard.vue
@@ -1,0 +1,47 @@
+<script setup lang="ts">
+/**
+ * A user's assigned devices, rendered in the app's canonical dense-list
+ * vocabulary (SectionCard + divide-y rows), mirroring MyAssetsWidget.
+ * Presentational: the profile bundle already fetches the devices, so
+ * they arrive as a prop rather than a second request.
+ */
+import type { Asset } from '@nosdesk/core/types/asset';
+import SectionCard from '@/components/common/SectionCard.vue';
+import AssetStatusBadge from '@/components/assets/AssetStatusBadge.vue';
+
+defineProps<{
+  devices: Asset[];
+}>();
+</script>
+
+<template>
+  <SectionCard content-padding="">
+    <template #title>{{ $t('user-profile-assets-title') }}</template>
+
+    <div
+      v-if="devices.length === 0"
+      class="px-4 py-6 text-sm text-secondary text-center"
+    >
+      {{ $t('user-profile-assets-empty') }}
+    </div>
+
+    <ul v-else class="divide-y divide-default">
+      <li v-for="d in devices" :key="d.id">
+        <router-link
+          :to="`/assets/${d.id}`"
+          class="flex items-center gap-3 px-4 py-2.5 hover:bg-surface-hover transition-colors group"
+        >
+          <div class="min-w-0 flex-1">
+            <p class="text-sm text-primary truncate group-hover:text-accent transition-colors">
+              {{ d.name }}
+            </p>
+            <p class="mt-0.5 text-[11px] text-tertiary truncate">
+              {{ [d.manufacturer, d.model].filter(Boolean).join(' ') || $t('user-profile-asset-manufacturer-unknown') }}<template v-if="d.asset_tag && d.asset_tag !== d.name"> &middot; {{ d.asset_tag }}</template>
+            </p>
+          </div>
+          <AssetStatusBadge :status="d.status" variant="plain" class="flex-shrink-0" />
+        </router-link>
+      </li>
+    </ul>
+  </SectionCard>
+</template>

--- a/frontend/src/components/settings/UserEmailsCard.vue
+++ b/frontend/src/components/settings/UserEmailsCard.vue
@@ -8,7 +8,7 @@ import { extractErrorMessage } from '@/utils/errors';
 import Spinner from '@/components/common/Spinner.vue';
 import Button from '@/components/common/Button.vue';
 import FormInput from '@/components/common/FormInput.vue';
-import Icon from '@/components/common/Icon.vue';
+import StatusPill from '@/components/common/StatusPill.vue';
 import EmptyState from '@/components/common/EmptyState.vue';
 
 const fluent = useFluent();
@@ -134,7 +134,7 @@ watch(() => props.userUuid, () => {
 </script>
 
 <template>
-  <SectionCard content-padding="p-4 sm:p-6">
+  <SectionCard content-padding="">
     <template #title>{{ $t('settings-emails-section-title') }}</template>
     <template #headerActions>
       <Button
@@ -148,10 +148,10 @@ watch(() => props.userUuid, () => {
     </template>
 
     <!-- Add email form. Sits above the list while open, framed as an
-         input zone so it reads as distinct from the existing rows. -->
+         input zone so it reads as distinct from the flush row list. -->
     <div
       v-if="showAddForm && canEdit"
-      class="mb-3 p-3 bg-surface-alt rounded-lg border border-subtle flex flex-col sm:flex-row gap-2"
+      class="mx-4 my-4 p-3 bg-surface-alt rounded-lg border border-subtle flex flex-col sm:flex-row gap-2"
     >
       <FormInput
         v-model="newEmailAddress"
@@ -176,58 +176,48 @@ watch(() => props.userUuid, () => {
     </div>
 
     <!-- Empty state -->
-    <EmptyState
-      v-else-if="userEmails.length === 0"
-      icon="inbox"
-      variant="card"
-      :title="$t('settings-emails-empty')"
-      :action-label="canEdit && !showAddForm ? $t('settings-emails-add-button') : undefined"
-      @action="showAddForm = true"
-    />
+    <div v-else-if="userEmails.length === 0" class="p-4">
+      <EmptyState
+        icon="inbox"
+        variant="card"
+        :title="$t('settings-emails-empty')"
+        :action-label="canEdit && !showAddForm ? $t('settings-emails-add-button') : undefined"
+        @action="showAddForm = true"
+      />
+    </div>
 
-    <!-- Email list -->
-    <div v-else class="flex flex-col gap-2">
-      <div
+    <!-- Email list. Dense divider rows in the app's canonical list
+         vocabulary (mirrors TicketRow / MyAssetsWidget). -->
+    <ul v-else class="divide-y divide-default">
+      <li
         v-for="email in userEmails"
         :key="email.id"
-        class="flex flex-col sm:flex-row sm:items-start gap-3 p-3 bg-surface-alt rounded-lg"
+        class="flex flex-col gap-2 px-4 py-2.5 sm:flex-row sm:items-center sm:gap-3"
       >
-        <!-- Identity: envelope tile + address + metadata -->
-        <div class="flex items-center gap-3 min-w-0 flex-1">
-          <div class="w-10 h-10 rounded-lg bg-surface-hover flex items-center justify-center shrink-0">
-            <Icon name="email" size="md" class="text-secondary" />
+        <!-- Address + metadata -->
+        <div class="min-w-0 flex-1">
+          <div class="flex items-center gap-2 min-w-0">
+            <span class="text-sm text-primary truncate">{{ email.email }}</span>
+            <StatusPill
+              v-if="email.is_primary"
+              :label="$t('settings-emails-primary-badge')"
+              tone="accent"
+              :dot="false"
+              class="flex-shrink-0"
+            />
           </div>
-          <div class="min-w-0">
-            <div class="flex items-center gap-2 flex-wrap">
-              <span class="text-sm font-medium text-primary truncate">{{ email.email }}</span>
-              <span
-                v-if="email.is_primary"
-                class="px-2 py-0.5 rounded-full text-xs font-medium bg-accent/20 text-accent shrink-0"
-              >
-                {{ $t('settings-emails-primary-badge') }}
-              </span>
-            </div>
-            <div class="flex items-center gap-1.5 text-xs text-tertiary mt-0.5">
-              <span class="capitalize">{{ email.email_type || $t('settings-emails-type-personal') }}</span>
-              <template v-if="email.source">
-                <span class="text-border-default">&middot;</span>
-                <span class="capitalize">{{ email.source }}</span>
-              </template>
-            </div>
+          <div class="mt-0.5 text-[11px] text-tertiary truncate">
+            <span class="capitalize">{{ email.email_type || $t('settings-emails-type-personal') }}</span>
+            <template v-if="email.source"> &middot; <span class="capitalize">{{ email.source }}</span></template>
           </div>
         </div>
 
         <!-- Verification status + row actions -->
-        <div class="flex items-center gap-2 flex-wrap sm:justify-end shrink-0 pl-13 sm:pl-0">
-          <span
-            class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium"
-            :class="email.is_verified
-              ? 'bg-status-success/20 text-status-success'
-              : 'bg-status-warning/20 text-status-warning'"
-          >
-            <Icon :name="email.is_verified ? 'checkCircle' : 'warning'" size="xs" />
-            {{ email.is_verified ? $t('settings-emails-verified-badge') : $t('settings-emails-unverified-badge') }}
-          </span>
+        <div class="flex items-center gap-2 flex-wrap flex-shrink-0 sm:justify-end">
+          <StatusPill
+            :label="email.is_verified ? $t('settings-emails-verified-badge') : $t('settings-emails-unverified-badge')"
+            :tone="email.is_verified ? 'positive' : 'caution'"
+          />
 
           <template v-if="canEdit && email.id !== 0 && !email.is_primary">
             <Button variant="secondary" size="sm" @click="setAsPrimary(email.id, email.email)">
@@ -243,8 +233,8 @@ watch(() => props.userUuid, () => {
             </Button>
           </template>
         </div>
-      </div>
-    </div>
+      </li>
+    </ul>
 
     <ConfirmModal
       :show="pendingDeleteEmail !== null"

--- a/frontend/src/views/UserProfileView.vue
+++ b/frontend/src/views/UserProfileView.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { formatDate as formatDateUtil } from '@nosdesk/core/utils/dateUtils';
 import { effectiveRole, type UserRole } from '@nosdesk/core/types/user';
 import { ref, computed, watch } from "vue";
 import { useRoute, useRouter } from "vue-router";
@@ -13,6 +12,7 @@ import UserEmailsCard from "@/components/settings/UserEmailsCard.vue";
 import UserContactCard from "@/components/settings/UserContactCard.vue";
 import UserPhonesCard from "@/components/settings/UserPhonesCard.vue";
 import UserAddressesCard from "@/components/settings/UserAddressesCard.vue";
+import UserDevicesCard from "@/components/settings/UserDevicesCard.vue";
 import UserAssignedTickets from "@/components/UserAssignedTickets.vue";
 import BaseDropdown from "@/components/common/BaseDropdown.vue";
 import Icon from "@/components/common/Icon.vue";
@@ -200,31 +200,6 @@ watch(
         }
     },
 );
-
-const formatDate = (dateString: string) => {
-    try {
-        const date = new Date(dateString);
-        const now = new Date();
-        const diffTime = now.getTime() - date.getTime();
-        const diffDays = Math.floor(diffTime / (1000 * 60 * 60 * 24));
-        const diffHours = Math.floor(diffTime / (1000 * 60 * 60));
-        const diffMinutes = Math.floor(diffTime / (1000 * 60));
-
-        if (diffMinutes < 1) {
-            return t('user-profile-relative-just-now');
-        } else if (diffMinutes < 60) {
-            return t('user-profile-relative-minutes-ago', { count: diffMinutes });
-        } else if (diffHours < 24) {
-            return t('user-profile-relative-hours-ago', { count: diffHours });
-        } else if (diffDays < 30) {
-            return t('user-profile-relative-days-ago', { count: diffDays });
-        } else {
-            return formatDateUtil(dateString, "MMM d, yyyy");
-        }
-    } catch {
-        return dateString;
-    }
-};
 
 // Save user (create or update)
 const saveUser = async () => {
@@ -641,118 +616,59 @@ watch(
                 </div>
 
                 <!-- Responsive Container for existing user -->
-                <div
-                    v-else-if="userProfile"
-                    class="flex flex-col xl:flex-row gap-4"
-                >
-                    <!-- User Info Area -->
-                    <div class="flex flex-col gap-4 xl:w-1/2 xl:min-w-0">
-                        <!-- User Profile Card (Read-only in profile view) -->
-                        <UserProfileCard
-                            :user="userProfile"
-                            :canEdit="false"
-                            :showEditableFields="false"
-                        />
+                <div v-else-if="userProfile" class="flex flex-col gap-4">
+                    <!-- Identity header (full width) -->
+                    <UserProfileCard
+                        :user="userProfile"
+                        :canEdit="false"
+                        :showEditableFields="false"
+                    />
 
+                    <!-- Detail and ticket cards flow into an adaptive masonry that
+                         packs to fill the width; with no related tickets the detail
+                         cards spread across every column, so there is no dead half.
+                         Mobile stays a single column in the same order as before. -->
+                    <div class="columns-1 md:columns-2 xl:columns-3 gap-4">
                         <!-- Email Addresses Section -->
-                        <UserEmailsCard
-                            v-if="userProfile?.uuid"
-                            :user-uuid="userProfile.uuid"
-                            :can-edit="false"
-                        />
+                        <div v-if="userProfile?.uuid" class="mb-4 break-inside-avoid">
+                            <UserEmailsCard
+                                :user-uuid="userProfile.uuid"
+                                :can-edit="false"
+                            />
+                        </div>
 
                         <!-- Contact details: standard + custom fields -->
-                        <UserContactCard
-                            v-if="userProfile?.uuid"
-                            :uuid="userProfile.uuid"
-                            :editable="canEdit"
-                        />
+                        <div v-if="userProfile?.uuid" class="mb-4 break-inside-avoid">
+                            <UserContactCard
+                                :uuid="userProfile.uuid"
+                                :editable="canEdit"
+                            />
+                        </div>
 
-                        <!-- Phone numbers + addresses -->
-                        <UserPhonesCard
-                            v-if="userProfile?.uuid"
-                            :uuid="userProfile.uuid"
-                            :editable="canEdit"
-                        />
-                        <UserAddressesCard
-                            v-if="userProfile?.uuid"
-                            :uuid="userProfile.uuid"
-                            :editable="canEdit"
-                        />
+                        <!-- Phone numbers -->
+                        <div v-if="userProfile?.uuid" class="mb-4 break-inside-avoid">
+                            <UserPhonesCard
+                                :uuid="userProfile.uuid"
+                                :editable="canEdit"
+                            />
+                        </div>
+
+                        <!-- Addresses -->
+                        <div v-if="userProfile?.uuid" class="mb-4 break-inside-avoid">
+                            <UserAddressesCard
+                                :uuid="userProfile.uuid"
+                                :editable="canEdit"
+                            />
+                        </div>
 
                         <!-- Devices Section -->
-                        <SectionCard content-padding="p-3">
-                            <template #title>{{ $t('user-profile-assets-title') }}</template>
-                            <div>
-                                <div
-                                    v-if="devices.length === 0"
-                                    class="text-secondary text-sm"
-                                >
-                                    {{ $t('user-profile-assets-empty') }}
-                                </div>
-                                <div v-else class="flex flex-col gap-3">
-                                    <RouterLink
-                                        v-for="device in devices"
-                                        :key="device.id"
-                                        :to="`/devices/${device.id}`"
-                                        class="block bg-surface-alt p-3 rounded-lg hover:bg-surface-hover transition-colors"
-                                    >
-                                        <div
-                                            class="flex items-start justify-between"
-                                        >
-                                            <div class="flex-1">
-                                                <h3
-                                                    class="font-medium text-primary"
-                                                >
-                                                    {{ device.name }}
-                                                </h3>
-                                                <p
-                                                    class="text-sm text-secondary"
-                                                >
-                                                    {{
-                                                        device.manufacturer ||
-                                                        $t('user-profile-asset-manufacturer-unknown')
-                                                    }}
-                                                    {{ device.model }}
-                                                </p>
-                                                <p
-                                                    class="text-xs text-tertiary"
-                                                >
-                                                    {{ $t('user-profile-asset-last-updated', { when: formatDate(device.updated_at) }) }}
-                                                </p>
-                                            </div>
-                                            <div v-if="device.attributes?.warranty_status" class="flex-shrink-0 ml-3">
-                                                <span
-                                                    class="text-xs px-2 py-1 rounded-full"
-                                                    :class="{
-                                                        'text-status-success bg-status-success/20':
-                                                            device.attributes.warranty_status ===
-                                                            'Active',
-                                                        'text-status-warning bg-status-warning/20':
-                                                            device.attributes.warranty_status ===
-                                                            'Warning',
-                                                        'text-status-error bg-status-error/20':
-                                                            device.attributes.warranty_status ===
-                                                            'Expired',
-                                                        'text-secondary bg-surface-alt':
-                                                            device.attributes.warranty_status ===
-                                                            'Unknown',
-                                                    }"
-                                                >
-                                                    {{ device.attributes.warranty_status }}
-                                                </span>
-                                            </div>
-                                        </div>
-                                    </RouterLink>
-                                </div>
-                            </div>
-                        </SectionCard>
+                        <div class="mb-4 break-inside-avoid">
+                            <UserDevicesCard :devices="devices" />
+                        </div>
 
                         <!-- Groups Section -->
-                        <SectionCard
-                            v-if="groups.length > 0"
-                            content-padding="p-3"
-                        >
+                        <div v-if="groups.length > 0" class="mb-4 break-inside-avoid">
+                        <SectionCard content-padding="p-3">
                             <template #title>{{ $t('user-profile-groups-title') }}</template>
                             <div class="flex flex-wrap gap-2">
                                 <button
@@ -771,32 +687,35 @@ watch(
                                 </button>
                             </div>
                         </SectionCard>
+                        </div>
 
-                        <!-- Plugin panels contributed to the user profile -->
-                        <PluginSlot
-                            target="user.sidebar.panel"
-                            :context="{ user: pluginUser }"
-                        />
-                    </div>
-
-                    <!-- Tickets Area -->
-                    <div class="flex flex-col gap-4 xl:w-1/2 xl:min-w-0">
-                        <!-- Assigned Tickets (only for technicians and admins) -->
-                        <UserAssignedTickets
-                            v-if="canHaveAssignedTickets"
-                            :user-uuid="userProfile.uuid"
-                            ticket-type="assigned"
-                            :limit="5"
-                            :show-filters="false"
-                        />
+                        <!-- Assigned Tickets (technicians and admins only) -->
+                        <div v-if="canHaveAssignedTickets" class="mb-4 break-inside-avoid">
+                            <UserAssignedTickets
+                                :user-uuid="userProfile.uuid"
+                                ticket-type="assigned"
+                                :limit="5"
+                                :show-filters="false"
+                            />
+                        </div>
 
                         <!-- Requested Tickets -->
-                        <UserAssignedTickets
-                            :user-uuid="userProfile.uuid"
-                            ticket-type="requested"
-                            :limit="5"
-                            :show-filters="false"
-                        />
+                        <div class="mb-4 break-inside-avoid">
+                            <UserAssignedTickets
+                                :user-uuid="userProfile.uuid"
+                                ticket-type="requested"
+                                :limit="5"
+                                :show-filters="false"
+                            />
+                        </div>
+
+                        <!-- Plugin panels contributed to the user profile -->
+                        <div class="mb-4 break-inside-avoid">
+                            <PluginSlot
+                                target="user.sidebar.panel"
+                                :context="{ user: pluginUser }"
+                            />
+                        </div>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Reworks the user profile view so it uses the full width and its detail cards match the rest of the app.

**Layout (Direction A)**
- Full-width identity header, then an adaptive masonry (`columns-1 md:2 xl:3`). Detail and ticket cards pack to fill the width, so a user with no related tickets leaves no empty half. Mobile stays a single column in the original order.

**Cards**
- Extract the inline devices block into `UserDevicesCard.vue` (prop-driven from the profile bundle, no extra request). Renders as a `divide-y` row list using the shared `AssetStatusBadge`, showing lifecycle status, and links to `/assets/:id` (the inline block linked to the stale `/devices/:id`).
- `UserEmailsCard` now renders dense divider rows with the shared `StatusPill`, replacing the boxed chip + icon tile. The row stacks below `sm` so the settings-page edit actions never crush the address.

Verified in both consumers (profile read-only, settings editable) at mobile, tablet, and desktop.

https://claude.ai/code/session_0199WATFeQtTBRo8dPkHEZhX