### PR TITLE
Name the process behind a relay status snapshot

### DIFF
--- a/backend/src/services/notifications/channels/relay_client.rs
+++ b/backend/src/services/notifications/channels/relay_client.rs
@@ -64,6 +64,18 @@ pub struct RelayStatus {
     pub last_success_at: Option<i64>,
     /// Unix seconds of the last attempt of any kind.
     pub last_attempt_at: Option<i64>,
+    /// Which process this snapshot describes.
+    ///
+    /// This status is deliberately process-local: each process holds its own
+    /// relay client, token cache and connectivity, so on a deployment running
+    /// several replicas two machines genuinely have different status. Merging
+    /// them into one shared value would flap between a healthy machine and a
+    /// failing one and hide the only thing worth knowing, which is *which*
+    /// machine is failing. Naming the process instead makes an alternating
+    /// answer legible rather than mysterious.
+    ///
+    /// Filled in at snapshot time, not stored, so [`Default`] stays trivial.
+    pub process_id: &'static str,
 }
 
 /// Why a relay call failed. Every variant is a static discriminator safe to log
@@ -191,9 +203,12 @@ impl RelayClient {
         })
     }
 
-    /// Snapshot for the admin edition surface.
+    /// Snapshot for the admin edition surface, stamped with this process's id.
     pub fn status(&self) -> RelayStatus {
-        self.status.read().expect("RwLock poisoned").clone()
+        RelayStatus {
+            process_id: crate::utils::process_id::process_id(),
+            ..self.status.read().expect("RwLock poisoned").clone()
+        }
     }
 
     fn record(&self, outcome: Option<&'static str>) {

--- a/backend/src/startup.rs
+++ b/backend/src/startup.rs
@@ -307,6 +307,10 @@ pub fn build_state(
             },
             sender = push_sender.name(),
             configured = push_sender.is_configured(),
+            // Same id the edition surface reports, so an operator on a
+            // multi-replica deployment can match a relay status to this
+            // machine's logs.
+            process_id = crate::utils::process_id::process_id(),
             "Push sender selected"
         );
         let push_sender_for_state = push_sender.clone();

--- a/backend/src/utils/mod.rs
+++ b/backend/src/utils/mod.rs
@@ -22,6 +22,7 @@ pub mod login_timing;
 pub mod markdown_export;
 pub mod mfa;
 pub mod pdf;
+pub mod process_id;
 pub mod rate_limit;
 pub mod rbac;
 pub mod redact;

--- a/backend/src/utils/process_id.rs
+++ b/backend/src/utils/process_id.rs
@@ -1,0 +1,35 @@
+//! Identity for this backend process.
+//!
+//! Distinct from `system_meta.instance_id`, which identifies the *installation*
+//! and is shared by every process serving it. This one changes on every restart
+//! and differs between replicas, which is exactly what makes it useful for
+//! telling two machines apart in an operator surface.
+
+use std::sync::OnceLock;
+use uuid::Uuid;
+
+/// Short, stable-for-this-process id.
+///
+/// Minted on first use rather than at startup so nothing has to remember to
+/// initialise it, and truncated to 8 characters because its only job is to let
+/// a human notice that two responses came from different processes. It is not a
+/// secret, not a correlation id for tracing, and never leaves an operator
+/// surface or a log line.
+pub fn process_id() -> &'static str {
+    static ID: OnceLock<String> = OnceLock::new();
+    ID.get_or_init(|| Uuid::now_v7().simple().to_string()[..8].to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Stable within a process: an operator comparing two responses must be
+    /// able to conclude "same machine" from a match.
+    #[test]
+    fn process_id_is_stable_and_short() {
+        assert_eq!(process_id(), process_id());
+        assert_eq!(process_id().len(), 8);
+        assert!(process_id().chars().all(|c| c.is_ascii_hexdigit()));
+    }
+}

--- a/packages/core/src/types/workspace.ts
+++ b/packages/core/src/types/workspace.ts
@@ -85,12 +85,21 @@ export interface EditionInfo {
   max_workspaces: number;
   active_workspaces: number;
   can_create_workspace: boolean;
-  /** Cloud push relay status. Null unless NOSDESK_PUSH_MODE=relay. */
+  /**
+   * Cloud push relay status. Null unless NOSDESK_PUSH_MODE=relay.
+   *
+   * Process-local by design: each backend process holds its own relay client
+   * and connectivity, so a deployment running several replicas will see this
+   * vary between calls. `process_id` says which one answered; two different
+   * ids mean two different machines, not a flapping relay.
+   */
   relay: {
-    /** `ok`, or a static failure kind such as `dpa_required`. */
+    /** `ok`, or a static failure kind such as `dpa_required` or `usage_cap`. */
     last_outcome: string | null;
     last_success_at: number | null;
     last_attempt_at: number | null;
+    /** Short id of the backend process that answered. */
+    process_id: string;
   } | null;
   license: {
     customer_id: string;


### PR DESCRIPTION
Resolves F2 from slice 4's acceptance run.

Relay status is process-local: each backend process holds its own relay client, token cache and connectivity. On a deployment running several replicas `GET /api/admin/edition` therefore reports whichever machine answered, and successive calls return different values with nothing on the surface to explain why. Seen live during acceptance, where the same endpoint returned `ok` and `null` on alternating calls.

`RelayStatus` now carries a short `process_id`, stamped at snapshot time so `Default` stays trivial, and the push boot line from #306 logs the same id. Two different ids across two responses then read as two machines rather than as a flapping relay, and a status can be matched to a machine's logs.

### This is deliberately not shared state, and the plan was wrong to imply it should be

The F2 note originally said hosted use "needs the status shared rather than per-process". Two corrections, both now in the plan:

**Hosted does not run relay mode.** It holds native APNs/FCM credentials, and the v1.1 relay client class is licensed self-hosted only. The split observed on `nosdesk-dev` was an artifact of putting a two-machine hosted deploy into relay mode for the acceptance test. The only real exposure is a self-hoster scaling replicas.

**A merged value would be worse than the current behaviour.** Two machines genuinely have different relay status, so merging them flaps between a healthy machine and a failing one and destroys the only signal worth having, which is *which* machine is failing. If multi-machine relay ever matters, the right shape is a per-machine listing, not a merged row. Persisting to `system_meta` was considered and rejected: a merged value nobody wants, at the cost of a database write per push, for a client class that does not exist.

### Note on identity

`process_id` is distinct from `system_meta.instance_id`, which identifies the *installation* and is shared by every process serving it — so it cannot tell two replicas apart, which is the whole problem here. The new id is minted per process, 8 hex characters, and appears only in operator surfaces and logs.

`cargo fmt --check` clean; `cargo test` exit 0, 1894 tests passing; `packages/core` type-check clean.

https://claude.ai/code/session_01KZdfqh5Fiqj27tPTBNNVbx