### PR TITLE
Fix mobile startup and register for push on every login

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -138,6 +138,36 @@ if (isTauriRuntime()) {
   })
 }
 
+// Register this device for push whenever a session goes live.
+//
+// This used to hang off the OIDC login button alone, so signing in with a
+// password, MFA, passkey or recovery code registered nothing and the user
+// silently received no push at all. Watching the auth flag instead covers every
+// login path, plus cold start with a restored session — which also picks up
+// APNs/FCM token rotation, since a rotated token otherwise leaves the device
+// permanently silent with no way back.
+//
+// Idempotent server-side (the endpoint upserts), so re-calling costs one
+// request. Best-effort by design: a push-registration failure must never block
+// getting into the app.
+if (isTauriRuntime()) {
+  onMounted(() => {
+    watch(
+      () => authStore.isAuthenticated,
+      async (authed) => {
+        if (!authed) return
+        try {
+          const { registerForPush } = await import('@nosdesk/mobile')
+          await registerForPush()
+        } catch (error) {
+          console.warn('[push] device registration failed', error)
+        }
+      },
+      { immediate: true }
+    )
+  })
+}
+
 // Ticket deep links (iOS Universal Links / Android App Links). Same shape as
 // the push route above: resolve where the tapped/scanned URL goes, waiting for
 // the session on a cold start. v1 rule: a ticket link whose host is the server

--- a/frontend/src/composables/useCrtEffect.ts
+++ b/frontend/src/composables/useCrtEffect.ts
@@ -11,6 +11,7 @@
  */
 import { ref, onMounted, onUnmounted } from 'vue'
 import { Z_INDEX } from '@nosdesk/core/constants/zIndex'
+import { createNoncedStyleElement } from '@/utils/cspNonce'
 
 interface CrtEffectOptions {
   theme?: string
@@ -43,8 +44,9 @@ export function useCrtEffect(options: CrtEffectOptions = {}) {
     overlay.className = 'crt-screen-effect'
     overlay.setAttribute('aria-hidden', 'true')
 
-    // Create style element for animations
-    styleElement = document.createElement('style')
+    // Create style element for animations. Nonced for the same reason as the
+    // theme injector: a bare <style> is blocked under Tauri's nonce CSP.
+    styleElement = createNoncedStyleElement()
     styleElement.textContent = `
       .crt-screen-effect {
         position: fixed;

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -62,8 +62,13 @@ async function bootstrap() {
   useThemeStore(pinia)
 
   // Fetch instance config (routing topology) in parallel with the initial route
-  // resolution so its value is settled before first paint. The fetch defaults to
-  // 'host' and never rejects, so it can't block or break the mount.
+  // resolution so its value is settled before first paint.
+  //
+  // The fetch defaults to 'host' and never rejects — but never rejecting is not
+  // the same as always settling, and an earlier version of this comment claimed
+  // the stronger property. It is bounded by CONFIG_REQUEST_TIMEOUT_MS in
+  // services/instanceConfig precisely so this await, and the router guard that
+  // shares the same promise, cannot hang the mount on an unreachable server.
   await Promise.all([fetchInstanceConfig(), router.isReady()])
   app.mount('#app')
 

--- a/frontend/src/themes/utils/cssInjector.ts
+++ b/frontend/src/themes/utils/cssInjector.ts
@@ -1,4 +1,5 @@
 import type { Theme } from '../types'
+import { createNoncedStyleElement } from '@/utils/cspNonce'
 
 /**
  * CSS Variable Injector
@@ -99,8 +100,10 @@ ${colors.syntax ? Object.entries(colors.syntax).map(([key, value]) => `
   // Get or create style element
   let styleEl = document.getElementById(STYLE_ID) as HTMLStyleElement | null
   if (!styleEl) {
-    styleEl = document.createElement('style')
-    styleEl.id = STYLE_ID
+    // Nonced: Tauri's runtime CSP nonce makes the browser ignore the
+    // `'unsafe-inline'` we configure, so a bare <style> is blocked and every
+    // token below silently fails to apply. See utils/cspNonce.
+    styleEl = createNoncedStyleElement(STYLE_ID)
     document.head.appendChild(styleEl)
   }
 

--- a/frontend/src/utils/cspNonce.ts
+++ b/frontend/src/utils/cspNonce.ts
@@ -1,0 +1,43 @@
+/**
+ * The Content-Security-Policy nonce for this document, when the host injects one.
+ *
+ * Tauri rewrites the configured CSP at load time to add a per-load nonce. Per the
+ * CSP spec, **a nonce makes the browser ignore `'unsafe-inline'`** — so a
+ * `<style>` element created at runtime without a nonce is blocked outright even
+ * though `tauri.conf.json` lists `style-src 'self' 'unsafe-inline'`. On Android
+ * that silently dropped every theme custom property and rendered the app
+ * unstyled, which looks exactly like a blank screen:
+ *
+ *   Applying inline style violates the following Content Security Policy
+ *   directive 'style-src 'self' 'unsafe-inline' 'nonce-…''. Note that
+ *   'unsafe-inline' is ignored if either a hash or nonce value is present.
+ *
+ * Web builds inject no nonce, so this returns `''` there and the existing
+ * `'unsafe-inline'` path keeps working unchanged.
+ *
+ * Two sources, because the policy can arrive as a response header (no meta tag
+ * to read) or as a meta tag: prefer an already-nonced element, since the `nonce`
+ * IDL property still returns the value after browsers hide the content
+ * attribute, then fall back to parsing the meta tag.
+ */
+export function cspNonce(): string {
+  const nonced = document.querySelector<HTMLElement>('script[nonce], style[nonce]')
+  if (nonced?.nonce) return nonced.nonce
+
+  const meta = document.querySelector('meta[http-equiv="Content-Security-Policy"]')
+  return meta?.getAttribute('content')?.match(/'nonce-([^']+)'/)?.[1] ?? ''
+}
+
+/**
+ * Create a `<style>` element that survives a nonce-based CSP.
+ *
+ * Use this instead of `document.createElement('style')` anywhere styles are
+ * injected at runtime; a bare one is dropped on native builds.
+ */
+export function createNoncedStyleElement(id?: string): HTMLStyleElement {
+  const el = document.createElement('style')
+  if (id) el.id = id
+  const nonce = cspNonce()
+  if (nonce) el.nonce = nonce
+  return el
+}

--- a/frontend/src/views/LoginView.vue
+++ b/frontend/src/views/LoginView.vue
@@ -414,7 +414,7 @@ const handleOidcLoginClick = async () => {
   // then hydrate the auth store from /me and route in. (No-op import on web.)
   if (isTauriRuntime()) {
     try {
-      const { loginWithOidc, registerForPush } = await import('@nosdesk/mobile');
+      const { loginWithOidc } = await import('@nosdesk/mobile');
       await loginWithOidc();
       // Force past the 5s fetch cooldown: a fresh session must load the user
       // even if a pre-sign-out /auth/me attempt is still within the window.
@@ -423,9 +423,9 @@ const handleOidcLoginClick = async () => {
       // fetchUserData is what flips true.
       await authStore.fetchUserData({ force: true });
       authStore.setAuthProvider('oidc');
-      // Session is live — register this device for push (best-effort; never
-      // blocks routing into the app).
-      void registerForPush();
+      // Push registration is not done here: App.vue registers on every
+      // transition to an authenticated session, which covers this path along
+      // with password, MFA, passkey and recovery sign-in.
       // Resolve + set the active workspace before navigating so views mount with
       // the slug (and thus the X-Nosdesk-Workspace header). The brief window
       // between the auth flip above and the slug being set is covered by the

--- a/packages/core/src/services/instanceConfig.ts
+++ b/packages/core/src/services/instanceConfig.ts
@@ -60,16 +60,51 @@ let configPromise: Promise<void> | null = null;
 const configResolved = ref(false);
 
 /**
+ * How long the boot-critical `/config` request may hang before we give up.
+ *
+ * Both `bootstrap()` and the router's workspace guard await this fetch, so a
+ * request that never settles blocks `app.mount()` and the initial navigation
+ * together — the app renders nothing, logs nothing, and never recovers. That is
+ * not hypothetical: a device with broken DNS showed a permanently blank screen
+ * with a clean console, because the request neither resolved nor rejected.
+ *
+ * "Never rejects" is not "always settles". Bounding the wait converts an
+ * unrecoverable hang into an ordinary failure, which the catch below already
+ * handles correctly: the memo clears, the next caller retries, `configResolved`
+ * stays false so workspace gates stay shut, and the app mounts and can show a
+ * real connection error instead of a white rectangle.
+ */
+const CONFIG_REQUEST_TIMEOUT_MS = 5000;
+
+/** Reject after `ms`, clearing the timer when the race is decided. */
+function rejectAfter(ms: number): { promise: Promise<never>; cancel: () => void } {
+  let timer: ReturnType<typeof setTimeout>;
+  const promise = new Promise<never>((_, reject) => {
+    timer = setTimeout(
+      () => reject(new Error(`instance config request timed out after ${ms}ms`)),
+      ms,
+    );
+  });
+  return { promise, cancel: () => clearTimeout(timer) };
+}
+
+/**
  * Fetch instance config once per server. The endpoint is public, so it's safe
  * before auth. Idempotent: repeat calls share one in-flight/settled promise. A
  * failed fetch clears the memo so the next call retries instead of latching the
  * 'host' default; resetInstanceConfig() re-arms it when the server changes.
+ * Bounded by {@link CONFIG_REQUEST_TIMEOUT_MS} so an unreachable server fails
+ * rather than hanging every awaiting caller.
  */
 export function fetchInstanceConfig(): Promise<void> {
   if (!configPromise) {
     configPromise = (async () => {
       try {
-        const { data } = await apiClient.get<InstanceConfig>('/config');
+        const deadline = rejectAfter(CONFIG_REQUEST_TIMEOUT_MS);
+        const { data } = await Promise.race([
+          apiClient.get<InstanceConfig>('/config'),
+          deadline.promise,
+        ]).finally(deadline.cancel);
         if (data?.workspace_routing === 'path' || data?.workspace_routing === 'host') {
           workspaceRouting = data.workspace_routing;
         }


### PR DESCRIPTION
Three mobile fixes, all verified on a real device earlier in the session.

**Register for push on every login (D6).** `registerForPush()` had a single caller, the OIDC login button, so signing in with a password, MFA, passkey or recovery code registered no device and the user silently received no push at all, permanently, with no way back. Nothing called it on launch or resume either, so a rotated APNs/FCM token left a device silent forever. `App.vue` now watches the auth flag with `immediate: true`, which covers every login path plus cold start with a restored session. The endpoint upserts, so re-calling is idempotent, and failures are swallowed: push registration must never block getting into the app.

This was diagnosed the hard way today. An iPhone that had been receiving pushes stopped after a sign-out and password sign-in, while an Android tablet that happened to use the OIDC button kept working. The relay send reported `sent=2` and looked healthy because both surviving tokens were Android; APNs was simply never called.

**Nonce runtime style injection so it survives Tauri's CSP.** Tauri injects a per-load nonce, which makes `'unsafe-inline'` ignored, so runtime-injected `<style>` elements were dropped and the app rendered unstyled (the blank screen on the Boox tablet). Adds `cspNonce()` / `createNoncedStyleElement()` and routes the theme and CRT injectors through them.

**Bound the instance-config request so it cannot hang the mount.** The config fetch was unbounded, so an unreachable or DNS-blackholed server hung `app.mount()` and left a grey screen with no error and no retry. Now races a 5s timeout.

Type-check and lint green across `packages/core` and `frontend`.

https://claude.ai/code/session_01KZdfqh5Fiqj27tPTBNNVbx