### PR TITLE
Pre-provision test partitions to end the month-rollover deadlock

### DIFF
--- a/backend/src/sync/partitions.rs
+++ b/backend/src/sync/partitions.rs
@@ -525,8 +525,9 @@ mod tests {
     #[test]
     fn ensure_partitions_is_idempotent() {
         let (_guard, mut conn) = provisioning_conn();
-        // Already-provisioned months from the substrate migration
-        // (May–Aug 2026) should not produce errors on a re-run.
+        // Already-provisioned months (the migration's seed months plus the
+        // current month the test harness provisions) should not error on a
+        // re-run.
         let touched = ensure_partitions(&mut conn, 60).expect("first run");
         // Touched should at least include current month; could
         // include more depending on `now()`. Just assert non-empty.

--- a/backend/src/test_helpers.rs
+++ b/backend/src/test_helpers.rs
@@ -50,6 +50,33 @@ fn ensure_test_db_migrated() {
             })?;
             conn.run_pending_migrations(MIGRATIONS)
                 .map_err(|e| format!("Failed to apply migrations to test DB: {e}"))?;
+
+            // Provision the partitions the current calendar month needs, once,
+            // COMMITTED. Every pool test connection runs inside an uncommitted
+            // test transaction (see `TestTransaction`), so if a data test were
+            // the first to touch a not-yet-provisioned month it would run the
+            // partition ATTACH inside that transaction and hold
+            // `SHARE UPDATE EXCLUSIVE` on the parent for the whole test, which
+            // deadlocks parallel tests (the `sync::partitions::tests`
+            // PARTITION_TEST_LOCK only serialises its own module). Provisioning
+            // here from `Utc::now` keeps `ensure_one_partition`'s `is_attached`
+            // fast path a no-op in every other test, and survives month
+            // rollover instead of relying on the migration's fixed seed months.
+            //
+            // A fresh single-connection pool with no `TestTransaction`
+            // customizer so it commits; `ResettingManager` acquires with
+            // `RESET ROLE`, i.e. the privileged login role the partition DDL
+            // (`ALTER TABLE ... OWNER TO`/`ATTACH`) needs.
+            let provisioning_pool = r2d2::Pool::builder()
+                .max_size(1)
+                .connection_timeout(Duration::from_secs(5))
+                .build(crate::db::ResettingManager::new(url))
+                .map_err(|e| format!("Failed to build partition-provisioning pool: {e}"))?;
+            let mut provisioning_conn = provisioning_pool
+                .get()
+                .map_err(|e| format!("Failed to check out partition-provisioning conn: {e}"))?;
+            crate::sync::partitions::ensure_partitions(&mut provisioning_conn, 35)
+                .map_err(|e| format!("Failed to provision test partitions: {e}"))?;
             Ok(())
         })
         .is_err()


### PR DESCRIPTION
## Symptom

Backend CI (`cargo test --lib`) began failing intermittently with `DatabaseError(Unknown, "deadlock detected")`, 1763 of 1764 tests passing, the failing test wandering between `sync::tests::record_*` and `sync::partitions::tests::partitions_eligible_for_drop_*`. It started at the September 1 date rollover.

## Root cause

A month-rollover time bomb:

- The test harness wraps every pool connection in an uncommitted `begin_test_transaction()`.
- `sync_actions` / `audit_log` are monthly partitions; the migration seeds them only through August 2026.
- After the rollover, `sync_actions_2026_09` did not exist, so every parallel test recording a sync action raced to `ATTACH` it inside its own uncommitted transaction. `ATTACH` holds `SHARE UPDATE EXCLUSIVE` on the parent for the whole test, so two threads deadlocked.
- `PARTITION_TEST_LOCK` only serialised the partitions module's own tests, never the data tests that also trigger the DDL.

## Fix

Provision the current + lookahead months once, committed, in the test-DB bootstrap (`ensure_test_db_migrated`), on a fresh committing pool. With the partition already attached, `ensure_one_partition`'s `is_attached` fast path returns before any lock, so no test runs partition DDL and the deadlock is structurally impossible. Computed from `Utc::now`, so it survives future rollovers instead of relying on the migration's fixed seed months.

## Verification

- `sync::` tests under `--test-threads=8`: 59 passed, 0 failed, 0.79s.
- Full `cargo test --lib` twice: 1764 passed, 0 failed (10.5s, 6.9s; was 1763/1764 and ~30s with lock waits).

https://claude.ai/code/session_01QmTQJJheSte3Ls4JWtu2fG