### PR TITLE
Give a user push preferences when their first device registers

### DIFF
--- a/backend/src/handlers/notifications.rs
+++ b/backend/src/handlers/notifications.rs
@@ -189,7 +189,18 @@ pub async fn register_push_device(
             &body.platform,
             token,
             body.app_version.as_deref(),
-        )
+        )?;
+        // First device for this user gets sensible push preferences. Best
+        // effort by intent: a seeding failure must not fail the registration,
+        // since a registered device with no preferences still works once the
+        // user visits notification settings, whereas a failed registration
+        // leaves them with no push at all.
+        if let Err(e) =
+            crate::repository::push_devices::seed_push_defaults(conn, user_uuid, workspace_id)
+        {
+            tracing::warn!(error = %e, "could not seed default push preferences");
+        }
+        Ok::<(), diesel::result::Error>(())
     });
     match res {
         Ok(_) => HttpResponse::Ok().json(serde_json::json!({ "success": true })),

--- a/backend/src/repository/push_devices.rs
+++ b/backend/src/repository/push_devices.rs
@@ -6,6 +6,7 @@
 
 use chrono::Utc;
 use diesel::prelude::*;
+use diesel::sql_types::{Array, Integer, Text, Uuid as SqlUuid};
 use uuid::Uuid;
 
 use crate::db::DbConnection;
@@ -48,6 +49,55 @@ pub fn register(
         ))
         .execute(conn)?;
     Ok(())
+}
+
+/// Notification types that get push enabled the first time a user registers a
+/// device.
+///
+/// Both are addressed to one person by name: an assignment makes a ticket
+/// yours, a mention asks for you specifically. Comment activity is deliberately
+/// absent — on a busy ticket it is the noisiest thing a helpdesk produces, and a
+/// phone buzzing for every reply is how users learn to disable push entirely.
+const PUSH_ON_FIRST_DEVICE: &[&str] = &["ticket_assigned", "mentioned"];
+
+// sync-audit-only: preference seeding; no sync client subscribes to preferences.
+/// Give a user sensible push preferences the first time one of their devices
+/// registers.
+///
+/// Push is off by default for every type, which is the right default for a
+/// browser: there is nothing to send to and no OS permission. But the mobile app
+/// asks for notification permission at sign-in, and granting it registered a
+/// device and then changed nothing observable — the prompt promised something
+/// the product did not deliver. This closes that gap at the only moment where
+/// consent and capability both exist.
+///
+/// `DO NOTHING` per row, so this can never overwrite a choice. A user who turns
+/// mentions off and later signs in on a second device keeps them off; the seed
+/// simply finds a row and declines. That also makes it idempotent, matching
+/// [`register`], which the client may call on every launch.
+pub fn seed_push_defaults(
+    conn: &mut DbConnection,
+    user: Uuid,
+    workspace: i32,
+) -> QueryResult<usize> {
+    diesel::sql_query(
+        "INSERT INTO notification_preferences \
+           (user_uuid, notification_type_id, channel, enabled, frequency, \
+            workspace_id, created_at, updated_at) \
+         SELECT $1, nt.id, 'push', TRUE, 'instant', $2, now(), now() \
+         FROM notification_types nt \
+         WHERE nt.code = ANY($3) \
+         ON CONFLICT (user_uuid, notification_type_id, channel) DO NOTHING",
+    )
+    .bind::<SqlUuid, _>(user)
+    .bind::<Integer, _>(workspace)
+    .bind::<Array<Text>, _>(
+        PUSH_ON_FIRST_DEVICE
+            .iter()
+            .map(|s| (*s).to_owned())
+            .collect::<Vec<_>>(),
+    )
+    .execute(conn)
 }
 
 // sync-audit-only: device-token lifecycle; no sync client subscribes to it.

--- a/backend/tests/push_preference_seeding.rs
+++ b/backend/tests/push_preference_seeding.rs
@@ -1,0 +1,131 @@
+//! Seeding push preferences when a user's first device registers.
+//!
+//! Push is off by default for every notification type, which is correct for a
+//! browser: nothing to send to, no OS permission. The mobile app, though, asks
+//! for notification permission at sign-in and registers a device — and until
+//! this seeding existed, granting that permission changed nothing observable.
+//!
+//! The property that matters is not "it turns push on". It is that it can never
+//! turn push on for someone who has turned it off, because a notification
+//! setting that reverts itself is worse than one that was never seeded.
+
+#![allow(clippy::expect_used)]
+
+use diesel::prelude::*;
+use uuid::Uuid;
+
+use backend::sync::actor::ActorContext;
+use backend::sync::session::with_actor_bypass_context;
+
+mod common;
+
+/// The (type code, enabled) push preferences a user currently holds.
+fn push_prefs(conn: &mut backend::db::DbConnection, user: Uuid) -> Vec<(String, bool)> {
+    use backend::schema::{notification_preferences as np, notification_types as nt};
+    np::table
+        .inner_join(nt::table.on(nt::id.eq(np::notification_type_id)))
+        .filter(np::user_uuid.eq(user))
+        .filter(np::channel.eq("push"))
+        .select((nt::code, np::enabled))
+        .order(nt::code)
+        .load(conn)
+        .expect("load push prefs")
+}
+
+fn seed(conn: &mut backend::db::DbConnection, user: Uuid, workspace: i32) {
+    let actor = ActorContext::system("test:seed_push").with_workspace(workspace);
+    with_actor_bypass_context::<_, diesel::result::Error>(conn, &actor, |c| {
+        backend::repository::push_devices::seed_push_defaults(c, user, workspace)?;
+        Ok(())
+    })
+    .expect("seed");
+}
+
+#[test]
+fn a_first_device_gets_assignments_and_mentions() {
+    common::ensure_test_keyring();
+    let db = common::TestDb::new();
+    let mut conn = db.conn();
+    let ws = common::seed_two_workspaces(&mut conn);
+    let user = ws.a.member_uuid;
+
+    assert!(
+        push_prefs(&mut conn, user).is_empty(),
+        "push is off by default for every type; nothing is seeded until a device exists"
+    );
+
+    seed(&mut conn, user, ws.a.workspace_id);
+
+    assert_eq!(
+        push_prefs(&mut conn, user),
+        vec![
+            ("mentioned".to_string(), true),
+            ("ticket_assigned".to_string(), true),
+        ],
+        "both are addressed to one person by name; comment activity is deliberately absent"
+    );
+}
+
+/// The guard that matters. A user who turns a push preference off and later
+/// signs in on another device must stay off: `register` is called on every
+/// launch, so a seed that overwrote would silently re-enable it forever.
+#[test]
+fn seeding_never_overwrites_a_users_choice() {
+    common::ensure_test_keyring();
+    let db = common::TestDb::new();
+    let mut conn = db.conn();
+    let ws = common::seed_two_workspaces(&mut conn);
+    let user = ws.a.member_uuid;
+
+    seed(&mut conn, user, ws.a.workspace_id);
+
+    // The user opens settings and turns mentions off.
+    {
+        use backend::schema::{notification_preferences as np, notification_types as nt};
+        let actor = ActorContext::system("test:user_opt_out").with_workspace(ws.a.workspace_id);
+        with_actor_bypass_context::<_, diesel::result::Error>(&mut conn, &actor, |c| {
+            let mentioned_id: i32 = nt::table
+                .filter(nt::code.eq("mentioned"))
+                .select(nt::id)
+                .first(c)?;
+            diesel::update(
+                np::table
+                    .filter(np::user_uuid.eq(user))
+                    .filter(np::notification_type_id.eq(mentioned_id))
+                    .filter(np::channel.eq("push")),
+            )
+            .set((np::enabled.eq(false), np::frequency.eq("off")))
+            .execute(c)?;
+            Ok(())
+        })
+        .expect("opt out");
+    }
+
+    // A second device registers, so the seed runs again.
+    seed(&mut conn, user, ws.a.workspace_id);
+
+    assert_eq!(
+        push_prefs(&mut conn, user),
+        vec![
+            ("mentioned".to_string(), false),
+            ("ticket_assigned".to_string(), true),
+        ],
+        "the opt-out must survive; ON CONFLICT DO NOTHING is what guarantees it"
+    );
+}
+
+/// Idempotent, because the client may call register on every launch.
+#[test]
+fn seeding_twice_creates_no_duplicates() {
+    common::ensure_test_keyring();
+    let db = common::TestDb::new();
+    let mut conn = db.conn();
+    let ws = common::seed_two_workspaces(&mut conn);
+    let user = ws.a.member_uuid;
+
+    seed(&mut conn, user, ws.a.workspace_id);
+    let after_first = push_prefs(&mut conn, user);
+    seed(&mut conn, user, ws.a.workspace_id);
+
+    assert_eq!(push_prefs(&mut conn, user), after_first);
+}


### PR DESCRIPTION
Resolves F3.

### The original F3 report was wrong, and this fixes the real thing

F3 was recorded as "only `ticket_assigned` defaults to push on, which is a surprising default". That was a misreading: I queried one staging account's *resolved preferences* and reported them as system defaults. `"push"` appears zero times in the seeded `default_channels` and no workspace defaults are seeded — push is off for **every** type, deliberately, and `preferences.rs:32` says why: it is opt-in after the user registers a device and grants OS permission.

The actual gap is narrower and worse. The mobile app asks for notification permission at sign-in and registers a device token. The user grants it, and nothing observable changes, because every type still resolves push to off. The OS prompt promises something the product does not deliver, and the only way to get push is to know to go and find notification settings.

### What this does

Registering a device seeds push for `ticket_assigned` and `mentioned`. Both are addressed to one person by name: an assignment makes a ticket yours, a mention asks for you specifically.

`comment_added` is deliberately excluded. On a busy ticket it is the noisiest thing a helpdesk produces, and a phone buzzing for every reply is how users learn to switch push off entirely. It remains one toggle away.

This keeps the documented design intent — push stays off until a device and OS permission both exist — while making the permission grant mean something. It fires at the only moment where consent and capability coincide.

### The property that matters

Not "it turns push on", but that it **can never turn push on for someone who turned it off**. `register` is called on every app launch, so a seed that overwrote would silently re-enable a setting the user had disabled, every launch, with no way to make it stick. `ON CONFLICT DO NOTHING` per row is what guarantees that, and `seeding_never_overwrites_a_users_choice` is the regression guard: it seeds, opts out of mentions, seeds again, and asserts the opt-out survives.

Seeding failure is logged rather than propagated. A registered device with no preferences still works once the user visits settings; a failed registration leaves them with no push at all.

`cargo fmt --check` clean, clippy clean in the touched files, `cargo test` exit 0 with 1909 tests passing including 3 new DB-backed ones.

https://claude.ai/code/session_01KZdfqh5Fiqj27tPTBNNVbx