### PR TITLE
Make the push skip paths visible to an operator

### DIFF
--- a/backend/src/services/notifications/channels/push.rs
+++ b/backend/src/services/notifications/channels/push.rs
@@ -14,7 +14,9 @@
 //! PRIVATE`). Set via `workspaces.settings.notification_push_detail`.
 
 use async_trait::async_trait;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use tracing::{debug, info};
 
 use super::super::types::{DeliverableNotification, NotificationChannel};
 use super::{ChannelError, ChannelResult, NotificationDeliveryChannel};
@@ -68,6 +70,10 @@ pub trait PushSender: Send + Sync {
     fn relay_status(&self) -> Option<super::relay_client::RelayStatus> {
         None
     }
+
+    /// Short static label for logs ("relay", "native", "none"). Lets the boot
+    /// line name the live sender without the caller matching on a concrete type.
+    fn name(&self) -> &'static str;
 }
 
 /// Placeholder sender: not configured, sends nothing. Replaced by APNs/FCM.
@@ -78,6 +84,9 @@ impl PushSender for NoopPushSender {
     fn is_configured(&self) -> bool {
         false
     }
+    fn name(&self) -> &'static str {
+        "none"
+    }
     async fn send(&self, _targets: &[PushTarget], _payload: &PushPayload) -> Vec<String> {
         Vec::new()
     }
@@ -87,11 +96,23 @@ impl PushSender for NoopPushSender {
 pub struct PushChannel {
     pool: Pool,
     sender: Arc<dyn PushSender>,
+    /// Whether the "no registered devices" case has been reported yet.
+    ///
+    /// That exit is the single most common reason push looks broken on a fresh
+    /// install, and it is silent: `deliver` returns `Ok(())` and nothing
+    /// distinguishes it from a delivered push. One line per process makes it
+    /// visible without logging on every notification for a workspace where most
+    /// people have not installed the app.
+    no_devices_reported: AtomicBool,
 }
 
 impl PushChannel {
     pub fn new(pool: Pool, sender: Arc<dyn PushSender>) -> Self {
-        Self { pool, sender }
+        Self {
+            pool,
+            sender,
+            no_devices_reported: AtomicBool::new(false),
+        }
     }
 }
 
@@ -123,6 +144,16 @@ impl NotificationDeliveryChannel for PushChannel {
         .collect();
 
         if targets.is_empty() {
+            // Info once, debug thereafter: enough to diagnose a fresh install,
+            // quiet enough for steady state.
+            if !self.no_devices_reported.swap(true, Ordering::Relaxed) {
+                info!(
+                    recipient = %recipient,
+                    "Push skipped: recipient has no registered devices. Devices register                      on sign-in from the mobile app; this is logged once per process."
+                );
+            } else {
+                debug!(recipient = %recipient, "Push skipped: no registered devices");
+            }
             return Ok(());
         }
 
@@ -175,5 +206,40 @@ impl NotificationDeliveryChannel for PushChannel {
             );
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Pins the once-per-process contract the no-devices notice relies on: the
+    /// first `swap` reports, every later one falls through to debug. A
+    /// workspace where most members have not installed the app would otherwise
+    /// log on nearly every notification it sends.
+    ///
+    /// This exercises the flag, not `deliver` — driving the real path needs a
+    /// pool and a seeded recipient, which is disproportionate for a log line.
+    #[test]
+    fn no_devices_notice_fires_once_per_process() {
+        let flag = AtomicBool::new(false);
+        assert!(
+            !flag.swap(true, Ordering::Relaxed),
+            "first hit reports at info"
+        );
+        for _ in 0..5 {
+            assert!(
+                flag.swap(true, Ordering::Relaxed),
+                "subsequent hits fall through to debug"
+            );
+        }
+    }
+
+    /// Every sender names itself, so the boot line can never print an empty
+    /// label for whichever one was selected.
+    #[test]
+    fn senders_report_a_static_name() {
+        assert_eq!(NoopPushSender.name(), "none");
+        assert!(!NoopPushSender.is_configured());
     }
 }

--- a/backend/src/services/notifications/channels/push_sender.rs
+++ b/backend/src/services/notifications/channels/push_sender.rs
@@ -499,6 +499,10 @@ impl NativePushSender {
 
 #[async_trait::async_trait]
 impl PushSender for NativePushSender {
+    fn name(&self) -> &'static str {
+        "native"
+    }
+
     fn is_configured(&self) -> bool {
         self.apns.is_some() || self.fcm.is_some()
     }

--- a/backend/src/services/notifications/channels/relay_client.rs
+++ b/backend/src/services/notifications/channels/relay_client.rs
@@ -361,6 +361,10 @@ impl super::push::PushSender for CloudRelayPushSender {
         Some(self.client.status())
     }
 
+    fn name(&self) -> &'static str {
+        "relay"
+    }
+
     async fn send(&self, targets: &[PushTarget], payload: &PushPayload) -> Vec<String> {
         match self.client.send(targets, payload).await {
             Ok(invalid) => invalid,

--- a/backend/src/services/notifications/service.rs
+++ b/backend/src/services/notifications/service.rs
@@ -107,6 +107,16 @@ impl NotificationService {
             )
             .await?;
 
+        // The resolved channel set, at debug. Push being absent here is a
+        // preference outcome, not a fault, and it is otherwise indistinguishable
+        // from a push that was attempted and failed.
+        tracing::debug!(
+            recipient = %payload.recipient_uuid,
+            notification_type = ?payload.notification_type,
+            channels = ?enabled_channels,
+            "Resolved delivery channels"
+        );
+
         if enabled_channels.is_empty() {
             tracing::debug!(
                 recipient = %payload.recipient_uuid,

--- a/backend/src/startup.rs
+++ b/backend/src/startup.rs
@@ -295,6 +295,20 @@ pub fn build_state(
                     "NOSDESK_PUSH_MODE={other:?} is not recognised (expected relay, native, or off)"
                 ),
             };
+        // Say which sender won, at info. Push has no request the operator can
+        // watch and every skip downstream is quiet, so without this line the
+        // only way to tell relay mode from native mode on a running instance is
+        // to read the process environment.
+        tracing::info!(
+            mode = if push_mode.is_empty() {
+                "unset"
+            } else {
+                push_mode.as_str()
+            },
+            sender = push_sender.name(),
+            configured = push_sender.is_configured(),
+            "Push sender selected"
+        );
         let push_sender_for_state = push_sender.clone();
         let push_channel = Arc::new(
             crate::services::notifications::channels::push::PushChannel::new(


### PR DESCRIPTION
Push has no request an operator can watch, and every reason a push does not arrive was silent. `PushChannel::deliver` returned `Ok(())` when the recipient had no registered devices, the dispatcher dropped an unavailable channel without comment, and both the all-channels-disabled and rate-limited exits logged at `debug`. So an operator who switched to relay mode and got nothing saw `relay.last_outcome: null` whether the relay was unreachable, the licence was refused, or simply nobody had installed the app.

This is not hypothetical. Diagnosing one missing iOS push during slice 4's acceptance today took three dead ends: no registered device, then `comment_added` defaulting to `push: false`, then needing an assignment to trigger the type that does push. On a self-hoster's instance none of those are discoverable.

Three targeted signals, rather than a line per exit, which would log on most notifications in a workspace where few members have the app installed:

- **Boot** (`startup.rs`): one info line naming the selected sender for all four modes, with `mode`, `sender` and `configured`. Previously the only way to tell relay mode from native on a running instance was to read its process environment. Adds `name()` to the `PushSender` trait, implemented on all three senders.
- **No registered devices** (`push.rs`): info once per process, debug thereafter, via an `AtomicBool` on the channel. This is the most common reason push looks broken on a fresh install. Once per process rather than globally is the right grain, since relay status is already per-process.
- **Resolved channel set** (`service.rs`): one debug line per notification. Push being absent from that set is a preference outcome, not a fault, and previously read identically to a push that was attempted and failed.

Deliberately unchanged: the native sender still logs nothing on a successful send, because a per-send line is noise at helpdesk volume and failures already warn. The unavailable-channel path is also left alone, since `relay_status.last_outcome` already carries `invalid_license` / `dpa_required` to the edition surface and the relay client warns on every failure.

The added test pins the once-per-process contract by exercising the flag, not `deliver` — driving the real path needs a pool and a seeded recipient, which is disproportionate for a log line. Its doc comment says so.

Local state at time of opening: `cargo fmt --check` clean, `cargo clippy` clean in the touched files, `cargo build --lib` green, and the two new unit tests pass. The full `cargo test` run was still compiling integration binaries when this was opened, so CI's `Backend (Rust)` is the authoritative gate.

https://claude.ai/code/session_01KZdfqh5Fiqj27tPTBNNVbx