### PR TITLE
Rework the license claim schema around a stable customer id

### DIFF
--- a/LICENSING.md
+++ b/LICENSING.md
@@ -11,12 +11,15 @@ edition limit, `POST /api/admin/workspaces` returns `402 license_required`.
 
 ## How a license works
 
-A license is an EdDSA-signed JWT carrying the licensee, an active-workspace
-cap, and an expiry. The public verification key is compiled into the binary;
-the private signing key is held only by Nosdesk. The server reads
-`NOSDESK_LICENSE_KEY` at boot, verifies it, and lifts the workspace cap to the
-license's `max_workspaces`. An absent, malformed, expired, or wrong-issuer
-license falls back to Community without failing startup.
+A license is an EdDSA-signed JWT carrying a stable customer id (`sub`, a
+UUID that survives reissues), a display name (`licensee`), a per-issuance
+id (`jti`, required), an active-workspace cap, an expiry, and an optional
+`features` list (empty in v1.1 — nothing new is gated on it). The public
+verification key is compiled into the binary; the private signing key is
+held only by Nosdesk. The server reads `NOSDESK_LICENSE_KEY` at boot,
+verifies it, and lifts the workspace cap to the license's `max_workspaces`.
+An absent, malformed, expired, or wrong-issuer license falls back to
+Community without failing startup.
 
 Like any open-source gate, this is bypassable by patching the binary. The
 license is a genuine signed artifact, not an honor-system flag.
@@ -36,10 +39,17 @@ Sign a license:
 ```bash
 nosdesk-cli license sign \
   --key license_private.pem \
+  --customer-id 550e8400-e29b-41d4-a716-446655440000 \
   --licensee "Acme Corp" \
   --max-workspaces 10 \
   --days 365
 ```
+
+`--customer-id` is required and must be a UUID. Reissues of the same
+customer **must** pass the same id; omitting it (or generating a fresh one)
+would split the usage meter. Record issued ids deliberately until
+control-plane issuance exists. `jti` is generated if `--license-id` is
+omitted.
 
 The token (prefixed `nsk_lic_`) is printed to stdout.
 
@@ -52,8 +62,8 @@ NOSDESK_LICENSE_KEY=nsk_lic_...
 ```
 
 The startup log line `Edition resolved edition=enterprise` confirms it
-verified. `GET /api/admin/edition` reports the active edition, cap, and
-current workspace count.
+verified. `GET /api/admin/edition` reports the active edition, cap,
+customer id, features, and current workspace count.
 
 ## Rotating the key
 

--- a/backend/src/bin/nosdesk_cli.rs
+++ b/backend/src/bin/nosdesk_cli.rs
@@ -103,7 +103,11 @@ enum LicenseCommand {
         /// Path to the Ed25519 private key (PKCS8 PEM).
         #[arg(long)]
         key: PathBuf,
-        /// Licensee (organisation the license is issued to).
+        /// Stable customer id (UUID). Required; reissues MUST pass the same
+        /// id or the usage meter starts over. Never defaulted.
+        #[arg(long)]
+        customer_id: String,
+        /// Display name of the licensee organisation.
         #[arg(long)]
         licensee: String,
         /// Maximum number of active workspaces the license permits.
@@ -115,6 +119,11 @@ enum LicenseCommand {
         /// License id (jti). Defaults to a generated id.
         #[arg(long)]
         license_id: Option<String>,
+        /// Feature keys to stamp (comma-separated). Unknown keys are
+        /// accepted at mint and dropped at verify against the binary's
+        /// known-key set. Empty in v1.1.
+        #[arg(long, value_delimiter = ',')]
+        features: Vec<String>,
     },
 }
 
@@ -335,22 +344,44 @@ fn run_license(cmd: LicenseCommand) -> Result<()> {
     match cmd {
         LicenseCommand::Sign {
             key,
+            customer_id,
             licensee,
             max_workspaces,
             days,
             license_id,
-        } => license_sign(&key, &licensee, max_workspaces, days, license_id),
+            features,
+        } => license_sign(
+            &key,
+            &customer_id,
+            &licensee,
+            max_workspaces,
+            days,
+            license_id,
+            features,
+        ),
     }
 }
 
 fn license_sign(
     key_path: &Path,
+    customer_id: &str,
     licensee: &str,
     max_workspaces: u32,
     days: i64,
     license_id: Option<String>,
+    features: Vec<String>,
 ) -> Result<()> {
     use jsonwebtoken::{encode, Algorithm, EncodingKey, Header};
+
+    let customer_id = uuid::Uuid::parse_str(customer_id.trim()).with_context(|| {
+        format!(
+            "--customer-id must be a UUID (got {customer_id:?}); \
+             reissues must pass the same id, never omit it"
+        )
+    })?;
+    if licensee.trim().is_empty() {
+        bail!("--licensee must not be empty");
+    }
 
     let pem = fs::read_to_string(key_path)
         .with_context(|| format!("reading private key from {}", key_path.display()))?;
@@ -363,11 +394,13 @@ fn license_sign(
 
     let claims = backend::license::LicenseClaims {
         iss: backend::license::LICENSE_ISSUER.to_string(),
-        sub: licensee.to_string(),
+        sub: customer_id.to_string(),
+        licensee: licensee.trim().to_string(),
         jti,
         iat: now,
         exp,
         max_workspaces,
+        features,
     };
 
     let token = encode(&Header::new(Algorithm::EdDSA), &claims, &enc).context("signing license")?;
@@ -375,7 +408,8 @@ fn license_sign(
     // Stderr carries the human-readable summary; stdout is just the token so
     // it can be piped straight into an env file or secret store.
     eprintln!(
-        "Signed license for {licensee}: max_workspaces={max_workspaces}, expires in {days} day(s)."
+        "Signed license for {licensee} (customer_id={customer_id}): \
+         max_workspaces={max_workspaces}, expires in {days} day(s)."
     );
     println!("{}{token}", backend::license::LICENSE_PREFIX);
     Ok(())

--- a/backend/src/handlers/admin_workspaces.rs
+++ b/backend/src/handlers/admin_workspaces.rs
@@ -185,10 +185,12 @@ pub async fn get_edition(req: HttpRequest, mut pc: PlatformConn) -> impl Respond
         "active_workspaces": active,
         "can_create_workspace": can_create,
         "license": edition.license().map(|l| serde_json::json!({
+            "customer_id": l.customer_id,
             "licensee": l.licensee,
             "license_id": l.license_id,
             "max_workspaces": l.max_workspaces,
             "expires_at": l.expires_at,
+            "features": l.features,
         })),
     }))
 }

--- a/backend/src/license.rs
+++ b/backend/src/license.rs
@@ -35,15 +35,26 @@ pub const LICENSE_PREFIX: &str = "nsk_lic_";
 /// Workspace cap applied with no (valid) license.
 pub const COMMUNITY_MAX_WORKSPACES: u32 = 1;
 
+/// Feature keys this binary understands. v1.1 is an empty gate list (O1):
+/// the claim is accepted, stored only for keys in this set, and nothing
+/// is gated on them. Unknown keys are ignored, not rejected.
+pub const KNOWN_FEATURES: &[&str] = &[];
+
 /// JWT claims carried by a license token.
+///
+/// `jti` has no `#[serde(default)]` on purpose: a missing jti must fail
+/// verification. `jsonwebtoken` 11's `required_spec_claims` only checks
+/// `exp`/`sub`/`iss`/`aud`/`nbf` and silently skips anything else, so
+/// listing `jti` there is a no-op — the struct field is the requirement.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct LicenseClaims {
     /// Issuer; must equal [`LICENSE_ISSUER`].
     pub iss: String,
-    /// Licensee (organisation/customer the license was issued to).
+    /// Stable opaque customer id (UUID). Constant across reissues.
     pub sub: String,
-    /// License id (jti) for support/revocation bookkeeping.
-    #[serde(default)]
+    /// Display name of the licensee organisation.
+    pub licensee: String,
+    /// Per-issuance license id. Required; never empty.
     pub jti: String,
     /// Expiry (unix seconds). Validated.
     pub exp: i64,
@@ -52,15 +63,25 @@ pub struct LicenseClaims {
     pub iat: i64,
     /// Maximum number of active workspaces this license permits.
     pub max_workspaces: u32,
+    /// Entitlement keys. `#[serde(default)]` so older mental-model tokens
+    /// without the claim still deserialize; unknown keys are dropped.
+    #[serde(default)]
+    pub features: Vec<String>,
 }
 
 /// Verified license details.
 #[derive(Debug, Clone)]
 pub struct LicenseInfo {
+    /// Stable customer id (the JWT `sub`). Survives reissues.
+    pub customer_id: String,
+    /// Display name (the JWT `licensee` claim).
     pub licensee: String,
+    /// Per-issuance id (the JWT `jti`).
     pub license_id: String,
     pub max_workspaces: u32,
     pub expires_at: i64,
+    /// Known feature keys only. Empty in v1.1.
+    pub features: Vec<String>,
 }
 
 /// The deployment's resolved edition.
@@ -97,6 +118,32 @@ impl Edition {
             Edition::Enterprise(info) => Some(info),
         }
     }
+
+    /// Whether this edition carries `feature`. Community is always false.
+    /// v1.1's known-key set is empty, so this is false for every live
+    /// license; the helper is the mechanism, the gate list is policy.
+    pub fn has_feature(&self, feature: &str) -> bool {
+        match self {
+            Edition::Community => false,
+            Edition::Enterprise(info) => info.features.iter().any(|f| f == feature),
+        }
+    }
+}
+
+/// Process-wide [`Edition::has_feature`]. Handlers that already have an
+/// `&Edition` should call the method; this is for the boot-cached current.
+pub fn has_feature(feature: &str) -> bool {
+    current().has_feature(feature)
+}
+
+fn missing_claim(name: &str) -> jsonwebtoken::errors::Error {
+    jsonwebtoken::errors::ErrorKind::MissingRequiredClaim(name.to_string()).into()
+}
+
+fn normalize_features(raw: Vec<String>) -> Vec<String> {
+    raw.into_iter()
+        .filter(|k| KNOWN_FEATURES.iter().any(|known| *known == k.as_str()))
+        .collect()
 }
 
 /// Verify a license token against the given public key (SPKI PEM). Pure and
@@ -116,15 +163,31 @@ pub fn verify_with_key(
     validation.validate_exp = true;
     validation.validate_aud = false;
     validation.set_issuer(&[LICENSE_ISSUER]);
-    validation.set_required_spec_claims(&["exp", "iss"]);
+    // `sub` is a real registered claim so this check works. `jti` is not
+    // — listing it here would be a silent no-op (see LicenseClaims).
+    validation.set_required_spec_claims(&["exp", "iss", "sub"]);
 
     let data = decode::<LicenseClaims>(token, &key, &validation)?;
     let c = data.claims;
+    if c.jti.trim().is_empty() {
+        return Err(missing_claim("jti"));
+    }
+    if c.licensee.trim().is_empty() {
+        return Err(missing_claim("licensee"));
+    }
+    // `sub` is present (set_required_spec_claims enforces that) but must be a
+    // UUID. That is a malformed claim, not a missing one — an operator who
+    // mis-mints sees only a warn line, so the error has to name the real fault.
+    if uuid::Uuid::parse_str(&c.sub).is_err() {
+        return Err(jsonwebtoken::errors::ErrorKind::InvalidSubject.into());
+    }
     Ok(LicenseInfo {
-        licensee: c.sub,
+        customer_id: c.sub,
+        licensee: c.licensee,
         license_id: c.jti,
         max_workspaces: c.max_workspaces,
         expires_at: c.exp,
+        features: normalize_features(c.features),
     })
 }
 
@@ -134,6 +197,7 @@ fn load_from_env() -> Edition {
         Ok(raw) if !raw.trim().is_empty() => match verify_with_key(&raw, LICENSE_PUBLIC_KEY) {
             Ok(info) => {
                 info!(
+                    customer_id = %info.customer_id,
                     licensee = %info.licensee,
                     license_id = %info.license_id,
                     max_workspaces = info.max_workspaces,
@@ -184,24 +248,50 @@ mod tests {
         MCowBQYDK2VwAyEAbQxmQHWB+LZXvtyh54SrZM41ptz/WroW9djdAx1HPZQ=\n\
         -----END PUBLIC KEY-----\n";
 
+    const TEST_CUSTOMER: &str = "550e8400-e29b-41d4-a716-446655440000";
+
     fn mint(iss: &str, max_workspaces: u32, exp_offset: i64) -> String {
+        mint_with(
+            iss,
+            TEST_CUSTOMER,
+            "Acme Corp",
+            "lic_test_1",
+            max_workspaces,
+            exp_offset,
+            vec![],
+        )
+    }
+
+    fn mint_with(
+        iss: &str,
+        sub: &str,
+        licensee: &str,
+        jti: &str,
+        max_workspaces: u32,
+        exp_offset: i64,
+        features: Vec<&str>,
+    ) -> String {
         #[derive(Serialize)]
         struct Mint<'a> {
             iss: &'a str,
             sub: &'a str,
+            licensee: &'a str,
             jti: &'a str,
             iat: i64,
             exp: i64,
             max_workspaces: u32,
+            features: Vec<&'a str>,
         }
         let now = chrono::Utc::now().timestamp();
         let claims = Mint {
             iss,
-            sub: "Acme Corp",
-            jti: "lic_test_1",
+            sub,
+            licensee,
+            jti,
             iat: now,
             exp: now + exp_offset,
             max_workspaces,
+            features,
         };
         encode(
             &Header::new(Algorithm::EdDSA),
@@ -215,8 +305,11 @@ mod tests {
     fn valid_license_verifies() {
         let token = mint(LICENSE_ISSUER, 10, 3600);
         let info = verify_with_key(&token, TEST_PUB).expect("valid license");
+        assert_eq!(info.customer_id, TEST_CUSTOMER);
         assert_eq!(info.licensee, "Acme Corp");
+        assert_eq!(info.license_id, "lic_test_1");
         assert_eq!(info.max_workspaces, 10);
+        assert!(info.features.is_empty());
     }
 
     #[test]
@@ -256,11 +349,93 @@ mod tests {
 
     fn enterprise(max: u32) -> Edition {
         Edition::Enterprise(LicenseInfo {
+            customer_id: TEST_CUSTOMER.into(),
             licensee: "Acme Corp".into(),
             license_id: "lic_test_1".into(),
             max_workspaces: max,
             expires_at: 0,
+            features: vec![],
         })
+    }
+
+    #[test]
+    fn missing_jti_is_rejected() {
+        #[derive(Serialize)]
+        struct NoJti<'a> {
+            iss: &'a str,
+            sub: &'a str,
+            licensee: &'a str,
+            iat: i64,
+            exp: i64,
+            max_workspaces: u32,
+        }
+        let now = chrono::Utc::now().timestamp();
+        let token = encode(
+            &Header::new(Algorithm::EdDSA),
+            &NoJti {
+                iss: LICENSE_ISSUER,
+                sub: TEST_CUSTOMER,
+                licensee: "Acme Corp",
+                iat: now,
+                exp: now + 3600,
+                max_workspaces: 10,
+            },
+            &EncodingKey::from_ed_pem(TEST_PRIV.as_bytes()).expect("encode key"),
+        )
+        .expect("mint");
+        assert!(verify_with_key(&token, TEST_PUB).is_err());
+    }
+
+    #[test]
+    fn empty_jti_is_rejected() {
+        let token = mint_with(
+            LICENSE_ISSUER,
+            TEST_CUSTOMER,
+            "Acme Corp",
+            "",
+            10,
+            3600,
+            vec![],
+        );
+        assert!(verify_with_key(&token, TEST_PUB).is_err());
+    }
+
+    #[test]
+    fn display_name_as_sub_is_rejected() {
+        let token = mint_with(
+            LICENSE_ISSUER,
+            "Acme Corp",
+            "Acme Corp",
+            "lic_test_1",
+            10,
+            3600,
+            vec![],
+        );
+        assert!(verify_with_key(&token, TEST_PUB).is_err());
+    }
+
+    #[test]
+    fn unknown_features_are_dropped() {
+        let token = mint_with(
+            LICENSE_ISSUER,
+            TEST_CUSTOMER,
+            "Acme Corp",
+            "lic_test_1",
+            10,
+            3600,
+            // Deliberately keys that will never enter KNOWN_FEATURES, so this
+            // test does not start failing the day a real feature is added.
+            vec!["not-a-key", "also-not-a-key"],
+        );
+        let info = verify_with_key(&token, TEST_PUB).expect("valid license");
+        assert!(info.features.is_empty());
+        let edition = Edition::Enterprise(info);
+        assert!(!edition.has_feature("not-a-key"));
+    }
+
+    #[test]
+    fn community_has_no_features() {
+        assert!(!Edition::Community.has_feature("scim"));
     }
 
     #[test]

--- a/packages/core/src/types/workspace.ts
+++ b/packages/core/src/types/workspace.ts
@@ -86,10 +86,12 @@ export interface EditionInfo {
   active_workspaces: number;
   can_create_workspace: boolean;
   license: {
+    customer_id: string;
     licensee: string;
     license_id: string;
     max_workspaces: number;
     expires_at: number;
+    features: string[];
   } | null;
 }
 


### PR DESCRIPTION
Slice 2 of the on-prem licensed tier / cloud push relay work.

`sub` becomes a stable customer UUID that survives reissues; the display name moves to a new `licensee` claim; `jti` becomes required; and a `features` string set carries local capability lifts. `nosdesk_cli` gains the matching mint flags, and `GET /api/admin/edition` plus `EditionInfo` expose `customer_id` and `features`.

This is a breaking claim-schema change, which is why it lands now: there are no issued licenses.

It is also a hard prerequisite for the cloud relay. The relay's token exchange parses `sub` as a UUID and requires `licensee`, so a license minted from the current schema cannot authenticate against it.

12 license tests pass.

https://claude.ai/code/session_01KZdfqh5Fiqj27tPTBNNVbx