### PR TITLE
Gate user-list bulk actions behind platform-admin

### DIFF
--- a/frontend/src/views/UsersListView.vue
+++ b/frontend/src/views/UsersListView.vue
@@ -215,10 +215,14 @@ const listView = useListView({
   pinnedColumnIds: ['user'],
 })
 
-// The deleted-users view is a platform-admin-only recovery surface
-// (matching who can restore/purge). The backend independently forces the
-// active filter for non-admins, so hiding the tab is the UI half of that
-// gate, not the enforcement.
+// Platform-admin gate for the account-lifecycle surfaces. Every user
+// mutation the backend exposes (bulk delete / set-role, single delete,
+// restore, purge) requires platform_admin, so a workspace admin who
+// isn't one would only hit "permission denied". We hide those
+// affordances rather than let them error: the deleted-users tab (its
+// restore/purge live there) and, via `selectable` on the table below,
+// row selection itself, which is only ever used to reach the bulk
+// actions. This is the UI half of the gate, not the enforcement.
 const isPlatformAdmin = computed(() => auth.user?.platform_role === 'platform_admin')
 
 // Active vs Deleted view. The "deleted" filter lives in the list-view
@@ -389,6 +393,7 @@ function formatPurgeAt(deletedAt: string): string {
           :data="items"
           :buckets="listView.buckets.value"
           :is-collapsed="listView.grouping.isCollapsed"
+          :selectable="isPlatformAdmin"
           :selected-items="listView.dt.selectedItems"
           item-id-field="uuid"
           :sort-field="listView.controls.sortField.value"


### PR DESCRIPTION
## What

Row selection in the users list now renders only for platform admins (`:selectable="isPlatformAdmin"`).

## Why

Every user mutation the backend exposes (`bulk_users` delete/set-role, `delete_user`, restore, purge) requires `platform_admin`. A workspace admin who is not one (e.g. any tenant admin on the hosted instance, where all members are `platform_role = user`) previously saw the bulk "Change role" / "Delete" buttons but only got "permission denied" on click. This surfaced when creating and then trying to delete a member from the product app.

Gating selection removes the checkboxes entirely, so the bulk bar never appears and the erroring buttons are unreachable. This matches the backend gate exactly, and also fixes the same broken buttons for non-platform-admin workspace admins on self-hosted (which a hosted-only check would have missed). The deleted-users tab (restore/purge) was already `isPlatformAdmin`-gated; this extends the same gate to the active-view bulk actions.

## Notes

- Hide-only, no i18n changes.
- Related to #281 (hosted create gate) / #282 (in-app add-member hand-off).

https://claude.ai/code/session_0199WATFeQtTBRo8dPkHEZhX