### PR TITLE
Clip the profile avatar behind the sticky settings tabs

### DIFF
--- a/frontend/src/components/settings/UserProfileCard.vue
+++ b/frontend/src/components/settings/UserProfileCard.vue
@@ -545,7 +545,7 @@ const getRoleDisplayName = (role: string) => {
             <RouterLink
                 v-if="enableAvatarNavigation && !isEditable && displayUser?.uuid"
                 :to="`/users/${displayUser.uuid}`"
-                class="block rounded-full overflow-hidden border-4 border-surface shadow-lg hover:ring-2 hover:ring-accent transition-all z-30"
+                class="block rounded-full overflow-hidden border-4 border-surface shadow-lg hover:ring-2 hover:ring-accent transition-all z-10"
                 :class="[
                     avatarSize,
                     showBanner ? `absolute ${avatarOffset} left-3 sm:left-4` : 'mx-auto mt-4'
@@ -564,7 +564,7 @@ const getRoleDisplayName = (role: string) => {
             <!-- Non-clickable avatar for edit mode or when navigation is disabled -->
             <div
                 v-else
-                class="rounded-full overflow-hidden border-4 border-surface shadow-lg z-30 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+                class="rounded-full overflow-hidden border-4 border-surface shadow-lg z-10 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
                 :class="[
                     avatarSize,
                     showBanner ? `absolute ${avatarOffset} left-3 sm:left-4` : 'mx-auto mt-4',


### PR DESCRIPTION
## Problem

On the mobile profile settings view, scrolling the profile card up floated the avatar over the Profile/Appearance/Language tab strip (and toward the top bar), reported on the iOS app.

## Cause

The avatar carried `z-30`, but the mobile settings tab strip is `sticky top-0 z-20`. Since neither the card nor an ancestor isolates it into a stacking context, the avatar's `z-30` competed against the tabs' `z-20` at the root and won.

## Fix

The avatar is a later DOM sibling than the banner, so it already paints above the banner without a high z-index. Dropping both avatar variants to `z-10` keeps it over the banner while letting the sticky chrome clip it.

Verified at a 390px viewport across the full scroll range: the avatar now clips cleanly behind the sticky tabs.

https://claude.ai/code/session_01QmTQJJheSte3Ls4JWtu2fG