### PR TITLE
Add admin-surface gating manifest and guardrail test

### DIFF
--- a/frontend/src/components/admin/adminSurfaceManifest.spec.ts
+++ b/frontend/src/components/admin/adminSurfaceManifest.spec.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest'
+import { adminNavGroups } from './adminNavData'
+import { ADMIN_SURFACE_TIER } from './adminSurfaceManifest'
+
+/**
+ * The affordance -> gate guardrail. Every `/admin` nav item must be classified
+ * in the manifest, and its `platformAdminOnly` nav flag must match that tier.
+ * This is what would have caught the operator-surfaces-shown-to-tenant-admins
+ * class: a new admin page with no classification, or a platform page missing its
+ * flag, fails here instead of dead-ending a tenant admin with a 403 in
+ * production.
+ */
+describe('admin surface gating manifest', () => {
+  const navItems = adminNavGroups.flatMap((g) => g.items)
+
+  it('classifies every admin nav route (a new surface must declare a tier)', () => {
+    const unclassified = navItems.map((i) => i.route).filter((route) => !(route in ADMIN_SURFACE_TIER))
+    expect(unclassified, `unclassified admin routes: ${unclassified.join(', ')}`).toEqual([])
+  })
+
+  it('has no stale manifest entries', () => {
+    const navRoutes = new Set(navItems.map((i) => i.route))
+    const stale = Object.keys(ADMIN_SURFACE_TIER).filter((route) => !navRoutes.has(route))
+    expect(stale, `manifest routes with no nav item: ${stale.join(', ')}`).toEqual([])
+  })
+
+  it('flags exactly the platform surfaces as platformAdminOnly', () => {
+    for (const item of navItems) {
+      const tier = ADMIN_SURFACE_TIER[item.route]
+      expect(
+        Boolean(item.platformAdminOnly),
+        `${item.route}: platformAdminOnly=${Boolean(item.platformAdminOnly)} but manifest tier=${tier}`,
+      ).toBe(tier === 'platform')
+    }
+  })
+})

--- a/frontend/src/components/admin/adminSurfaceManifest.ts
+++ b/frontend/src/components/admin/adminSurfaceManifest.ts
@@ -1,0 +1,53 @@
+/**
+ * Tenant-vs-platform classification of every admin surface: the source of truth
+ * for who may reach each `/admin` page. `tenant` = any workspace admin
+ * (self-serve); `platform` = Nosdesk operators only (cross-tenant lifecycle /
+ * instance infrastructure), which must be hidden from tenant admins in the nav
+ * (`platformAdminOnly`) and route-guarded (`platformAdminRequired`).
+ *
+ * Adding an admin nav item without classifying it here fails
+ * `adminSurfaceManifest.spec.ts`, forcing a deliberate gate decision so a new
+ * operator surface can never silently leak to tenant admins and dead-end them
+ * with a 403. See docs/code-review/saas-principles-review-2026-08.md and
+ * docs/architecture/workspace-function-tiers.md.
+ */
+export type AdminSurfaceTier = 'tenant' | 'platform';
+
+export const ADMIN_SURFACE_TIER: Record<string, AdminSurfaceTier> = {
+  // Tenant self-serve: running your own workspace.
+  '/admin/groups': 'tenant',
+  '/admin/categories': 'tenant',
+  '/admin/user-fields': 'tenant',
+  '/admin/assignment-rules': 'tenant',
+  '/admin/workflow': 'tenant',
+  '/admin/asset-kinds': 'tenant',
+  '/admin/sla': 'tenant',
+  '/admin/canned-responses': 'tenant',
+  '/admin/channels': 'tenant',
+  '/admin/email': 'tenant',
+  '/admin/notification-defaults': 'tenant',
+  '/admin/api-tokens': 'tenant',
+  '/admin/webhooks': 'tenant',
+  '/admin/plugins': 'tenant',
+  '/admin/data-import': 'tenant',
+  '/admin/ldap': 'tenant',
+  '/admin/audit': 'tenant',
+  '/admin/settings/branding': 'tenant',
+  '/admin/guest-access': 'tenant',
+  // The System-settings page is tenant-facing (workspace data export); its
+  // instance-wide maintenance buttons are gated inside the view.
+  '/admin/system-settings': 'tenant',
+
+  // Platform operator: cross-tenant lifecycle and instance infrastructure.
+  '/admin/workspaces': 'platform',
+  '/admin/auth-providers': 'platform',
+  '/admin/search': 'platform',
+  '/admin/backup-restore': 'platform',
+  '/admin/inbound/unrouted': 'platform',
+  '/admin/bug-reports': 'platform',
+};
+
+/** True when the given admin route is platform-operator-only. */
+export function isPlatformAdminSurface(route: string): boolean {
+  return ADMIN_SURFACE_TIER[route] === 'platform';
+}

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -865,13 +865,13 @@ const router = createRouter({
           path: 'inbound/unrouted',
           name: 'admin-inbound-unrouted',
           component: () => import('../views/InboundUnroutedView.vue'),
-          meta: { titleKey: 'route-title-admin-unrouted-inbound', requiresAuth: true, adminRequired: true }
+          meta: { titleKey: 'route-title-admin-unrouted-inbound', requiresAuth: true, adminRequired: true, platformAdminRequired: true }
         },
         {
           path: 'bug-reports',
           name: 'admin-bug-reports',
           component: () => import('../views/admin/BugReportsView.vue'),
-          meta: { titleKey: 'route-title-admin-bug-reports', requiresAuth: true, adminRequired: true }
+          meta: { titleKey: 'route-title-admin-bug-reports', requiresAuth: true, adminRequired: true, platformAdminRequired: true }
         },
         {
           path: 'data-import',


### PR DESCRIPTION
Reopened onto main after the base branch was squash-merged and deleted (original #288).

Adds the admin-surface gating manifest and a guardrail test that keeps operator-only admin surfaces hidden from workspace admins.

https://claude.ai/code/session_01QmTQJJheSte3Ls4JWtu2fG