### PR TITLE
Add and edit requesters in-product (agent-level)

### DIFF
--- a/backend/src/handlers/user_contact.rs
+++ b/backend/src/handlers/user_contact.rs
@@ -20,11 +20,39 @@ use crate::models::{
 use crate::repository::user_contact as repo;
 use crate::services::custom_fields::schema as field_schema;
 
-/// Self-or-admin gate shared by the contact mutation handlers. Returns the
-/// forbidden response to early-return, or None when the caller is authorized.
-fn guard_self_or_admin(auth: &AuthContext, user_uuid: Uuid) -> Option<HttpResponse> {
-    (auth.user_uuid != user_uuid && !auth.is_workspace_admin())
-        .then(|| errors::forbidden("You can only edit your own contact details"))
+/// Contact-mutation gate shared by the handlers: self, workspace-admin, OR an
+/// agent editing a REQUESTER (a `member`) of this workspace. Agents log and
+/// manage customers, but never edit another staff member's contact (that stays
+/// self-or-admin). Returns the forbidden response to early-return, or None when
+/// authorized.
+fn guard_contact_edit(
+    auth: &AuthContext,
+    tc: &mut TenantConn,
+    user_uuid: Uuid,
+) -> Option<HttpResponse> {
+    if auth.user_uuid == user_uuid || auth.is_workspace_admin() {
+        return None;
+    }
+    // Agent-or-above may edit a requester (member) of their own workspace. The
+    // membership read is RLS-scoped to the pinned workspace, so it can only see
+    // the caller's own tenant; a staff target (agent/admin) is not a requester
+    // and falls through to forbidden.
+    if auth.can_handle_tickets() {
+        if let Some(ws_id) = tc.workspace_id() {
+            if let Ok(Some(m)) =
+                tc.run(|conn| crate::repository::workspaces::membership(conn, ws_id, user_uuid))
+            {
+                if crate::models::WorkspaceRole::from_db(&m.role)
+                    == crate::models::WorkspaceRole::Member
+                {
+                    return None;
+                }
+            }
+        }
+    }
+    Some(errors::forbidden(
+        "You can only edit your own contact details, or a requester in your workspace.",
+    ))
 }
 
 /// A satellite contact row carrying ownership + sync provenance.
@@ -278,7 +306,7 @@ pub async fn add_user_phone(
     auth: AuthContext,
 ) -> impl Responder {
     let user_uuid = params.into_inner();
-    if let Some(resp) = guard_self_or_admin(&auth, user_uuid) {
+    if let Some(resp) = guard_contact_edit(&auth, &mut tc, user_uuid) {
         return resp;
     }
     let input = body.into_inner();
@@ -298,7 +326,7 @@ pub async fn update_user_phone(
     auth: AuthContext,
 ) -> impl Responder {
     let (user_uuid, id) = params.into_inner();
-    if let Some(resp) = guard_self_or_admin(&auth, user_uuid) {
+    if let Some(resp) = guard_contact_edit(&auth, &mut tc, user_uuid) {
         return resp;
     }
     let input = body.into_inner();
@@ -322,7 +350,7 @@ pub async fn delete_user_phone(
     auth: AuthContext,
 ) -> impl Responder {
     let (user_uuid, id) = params.into_inner();
-    if let Some(resp) = guard_self_or_admin(&auth, user_uuid) {
+    if let Some(resp) = guard_contact_edit(&auth, &mut tc, user_uuid) {
         return resp;
     }
     let result = tc.run(|conn| {
@@ -364,7 +392,7 @@ pub async fn add_user_address(
     auth: AuthContext,
 ) -> impl Responder {
     let user_uuid = params.into_inner();
-    if let Some(resp) = guard_self_or_admin(&auth, user_uuid) {
+    if let Some(resp) = guard_contact_edit(&auth, &mut tc, user_uuid) {
         return resp;
     }
     let input = body.into_inner();
@@ -384,7 +412,7 @@ pub async fn update_user_address(
     auth: AuthContext,
 ) -> impl Responder {
     let (user_uuid, id) = params.into_inner();
-    if let Some(resp) = guard_self_or_admin(&auth, user_uuid) {
+    if let Some(resp) = guard_contact_edit(&auth, &mut tc, user_uuid) {
         return resp;
     }
     let input = body.into_inner();
@@ -408,7 +436,7 @@ pub async fn delete_user_address(
     auth: AuthContext,
 ) -> impl Responder {
     let (user_uuid, id) = params.into_inner();
-    if let Some(resp) = guard_self_or_admin(&auth, user_uuid) {
+    if let Some(resp) = guard_contact_edit(&auth, &mut tc, user_uuid) {
         return resp;
     }
     let result = tc.run(|conn| {

--- a/backend/src/handlers/users.rs
+++ b/backend/src/handlers/users.rs
@@ -832,28 +832,46 @@ pub async fn create_user(
     user_data: web::Json<CreateUserRequest>,
     req: HttpRequest,
 ) -> impl Responder {
-    // Authorization: creating a user (and assigning its role) is a
-    // workspace-admin operation. Without this gate any authenticated
-    // user could POST role:"admin" / "audit_reviewer" plus a password
-    // and mint a privileged account. See security-audit-2026-06.
-    let actor_claims =
-        match crate::utils::rbac::require_workspace_role(&req, crate::models::WorkspaceRole::Admin)
+    // The intended role decides the gate (roles map to the platform+workspace
+    // split via parse_roles, so we resolve it up front).
+    //
+    // A plain requester (end-user) is a tenant-local `member` with platform
+    // role `user`: not a billed seat and with no control-plane identity. Any
+    // agent-or-above may add one directly, in hosted and self-hosted alike (an
+    // agent logging a phone-in ticket). Staff and platform roles (agent/admin/
+    // audit_reviewer) are seats: workspace-admin, and without this gate any
+    // authenticated user could POST role:"admin" and mint a privileged account
+    // (security-audit-2026-06). In hosted they are control-plane owned, so hand
+    // off there rather than mint a local account that can never sign in.
+    let (platform_role, workspace_role) = match utils::parse_roles(&user_data.role) {
+        Ok(roles) => roles,
+        Err(e) => return e.into(),
+    };
+    let is_requester = platform_role == crate::models::PlatformRole::User
+        && workspace_role == crate::models::WorkspaceRole::Member;
+
+    let actor_claims = if is_requester {
+        match crate::utils::rbac::require_workspace_role(&req, crate::models::WorkspaceRole::Agent)
         {
             Ok(c) => c,
             Err(resp) => return resp,
+        }
+    } else {
+        let claims = match crate::utils::rbac::require_workspace_role(
+            &req,
+            crate::models::WorkspaceRole::Admin,
+        ) {
+            Ok(c) => c,
+            Err(resp) => return resp,
         };
-
-    // In hosted mode, user identity is owned by the control plane. Creating a
-    // local user here mints an account that can never sign in (no control-plane
-    // identity, and hosted local login is disabled), so refuse rather than
-    // strand a member, and direct admins to the control-plane seat invite.
-    // Self-hosted keeps the local creation flow below.
-    if !crate::middleware::workspace_context::local_credentials_permitted() {
-        return errors::forbidden(
-            "In hosted deployments, members are added from the Nosdesk control plane \
-             (Instances -> Seats). Direct user creation is only available in self-hosted mode.",
-        );
-    }
+        if !crate::middleware::workspace_context::local_credentials_permitted() {
+            return errors::forbidden(
+                "In hosted deployments, team members are added from the Nosdesk control \
+                 plane (Instances -> Seats). Only requesters can be added directly.",
+            );
+        }
+        claims
+    };
 
     let mut conn = match helpers::db_conn(&db_pool) {
         Ok(c) => c,
@@ -920,10 +938,6 @@ pub async fn create_user(
         }));
     }
 
-    // Validate role
-    let _role_enum = user_data.role.as_str();
-    // Role is already validated by the enum type
-
     // Validate optional fields
     if let Some(ref pronouns) = user_data.pronouns {
         if pronouns.len() > 50 {
@@ -958,13 +972,6 @@ pub async fn create_user(
 
     // Use provided UUID or generate a new UUIDv7
     let user_uuid = user_data.uuid.unwrap_or_else(uuid::Uuid::now_v7);
-
-    // Map the requested role string onto the platform + workspace
-    // role split.
-    let (platform_role, workspace_role) = match utils::parse_roles(&user_data.role) {
-        Ok(roles) => roles,
-        Err(e) => return e.into(),
-    };
 
     // Create new user with normalized data using builder
     let (normalized_name, normalized_email) =


### PR DESCRIPTION
Phases A + A.2 of the Team/Requesters split (`docs/plans/hosted-people-split.md`), decision 1: agents add AND edit requesters.

## A. create_user, keyed on role
- **Requester** (`platform_role == user` AND `workspace_role == member`): any **agent-or-above** may add one, hosted and self-hosted. No control-plane hand-off (not a seat, no CP identity).
- **Staff / platform roles** (agent/admin/audit_reviewer): still workspace-admin, and in hosted still hand off to the control plane. Requester test checks both role halves so `audit_reviewer` stays on the staff path; an agent POSTing `role:"admin"` still fails the admin gate.

## A.2. contact edit
- The contact-mutation gate (`user_contact.rs`) was self-or-workspace-admin. Widened so an agent may edit the contact details of a **requester (member) in their own workspace**. The membership lookup is RLS-scoped to the pinned workspace, so it only sees the caller's tenant; a staff target isn't a requester and stays self-or-admin.

## Verification
`cargo check` clean on both. No handler tests assumed the old behavior.

## Next
Phase B (the People/Team/Requesters frontend split) and Phase C (CP seats deep-link) build on this.

https://claude.ai/code/session_01QmTQJJheSte3Ls4JWtu2fG