### PR TITLE
Add a Fastlane + GitHub Actions mobile release pipeline

### DIFF
--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -1,0 +1,135 @@
+name: Mobile release
+
+# Manual only for now. Once a credentialed run is green, a `push: { tags: ['v*'] }`
+# trigger can be added, but note that couples every version tag to a store
+# build, so opt into it deliberately rather than by default.
+on:
+  workflow_dispatch:
+    inputs:
+      platform:
+        description: Which app(s) to build and upload
+        type: choice
+        options: [both, ios, android]
+        default: both
+
+permissions:
+  contents: read
+
+concurrency:
+  # Never cancel an in-flight upload; queue instead.
+  group: mobile-release-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  APP_IDENTIFIER: com.nosdesk.app
+  # Monotonic build identifiers so re-uploads of the same marketing version do
+  # not collide on TestFlight / Play.
+  BUILD_NUMBER: ${{ github.run_number }}
+  NOSDESK_VERSION_CODE: ${{ github.run_number }}
+
+jobs:
+  ios:
+    if: ${{ inputs.platform == 'both' || inputs.platform == 'ios' }}
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "24"
+          cache: pnpm
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+        with:
+          toolchain: "1.95.0"
+          targets: aarch64-apple-ios
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
+        with:
+          workspaces: mobile/src-tauri -> target
+
+      - name: Install JS deps + build workspace prerequisites
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm --filter @nosdesk/plugin-runtime run build
+          pnpm --filter @nosdesk/core run build:slots
+
+      - name: Install fastlane
+        working-directory: mobile
+        run: bundle install
+
+      - name: Build + upload to TestFlight
+        working-directory: mobile
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          ITC_TEAM_ID: ${{ secrets.ITC_TEAM_ID }}
+          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+          ASC_KEY_CONTENT: ${{ secrets.ASC_KEY_CONTENT }}
+          MATCH_GIT_URL: ${{ secrets.MATCH_GIT_URL }}
+          MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+          MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}
+        run: bundle exec fastlane ios beta
+
+  android:
+    if: ${{ inputs.platform == 'both' || inputs.platform == 'android' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "24"
+          cache: pnpm
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+        with:
+          toolchain: "1.95.0"
+          targets: aarch64-linux-android,armv7-linux-androideabi,x86_64-linux-android,i686-linux-android
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
+        with:
+          workspaces: mobile/src-tauri -> target
+
+      - name: Select JDK 17 and pin the NDK
+        run: |
+          echo "JAVA_HOME=$JAVA_HOME_17_X64" >> "$GITHUB_ENV"
+          echo "ANDROID_HOME=$ANDROID_SDK_ROOT" >> "$GITHUB_ENV"
+          "$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager" "ndk;30.0.14904198"
+          echo "NDK_HOME=$ANDROID_SDK_ROOT/ndk/30.0.14904198" >> "$GITHUB_ENV"
+
+      - name: Install JS deps + build workspace prerequisites
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm --filter @nosdesk/plugin-runtime run build
+          pnpm --filter @nosdesk/core run build:slots
+
+      - name: Write signing + Firebase material from secrets
+        working-directory: mobile/src-tauri/gen/android
+        env:
+          KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+          KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+          GOOGLE_SERVICES_JSON_BASE64: ${{ secrets.GOOGLE_SERVICES_JSON_BASE64 }}
+        run: |
+          echo "$KEYSTORE_BASE64" | base64 --decode > app/upload-keystore.jks
+          {
+            echo "storeFile=upload-keystore.jks"
+            echo "storePassword=$KEYSTORE_PASSWORD"
+            echo "keyAlias=$KEY_ALIAS"
+            echo "keyPassword=$KEY_PASSWORD"
+          } > app/keystore.properties
+          echo "$GOOGLE_SERVICES_JSON_BASE64" | base64 --decode > app/google-services.json
+
+      - name: Write Play service-account key
+        env:
+          PLAY_JSON_KEY_BASE64: ${{ secrets.PLAY_JSON_KEY_BASE64 }}
+        run: |
+          echo "$PLAY_JSON_KEY_BASE64" | base64 --decode > "$RUNNER_TEMP/play-key.json"
+          echo "PLAY_JSON_KEY_PATH=$RUNNER_TEMP/play-key.json" >> "$GITHUB_ENV"
+
+      - name: Install fastlane
+        working-directory: mobile
+        run: bundle install
+
+      - name: Build + upload to Play internal
+        working-directory: mobile
+        run: bundle exec fastlane android beta

--- a/mobile/Gemfile
+++ b/mobile/Gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+# Mobile store automation (build signing + TestFlight / Play upload).
+# Run lanes with `bundle exec fastlane <platform> <lane>` from `mobile/`.
+gem "fastlane"

--- a/mobile/fastlane/Appfile
+++ b/mobile/fastlane/Appfile
@@ -1,0 +1,12 @@
+# App identifiers. Everything sensitive comes from the environment so nothing
+# is committed. See fastlane/README.md for the full variable list.
+
+app_identifier(ENV.fetch("APP_IDENTIFIER", "com.nosdesk.app"))
+
+# iOS / App Store Connect
+apple_id(ENV["APPLE_ID"]) if ENV["APPLE_ID"]
+team_id(ENV["APPLE_TEAM_ID"]) if ENV["APPLE_TEAM_ID"]
+itc_team_id(ENV["ITC_TEAM_ID"]) if ENV["ITC_TEAM_ID"]
+
+# Android / Google Play
+package_name(ENV.fetch("APP_IDENTIFIER", "com.nosdesk.app"))

--- a/mobile/fastlane/Fastfile
+++ b/mobile/fastlane/Fastfile
@@ -1,0 +1,105 @@
+# Fastlane pipeline for the Nosdesk Tauri mobile app.
+#
+# Division of labour: Tauri owns the build (frontend + Rust + native shell),
+# Fastlane owns signing and store upload. iOS signing uses `match` (certs in a
+# private git repo); Android signing uses a keystore written from a CI secret,
+# consumed by the release signingConfig in app/build.gradle.kts.
+#
+# The app selects its server at runtime, so one build serves any environment.
+# All paths are relative to `mobile/` (where fastlane runs).
+
+APP_ID          = ENV.fetch("APP_IDENTIFIER", "com.nosdesk.app")
+APPLE_PROJECT   = "src-tauri/gen/apple/#{ENV.fetch('APPLE_PROJECT_NAME', 'Nosdesk')}.xcodeproj"
+APPLE_INFO_PLIST = "src-tauri/gen/apple/app_iOS/Info.plist"
+IPA_PATH        = "src-tauri/gen/apple/build/arm64/#{ENV.fetch('APPLE_PROJECT_NAME', 'Nosdesk')}.ipa"
+AAB_PATH        = "src-tauri/gen/android/app/build/outputs/bundle/universalRelease/app-universal-release.aab"
+
+# Monotonic build number so re-uploads of the same marketing version never
+# collide on either store. CI passes github.run_number; local runs get 1.
+def build_number
+  ENV["BUILD_NUMBER"] || "1"
+end
+
+# Run the Tauri CLI through the workspace's pinned pnpm.
+def tauri(*args)
+  sh("pnpm", "tauri", *args)
+end
+
+platform :ios do
+  desc "Build and upload an iOS build to TestFlight"
+  lane :beta do
+    setup_ci # ephemeral keychain on hosted runners; a no-op locally
+
+    api_key = app_store_connect_api_key(
+      key_id: ENV.fetch("ASC_KEY_ID"),
+      issuer_id: ENV.fetch("ASC_ISSUER_ID"),
+      key_content: ENV.fetch("ASC_KEY_CONTENT"), # base64 of the .p8
+      is_key_content_base64: true,
+    )
+
+    # Installs the distribution cert + appstore profile into the keychain.
+    match(type: "appstore", readonly: true, api_key: api_key)
+
+    # Stamp the build number before Tauri drives xcodebuild.
+    set_info_plist_value(path: APPLE_INFO_PLIST, key: "CFBundleVersion", value: build_number)
+
+    # Force manual signing with the profile match just installed, so Tauri's
+    # xcodebuild picks it up headlessly. match exports the profile name under
+    # this env key.
+    profile_name = ENV["sigh_#{APP_ID}_appstore_profile-name"]
+    update_code_signing_settings(
+      path: APPLE_PROJECT,
+      use_automatic_signing: false,
+      team_id: ENV.fetch("APPLE_TEAM_ID"),
+      code_sign_identity: "Apple Distribution",
+      profile_name: profile_name,
+    )
+
+    tauri("ios", "build", "--export-method", "app-store-connect")
+
+    upload_to_testflight(
+      api_key: api_key,
+      ipa: IPA_PATH,
+      skip_waiting_for_build_processing: true,
+    )
+  end
+
+  desc "Promote the latest TestFlight build to App Store review"
+  lane :release do
+    # First submission is done by hand in App Store Connect (listing, privacy,
+    # screenshots). Once the listing exists this can call deliver(...).
+    UI.message("Submit/promote in App Store Connect, or wire deliver() here.")
+  end
+end
+
+platform :android do
+  desc "Build and upload an Android build to the Play internal track"
+  lane :beta do
+    tauri("android", "build", "--aab")
+    upload_to_play_store(
+      track: "internal",
+      aab: AAB_PATH,
+      json_key: ENV.fetch("PLAY_JSON_KEY_PATH"),
+      release_status: "draft",
+      skip_upload_metadata: true,
+      skip_upload_changelogs: true,
+      skip_upload_images: true,
+      skip_upload_screenshots: true,
+    )
+  end
+
+  desc "Promote the Play internal track to production"
+  lane :promote do
+    upload_to_play_store(
+      track: "internal",
+      track_promote_to: "production",
+      json_key: ENV.fetch("PLAY_JSON_KEY_PATH"),
+      skip_upload_apk: true,
+      skip_upload_aab: true,
+      skip_upload_metadata: true,
+      skip_upload_changelogs: true,
+      skip_upload_images: true,
+      skip_upload_screenshots: true,
+    )
+  end
+end

--- a/mobile/fastlane/Matchfile
+++ b/mobile/fastlane/Matchfile
@@ -1,0 +1,12 @@
+# iOS code signing via match: the distribution certificate and provisioning
+# profile live in a private git repo (MATCH_GIT_URL), encrypted with
+# MATCH_PASSWORD. Populate it once locally with `bundle exec fastlane match
+# appstore`; CI then reads it read-only. See fastlane/README.md.
+
+git_url(ENV["MATCH_GIT_URL"])
+storage_mode("git")
+type("appstore")
+app_identifier([ENV.fetch("APP_IDENTIFIER", "com.nosdesk.app")])
+
+# Never mint or mutate certs on CI; only the local bootstrap run may write.
+readonly(ENV["CI"] == "true")

--- a/mobile/fastlane/README.md
+++ b/mobile/fastlane/README.md
@@ -1,0 +1,82 @@
+# Mobile release pipeline
+
+Tauri builds the app; Fastlane signs and uploads it. Lanes run from `mobile/`.
+CI is `.github/workflows/mobile-release.yml` (manual dispatch: pick `both`,
+`ios`, or `android`). The app picks its server at runtime, so one build serves
+staging and production.
+
+- **iOS** -> TestFlight (`fastlane ios beta`), signed with `match`.
+- **Android** -> Play internal track (`fastlane android beta`), signed with an
+  upload keystore. `fastlane android promote` moves internal -> production.
+
+Build numbers come from `github.run_number` (env `BUILD_NUMBER` /
+`NOSDESK_VERSION_CODE`) so re-uploads never collide.
+
+## One-time account setup (no pipeline removes this)
+
+1. **Apple Developer Program** membership; in **App Store Connect** create the
+   app record for bundle id `com.nosdesk.app`. `ITSAppUsesNonExemptEncryption`
+   is already set to `false` in `app_iOS/Info.plist`, so TestFlight won't ask
+   the export-compliance question.
+2. **Google Play Console** ($25 once); create the app for `com.nosdesk.app`,
+   enroll in **Play App Signing** with a dedicated *upload* key, and upload the
+   first AAB by hand (the API can't create the app). After that `supply` works.
+3. **iOS signing (match), once, locally:** create a private git repo for the
+   certs, then from `mobile/`:
+   ```sh
+   MATCH_GIT_URL=<repo> bundle exec fastlane match appstore
+   ```
+   Give CI read access to that repo (a deploy key, or a PAT via
+   `MATCH_GIT_BASIC_AUTHORIZATION`).
+4. **Play service account:** in Google Cloud, a service account with the Play
+   Developer API enabled, granted release permissions in the Play Console.
+   Download its JSON key.
+
+## GitHub secrets
+
+iOS:
+- `APPLE_ID`, `APPLE_TEAM_ID`, `ITC_TEAM_ID`
+- `ASC_KEY_ID`, `ASC_ISSUER_ID`, `ASC_KEY_CONTENT` (base64 of the App Store
+  Connect API `.p8`)
+- `MATCH_GIT_URL`, `MATCH_PASSWORD`, and either a deploy key or
+  `MATCH_GIT_BASIC_AUTHORIZATION` (base64 `user:token`)
+
+Android:
+- `ANDROID_KEYSTORE_BASE64` (base64 of the upload `.jks`),
+  `ANDROID_KEYSTORE_PASSWORD`, `ANDROID_KEY_ALIAS`, `ANDROID_KEY_PASSWORD`
+- `GOOGLE_SERVICES_JSON_BASE64` (base64 of `app/google-services.json`, which is
+  gitignored)
+- `PLAY_JSON_KEY_BASE64` (base64 of the Play service-account JSON)
+
+## Local release-signing test (no store credentials needed)
+
+The Android build+sign leg is fully testable offline. Generate a throwaway
+keystore, point `keystore.properties` at it, and build:
+
+```sh
+cd mobile/src-tauri/gen/android/app
+keytool -genkeypair -v -keystore upload-keystore.jks -alias upload \
+  -keyalg RSA -keysize 2048 -validity 3650 \
+  -storepass test1234 -keypass test1234 -dname "CN=Nosdesk Test"
+printf 'storeFile=upload-keystore.jks\nstorePassword=test1234\nkeyAlias=upload\nkeyPassword=test1234\n' > keystore.properties
+cd ../../../../..            # back to mobile/
+pnpm tauri android build --apk --target aarch64
+apksigner verify --print-certs \
+  src-tauri/gen/android/app/build/outputs/apk/universal/release/app-universal-release.aab 2>/dev/null || \
+  "$ANDROID_HOME/build-tools/"*/apksigner verify src-tauri/gen/android/app/build/outputs/apk/universal/release/*.apk
+```
+
+Delete `upload-keystore.jks` and `keystore.properties` afterwards (both are
+gitignored).
+
+## What can't be verified without credentials
+
+Two legs need real accounts and will likely need one round of iteration:
+
+- the **iOS match -> Tauri xcodebuild signing handshake** (the CI runner's Xcode
+  version and the exact match profile name plumbed into
+  `update_code_signing_settings`), and
+- the **TestFlight / Play uploads** themselves.
+
+Everything else (frontend + Rust + native build, the Android signingConfig, the
+Fastfile) is exercised by the local test above and the workflow's build steps.

--- a/mobile/src-tauri/gen/android/.gitignore
+++ b/mobile/src-tauri/gen/android/.gitignore
@@ -18,3 +18,8 @@ keystore.properties
 
 /.tauri
 /tauri.settings.gradle
+# Release signing material written from CI secrets (never commit).
+app/keystore.properties
+*.jks
+*.keystore
+app/google-services.json

--- a/mobile/src-tauri/gen/android/app/build.gradle.kts
+++ b/mobile/src-tauri/gen/android/app/build.gradle.kts
@@ -13,6 +13,16 @@ val tauriProperties = Properties().apply {
     }
 }
 
+// Release signing. CI (or a local release build) writes app/keystore.properties
+// from a base64 secret; it and the keystore are gitignored. Without it, release
+// builds stay unsigned (debug builds are always debug-signed).
+val keystorePropertiesFile = file("keystore.properties")
+val keystoreProperties = Properties().apply {
+    if (keystorePropertiesFile.exists()) {
+        keystorePropertiesFile.inputStream().use { load(it) }
+    }
+}
+
 android {
     compileSdk = 36
     namespace = "com.nosdesk.app"
@@ -21,8 +31,19 @@ android {
         applicationId = "com.nosdesk.app"
         minSdk = 24
         targetSdk = 36
-        versionCode = tauriProperties.getProperty("tauri.android.versionCode", "1").toInt()
+        versionCode = (System.getenv("NOSDESK_VERSION_CODE")
+            ?: tauriProperties.getProperty("tauri.android.versionCode", "1")).toInt()
         versionName = tauriProperties.getProperty("tauri.android.versionName", "1.0")
+    }
+    signingConfigs {
+        create("release") {
+            if (keystorePropertiesFile.exists()) {
+                storeFile = file(keystoreProperties.getProperty("storeFile"))
+                storePassword = keystoreProperties.getProperty("storePassword")
+                keyAlias = keystoreProperties.getProperty("keyAlias")
+                keyPassword = keystoreProperties.getProperty("keyPassword")
+            }
+        }
     }
     buildTypes {
         getByName("debug") {
@@ -38,6 +59,9 @@ android {
             }
         }
         getByName("release") {
+            if (keystorePropertiesFile.exists()) {
+                signingConfig = signingConfigs.getByName("release")
+            }
             isMinifyEnabled = true
             proguardFiles(
                 *fileTree(".") { include("**/*.pro") }

--- a/mobile/src-tauri/gen/apple/app_iOS/Info.plist
+++ b/mobile/src-tauri/gen/apple/app_iOS/Info.plist
@@ -18,6 +18,8 @@
 	<string>0.1.0</string>
 	<key>CFBundleVersion</key>
 	<string>0.1.0</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSCameraUsageDescription</key>


### PR DESCRIPTION
A manual-dispatch pipeline that builds and ships the Tauri mobile app: iOS to TestFlight, Android to the Play internal track.

**Workflow** (`.github/workflows/mobile-release.yml`): `workflow_dispatch` with a `both`/`ios`/`android` choice. iOS on macOS, Android on Ubuntu. Actions SHA-pinned, `permissions: contents: read`, build numbers from `run_number` so re-uploads never collide. Deliberately manual for now (a `v*` trigger would couple every server release to a store build).

**Fastlane** (`mobile/fastlane/`): `ios beta` (match + Tauri build + TestFlight), `android beta` (Tauri AAB + Play internal), plus `ios release` / `android promote`.

**Signing**: iOS via Fastlane `match`; Android via a CI-written keystore consumed by a new release `signingConfig` in `build.gradle.kts`. Keystore, `keystore.properties`, and `google-services.json` are gitignored.

**Verified without credentials**: Android build → sign → `apksigner` confirms a V2 signature; all Fastlane files parse; workflow is SHA-pinned with a minimal permissions block. Credential-blocked legs (documented in `mobile/fastlane/README.md`): the iOS match→xcodebuild handshake and the actual store uploads.

Setup + full secrets checklist: `mobile/fastlane/README.md`.

https://claude.ai/code/session_0199WATFeQtTBRo8dPkHEZhX