### PR TITLE
Correct the stale "Android stubbed" note on the push plugin

### DIFF
--- a/mobile/src-tauri/src/lib.rs
+++ b/mobile/src-tauri/src/lib.rs
@@ -14,7 +14,8 @@ pub fn run() {
     .plugin(tauri_plugin_opener::init())
     // Keystore/Keychain-backed storage for the auth refresh token.
     .plugin(tauri_plugin_secure_store::init())
-    // APNs/FCM push device-token registration (iOS live, Android stubbed).
+    // APNs/FCM push device-token registration. Both platforms are live: the
+    // Swift plugin registers with APNs, the Kotlin one with FirebaseMessaging.
     .plugin(tauri_plugin_push::init())
     // Haptic feedback for the pull-to-refresh arm tick. iOS/Android only;
     // on desktop the commands error and the JS facade swallows it.


### PR DESCRIPTION
Android push is fully implemented: `PushPlugin.kt` registers with `FirebaseMessaging` and `PushMessagingService.kt` receives. It is how the Android tablet took delivery during relay acceptance testing earlier in this work.

Found while writing the bring-your-own-credential push runbook (nosdesk-com#112). The comment matters more than a stale comment usually would: a self-hoster reading it while wiring up their own FCM credentials would reasonably conclude Android was unsupported and skip the Firebase half entirely.

Comment only, no behaviour change.

https://claude.ai/code/session_01KZdfqh5Fiqj27tPTBNNVbx