### PR TITLE
Hide hosted-broken identity affordances (passkey enroll, /users/new)

### DIFF
--- a/frontend/src/components/settings/PasskeySettings.vue
+++ b/frontend/src/components/settings/PasskeySettings.vue
@@ -10,6 +10,7 @@ import Spinner from '@/components/common/Spinner.vue';
 import SectionCard from '@/components/common/SectionCard.vue';
 import { extractErrorMessage } from '@/utils/errors';
 import { formatDate as formatDateOnly } from '@nosdesk/core/utils/dateUtils';
+import { isHostedDeployment } from '@nosdesk/core/services/instanceConfig';
 import Button from '@/components/common/Button.vue';
 import FormInput from '@/components/common/FormInput.vue';
 import Modal from '@/components/Modal.vue';
@@ -50,6 +51,11 @@ const {
   formatDate,
   clearMessages,
 } = usePasskeys();
+
+// Passkeys registered here can only sign in when local auth is enabled, which
+// hosted mode disables (login is control-plane OIDC). Hide the enroll affordance
+// in hosted so a user can't create a credential that can never authenticate.
+const canAddPasskeyHere = computed(() => canAddPasskey.value && !isHostedDeployment());
 
 // Admin mode state
 const adminPasskeys = ref<PasskeyInfo[]>([]);
@@ -284,7 +290,7 @@ onMounted(async () => {
             <p class="text-sm text-secondary">{{ $t('settings-passkey-empty-title') }}</p>
             <p class="text-xs text-tertiary mt-0.5">{{ $t('settings-passkey-empty-self-description') }}</p>
           </div>
-          <Button class="flex-shrink-0" @click="showAddModal = true">
+          <Button v-if="canAddPasskeyHere" class="flex-shrink-0" @click="showAddModal = true">
             {{ $t('settings-passkey-add-button') }}
           </Button>
         </div>
@@ -337,7 +343,7 @@ onMounted(async () => {
 
           <!-- Add Passkey button at bottom of list -->
           <button
-            v-if="canAddPasskey"
+            v-if="canAddPasskeyHere"
             @click="showAddModal = true"
             class="flex items-center justify-center gap-2 p-4 border-2 border-dashed border-subtle hover:border-accent rounded-lg text-secondary hover:text-accent transition-colors"
           >

--- a/frontend/src/views/UserProfileView.vue
+++ b/frontend/src/views/UserProfileView.vue
@@ -6,6 +6,8 @@ import { useUserProfileBundle } from '@/composables/useUserProfileBundle';
 import { useDelayedFlag } from '@/composables/useDelayedFlag';
 import { useFluent } from 'fluent-vue';
 import { useAuthStore } from "@/stores/auth";
+import { useToastStore } from '@nosdesk/core/stores/toast';
+import { isHostedDeployment, getControlPlaneUrl } from '@nosdesk/core/services/instanceConfig';
 import BackButton from "@/components/common/BackButton.vue";
 import UserProfileCard from "@/components/settings/UserProfileCard.vue";
 import UserEmailsCard from "@/components/settings/UserEmailsCard.vue";
@@ -52,6 +54,17 @@ const error = ref<string | null>(null);
 // Creation mode (no uuid, or "new") runs no query: it's a form.
 const userUuid = computed(() => route.params.uuid as string | undefined);
 const isCreationMode = computed(() => !userUuid.value || userUuid.value === 'new');
+const toast = useToastStore();
+
+// A deep link to the create form in hosted mode would build a dead, unloggable
+// account (identity is control-plane owned), so hand off to the control plane
+// like the Users-list create action rather than render the form.
+if (isCreationMode.value && isHostedDeployment()) {
+  const cp = getControlPlaneUrl();
+  if (cp) window.open(`${cp}/instances`, '_blank', 'noopener');
+  toast.info(t('user-mgmt-hosted-add-in-control-plane'));
+  void router.replace('/users');
+}
 
 // Shared bundle query (single source of truth for the cache key + shape;
 // see useUserProfileBundle). ProfileSettingsView uses the same composable,


### PR DESCRIPTION
Remediation PR 1b (hosted identity/credential affordance hides), stacked on #284. Base retargets to `main` once #284 merges.

## What
- `PasskeySettings.vue`: gate the add-passkey affordances (empty-state and "add another") on a new `canAddPasskeyHere` computed that is false in hosted mode.
- `UserProfileView.vue`: on a `/users/new` deep link in hosted mode, hand off to the control plane (`window.open` + toast + redirect to `/users`), mirroring `UsersListView.navigateToCreateUser`.

## Why
Hosted disables local auth (`hosted_local_auth_disabled`; login is CP OIDC). A passkey enrolled here can never be used to sign in, and a directly-created user has no CP identity, both stranded states. This hides the affordances rather than let them produce dead credentials/accounts. Rule A in `docs/architecture/workspace-function-tiers.md`. No new i18n (reuses `user-mgmt-hosted-add-in-control-plane`).

https://claude.ai/code/session_01QmTQJJheSte3Ls4JWtu2fG