### PR TITLE
Refuse product-side user creation in hosted mode

### DIFF
--- a/backend/src/handlers/users.rs
+++ b/backend/src/handlers/users.rs
@@ -843,6 +843,18 @@ pub async fn create_user(
             Err(resp) => return resp,
         };
 
+    // In hosted mode, user identity is owned by the control plane. Creating a
+    // local user here mints an account that can never sign in (no control-plane
+    // identity, and hosted local login is disabled), so refuse rather than
+    // strand a member, and direct admins to the control-plane seat invite.
+    // Self-hosted keeps the local creation flow below.
+    if !crate::middleware::workspace_context::local_credentials_permitted() {
+        return errors::forbidden(
+            "In hosted deployments, members are added from the Nosdesk control plane \
+             (Instances -> Seats). Direct user creation is only available in self-hosted mode.",
+        );
+    }
+
     let mut conn = match helpers::db_conn(&db_pool) {
         Ok(c) => c,
         Err(e) => return e,


### PR DESCRIPTION
In hosted (multi-tenant) mode, user identity is owned by the control plane and hosted local login is disabled, so a user created via the product's `POST /api/users` can never sign in. Worse, the credential-write repository already refuses the local-identity write in hosted mode, so `create_user` got partway (user row + membership) then failed, **stranding a half-created member** that shows in the member list but can't authenticate. This is what an admin hit trying to add a teammate.

This gates `create_user` on `local_credentials_permitted()` (the same predicate the credential-write repo uses) **before any writes**, returning a clear message directing admins to the control-plane seat invite (Instances -> Seats). Self-hosted keeps the local creation flow untouched.

This is the safety half. Adding staff in hosted mode already works today via the control-plane dashboard (`manage.nosdesk.com` -> Instances -> Seats -> grant by email). A follow-up PR wires an in-app entry point (hosted-mode "Add member" links to the control plane).

https://claude.ai/code/session_0199WATFeQtTBRo8dPkHEZhX