### PR TITLE
Make the edition handler's push sender extractor optional

### DIFF
--- a/backend/src/handlers/admin_workspaces.rs
+++ b/backend/src/handlers/admin_workspaces.rs
@@ -169,8 +169,12 @@ pub async fn list_workspaces(
 pub async fn get_edition(
     req: HttpRequest,
     mut pc: PlatformConn,
-    push_sender: web::Data<
-        std::sync::Arc<dyn crate::services::notifications::channels::push::PushSender>,
+    // Optional so a slimmer App (tests, and any future partial wiring) still
+    // serves the edition summary instead of 500-ing on a missing extractor.
+    // A sender that is not registered has no relay to report on, which is the
+    // same `null` the native and off modes produce.
+    push_sender: Option<
+        web::Data<std::sync::Arc<dyn crate::services::notifications::channels::push::PushSender>>,
     >,
 ) -> impl Responder {
     if let Err(resp) = rbac::require_platform_admin(&req) {
@@ -193,7 +197,7 @@ pub async fn get_edition(
         // Null outside relay push mode. This is the operator's sole
         // diagnostic when relayed push stops working, and it distinguishes an
         // unreachable relay from a refused licence from an unaccepted DPA.
-        "relay": push_sender.relay_status(),
+        "relay": push_sender.and_then(|p| p.relay_status()),
         "license": edition.license().map(|l| serde_json::json!({
             "customer_id": l.customer_id,
             "licensee": l.licensee,


### PR DESCRIPTION
Fixes main's red `Backend (Rust)` run from #300.

A required `web::Data` extractor 500s when the data is absent. #300 added one to `get_edition`, which broke `tests/workspace_cap_hosted.rs`: it builds a slim `App` that registers the handler without the sender. Production wiring was never affected, since `configure_app` registers it.

Making the extractor optional is also the more honest shape. A sender that is not registered has no relay to report on, which is the same `null` the native and off modes already produce, and it means the endpoint cannot be broken by wiring order.

Full `cargo test` green, integration tests included. The `--lib`-only gate that let #300 through is the reason this was missed.

https://claude.ai/code/session_01KZdfqh5Fiqj27tPTBNNVbx