### PR TITLE
Add the cloud relay push sender and NOSDESK_PUSH_MODE

### DIFF
--- a/backend/src/handlers/admin_workspaces.rs
+++ b/backend/src/handlers/admin_workspaces.rs
@@ -166,7 +166,13 @@ pub async fn list_workspaces(
 /// (disable Create + show an upgrade note) rather than hard-coding it
 /// client-side. The server gate in `create_workspace` is the real
 /// enforcement; this is purely for display.
-pub async fn get_edition(req: HttpRequest, mut pc: PlatformConn) -> impl Responder {
+pub async fn get_edition(
+    req: HttpRequest,
+    mut pc: PlatformConn,
+    push_sender: web::Data<
+        std::sync::Arc<dyn crate::services::notifications::channels::push::PushSender>,
+    >,
+) -> impl Responder {
     if let Err(resp) = rbac::require_platform_admin(&req) {
         return resp;
     }
@@ -184,6 +190,10 @@ pub async fn get_edition(req: HttpRequest, mut pc: PlatformConn) -> impl Respond
         "max_workspaces": max,
         "active_workspaces": active,
         "can_create_workspace": can_create,
+        // Present only in relay push mode. This is the operator's sole
+        // diagnostic when relayed push stops working, and it distinguishes an
+        // unreachable relay from a refused licence from an unaccepted DPA.
+        "relay": push_sender.relay_status(),
         "license": edition.license().map(|l| serde_json::json!({
             "customer_id": l.customer_id,
             "licensee": l.licensee,

--- a/backend/src/handlers/admin_workspaces.rs
+++ b/backend/src/handlers/admin_workspaces.rs
@@ -190,7 +190,7 @@ pub async fn get_edition(
         "max_workspaces": max,
         "active_workspaces": active,
         "can_create_workspace": can_create,
-        // Present only in relay push mode. This is the operator's sole
+        // Null outside relay push mode. This is the operator's sole
         // diagnostic when relayed push stops working, and it distinguishes an
         // unreachable relay from a refused licence from an unaccepted DPA.
         "relay": push_sender.relay_status(),

--- a/backend/src/handlers/asset_audits.rs
+++ b/backend/src/handlers/asset_audits.rs
@@ -131,32 +131,42 @@ pub async fn record(
                     let asset_workspace = tc
                         .workspace_id()
                         .unwrap_or(crate::sync::actor::BOOTSTRAP_WORKSPACE_ID);
-                    for recipient_uuid in recipients {
-                        let payload = NotificationPayload::new(
-                            NotificationTypeCode::AssetLowStock,
-                            recipient_uuid,
-                            NotificationActor {
-                                uuid: actor_uuid,
-                                name: actor_name.clone(),
-                                avatar_thumb: None,
-                                kind: crate::sync::ActorKind::User,
-                            },
-                            NotificationEntity::Asset {
-                                id: asset_id,
-                                name: outcome.asset_name.clone(),
-                            },
-                            asset_workspace,
-                        )
-                        .with_body(body_text.clone());
-                        if let Err(e) = notification_service.notify(payload).await {
-                            error!(
-                                asset_id,
-                                recipient = %recipient_uuid,
-                                error = %e,
-                                "Failed to deliver asset_low_stock notification from audit",
-                            );
+                    // Spawned, not awaited (plan O2). See the identical
+                    // comment in `asset_usage::record`: awaiting `notify()`
+                    // here holds this handler's `TenantConn` across a push
+                    // delivery, which in relay mode is a network call to the
+                    // control plane. `outcome` is still needed for the
+                    // response, so the name is cloned out rather than moved.
+                    let asset_name = outcome.asset_name.clone();
+                    let notification_service = notification_service.clone();
+                    tokio::spawn(async move {
+                        for recipient_uuid in recipients {
+                            let payload = NotificationPayload::new(
+                                NotificationTypeCode::AssetLowStock,
+                                recipient_uuid,
+                                NotificationActor {
+                                    uuid: actor_uuid,
+                                    name: actor_name.clone(),
+                                    avatar_thumb: None,
+                                    kind: crate::sync::ActorKind::User,
+                                },
+                                NotificationEntity::Asset {
+                                    id: asset_id,
+                                    name: asset_name.clone(),
+                                },
+                                asset_workspace,
+                            )
+                            .with_body(body_text.clone());
+                            if let Err(e) = notification_service.notify(payload).await {
+                                error!(
+                                    asset_id,
+                                    recipient = %recipient_uuid,
+                                    error = %e,
+                                    "Failed to deliver asset_low_stock notification from audit",
+                                );
+                            }
                         }
-                    }
+                    });
                 }
             }
             HttpResponse::Created().json(outcome.row)

--- a/backend/src/handlers/asset_usage.rs
+++ b/backend/src/handlers/asset_usage.rs
@@ -186,33 +186,45 @@ pub async fn record(
                     let asset_workspace = tc
                         .workspace_id()
                         .unwrap_or(crate::sync::actor::BOOTSTRAP_WORKSPACE_ID);
-                    for recipient_uuid in recipients {
-                        let payload = NotificationPayload::new(
-                            NotificationTypeCode::AssetLowStock,
-                            recipient_uuid,
-                            NotificationActor {
-                                uuid: actor_uuid,
-                                name: actor_name.clone(),
-                                avatar_thumb: None,
-                                kind: crate::sync::ActorKind::User,
-                            },
-                            NotificationEntity::Asset {
-                                id: asset_id,
-                                name: asset_name.clone(),
-                            },
-                            asset_workspace,
-                        )
-                        .with_body(body.clone());
+                    // Spawned, not awaited (plan O2). `notify()` fans out to
+                    // the push channel, which in relay mode makes a network
+                    // call to the control plane; a cold relay costs ~6.7s
+                    // measured, and awaiting that here would hold this
+                    // handler's `TenantConn` for the duration — once per
+                    // recipient. Nine of the eleven other `notify()` call
+                    // sites already spawn; this was one of the two that did
+                    // not. Best-effort by design: a delivery failure must not
+                    // fail the usage write.
+                    let notification_service = notification_service.clone();
+                    tokio::spawn(async move {
+                        for recipient_uuid in recipients {
+                            let payload = NotificationPayload::new(
+                                NotificationTypeCode::AssetLowStock,
+                                recipient_uuid,
+                                NotificationActor {
+                                    uuid: actor_uuid,
+                                    name: actor_name.clone(),
+                                    avatar_thumb: None,
+                                    kind: crate::sync::ActorKind::User,
+                                },
+                                NotificationEntity::Asset {
+                                    id: asset_id,
+                                    name: asset_name.clone(),
+                                },
+                                asset_workspace,
+                            )
+                            .with_body(body.clone());
 
-                        if let Err(e) = notification_service.notify(payload).await {
-                            error!(
-                                asset_id,
-                                recipient = %recipient_uuid,
-                                error = %e,
-                                "Failed to deliver asset_low_stock notification",
-                            );
+                            if let Err(e) = notification_service.notify(payload).await {
+                                error!(
+                                    asset_id,
+                                    recipient = %recipient_uuid,
+                                    error = %e,
+                                    "Failed to deliver asset_low_stock notification",
+                                );
+                            }
                         }
-                    }
+                    });
                 }
             }
             HttpResponse::Created().json(outcome.row)

--- a/backend/src/services/notifications/channels/mod.rs
+++ b/backend/src/services/notifications/channels/mod.rs
@@ -7,6 +7,7 @@ pub mod email;
 pub mod in_app;
 pub mod push;
 pub mod push_sender;
+pub mod relay_client;
 
 use async_trait::async_trait;
 use std::fmt;

--- a/backend/src/services/notifications/channels/push.rs
+++ b/backend/src/services/notifications/channels/push.rs
@@ -56,6 +56,18 @@ pub trait PushSender: Send + Sync {
     fn is_configured(&self) -> bool;
     /// Send `payload` to each target; return permanently-invalid tokens to revoke.
     async fn send(&self, targets: &[PushTarget], payload: &PushPayload) -> Vec<String>;
+
+    /// Last relay interaction, when this sender forwards through the cloud
+    /// relay. `None` for the native and no-op senders, which have no remote to
+    /// report on.
+    ///
+    /// Surfaced on `GET /api/admin/edition`: it is the only signal a
+    /// self-hoster gets for why relayed push is failing, and it separates
+    /// "cannot reach the relay" from "the relay refused this licence" from
+    /// "the DPA has not been accepted".
+    fn relay_status(&self) -> Option<super::relay_client::RelayStatus> {
+        None
+    }
 }
 
 /// Placeholder sender: not configured, sends nothing. Replaced by APNs/FCM.

--- a/backend/src/services/notifications/channels/push.rs
+++ b/backend/src/services/notifications/channels/push.rs
@@ -25,7 +25,10 @@ use crate::db::Pool;
 /// is a "who did what" line; in `private` mode `title` is the generic type
 /// label and `body` is `None` ("tap to view"). Either way it carries no comment
 /// text — the same exposure as the notification email.
-#[derive(Debug, Clone)]
+/// `Serialize` is for the cloud relay wire format only (see
+/// `relay_client`), which forwards this struct verbatim. It carries alert text,
+/// so do not serialize it into a log line.
+#[derive(Debug, Clone, serde::Serialize)]
 pub struct PushPayload {
     pub title: String,
     /// Context line ("Alice mentioned you"); `None` in the workspace's private mode.

--- a/backend/src/services/notifications/channels/relay_client.rs
+++ b/backend/src/services/notifications/channels/relay_client.rs
@@ -362,6 +362,10 @@ impl super::push::PushSender for CloudRelayPushSender {
         self.client.is_usable()
     }
 
+    fn relay_status(&self) -> Option<RelayStatus> {
+        Some(self.client.status())
+    }
+
     async fn send(&self, targets: &[PushTarget], payload: &PushPayload) -> Vec<String> {
         match self.client.send(targets, payload).await {
             Ok(invalid) => invalid,

--- a/backend/src/services/notifications/channels/relay_client.rs
+++ b/backend/src/services/notifications/channels/relay_client.rs
@@ -1,0 +1,403 @@
+//! Client for the Nosdesk cloud push relay (plan slice 4).
+//!
+//! A licensed self-hosted instance cannot push to the official mobile app
+//! itself: the app is one binary with one identity (`com.nosdesk.app`), so only
+//! the holder of that app's APNs `.p8` and Firebase project can deliver to its
+//! device tokens. The relay is that holder. This client exchanges the
+//! instance's edition licence for a short-lived derived token, then posts
+//! device tokens and an already-composed payload for forwarding.
+//!
+//! ## What is sent
+//!
+//! Device tokens and the alert the instance composed — nothing else. The relay
+//! is stateless for token custody: it forwards and returns the tokens to prune,
+//! and never stores them. The licence is presented **once per exchange**, never
+//! on a send, because it is the customer's long-lived entitlement artifact and
+//! putting it on a hot path multiplies its exposure for nothing.
+//!
+//! ## Timeout
+//!
+//! 10s, from the B3 measurement against the deployed staging relay: warm
+//! exchanges land in ~0.12s, but the control plane runs with
+//! `min_machines_running = 0`, and a cold start measured **~6.7s** across five
+//! samples (6.09-6.94s) with the whole delay in TTFB while Fly's proxy holds
+//! the request. The earlier 2s guess would have dropped every push that landed
+//! on a cold relay — and with no retry queue, that silently loses the first
+//! notification after any quiet period, which for a helpdesk is the one that
+//! matters most.
+//!
+//! ## Logging
+//!
+//! Never log the licence, a derived token, a device token, or an alert body
+//! (plan O7). Failure reasons are a closed set of static strings.
+
+use std::sync::RwLock;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use serde::{Deserialize, Serialize};
+use tokio::sync::Mutex;
+
+use super::push::{PushPayload, PushTarget};
+
+/// Where the relay lives. Overridable so an instance can be pointed at staging.
+const RELAY_URL_ENV: &str = "NOSDESK_RELAY_URL";
+const DEFAULT_RELAY_URL: &str = "https://api.nosdesk.com";
+
+/// See the module docs: sized to clear a control-plane cold start, not just
+/// steady-state latency.
+const RELAY_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Re-exchange this long before the derived token expires, so a send never
+/// fires with a token that lapses in flight.
+const REFRESH_MARGIN_SECS: u64 = 120;
+
+/// What happened on the last relay interaction, for the admin edition surface.
+///
+/// This is the only diagnostic a self-hoster has when push stops working, so it
+/// distinguishes "we cannot reach the relay" from "the relay refused us" from
+/// "you have not accepted the DPA". All values are static strings.
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct RelayStatus {
+    /// `ok`, or a static failure kind. `None` before the first attempt.
+    pub last_outcome: Option<&'static str>,
+    /// Unix seconds of the last successful exchange.
+    pub last_success_at: Option<i64>,
+    /// Unix seconds of the last attempt of any kind.
+    pub last_attempt_at: Option<i64>,
+}
+
+/// Why a relay call failed. Every variant is a static discriminator safe to log
+/// and to surface to an operator.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RelayFailure {
+    /// The relay rejected the licence: expired, wrong issuer, or denylisted.
+    /// Deliberately not distinguished — the relay does not tell us which.
+    InvalidLicense,
+    /// The customer has not accepted the data-processing agreement, so relay
+    /// mode is refused. Operator-actionable, which is why it is its own kind.
+    DpaRequired,
+    /// Throttled: either the exchange's per-IP limit or the send burst limit.
+    RateLimited,
+    /// The relay is deployed but not configured (missing keys on its side).
+    RelayUnavailable,
+    /// Could not reach the relay at all, or it timed out.
+    Unreachable,
+    /// The relay answered with something unexpected.
+    Unexpected,
+}
+
+impl RelayFailure {
+    pub fn kind(self) -> &'static str {
+        match self {
+            Self::InvalidLicense => "invalid_license",
+            Self::DpaRequired => "dpa_required",
+            Self::RateLimited => "rate_limited",
+            Self::RelayUnavailable => "relay_unavailable",
+            Self::Unreachable => "unreachable",
+            Self::Unexpected => "unexpected",
+        }
+    }
+}
+
+/// Map a relay HTTP status onto an action. Pure, so the interesting decision is
+/// testable without a network — and it must agree with the control plane's
+/// handler, which is the thing most likely to drift.
+pub fn classify_status(status: u16) -> Result<(), RelayFailure> {
+    match status {
+        200..=299 => Ok(()),
+        401 => Err(RelayFailure::InvalidLicense),
+        403 => Err(RelayFailure::DpaRequired),
+        429 => Err(RelayFailure::RateLimited),
+        503 => Err(RelayFailure::RelayUnavailable),
+        _ => Err(RelayFailure::Unexpected),
+    }
+}
+
+#[derive(Serialize)]
+struct ExchangeRequest<'a> {
+    license: &'a str,
+    instance_id: &'a str,
+}
+
+#[derive(Deserialize)]
+struct ExchangeResponse {
+    token: String,
+    exp: u64,
+}
+
+#[derive(Serialize)]
+struct RelayTarget<'a> {
+    platform: &'a str,
+    token: &'a str,
+}
+
+#[derive(Serialize)]
+struct PushRequest<'a> {
+    targets: Vec<RelayTarget<'a>>,
+    payload: &'a PushPayload,
+}
+
+#[derive(Deserialize)]
+struct PushResponse {
+    invalid_tokens: Vec<String>,
+}
+
+struct CachedToken {
+    token: String,
+    exp: u64,
+}
+
+/// Talks to the cloud relay on behalf of one instance.
+pub struct RelayClient {
+    http: reqwest::Client,
+    base_url: String,
+    license: String,
+    instance_id: String,
+    token: Mutex<Option<CachedToken>>,
+    status: RwLock<RelayStatus>,
+}
+
+impl RelayClient {
+    /// Build from env plus the instance's durable id.
+    ///
+    /// `instance_id` comes from `system_meta`, which means the client must be
+    /// constructed **after** `initialize_database` — that is where the id is
+    /// minted. An empty id is tolerated rather than fatal, because
+    /// `ensure_instance_id` is warn-only on boot; the relay then falls back to
+    /// a shared burst bucket for this customer, which is a degraded but working
+    /// state and better than refusing to push at all.
+    pub fn new(license: String, instance_id: String) -> reqwest::Result<Self> {
+        let base_url = std::env::var(RELAY_URL_ENV)
+            .ok()
+            .filter(|s| !s.trim().is_empty())
+            .unwrap_or_else(|| DEFAULT_RELAY_URL.to_string());
+        Ok(Self {
+            http: reqwest::Client::builder().timeout(RELAY_TIMEOUT).build()?,
+            base_url: base_url.trim_end_matches('/').to_string(),
+            license,
+            instance_id,
+            token: Mutex::new(None),
+            status: RwLock::new(RelayStatus::default()),
+        })
+    }
+
+    /// Snapshot for the admin edition surface.
+    pub fn status(&self) -> RelayStatus {
+        self.status.read().expect("RwLock poisoned").clone()
+    }
+
+    fn record(&self, outcome: Option<&'static str>) {
+        let now = unix_now() as i64;
+        let mut s = self.status.write().expect("RwLock poisoned");
+        s.last_attempt_at = Some(now);
+        s.last_outcome = outcome;
+        if outcome == Some("ok") {
+            s.last_success_at = Some(now);
+        }
+    }
+
+    /// A usable derived token, exchanging when the cached one is absent or
+    /// close to expiry.
+    async fn token(&self) -> Result<String, RelayFailure> {
+        let mut guard = self.token.lock().await;
+        if let Some(cached) = guard.as_ref() {
+            if cached.exp > unix_now() + REFRESH_MARGIN_SECS {
+                return Ok(cached.token.clone());
+            }
+        }
+
+        let res = self
+            .http
+            .post(format!("{}/api/relay/v1/token", self.base_url))
+            .json(&ExchangeRequest {
+                license: &self.license,
+                instance_id: &self.instance_id,
+            })
+            .send()
+            .await
+            .map_err(|e| {
+                // `without_url` for consistency with the provider clients; the
+                // relay URL is not secret, but the licence must never end up in
+                // a rendered error.
+                log::warn!("relay exchange transport error: {}", e.without_url());
+                RelayFailure::Unreachable
+            })?;
+
+        let status = res.status().as_u16();
+        if let Err(failure) = classify_status(status) {
+            self.record(Some(failure.kind()));
+            log::warn!("relay exchange refused: error_kind={}", failure.kind());
+            return Err(failure);
+        }
+
+        let body: ExchangeResponse = res.json().await.map_err(|_| {
+            self.record(Some(RelayFailure::Unexpected.kind()));
+            RelayFailure::Unexpected
+        })?;
+
+        *guard = Some(CachedToken {
+            token: body.token.clone(),
+            exp: body.exp,
+        });
+        self.record(Some("ok"));
+        Ok(body.token)
+    }
+
+    /// Drop the cached token so the next call re-exchanges.
+    async fn invalidate_token(&self) {
+        *self.token.lock().await = None;
+    }
+
+    /// Relay one payload to a set of devices; returns tokens to prune.
+    ///
+    /// A 401 on send means the derived token stopped being accepted mid-life
+    /// (revoked licence, or a relay restart). Re-exchange and retry **once**:
+    /// a persistent 401 means the licence itself is refused, and looping would
+    /// hammer the exchange for a condition no retry can fix.
+    pub async fn send(
+        &self,
+        targets: &[PushTarget],
+        payload: &PushPayload,
+    ) -> Result<Vec<String>, RelayFailure> {
+        match self.try_send(targets, payload).await {
+            Err(RelayFailure::InvalidLicense) => {
+                self.invalidate_token().await;
+                self.try_send(targets, payload).await
+            }
+            other => other,
+        }
+    }
+
+    async fn try_send(
+        &self,
+        targets: &[PushTarget],
+        payload: &PushPayload,
+    ) -> Result<Vec<String>, RelayFailure> {
+        let token = self.token().await?;
+
+        // No idempotency key. The plan's O3 form is
+        // `notification_id:device_token`, but `PushSender::send` does not carry
+        // a notification id, and inventing a substitute would key on something
+        // that is not stable per notification. O3 also settled that it
+        // deduplicates nothing in v1.1, since nothing retries; the relay
+        // accepts the field as optional, so this stays absent until a retry
+        // path exists and the trait carries an id to key on.
+        let res = self
+            .http
+            .post(format!("{}/api/relay/v1/push", self.base_url))
+            .bearer_auth(&token)
+            .json(&PushRequest {
+                targets: targets
+                    .iter()
+                    .map(|t| RelayTarget {
+                        platform: &t.platform,
+                        token: &t.token,
+                    })
+                    .collect(),
+                payload,
+            })
+            .send()
+            .await
+            .map_err(|e| {
+                log::warn!("relay send transport error: {}", e.without_url());
+                self.record(Some(RelayFailure::Unreachable.kind()));
+                RelayFailure::Unreachable
+            })?;
+
+        let status = res.status().as_u16();
+        if let Err(failure) = classify_status(status) {
+            self.record(Some(failure.kind()));
+            log::warn!("relay send refused: error_kind={}", failure.kind());
+            return Err(failure);
+        }
+
+        let body: PushResponse = res.json().await.map_err(|_| {
+            self.record(Some(RelayFailure::Unexpected.kind()));
+            RelayFailure::Unexpected
+        })?;
+        self.record(Some("ok"));
+        Ok(body.invalid_tokens)
+    }
+}
+
+fn unix_now() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock predates Unix epoch")
+        .as_secs()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// These must agree with the control plane's relay handlers. Each status
+    /// here is one the CP actually emits.
+    #[test]
+    fn status_mapping_matches_the_relay_contract() {
+        assert!(classify_status(200).is_ok());
+        assert_eq!(classify_status(401), Err(RelayFailure::InvalidLicense));
+        assert_eq!(classify_status(403), Err(RelayFailure::DpaRequired));
+        assert_eq!(classify_status(429), Err(RelayFailure::RateLimited));
+        assert_eq!(classify_status(503), Err(RelayFailure::RelayUnavailable));
+    }
+
+    #[test]
+    fn unknown_statuses_are_unexpected_not_silently_ok() {
+        for s in [400, 404, 418, 500, 502] {
+            assert_eq!(
+                classify_status(s),
+                Err(RelayFailure::Unexpected),
+                "status {s} must not be treated as success"
+            );
+        }
+    }
+
+    #[test]
+    fn failure_kinds_are_static_and_distinct() {
+        let kinds = [
+            RelayFailure::InvalidLicense.kind(),
+            RelayFailure::DpaRequired.kind(),
+            RelayFailure::RateLimited.kind(),
+            RelayFailure::RelayUnavailable.kind(),
+            RelayFailure::Unreachable.kind(),
+            RelayFailure::Unexpected.kind(),
+        ];
+        for k in kinds {
+            assert!(!k.is_empty());
+        }
+        let mut sorted = kinds;
+        sorted.sort_unstable();
+        let mut deduped = sorted.to_vec();
+        deduped.dedup();
+        assert_eq!(deduped.len(), kinds.len(), "kinds must be distinguishable");
+    }
+
+    #[test]
+    fn status_starts_empty_and_records_outcomes() {
+        let client = RelayClient::new("licence".into(), "inst".into()).expect("client");
+        let s = client.status();
+        assert!(s.last_outcome.is_none());
+        assert!(s.last_attempt_at.is_none());
+
+        client.record(Some("ok"));
+        let s = client.status();
+        assert_eq!(s.last_outcome, Some("ok"));
+        assert!(s.last_success_at.is_some());
+
+        // A later failure must not erase the last success: an operator needs
+        // to see both "it is failing now" and "it last worked at T".
+        client.record(Some(RelayFailure::DpaRequired.kind()));
+        let s = client.status();
+        assert_eq!(s.last_outcome, Some("dpa_required"));
+        assert!(s.last_success_at.is_some());
+    }
+
+    #[test]
+    fn relay_url_is_overridable_and_trims_a_trailing_slash() {
+        // Not using the env var here (tests share a process); the constructor's
+        // trimming is what matters, since the paths are joined with a leading /.
+        let client = RelayClient::new("l".into(), "i".into()).expect("client");
+        assert!(!client.base_url.ends_with('/'));
+    }
+}

--- a/backend/src/services/notifications/channels/relay_client.rs
+++ b/backend/src/services/notifications/channels/relay_client.rs
@@ -349,11 +349,6 @@ impl CloudRelayPushSender {
             client: RelayClient::new(license, instance_id)?,
         })
     }
-
-    /// Snapshot for `GET /api/admin/edition`.
-    pub fn status(&self) -> RelayStatus {
-        self.client.status()
-    }
 }
 
 #[async_trait::async_trait]

--- a/backend/src/services/notifications/channels/relay_client.rs
+++ b/backend/src/services/notifications/channels/relay_client.rs
@@ -318,6 +318,63 @@ impl RelayClient {
         self.record(Some("ok"));
         Ok(body.invalid_tokens)
     }
+
+    /// Whether the channel should present itself as configured.
+    ///
+    /// Deliberately not "have we had a successful exchange". `is_configured`
+    /// gates the channel, and the channel is what triggers the first exchange,
+    /// so latching false until success would deadlock: no exchange, so never
+    /// configured, so no exchange. Instead this is false only once the relay
+    /// has told us this licence will *not* work — a bad licence or an
+    /// unaccepted DPA. Transient failures stay usable so the next notification
+    /// retries, which is also the plan's "do not cache configured independently
+    /// of the last exchange".
+    pub fn is_usable(&self) -> bool {
+        !matches!(
+            self.status().last_outcome,
+            Some("invalid_license") | Some("dpa_required")
+        )
+    }
+}
+
+/// [`PushSender`] that forwards through the cloud relay instead of holding
+/// APNs/FCM credentials locally.
+pub struct CloudRelayPushSender {
+    client: RelayClient,
+}
+
+impl CloudRelayPushSender {
+    pub fn new(license: String, instance_id: String) -> reqwest::Result<Self> {
+        Ok(Self {
+            client: RelayClient::new(license, instance_id)?,
+        })
+    }
+
+    /// Snapshot for `GET /api/admin/edition`.
+    pub fn status(&self) -> RelayStatus {
+        self.client.status()
+    }
+}
+
+#[async_trait::async_trait]
+impl super::push::PushSender for CloudRelayPushSender {
+    fn is_configured(&self) -> bool {
+        self.client.is_usable()
+    }
+
+    async fn send(&self, targets: &[PushTarget], payload: &PushPayload) -> Vec<String> {
+        match self.client.send(targets, payload).await {
+            Ok(invalid) => invalid,
+            // Prune nothing on failure. The relay could not tell us which
+            // tokens are bad, and discarding a live registration because the
+            // relay was briefly unreachable would silently stop that device
+            // receiving push with no way back.
+            Err(failure) => {
+                log::warn!("relay push failed: error_kind={}", failure.kind());
+                Vec::new()
+            }
+        }
+    }
 }
 
 fn unix_now() -> u64 {

--- a/backend/src/startup.rs
+++ b/backend/src/startup.rs
@@ -222,19 +222,73 @@ pub fn build_state(
             service.register_channel(email_channel);
         }
 
-        // Push channel: provider-agnostic. Use the native APNs/FCM sender when
-        // credentials are configured (NOSDESK_APNS_* / NOSDESK_FCM_*), else keep
-        // the inert no-op sender (is_available=false → push preferences exist and
-        // device registration works, but nothing is delivered). A configured-but-
-        // malformed provider is fatal, so a half-provisioned deploy fails loudly.
+        // Push channel: provider-agnostic, selected by `NOSDESK_PUSH_MODE`.
+        //
+        //   unset   — exactly the historical behaviour: native when
+        //             NOSDESK_APNS_* / NOSDESK_FCM_* are set, else inert. Hosted
+        //             therefore needs no new variable.
+        //   native  — same, stated explicitly.
+        //   relay   — forward through the cloud relay, which holds the
+        //             com.nosdesk.app credentials. Native creds are IGNORED in
+        //             this mode, so a self-hoster cannot accidentally send
+        //             official-app device tokens with their own key.
+        //   off     — inert even when credentials are present.
+        //
+        // Inert means is_available=false: push preferences still exist and
+        // device registration still works, nothing is delivered. A
+        // configured-but-malformed provider is fatal, so a half-provisioned
+        // deploy fails loudly rather than going quiet.
+        let push_mode = std::env::var("NOSDESK_PUSH_MODE")
+            .unwrap_or_default()
+            .trim()
+            .to_ascii_lowercase();
         let push_sender: Arc<dyn crate::services::notifications::channels::push::PushSender> =
-            match crate::services::notifications::channels::push_sender::NativePushSender::from_env(
-            ) {
-                Ok(Some(sender)) => sender,
-                Ok(None) => {
-                    Arc::new(crate::services::notifications::channels::push::NoopPushSender)
+            match push_mode.as_str() {
+                "relay" => {
+                    // The licence is the relay credential. Without one there is
+                    // nothing to exchange, so stay inert rather than pretending.
+                    match std::env::var("NOSDESK_LICENSE_KEY")
+                        .ok()
+                        .filter(|s| !s.trim().is_empty())
+                    {
+                        Some(license) => {
+                            // `instance_id` is minted by `initialize_database`,
+                            // which `build_server` runs before this. Empty is
+                            // tolerated: `ensure_instance_id` is warn-only, and
+                            // a shared burst bucket beats refusing to push.
+                            let instance_id = pool
+                                .get()
+                                .ok()
+                                .and_then(|mut c| crate::sync::system_meta::instance_id(&mut c).ok())
+                                .unwrap_or_default();
+                            match crate::services::notifications::channels::relay_client::CloudRelayPushSender::new(
+                                license, instance_id,
+                            ) {
+                                Ok(sender) => Arc::new(sender),
+                                Err(e) => panic!("relay push sender is configured but invalid: {e}"),
+                            }
+                        }
+                        None => {
+                            tracing::warn!(
+                                "NOSDESK_PUSH_MODE=relay but NOSDESK_LICENSE_KEY is unset; push is inert"
+                            );
+                            Arc::new(crate::services::notifications::channels::push::NoopPushSender)
+                        }
+                    }
                 }
-                Err(e) => panic!("push sender is configured but invalid: {e:#}"),
+                "off" => Arc::new(crate::services::notifications::channels::push::NoopPushSender),
+                "" | "native" => {
+                    match crate::services::notifications::channels::push_sender::NativePushSender::from_env() {
+                        Ok(Some(sender)) => sender,
+                        Ok(None) => {
+                            Arc::new(crate::services::notifications::channels::push::NoopPushSender)
+                        }
+                        Err(e) => panic!("push sender is configured but invalid: {e:#}"),
+                    }
+                }
+                other => panic!(
+                    "NOSDESK_PUSH_MODE={other:?} is not recognised (expected relay, native, or off)"
+                ),
             };
         let push_channel = Arc::new(
             crate::services::notifications::channels::push::PushChannel::new(

--- a/backend/src/startup.rs
+++ b/backend/src/startup.rs
@@ -33,6 +33,11 @@ pub struct AppState {
     pub analytics_cache: web::Data<Option<Arc<crate::utils::analytics_cache::AnalyticsCache>>>,
     pub sse_state: web::Data<crate::handlers::sse::SseState>,
     pub notification_service: web::Data<crate::services::notifications::NotificationService>,
+    /// The live push sender, so `GET /api/admin/edition` can report relay
+    /// status. Held separately because the sender is otherwise buried inside
+    /// the notification service's channel registry.
+    pub push_sender_data:
+        web::Data<Arc<dyn crate::services::notifications::channels::push::PushSender>>,
     pub outbound_resolver_data:
         web::Data<Arc<crate::services::outbound_email::OutboundEmailResolver>>,
     pub webhook_service: web::Data<crate::services::webhooks::WebhookService>,
@@ -187,7 +192,7 @@ pub fn build_state(
     }
 
     // Initialize notification service for in-app and email notifications
-    let notification_service = {
+    let (notification_service, push_sender_data) = {
         use std::collections::HashMap;
         use std::sync::Arc;
         use tokio::sync::RwLock as TokioRwLock;
@@ -290,6 +295,7 @@ pub fn build_state(
                     "NOSDESK_PUSH_MODE={other:?} is not recognised (expected relay, native, or off)"
                 ),
             };
+        let push_sender_for_state = push_sender.clone();
         let push_channel = Arc::new(
             crate::services::notifications::channels::push::PushChannel::new(
                 pool.clone(),
@@ -298,7 +304,10 @@ pub fn build_state(
         );
         service.register_channel(push_channel);
 
-        web::Data::new(service)
+        (
+            web::Data::new(service),
+            web::Data::new(push_sender_for_state),
+        )
     };
 
     // Inject the outbound resolver so the comment handler can gate the
@@ -492,6 +501,7 @@ pub fn build_state(
             analytics_cache,
             sse_state,
             notification_service,
+            push_sender_data,
             outbound_resolver_data,
             webhook_service,
             plugin_proxy_service,
@@ -665,6 +675,7 @@ pub fn configure_app(
             .app_data(state.yjs_app_state.clone())
             .app_data(state.sse_state.clone())
             .app_data(state.system_state.clone())
+            .app_data(state.push_sender_data.clone())
             .app_data(state.storage_data.clone())
             .app_data(state.notification_service.clone())
             .app_data(state.outbound_resolver_data.clone())

--- a/packages/core/src/types/workspace.ts
+++ b/packages/core/src/types/workspace.ts
@@ -85,7 +85,7 @@ export interface EditionInfo {
   max_workspaces: number;
   active_workspaces: number;
   can_create_workspace: boolean;
-  /** Cloud push relay status; present only when NOSDESK_PUSH_MODE=relay. */
+  /** Cloud push relay status. Null unless NOSDESK_PUSH_MODE=relay. */
   relay: {
     /** `ok`, or a static failure kind such as `dpa_required`. */
     last_outcome: string | null;

--- a/packages/core/src/types/workspace.ts
+++ b/packages/core/src/types/workspace.ts
@@ -85,6 +85,13 @@ export interface EditionInfo {
   max_workspaces: number;
   active_workspaces: number;
   can_create_workspace: boolean;
+  /** Cloud push relay status; present only when NOSDESK_PUSH_MODE=relay. */
+  relay: {
+    /** `ok`, or a static failure kind such as `dpa_required`. */
+    last_outcome: string | null;
+    last_success_at: number | null;
+    last_attempt_at: number | null;
+  } | null;
   license: {
     customer_id: string;
     licensee: string;


### PR DESCRIPTION
Slice 4 of the on-prem licensed tier / cloud push relay work. Depends on #298 (C0), now merged.

**`CloudRelayPushSender`** forwards notifications through the cloud relay instead of holding APNs/FCM credentials locally. `RelayClient` exchanges the edition licence for a short-lived derived token, caches it in memory, and re-exchanges ahead of expiry.

**`NOSDESK_PUSH_MODE`** selects the sender explicitly: `relay`, `native`, `off`, or unset (native if credentials are present). An unrecognised value panics at boot rather than silently degrading to no push.

**Relay status on `GET /api/admin/edition`.** `relay_status()` joins the `PushSender` trait, defaulting to `None` for the native and no-op senders. It is the only signal a self-hoster gets for why relayed push is failing, and it separates an unreachable relay from a refused licence from an unaccepted DPA.

**Two request-path notification call sites move to `tokio::spawn`** (asset usage, asset audits). Both looped `notify()` inline, which now means a relay round trip per iteration on the request thread.

Notes:
- The relay timeout is 10s, from B3's measured 6.7s CP cold start. The 2s budget originally sketched would have dropped every cold-start push.
- `is_configured` returns false only for `invalid_license` and `dpa_required`, never for transient failures. Latching on "have we succeeded" would deadlock: the channel gates on `is_configured`, and the channel is what triggers the first exchange.
- Send failures prune no tokens. The relay cannot say which tokens are bad, and dropping a live registration because the relay blinked would silently stop that device receiving push with no way back.

1776 backend tests pass. Relay mode is opt-in behind the env var, so this is inert for existing deployments.

Not yet verified end to end against the staging relay; that is slice 4's acceptance step and is tracked in the plan.

https://claude.ai/code/session_01KZdfqh5Fiqj27tPTBNNVbx