### PR TITLE
Hand off member creation to the control plane in hosted mode

### DIFF
--- a/backend/src/handlers/app_config.rs
+++ b/backend/src/handlers/app_config.rs
@@ -36,9 +36,14 @@ pub async fn get_public_config() -> impl Responder {
     let inbound_forwarding_enabled = std::env::var("NOSDESK_INBOUND_DOMAIN")
         .map(|s| !s.is_empty())
         .unwrap_or(false);
+    // The control-plane dashboard base URL (hosted mode), where members are
+    // added and managed (Instances -> Seats). Empty when unset; the SPA renders
+    // the in-app "add member" hand-off link only when this is present.
+    let control_plane_url = std::env::var("CONTROL_PLANE_URL").unwrap_or_default();
     HttpResponse::Ok().json(json!({
         "workspace_routing": workspace_routing,
         "deployment_mode": deployment_mode,
         "inbound_forwarding_enabled": inbound_forwarding_enabled,
+        "control_plane_url": control_plane_url,
     }))
 }

--- a/frontend/src/views/UsersListView.vue
+++ b/frontend/src/views/UsersListView.vue
@@ -6,6 +6,7 @@ import { useFluent } from 'fluent-vue'
 import { extractErrorMessage } from '@/utils/errors'
 import { formatDate } from '@nosdesk/core/utils/dateUtils'
 import { useToastStore } from '@nosdesk/core/stores/toast'
+import { isHostedDeployment, getControlPlaneUrl } from '@nosdesk/core/services/instanceConfig'
 
 import DataTable from '@/components/common/DataTable.vue'
 import PaginationControls from '@/components/common/PaginationControls.vue'
@@ -45,6 +46,15 @@ const scrollContainerRef = computed<HTMLElement | null>(
 )
 
 const navigateToCreateUser = () => {
+  // In hosted mode identity is owned by the control plane; a user created here
+  // can't sign in. Hand off to the control-plane dashboard (Instances -> Seats)
+  // rather than open a create form that produces a dead account.
+  if (isHostedDeployment()) {
+    const cp = getControlPlaneUrl()
+    if (cp) window.open(`${cp}/instances`, '_blank', 'noopener')
+    toast.info(t('user-mgmt-hosted-add-in-control-plane'))
+    return
+  }
   void router.push('/users/new')
 }
 const navigateToUser = (user: User) => {

--- a/i18n/locales/en-US/main.ftl
+++ b/i18n/locales/en-US/main.ftl
@@ -2392,6 +2392,7 @@ user-mgmt-deleted-badge = Deleted
 user-mgmt-deleted-purges-on = Purges on { $date }
 user-mgmt-restore = Restore user
 user-mgmt-restored = { $name } restored
+user-mgmt-hosted-add-in-control-plane = Members are added in the Nosdesk control plane.
 user-mgmt-restore-error = Failed to restore user.
 user-mgmt-purge-now = Permanently delete
 user-mgmt-purged = { $name } permanently deleted

--- a/i18n/locales/fr-FR/main.ftl
+++ b/i18n/locales/fr-FR/main.ftl
@@ -2248,6 +2248,8 @@ user-mgmt-deleted-badge = Supprimé
 user-mgmt-deleted-purges-on = Suppression définitive le { $date }
 user-mgmt-restore = Restaurer l'utilisateur
 user-mgmt-restored = { $name } restauré
+# Traduction automatique, en attente de relecture par un locuteur natif.
+user-mgmt-hosted-add-in-control-plane = Les membres sont ajoutés dans la console de gestion Nosdesk.
 user-mgmt-restore-error = Impossible de restaurer cet utilisateur.
 user-mgmt-purge-now = Supprimer définitivement
 user-mgmt-purged = { $name } supprimé définitivement

--- a/i18n/locales/nl-NL/main.ftl
+++ b/i18n/locales/nl-NL/main.ftl
@@ -2245,6 +2245,8 @@ user-mgmt-deleted-badge = Verwijderd
 user-mgmt-deleted-purges-on = Definitief verwijderd op { $date }
 user-mgmt-restore = Gebruiker herstellen
 user-mgmt-restored = { $name } hersteld
+# Automatische vertaling, wacht op controle door een moedertaalspreker.
+user-mgmt-hosted-add-in-control-plane = Leden worden toegevoegd in de Nosdesk-beheerconsole.
 user-mgmt-restore-error = Kon die gebruiker niet herstellen.
 user-mgmt-purge-now = Permanent verwijderen
 user-mgmt-purged = { $name } permanent verwijderd

--- a/packages/core/src/services/instanceConfig.ts
+++ b/packages/core/src/services/instanceConfig.ts
@@ -19,6 +19,8 @@ interface InstanceConfig {
   workspace_routing: WorkspaceRouting;
   deployment_mode: DeploymentMode;
   inbound_forwarding_enabled: boolean;
+  /** Control-plane dashboard base URL (hosted mode); '' when unset. */
+  control_plane_url: string;
 }
 
 // Default 'host': the subdomain / self-hosted model every current deployment
@@ -36,6 +38,11 @@ let deploymentMode: DeploymentMode = 'self_hosted';
 // domain (the hosted SES-receiving path), absent on self-host. The admin UI
 // hides the forwarding channel type until the config confirms it's available.
 let inboundForwardingEnabled = false;
+
+// Control-plane dashboard base URL, hosted mode only. Empty by default and
+// until the config resolves; the hosted "add member" hand-off renders its link
+// only when this is non-empty (unset -> a plain explainer, never a dead form).
+let controlPlaneUrl = '';
 
 // Memoised so bootstrap and the router guard share one fetch. The guard awaits
 // this before reading the routing mode, so a cold load (hard refresh, deep link)
@@ -70,6 +77,9 @@ export function fetchInstanceConfig(): Promise<void> {
         if (typeof data?.inbound_forwarding_enabled === 'boolean') {
           inboundForwardingEnabled = data.inbound_forwarding_enabled;
         }
+        if (typeof data?.control_plane_url === 'string') {
+          controlPlaneUrl = data.control_plane_url;
+        }
         configResolved.value = true;
       } catch (e) {
         logger.error('Failed to fetch instance config; will retry on next call', e);
@@ -98,6 +108,7 @@ export function resetInstanceConfig(): void {
   workspaceRouting = 'host';
   deploymentMode = 'self_hosted';
   inboundForwardingEnabled = false;
+  controlPlaneUrl = '';
 }
 
 /** Reactive: `true` once {@link fetchInstanceConfig} has settled (success or
@@ -123,4 +134,10 @@ export function isHostedDeployment(): boolean {
 /** True when forwarding-based inbound email is available on this instance. */
 export function isInboundForwardingEnabled(): boolean {
   return inboundForwardingEnabled;
+}
+
+/** Control-plane dashboard base URL (hosted mode); '' when unset. Consumers
+ *  render a hand-off link only when non-empty. */
+export function getControlPlaneUrl(): string {
+  return controlPlaneUrl;
 }


### PR DESCRIPTION
Follow-up to #281 (the backend gate). Gives hosted-mode admins a working in-app entry point for adding members.

**What changed**
- `/api/config` now exposes `control_plane_url` (from the `CONTROL_PLANE_URL` env var; empty when unset).
- `instanceConfig` (core) parses/stores it with a `getControlPlaneUrl()` getter, alongside the existing `isHostedDeployment()`.
- `UsersListView`'s "Add member" action, in hosted mode, opens the control-plane dashboard (`<CONTROL_PLANE_URL>/instances` -> Seats) in a new tab and shows an explainer toast, instead of the local create-user form that produces an un-loggable account. Self-hosted is unchanged. When `CONTROL_PLANE_URL` is unset it shows the explainer without a link (never the dead form).
- i18n: en-US + machine fr-FR/nl-NL (flagged pending native review).

**Deploy note:** set `CONTROL_PLANE_URL` per environment for the link to render, e.g. `https://manage.nosdesk.dev` (staging), `https://manage.nosdesk.com` (prod).

**Deliberately deferred (A1 / separate CP PR):** a precise per-instance seats deep-link. v1 lands the admin on the instances list; a ~10-line `manage.*` change to auto-forward `/instances?workspace=<slug>` would take them straight to the right Seats page. Not building the reverse product->CP trust channel now.

https://claude.ai/code/session_0199WATFeQtTBRo8dPkHEZhX