### PR TITLE
Hide operator-only admin surfaces from workspace admins

### DIFF
--- a/frontend/src/components/admin/adminNavData.ts
+++ b/frontend/src/components/admin/adminNavData.ts
@@ -180,7 +180,8 @@ export const adminNavGroups: AdminNavGroup[] = [
         descriptionKey: 'admin-nav-workspaces-description',
         icon: 'folder',
         route: '/admin/workspaces',
-        keywords: ['workspaces', 'tenants', 'lifecycle', 'archive', 'members', 'multi-tenant']
+        keywords: ['workspaces', 'tenants', 'lifecycle', 'archive', 'members', 'multi-tenant'],
+        platformAdminOnly: true
       },
       {
         titleKey: 'admin-nav-guest-access-title',
@@ -194,14 +195,16 @@ export const adminNavGroups: AdminNavGroup[] = [
         descriptionKey: 'admin-nav-auth-providers-description',
         icon: 'lock',
         route: '/admin/auth-providers',
-        keywords: ['auth', 'authentication', 'sso', 'saml', 'oidc', 'oauth', 'microsoft', 'entra', 'ldap', 'login', 'providers']
+        keywords: ['auth', 'authentication', 'sso', 'saml', 'oidc', 'oauth', 'microsoft', 'entra', 'ldap', 'login', 'providers'],
+        platformAdminOnly: true
       },
       {
         titleKey: 'admin-nav-search-title',
         descriptionKey: 'admin-nav-search-description',
         icon: 'search',
         route: '/admin/search',
-        keywords: ['search', 'index', 'indexing', 'reindex', 'statistics']
+        keywords: ['search', 'index', 'indexing', 'reindex', 'statistics'],
+        platformAdminOnly: true
       },
       {
         titleKey: 'admin-nav-system-settings-title',
@@ -215,7 +218,8 @@ export const adminNavGroups: AdminNavGroup[] = [
         descriptionKey: 'admin-nav-backup-restore-description',
         icon: 'archive',
         route: '/admin/backup-restore',
-        keywords: ['backup', 'restore', 'export', 'import', 'data', 'recovery']
+        keywords: ['backup', 'restore', 'export', 'import', 'data', 'recovery'],
+        platformAdminOnly: true
       },
       {
         titleKey: 'admin-nav-unrouted-inbound-title',

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -43,6 +43,11 @@ declare module 'vue-router' {
      * as opposed to `adminRequired` which also admits platform admins.
      * Used by the workspace member-management page. */
     workspaceAdminRequired?: boolean;
+    /** Gate to platform admins only (Nosdesk operators). Operator/instance
+     * surfaces a workspace admin must never reach even in the /admin console:
+     * cross-tenant workspace lifecycle, backups, search index, auth providers.
+     * Further restricts an `adminRequired` subtree (see checkPlatformAdminAccess). */
+    platformAdminRequired?: boolean;
     /** Within an adminRequired subtree, also allow the standalone
      * audit_reviewer role to reach this route (Item C/D4). */
     auditReviewerAllowed?: boolean;
@@ -666,7 +671,7 @@ const router = createRouter({
           path: 'workspaces',
           name: 'admin-workspaces',
           component: () => import('../views/admin/AdminWorkspacesView.vue'),
-          meta: { titleKey: 'route-title-admin-workspaces' }
+          meta: { titleKey: 'route-title-admin-workspaces', platformAdminRequired: true }
         },
         {
           path: 'workspaces/:id(\\d+)/members',
@@ -764,13 +769,13 @@ const router = createRouter({
           path: 'auth-providers',
           name: 'admin-auth-providers',
           component: () => import('../views/AuthProvidersView.vue'),
-          meta: { titleKey: 'route-title-admin-auth-providers' }
+          meta: { titleKey: 'route-title-admin-auth-providers', platformAdminRequired: true }
         },
         {
           path: 'search',
           name: 'admin-search',
           component: () => import('../views/SearchManagementView.vue'),
-          meta: { titleKey: 'route-title-admin-search' }
+          meta: { titleKey: 'route-title-admin-search', platformAdminRequired: true }
         },
         {
           path: 'system-settings',
@@ -896,7 +901,7 @@ const router = createRouter({
           path: 'backup-restore',
           name: 'admin-backup-restore',
           component: () => import('../views/BackupRestoreView.vue'),
-          meta: { titleKey: 'route-title-admin-backup-restore' }
+          meta: { titleKey: 'route-title-admin-backup-restore', platformAdminRequired: true }
         }
       ]
     },
@@ -1264,11 +1269,24 @@ async function checkWorkspaceAdminAccess(to: RouteLocationNormalized) {
   return { name: 'home' };
 }
 
+// Gate operator/instance routes to platform admins only. Runs after
+// checkAdminAccess (which admits workspace admins on an adminRequired subtree),
+// so it further restricts the operator subset a tenant admin must never reach,
+// matching the backend `require_platform_admin` gate on these handlers.
+async function checkPlatformAdminAccess(to: RouteLocationNormalized) {
+  const needs = to.matched.some((record) => record.meta.platformAdminRequired);
+  if (!needs) return;
+  const { useAuthStore } = await import('@/stores/auth');
+  if (useAuthStore().isPlatformAdmin) return;
+  return { name: 'home' };
+}
+
 // Register middleware in order of execution
 router.beforeEach(checkOnboarding);
 router.beforeEach(checkAuthentication);
 router.beforeEach(checkAdminAccess);
 router.beforeEach(checkWorkspaceAdminAccess);
+router.beforeEach(checkPlatformAdminAccess);
 
 // Diagnostic breadcrumb on every successful navigation. Uses
 // `to.path` (no query/fragment) and scrubUrl masks UUID segments

--- a/frontend/src/views/SystemSettingsView.vue
+++ b/frontend/src/views/SystemSettingsView.vue
@@ -11,8 +11,10 @@
       <!-- Workspace data export (owner-only, self-serve DSAR return) -->
       <WorkspaceDataExportCard v-if="authStore.isOwner" />
 
-      <!-- Storage Management Section -->
-      <div class="bg-surface border border-default rounded-xl hover:border-strong transition-colors">
+      <!-- Storage Management Section. Instance-wide storage maintenance is a
+           platform-operator action (backend requires platform_admin); hidden
+           from workspace admins, who would only hit permission denied. -->
+      <div v-if="authStore.isPlatformAdmin" class="bg-surface border border-default rounded-xl hover:border-strong transition-colors">
         <div class="p-4 flex flex-col gap-3">
           <!-- Header row with icon -->
           <div class="flex items-center gap-3">
@@ -82,8 +84,9 @@
         </div>
       </div>
 
-      <!-- Thumbnail Regeneration Section -->
-      <div class="bg-surface border border-default rounded-xl hover:border-strong transition-colors">
+      <!-- Thumbnail Regeneration Section. Same as storage cleanup: an
+           instance-wide platform-operator action, hidden from workspace admins. -->
+      <div v-if="authStore.isPlatformAdmin" class="bg-surface border border-default rounded-xl hover:border-strong transition-colors">
         <div class="p-4 flex flex-col gap-3">
           <div class="flex items-center gap-3">
             <div class="flex-shrink-0 h-9 w-9 rounded-lg bg-accent/20 flex items-center justify-center text-accent">


### PR DESCRIPTION
Remediation PR 1 (operator-surface hygiene) from `docs/architecture/workspace-function-tiers.md`, tier 2.

## What
- `adminNavData.ts`: flag Workspaces, Auth providers, Search, Backup/restore as `platformAdminOnly` (they were shown to any workspace admin).
- `router/index.ts`: add a `platformAdminRequired` route meta + `checkPlatformAdminAccess` guard, applied to those four routes, so a direct URL redirects non-platform-admins home rather than loading a page that 403s.
- `SystemSettingsView.vue`: gate the two storage-maintenance cards (cleanup images, regenerate thumbnails) on `isPlatformAdmin`. The workspace export card (tenant-facing, `isOwner`) stays.

## Why
These handlers are gated `require_platform_admin`; the frontend rendered them for workspace admins, so a tenant admin (hosted) or non-bootstrap admin (self-hosted) hit permission denied on entry. Backend gates unchanged; this aligns the affordances with them. Part of the class found in `docs/code-review/saas-principles-review-2026-08.md`.

## Scope
Operator surfaces only. The mis-gated tenant functions (guest settings, email config, member recovery) are separate backend re-gate PRs; hosted identity/credential affordance hides (passkey enroll, `/users/new` deep link, self-delete) are a follow-up.

https://claude.ai/code/session_01QmTQJJheSte3Ls4JWtu2fG