### PR TITLE
Re-gate guest and email config to workspace admin

### DIFF
--- a/backend/src/handlers/email.rs
+++ b/backend/src/handlers/email.rs
@@ -55,14 +55,14 @@ pub async fn get_email_config(
     req: HttpRequest,
     resolver: web::Data<std::sync::Arc<crate::services::outbound_email::OutboundEmailResolver>>,
 ) -> impl Responder {
-    // Extract claims from cookie auth middleware
-    let claims = match req.extensions().get::<crate::models::Claims>() {
-        Some(claims) => claims.clone(),
-        None => return errors::unauthorized("Authentication required"),
-    };
-
-    if !crate::utils::rbac::is_platform_admin(&claims) {
-        return errors::forbidden("Only administrators can view email configuration");
+    // Per-workspace email config: a workspace admin owns it. Was platform-admin,
+    // which broke the Setup tab's own bootstrap read for tenant admins. TenantConn
+    // scopes the read; the hosted branch below redacts the platform relay and
+    // reports the workspace's effective sending identity.
+    if let Err(resp) =
+        crate::utils::rbac::require_workspace_role(&req, crate::models::WorkspaceRole::Admin)
+    {
+        return resp;
     }
 
     // SMTP transport. EmailService::from_env reports is_configured for the
@@ -160,14 +160,12 @@ pub async fn send_test_email(
     req: HttpRequest,
     request: web::Json<TestEmailRequest>,
 ) -> impl Responder {
-    // Extract claims from cookie auth middleware
-    let claims = match req.extensions().get::<crate::models::Claims>() {
-        Some(claims) => claims.clone(),
-        None => return errors::unauthorized("Authentication required"),
-    };
-
-    if !crate::utils::rbac::is_platform_admin(&claims) {
-        return errors::forbidden("Only administrators can send test emails");
+    // Per-workspace test send (targets this workspace's identity). A workspace
+    // admin owns it, matching the sibling outbound endpoints. Was platform-admin.
+    if let Err(resp) =
+        crate::utils::rbac::require_workspace_role(&req, crate::models::WorkspaceRole::Admin)
+    {
+        return resp;
     }
 
     // Create email service

--- a/backend/src/handlers/guest_settings.rs
+++ b/backend/src/handlers/guest_settings.rs
@@ -1,13 +1,13 @@
 //! Admin-only handlers for the guest-access feature flags in `site_settings`.
 //! Exposed at `/api/admin/guest-settings`.
 
-use actix_web::{web, HttpMessage, HttpRequest, HttpResponse, Responder};
+use actix_web::{web, HttpRequest, HttpResponse, Responder};
 use serde::Deserialize;
 use tracing::error;
 
 use crate::extractors::TenantConn;
 use crate::handlers::errors;
-use crate::models::{Claims, SiteSettingsResponse, UpdateSiteSettings};
+use crate::models::{SiteSettingsResponse, UpdateSiteSettings};
 use crate::repository::site_settings;
 use crate::utils;
 
@@ -39,7 +39,16 @@ pub struct UpdateGuestSettingsRequest {
     pub guest_ticket_intro_message: Option<Option<String>>,
 }
 
-pub async fn get_guest_settings(mut tc: TenantConn) -> impl Responder {
+pub async fn get_guest_settings(mut tc: TenantConn, req: HttpRequest) -> impl Responder {
+    // Per-workspace guest config (site_settings, RLS-isolated via TenantConn),
+    // so a workspace admin owns it. The read was ungated while the write
+    // demanded platform-admin; both are now workspace-admin. The public portal
+    // reads guest config through handlers/guest.rs, not this admin endpoint.
+    if let Err(resp) =
+        crate::utils::rbac::require_workspace_role(&req, crate::models::WorkspaceRole::Admin)
+    {
+        return resp;
+    }
     match tc.run(site_settings::get_site_settings) {
         Ok(settings) => {
             let response: SiteSettingsResponse = settings.into();
@@ -57,14 +66,14 @@ pub async fn update_guest_settings(
     req: HttpRequest,
     body: web::Json<UpdateGuestSettingsRequest>,
 ) -> impl Responder {
-    let claims = match req.extensions().get::<Claims>() {
-        Some(c) => c.clone(),
-        None => return HttpResponse::Unauthorized().finish(),
-    };
-
-    if !crate::utils::rbac::is_platform_admin(&claims) {
-        return errors::forbidden("Admin required");
-    }
+    // Per-workspace guest config, so a workspace admin owns it. Was
+    // platform-admin, which dead-ended every tenant admin on save.
+    let claims =
+        match crate::utils::rbac::require_workspace_role(&req, crate::models::WorkspaceRole::Admin)
+        {
+            Ok(c) => c,
+            Err(resp) => return resp,
+        };
 
     let user_uuid = match utils::parse_uuid(&claims.sub) {
         Ok(u) => u,


### PR DESCRIPTION
Remediation PR 2a (tenant config re-gates) from `docs/architecture/workspace-function-tiers.md`, tier 1.

## What
- `guest_settings.rs`: `get_guest_settings` (was ungated) and `update_guest_settings` (was platform-admin) now both `require_workspace_role(Admin)`.
- `email.rs`: `get_email_config` and `send_test_email` (both platform-admin) now `require_workspace_role(Admin)`.

## Why / safety
These are per-workspace configuration, not operator infra. They run on `TenantConn` (RLS-scoped to the caller's `app.workspace_id`) with **no target user**, so the existing tenant scoping is the isolation boundary, this is a pure gate correction, not a boundary change. A tenant admin could open both pages but every save (and the Email Setup tab's own bootstrap read) returned permission denied.

Verified: the public guest portal reads its config through `handlers/guest.rs`, not `/admin/guest-settings`, so anonymous ticket submission is unaffected. The hosted redaction in `get_email_config` (platform SMTP relay hidden, workspace effective identity reported) is unchanged. `cargo check` clean.

## Scope
No target-user handlers here. Member security recovery and invite resend (which need target membership resolution) are the next PR.

https://claude.ai/code/session_01QmTQJJheSte3Ls4JWtu2fG