### PR TITLE
Let the push boot line actually say which sender was selected

### DIFF
--- a/backend/src/utils/tracing_redact.rs
+++ b/backend/src/utils/tracing_redact.rs
@@ -93,13 +93,25 @@ const ALLOWED_FIELDS: &[&str] = &[
     "aggregate",
     "category",
     "classification",
+    // Push sender selection, logged once at boot: `mode` and `sender` are
+    // closed sets ("relay" / "native" / "off" / "unset"), `configured` is a
+    // bool. Without these the boot line reads "Push sender selected" and names
+    // nothing, which defeats the one signal an operator has for telling relay
+    // mode from native on a running instance.
+    "configured",
     "entity",
     "event_type",
     "kind",
+    "mode",
     "op",
     "priority",
     "recurrence",
     "role",
+    // Which backend process answered. A random per-process id, not tied to a
+    // user, a tenant or a machine address; it exists so two replicas can be
+    // told apart in logs and on the edition surface.
+    "process_id",
+    "sender",
     "status",
     // External (third-party-provider) stable identifiers. Like the
     // intra-tenant uuids above, these are stable IDs assigned by
@@ -433,6 +445,13 @@ mod tests {
             "event_type",
             "op",
             "aggregate",
+            // Push boot line. Regression guard: these were added after the line
+            // shipped logging "Push sender selected" with redacted:4 and naming
+            // nothing at all.
+            "mode",
+            "sender",
+            "configured",
+            "process_id",
             "status",
             "priority",
             "role",


### PR DESCRIPTION
Completes F1. The boot line added in #306 does not work in production.

It logs as:

```json
{"fields":{"message":"Push sender selected"},"level":"INFO","redacted":4,...}
```

`mode`, `sender`, `configured` and `process_id` are structured fields, none of them on the tracing allowlist, so all four are dropped and counted under `redacted`. The line I added specifically so an operator could tell relay mode from native on a running instance names nothing at all.

Found by reading real output from a deployed instance while chasing an iOS delivery failure. The code compiled, the tests passed, and the feature did not work — a unit test cannot catch a field being dropped by a redaction layer at the output boundary.

All four are safe to emit:

- `mode` and `sender` are closed sets (`relay` / `native` / `off` / `unset`).
- `configured` is a bool.
- `process_id` is a random per-process id. It identifies no user, tenant or machine address; it exists so two replicas can be told apart in logs and on the edition surface, which is the F2 resolution in #308.

Extends `allowed_fields_pass`, whose doc comment already states its purpose: *"if this fails, an entry was removed from `ALLOWED_FIELDS` and a downstream log call just broke."* That is exactly what happened, in the other direction — the entry was never added.

`cargo fmt --check` clean, `cargo test` exit 0 with 1909 tests passing.

https://claude.ai/code/session_01KZdfqh5Fiqj27tPTBNNVbx