### PR TITLE
Move the sub-xs type sizes into the theme

### DIFF
--- a/frontend/src/assets/main.css
+++ b/frontend/src/assets/main.css
@@ -40,6 +40,30 @@
   --container-8xl: 90rem;
 
   /* ===========================================================
+     Sub-xs type scale.
+     -----------------------------------------------------------
+     These four sizes were previously written as arbitrary values
+     (`text-[11px]` and friends) at ~348 call sites. Arbitrary px
+     bypasses every scaling mechanism there is: it ignores the root
+     font size, so a user who raises their browser or OS text size
+     gets nothing from it (WCAG 1.4.4 asks for text to scale to
+     200%), and it renders far smaller on a high-density tablet
+     than the same markup does on a desktop monitor.
+     Expressed in rem, one root-level change scales all of them
+     coherently. Borders and hairlines stay in px on purpose --
+     those should NOT grow with type.
+     No `--line-height` is defined: the arbitrary values these
+     replace set font-size only, so adding one would change
+     rendering rather than preserve it.
+     ----------------------------------------------------------- */
+  --text-2xs: 0.6875rem; /* 11px */
+  --text-3xs: 0.625rem; /* 10px */
+  --text-4xs: 0.5625rem; /* 9px */
+  /* Sits between Tailwind's xs (12px) and sm (14px); no conventional
+     name exists for that gap, hence the explicit one. */
+  --text-xs-plus: 0.8125rem; /* 13px */
+
+  /* ===========================================================
      Metric type scale (dashboard KPI numerals + embedded stats).
      Distinct from the heading scale so KPI numbers can dominate a
      dashboard while page titles stay supporting; aligned to parent

--- a/frontend/src/components/GlobalSearch/GlobalSearchModal.vue
+++ b/frontend/src/components/GlobalSearch/GlobalSearchModal.vue
@@ -393,7 +393,7 @@ onScopeDispose(() => restoreScroll?.());
               <button
                 v-if="activeTypes"
                 @click="clearTypes"
-                class="inline-flex items-center gap-1 px-2 h-6 text-[11px] font-medium rounded-md bg-accent/10 text-accent border border-accent/20 hover:bg-accent/20 transition-colors flex-shrink-0"
+                class="inline-flex items-center gap-1 px-2 h-6 text-2xs font-medium rounded-md bg-accent/10 text-accent border border-accent/20 hover:bg-accent/20 transition-colors flex-shrink-0"
               >
                 {{ scopeLabel(activeTypes) }}
                 <Icon name="close" size="xs" />
@@ -404,7 +404,7 @@ onScopeDispose(() => restoreScroll?.());
               <button
                 v-if="authorFilter"
                 @click="clearAuthor"
-                class="inline-flex items-center gap-1 px-2 h-6 text-[11px] font-medium rounded-md bg-brand-pink/10 text-brand-pink border border-brand-pink/20 hover:bg-brand-pink/20 transition-colors flex-shrink-0 max-w-[10rem]"
+                class="inline-flex items-center gap-1 px-2 h-6 text-2xs font-medium rounded-md bg-brand-pink/10 text-brand-pink border border-brand-pink/20 hover:bg-brand-pink/20 transition-colors flex-shrink-0 max-w-[10rem]"
                 :title="t('search-global-from-chip', { name: authorFilter.name })"
               >
                 <Icon name="user" size="xs" class="flex-shrink-0" />
@@ -459,7 +459,7 @@ onScopeDispose(() => restoreScroll?.());
                  the person chip and drops the token. -->
             <div v-else-if="fromPromptActive" class="py-1 px-1">
               <div class="px-2 pt-2 pb-1">
-                <span class="text-[10px] font-semibold uppercase tracking-wider text-tertiary">
+                <span class="text-3xs font-semibold uppercase tracking-wider text-tertiary">
                   {{ t('search-global-from-heading') }}
                 </span>
               </div>
@@ -481,11 +481,11 @@ onScopeDispose(() => restoreScroll?.());
                 </span>
                 <span class="flex-1 min-w-0">
                   <span class="block text-sm text-primary font-medium truncate">{{ user.title }}</span>
-                  <span v-if="user.preview" class="block text-[11px] text-tertiary truncate">{{ user.preview }}</span>
+                  <span v-if="user.preview" class="block text-2xs text-tertiary truncate">{{ user.preview }}</span>
                 </span>
                 <kbd
                   v-if="index === selectedAuthorIndex"
-                  class="hidden sm:inline-flex items-center justify-center min-w-[1.25rem] h-4 px-1 rounded bg-surface border border-default text-[9px] font-medium text-secondary"
+                  class="hidden sm:inline-flex items-center justify-center min-w-[1.25rem] h-4 px-1 rounded bg-surface border border-default text-4xs font-medium text-secondary"
                 >⏎</kbd>
               </button>
               <!-- Nothing typed yet, or no matches. -->
@@ -503,7 +503,7 @@ onScopeDispose(() => restoreScroll?.());
                  decision is actually made: before the query. -->
             <div v-else-if="scopePromptActive" class="py-1 px-1">
               <div class="px-2 pt-2 pb-1">
-                <span class="text-[10px] font-semibold uppercase tracking-wider text-tertiary">
+                <span class="text-3xs font-semibold uppercase tracking-wider text-tertiary">
                   {{ t('search-global-scope-heading') }}
                 </span>
               </div>
@@ -528,7 +528,7 @@ onScopeDispose(() => restoreScroll?.());
                 </span>
                 <kbd
                   v-if="row.index === selectedScopeIndex"
-                  class="hidden sm:inline-flex items-center justify-center min-w-[1.25rem] h-4 px-1 rounded bg-surface border border-default text-[9px] font-medium text-secondary"
+                  class="hidden sm:inline-flex items-center justify-center min-w-[1.25rem] h-4 px-1 rounded bg-surface border border-default text-4xs font-medium text-secondary"
                 >⇥</kbd>
               </button>
             </div>
@@ -614,24 +614,24 @@ onScopeDispose(() => restoreScroll?.());
                hint, stats aren't worth a bar — so the results list
                takes the height instead. -->
           <div
-            class="hidden sm:flex items-center justify-between gap-3 px-3 h-9 border-t border-default bg-surface-alt/50 text-[11px] text-tertiary flex-shrink-0"
+            class="hidden sm:flex items-center justify-between gap-3 px-3 h-9 border-t border-default bg-surface-alt/50 text-2xs text-tertiary flex-shrink-0"
           >
             <div class="hidden sm:flex items-center gap-3">
               <span class="inline-flex items-center gap-1">
-                <kbd class="inline-flex items-center justify-center w-4 h-4 rounded bg-surface border border-default text-[9px] font-medium text-secondary">↑</kbd>
-                <kbd class="inline-flex items-center justify-center w-4 h-4 rounded bg-surface border border-default text-[9px] font-medium text-secondary">↓</kbd>
+                <kbd class="inline-flex items-center justify-center w-4 h-4 rounded bg-surface border border-default text-4xs font-medium text-secondary">↑</kbd>
+                <kbd class="inline-flex items-center justify-center w-4 h-4 rounded bg-surface border border-default text-4xs font-medium text-secondary">↓</kbd>
                 <span>{{ t('search-global-hint-navigate') }}</span>
               </span>
               <span v-if="scopePromptActive" class="inline-flex items-center gap-1">
-                <kbd class="inline-flex items-center justify-center min-w-[1rem] h-4 px-1 rounded bg-surface border border-default text-[9px] font-medium text-secondary">⇥</kbd>
+                <kbd class="inline-flex items-center justify-center min-w-[1rem] h-4 px-1 rounded bg-surface border border-default text-4xs font-medium text-secondary">⇥</kbd>
                 <span>{{ t('search-global-hint-scope') }}</span>
               </span>
               <span v-if="searchState === 'results'" class="inline-flex items-center gap-1">
-                <kbd class="inline-flex items-center justify-center min-w-[1rem] h-4 px-1 rounded bg-surface border border-default text-[9px] font-medium text-secondary">↵</kbd>
+                <kbd class="inline-flex items-center justify-center min-w-[1rem] h-4 px-1 rounded bg-surface border border-default text-4xs font-medium text-secondary">↵</kbd>
                 <span>{{ t('search-global-hint-open') }}</span>
               </span>
               <span class="inline-flex items-center gap-1">
-                <kbd class="inline-flex items-center justify-center min-w-[1.5rem] h-4 px-1 rounded bg-surface border border-default text-[9px] font-medium text-secondary">esc</kbd>
+                <kbd class="inline-flex items-center justify-center min-w-[1.5rem] h-4 px-1 rounded bg-surface border border-default text-4xs font-medium text-secondary">esc</kbd>
                 <span>{{ t('search-global-hint-close') }}</span>
               </span>
             </div>

--- a/frontend/src/components/GlobalSearch/SearchResultGroup.vue
+++ b/frontend/src/components/GlobalSearch/SearchResultGroup.vue
@@ -46,14 +46,14 @@ const groupLabel = computed(() => {
       class="group/header flex w-full items-baseline gap-2 px-2 pt-2 pb-1 text-left rounded-md transition-colors hover:bg-surface-hover/60"
       @click="emit('scope', props.type)"
     >
-      <span class="text-[10px] font-semibold uppercase tracking-wider text-tertiary">
+      <span class="text-3xs font-semibold uppercase tracking-wider text-tertiary">
         {{ groupLabel }}
       </span>
-      <span class="text-[10px] text-tertiary/60 tabular-nums">
+      <span class="text-3xs text-tertiary/60 tabular-nums">
         {{ results.length }}
       </span>
       <span
-        class="ml-auto text-[10px] text-tertiary/60 opacity-0 group-hover/header:opacity-100 transition-opacity"
+        class="ml-auto text-3xs text-tertiary/60 opacity-0 group-hover/header:opacity-100 transition-opacity"
       >
         {{ t('search-global-group-scope-hint') }}
       </span>

--- a/frontend/src/components/GlobalSearch/SearchResultItem.vue
+++ b/frontend/src/components/GlobalSearch/SearchResultItem.vue
@@ -82,7 +82,7 @@ const formattedTime = computed(() => {
     <div class="flex-1 min-w-0">
       <div class="flex items-center gap-2">
         <span
-          class="font-medium text-[13px] truncate"
+          class="font-medium text-xs-plus truncate"
           :class="isSelected ? 'text-primary' : 'text-primary'"
         >
           {{ result.title }}
@@ -93,21 +93,21 @@ const formattedTime = computed(() => {
              current user has staff access. -->
         <span
           v-if="result.is_internal"
-          class="flex-shrink-0 inline-flex items-center px-1.5 h-[15px] rounded text-[9px] font-semibold uppercase tracking-wide bg-status-warning-muted text-status-warning"
+          class="flex-shrink-0 inline-flex items-center px-1.5 h-[15px] rounded text-4xs font-semibold uppercase tracking-wide bg-status-warning-muted text-status-warning"
           :title="t('search-result-item-internal-title')"
         >
           {{ t('search-result-item-internal-badge') }}
         </span>
         <span
           v-if="formattedTime"
-          class="flex-shrink-0 text-[10px] text-tertiary tabular-nums"
+          class="flex-shrink-0 text-3xs text-tertiary tabular-nums"
         >
           {{ formattedTime }}
         </span>
       </div>
       <div
         v-if="result.preview"
-        class="text-[11px] text-secondary truncate mt-0.5"
+        class="text-2xs text-secondary truncate mt-0.5"
       >
         {{ result.preview }}
       </div>
@@ -120,7 +120,7 @@ const formattedTime = computed(() => {
          chrome on a random row. -->
     <kbd
       v-if="isSelected"
-      class="flex-shrink-0 hidden sm:inline-flex items-center justify-center w-5 h-5 rounded border border-default bg-surface text-[10px] font-medium text-secondary"
+      class="flex-shrink-0 hidden sm:inline-flex items-center justify-center w-5 h-5 rounded border border-default bg-surface text-3xs font-medium text-secondary"
     >
       ↵
     </kbd>

--- a/frontend/src/components/GlobalSearch/SearchSortToggle.vue
+++ b/frontend/src/components/GlobalSearch/SearchSortToggle.vue
@@ -36,7 +36,7 @@ const options: { value: SearchSortOrder; labelKey: string }[] = [
       :data-sort-active="opt.value === modelValue"
       :aria-pressed="opt.value === modelValue"
       :class="[
-        'px-2 h-5 rounded text-[11px] font-medium transition-colors',
+        'px-2 h-5 rounded text-2xs font-medium transition-colors',
         opt.value === modelValue
           ? 'bg-surface text-primary shadow-sm'
           : 'text-tertiary hover:text-secondary',

--- a/frontend/src/components/Navbar.vue
+++ b/frontend/src/components/Navbar.vue
@@ -495,7 +495,7 @@ const isOverflowRouteActive = computed(() =>
                     class="flex flex-col gap-0.5"
                 >
                     <h3
-                        class="px-2.5 text-[10px] font-semibold text-tertiary tracking-wide uppercase select-none"
+                        class="px-2.5 text-3xs font-semibold text-tertiary tracking-wide uppercase select-none"
                     >
                         {{ $t(group.label) }}
                     </h3>

--- a/frontend/src/components/NotificationBell.vue
+++ b/frontend/src/components/NotificationBell.vue
@@ -294,7 +294,7 @@ onMounted(() => {
           {{ tab.label }}
           <span
             v-if="tab.value === 'unread' && hasUnread"
-            class="rounded-full bg-accent/15 px-1.5 py-0.5 text-[10px] font-semibold leading-none text-accent"
+            class="rounded-full bg-accent/15 px-1.5 py-0.5 text-3xs font-semibold leading-none text-accent"
           >
             {{ displayCount }}
           </span>
@@ -356,7 +356,7 @@ onMounted(() => {
             class="border-b border-default last:border-b-0"
           >
             <h4
-              class="sticky top-0 z-10 bg-surface/95 px-4 py-1.5 text-[11px] font-semibold uppercase tracking-wide text-tertiary backdrop-blur"
+              class="sticky top-0 z-10 bg-surface/95 px-4 py-1.5 text-2xs font-semibold uppercase tracking-wide text-tertiary backdrop-blur"
             >
               {{ group.label }}
             </h4>

--- a/frontend/src/components/QuickTooltip.vue
+++ b/frontend/src/components/QuickTooltip.vue
@@ -167,7 +167,7 @@ watch(tooltipVisible, (newValue) => {
               </span>
             </div>
           </div>
-          <div v-if="details.created" class="text-[11px] text-tertiary">
+          <div v-if="details.created" class="text-2xs text-tertiary">
             {{ details.created }}
           </div>
         </div>

--- a/frontend/src/components/RecentTickets.vue
+++ b/frontend/src/components/RecentTickets.vue
@@ -286,7 +286,7 @@ onMounted(() => {
           </span>
 
           <!-- Time -->
-          <span class="text-[10px] text-tertiary flex-shrink-0">
+          <span class="text-3xs text-tertiary flex-shrink-0">
             {{ formatCompactRelativeTime(ticket.last_viewed_at) }}
           </span>
         </div>

--- a/frontend/src/components/TicketHeatmap.vue
+++ b/frontend/src/components/TicketHeatmap.vue
@@ -232,11 +232,11 @@ onActivated(() => {
                 <span class="inline-block h-2.5 w-28 rounded bg-surface-alt animate-pulse" />
             </div>
             <div v-else class="flex flex-1 min-w-0 items-center justify-between gap-2">
-                <p class="text-[10px] text-tertiary tabular-nums truncate min-w-0">
+                <p class="text-3xs text-tertiary tabular-nums truncate min-w-0">
                     {{ $t('ticket-heatmap-days-with-activity', { count: daysWithActivity }) }}
                 </p>
 
-                <div class="flex items-center gap-1.5 text-[9px] text-tertiary shrink-0">
+                <div class="flex items-center gap-1.5 text-4xs text-tertiary shrink-0">
                     <span class="sr-only">{{ $t('ticket-heatmap-legend-less') }}</span>
                     <div class="flex gap-0.5" aria-hidden="true">
                         <div

--- a/frontend/src/components/TicketRow.vue
+++ b/frontend/src/components/TicketRow.vue
@@ -136,7 +136,7 @@ const ariaLabel = computed(() => {
     <div class="flex items-center gap-2.5 pl-4 pr-3 h-10 min-w-0">
       <TicketStatusIcon :category="statusCategory" :title="statusName || undefined" class="w-3.5 h-3.5" />
 
-      <span class="flex items-center gap-1.5 flex-shrink-0 font-mono text-[11px] text-tertiary tabular-nums">
+      <span class="flex items-center gap-1.5 flex-shrink-0 font-mono text-2xs text-tertiary tabular-nums">
         <span
           v-if="newActivity"
           class="w-1.5 h-1.5 rounded-full bg-accent flex-shrink-0"
@@ -148,7 +148,7 @@ const ariaLabel = computed(() => {
 
       <div class="flex-1 min-w-0 flex items-baseline gap-2">
         <h3
-          class="text-[13px] truncate min-w-0 group-hover:text-accent transition-colors"
+          class="text-xs-plus truncate min-w-0 group-hover:text-accent transition-colors"
           :class="[
             newActivity ? 'font-semibold' : 'font-medium',
             isTerminal ? 'text-tertiary' : 'text-primary',
@@ -158,7 +158,7 @@ const ariaLabel = computed(() => {
         </h3>
         <span
           v-if="requester"
-          class="text-[11px] text-tertiary truncate flex-shrink min-w-0 whitespace-nowrap"
+          class="text-2xs text-tertiary truncate flex-shrink min-w-0 whitespace-nowrap"
           :title="`From ${requester.name}`"
         >
           {{ requester.name }}
@@ -175,7 +175,7 @@ const ariaLabel = computed(() => {
         :title="`From ${requester.name}`"
       />
       <span
-        class="text-[11px] text-tertiary tabular-nums flex-shrink-0 min-w-[1.75rem] text-right"
+        class="text-2xs text-tertiary tabular-nums flex-shrink-0 min-w-[1.75rem] text-right"
         :title="formatDateTime(timestamp)"
       >
         {{ formatCompactRelativeTime(timestamp) }}

--- a/frontend/src/components/admin/AdminSidebar.vue
+++ b/frontend/src/components/admin/AdminSidebar.vue
@@ -76,7 +76,7 @@ const isActive = (itemRoute: string) => isAdminRouteActive(route.path, itemRoute
     <!-- Nav Groups -->
     <nav class="flex-1 px-2 pb-4 flex flex-col gap-4 overflow-y-auto">
       <div v-for="group in filteredGroups" :key="group.labelKey">
-        <h3 class="px-2 mb-1 text-[11px] font-semibold uppercase tracking-wider text-tertiary">
+        <h3 class="px-2 mb-1 text-2xs font-semibold uppercase tracking-wider text-tertiary">
           {{ $t(group.labelKey) }}
         </h3>
         <div class="flex flex-col gap-0.5">

--- a/frontend/src/components/admin/WeekScheduleEditor.vue
+++ b/frontend/src/components/admin/WeekScheduleEditor.vue
@@ -76,7 +76,7 @@ watch(allRangesValid, (v) => emit('update:valid', v), { immediate: true })
       class="flex items-center gap-3"
     >
       <span
-        class="w-10 flex-shrink-0 text-[11px] font-semibold text-tertiary uppercase tracking-wide"
+        class="w-10 flex-shrink-0 text-2xs font-semibold text-tertiary uppercase tracking-wide"
       >
         {{ $t(day.labelKey) }}
       </span>
@@ -87,7 +87,7 @@ watch(allRangesValid, (v) => emit('update:valid', v), { immediate: true })
         @update:ranges="(ranges: DaySchedule) => setDayRanges(day.key, ranges)"
       />
     </div>
-    <p class="text-[10px] text-tertiary italic mt-1">
+    <p class="text-3xs text-tertiary italic mt-1">
       {{ $t('admin-sla-schedule-timeline-hint') }}
     </p>
   </div>

--- a/frontend/src/components/assets/AssetMediaPanel.vue
+++ b/frontend/src/components/assets/AssetMediaPanel.vue
@@ -301,14 +301,14 @@ useSyncActions(
           <div class="flex items-center gap-1.5 justify-end">
             <button
               type="button"
-              class="text-[10px] px-2 py-0.5 rounded text-white/80 hover:text-white"
+              class="text-3xs px-2 py-0.5 rounded text-white/80 hover:text-white"
               @click="cancelCaptionEdit"
             >
               {{ $t('asset-media-caption-cancel') }}
             </button>
             <button
               type="button"
-              class="text-[10px] px-2 py-0.5 rounded bg-accent text-on-accent"
+              class="text-3xs px-2 py-0.5 rounded bg-accent text-on-accent"
               :disabled="captionSaving"
               @click="saveCaption(item)"
             >

--- a/frontend/src/components/common/AssignmentPicker.vue
+++ b/frontend/src/components/common/AssignmentPicker.vue
@@ -191,7 +191,7 @@ onBeforeUnmount(() => {
         <template v-else>
           <!-- Groups section -->
           <div v-if="filteredGroups.length > 0">
-            <div class="px-3 py-1.5 text-[10px] font-semibold text-tertiary uppercase tracking-wider bg-surface-alt">
+            <div class="px-3 py-1.5 text-3xs font-semibold text-tertiary uppercase tracking-wider bg-surface-alt">
               {{ $t('assignment-picker-section-groups') }}
             </div>
             <button
@@ -207,7 +207,7 @@ onBeforeUnmount(() => {
 
           <!-- Users section -->
           <div v-if="filteredUsers.length > 0">
-            <div class="px-3 py-1.5 text-[10px] font-semibold text-tertiary uppercase tracking-wider bg-surface-alt">
+            <div class="px-3 py-1.5 text-3xs font-semibold text-tertiary uppercase tracking-wider bg-surface-alt">
               {{ $t('assignment-picker-section-users') }}
             </div>
             <button
@@ -223,11 +223,11 @@ onBeforeUnmount(() => {
                   :alt="user.name"
                   class="w-full h-full object-cover"
                 />
-                <span v-else class="text-[10px] font-medium text-accent">{{ user.name.charAt(0).toUpperCase() }}</span>
+                <span v-else class="text-3xs font-medium text-accent">{{ user.name.charAt(0).toUpperCase() }}</span>
               </div>
               <div class="flex-1 min-w-0">
                 <div class="text-sm text-primary truncate">{{ user.name }}</div>
-                <div class="text-[11px] text-tertiary truncate">{{ user.email }}</div>
+                <div class="text-2xs text-tertiary truncate">{{ user.email }}</div>
               </div>
             </button>
           </div>

--- a/frontend/src/components/common/DataTable.vue
+++ b/frontend/src/components/common/DataTable.vue
@@ -245,7 +245,7 @@ const dataCellPadding = computed(() =>
         </div>
 
         <!-- Column Headers. Compact uppercase treatment mirroring
-             the tickets table: text-[10px] uppercase + tertiary
+             the tickets table: text-3xs uppercase + tertiary
              text + tracking-wider, with a subtle bottom rule so
              the header row reads as scaffolding rather than
              competing with the data cells. When `columnReorder`
@@ -260,7 +260,7 @@ const dataCellPadding = computed(() =>
           :draggable="columnReorder ? columnReorder.isReorderable(column.field) : false"
           :class="[
             headerCellPadding,
-            'first:pl-4 [&:nth-last-child(2)]:pr-4 flex items-center text-[10px] font-semibold uppercase tracking-wider text-tertiary bg-surface border-b border-subtle sticky top-0 z-10 relative',
+            'first:pl-4 [&:nth-last-child(2)]:pr-4 flex items-center text-3xs font-semibold uppercase tracking-wider text-tertiary bg-surface border-b border-subtle sticky top-0 z-10 relative',
             getColumnVisibility(column),
             column.sortable ? 'cursor-pointer hover:bg-surface-hover hover:text-primary' : '',
             columnReorder?.sourceId.value === column.field ? 'opacity-50' : '',
@@ -392,7 +392,7 @@ const dataCellPadding = computed(() =>
               <path d="M2 4l4 4 4-4z" />
             </svg>
             <span class="text-xs font-medium text-primary">{{ bucket.label }}</span>
-            <span class="text-[10px] text-tertiary tabular-nums">{{ bucket.items.length }}</span>
+            <span class="text-3xs text-tertiary tabular-nums">{{ bucket.items.length }}</span>
           </button>
 
           <template v-if="!isCollapsed?.(bucket.key)">

--- a/frontend/src/components/common/MenuList.vue
+++ b/frontend/src/components/common/MenuList.vue
@@ -78,7 +78,7 @@ const emit = defineEmits<{
          the items underneath them. -->
     <div
       v-if="item.heading"
-      class="w-full px-3 pt-2 pb-1 flex items-center gap-2 text-[10px] font-semibold tracking-wide text-tertiary uppercase select-none"
+      class="w-full px-3 pt-2 pb-1 flex items-center gap-2 text-3xs font-semibold tracking-wide text-tertiary uppercase select-none"
     >
       <span class="w-3.5 h-3.5 flex-shrink-0" aria-hidden="true"></span>
       <span>{{ item.label }}</span>
@@ -138,7 +138,7 @@ const emit = defineEmits<{
         />
       </span>
       <span class="flex-1 truncate">{{ item.label }}</span>
-      <span v-if="item.trailing" class="ml-auto pl-2 text-[10px] text-tertiary flex-shrink-0">
+      <span v-if="item.trailing" class="ml-auto pl-2 text-3xs text-tertiary flex-shrink-0">
         {{ item.trailing }}
       </span>
     </button>

--- a/frontend/src/components/common/SectionCard.vue
+++ b/frontend/src/components/common/SectionCard.vue
@@ -56,7 +56,7 @@ withDefaults(defineProps<Props>(), {
       <!-- Optional leading content (icon, dot indicator). -->
       <slot name="leading" />
 
-      <h2 class="text-[13px] font-semibold text-primary truncate flex-1 tracking-tight">
+      <h2 class="text-xs-plus font-semibold text-primary truncate flex-1 tracking-tight">
         <slot name="title" />
       </h2>
 
@@ -66,7 +66,7 @@ withDefaults(defineProps<Props>(), {
       <router-link
         v-if="actionTo"
         :to="actionTo"
-        class="text-[11px] font-medium text-accent hover:underline whitespace-nowrap"
+        class="text-2xs font-medium text-accent hover:underline whitespace-nowrap"
       >
         {{ actionLabel }} →
       </router-link>

--- a/frontend/src/components/common/StatusPill.vue
+++ b/frontend/src/components/common/StatusPill.vue
@@ -45,7 +45,7 @@ const toneClasses = computed(() => {
 const sizeClasses = computed(() =>
   props.size === 'sm'
     ? 'text-xs px-2 py-0.5 gap-1.5'
-    : 'text-[10px] px-1.5 py-0.5 gap-1',
+    : 'text-3xs px-1.5 py-0.5 gap-1',
 )
 </script>
 

--- a/frontend/src/components/common/TicketDragPreview.vue
+++ b/frontend/src/components/common/TicketDragPreview.vue
@@ -99,7 +99,7 @@ const priorityLevel = computed((): 'low' | 'medium' | 'high' | undefined => {
               size="xs"
               class="mt-0.5 shrink-0"
             />
-            <h4 class="text-[13px] font-medium text-primary line-clamp-2 flex-1 min-w-0">
+            <h4 class="text-xs-plus font-medium text-primary line-clamp-2 flex-1 min-w-0">
               {{ ticket.title }}
             </h4>
             <PriorityIndicator
@@ -109,7 +109,7 @@ const priorityLevel = computed((): 'low' | 'medium' | 'high' | undefined => {
               class="shrink-0 mt-0.5"
             />
           </div>
-          <div class="flex items-center justify-between mt-1.5 text-[11px] text-tertiary">
+          <div class="flex items-center justify-between mt-1.5 text-2xs text-tertiary">
             <span class="font-mono">#{{ ticket.id }}</span>
             <UserAvatar
               v-if="ticket.assigneeUuid"
@@ -118,11 +118,11 @@ const priorityLevel = computed((): 'low' | 'medium' | 'high' | undefined => {
               :show-name="false"
               :clickable="false"
             />
-            <span v-else class="italic text-[10px]">{{ $t('filter-assignee-unassigned') }}</span>
+            <span v-else class="italic text-3xs">{{ $t('filter-assignee-unassigned') }}</span>
           </div>
           <div
             v-if="extraCount && extraCount > 0"
-            class="text-[10px] text-tertiary mt-1"
+            class="text-3xs text-tertiary mt-1"
           >
             + {{ extraCount }} more
           </div>

--- a/frontend/src/components/cycles/CycleBurnupChart.vue
+++ b/frontend/src/components/cycles/CycleBurnupChart.vue
@@ -372,7 +372,7 @@ const readoutLeft = computed(() => xPct(hoverX.value) <= 55)
         <!-- Text + marker overlay. Fixed-size type, dots that stay round,
              all positioned by percentage so they track the geometry at
              any width. Non-interactive so pointer events reach the frame. -->
-        <div class="pointer-events-none absolute inset-0 text-[10px] leading-none">
+        <div class="pointer-events-none absolute inset-0 text-3xs leading-none">
           <!-- Y ticks -->
           <span
             class="absolute -translate-y-1/2 text-tertiary tabular-nums"
@@ -394,7 +394,7 @@ const readoutLeft = computed(() => xPct(hoverX.value) <= 55)
           <!-- Today label -->
           <span
             v-if="hasFuture"
-            class="absolute -translate-x-1/2 text-[9px] uppercase tracking-wide text-tertiary"
+            class="absolute -translate-x-1/2 text-4xs uppercase tracking-wide text-tertiary"
             :style="{ left: `${xPct(todayX)}%`, top: '0' }"
             >{{ t('cycle-burnup-today') }}</span
           >
@@ -463,7 +463,7 @@ const readoutLeft = computed(() => xPct(hoverX.value) <= 55)
       </div>
 
       <!-- Scope-creep callout, promoted from fine print -->
-      <p v-if="scopeAdded > 0" class="text-[11px] text-tertiary">
+      <p v-if="scopeAdded > 0" class="text-2xs text-tertiary">
         {{ t('tickets-cycle-scope-added', { count: scopeAdded }) }}
       </p>
 

--- a/frontend/src/components/cycles/CycleCard.vue
+++ b/frontend/src/components/cycles/CycleCard.vue
@@ -115,7 +115,7 @@ const dateRange = computed(() => `${fmt(props.cycle.start_at)} → ${fmt(props.c
       <button
         v-if="cycle.state === 'planned'"
         type="button"
-        class="text-[11px] text-secondary hover:text-primary px-2 py-1 rounded hover:bg-surface-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+        class="text-2xs text-secondary hover:text-primary px-2 py-1 rounded hover:bg-surface-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
         @click="emit('promote')"
       >
         {{ t('project-cycles-action-promote') }}
@@ -123,7 +123,7 @@ const dateRange = computed(() => `${fmt(props.cycle.start_at)} → ${fmt(props.c
       <button
         v-if="cycle.state === 'active'"
         type="button"
-        class="text-[11px] text-secondary hover:text-primary px-2 py-1 rounded hover:bg-surface-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+        class="text-2xs text-secondary hover:text-primary px-2 py-1 rounded hover:bg-surface-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
         @click="emit('complete')"
       >
         {{ t('project-cycles-action-complete') }}
@@ -131,7 +131,7 @@ const dateRange = computed(() => `${fmt(props.cycle.start_at)} → ${fmt(props.c
       <button
         v-if="cycle.state !== 'completed'"
         type="button"
-        class="text-[11px] text-tertiary hover:text-status-error px-2 py-1 rounded hover:bg-surface-hover ml-auto focus:outline-none focus-visible:ring-2 focus-visible:ring-status-error"
+        class="text-2xs text-tertiary hover:text-status-error px-2 py-1 rounded hover:bg-surface-hover ml-auto focus:outline-none focus-visible:ring-2 focus-visible:ring-status-error"
         @click="emit('archive')"
       >
         {{ t('project-cycles-action-archive') }}

--- a/frontend/src/components/cycles/CycleHero.vue
+++ b/frontend/src/components/cycles/CycleHero.vue
@@ -148,14 +148,14 @@ function categoryPct(count: number): number {
             class="text-sm font-semibold text-primary truncate"
             :class="to ? 'transition-colors group-hover:text-accent' : ''"
           >{{ cycle.name }}</h3>
-          <p v-if="dateRange" class="text-[11px] text-tertiary tabular-nums mt-0.5">
+          <p v-if="dateRange" class="text-2xs text-tertiary tabular-nums mt-0.5">
             {{ dateRange }}
           </p>
         </div>
         <div class="flex items-center gap-1.5 shrink-0">
           <span
             v-if="isFrozen"
-            class="text-[11px] uppercase tracking-wide font-semibold text-tertiary"
+            class="text-2xs uppercase tracking-wide font-semibold text-tertiary"
           >{{ t('tickets-cycle-burndown-frozen') }}</span>
           <StatusPill v-else-if="health" :tone="health.tone" :label="health.label" />
           <Icon
@@ -173,15 +173,15 @@ function categoryPct(count: number): number {
           <div class="text-2xl font-semibold text-primary tabular-nums">
             {{ stats.completed }}<span class="text-tertiary">/{{ stats.total }}</span>
           </div>
-          <div class="text-[11px] uppercase tracking-wide text-tertiary">{{ t('tickets-cycle-burndown-tickets-done') }}</div>
+          <div class="text-2xs uppercase tracking-wide text-tertiary">{{ t('tickets-cycle-burndown-tickets-done') }}</div>
         </div>
         <div>
           <div class="text-2xl font-semibold text-primary tabular-nums">{{ completionPct }}%</div>
-          <div class="text-[11px] uppercase tracking-wide text-tertiary">{{ t('tickets-cycle-burndown-complete') }}</div>
+          <div class="text-2xs uppercase tracking-wide text-tertiary">{{ t('tickets-cycle-burndown-complete') }}</div>
         </div>
         <div v-if="daysRemaining != null">
           <div class="text-2xl font-semibold text-primary tabular-nums">{{ daysRemaining }}</div>
-          <div class="text-[11px] uppercase tracking-wide text-tertiary">
+          <div class="text-2xs uppercase tracking-wide text-tertiary">
             {{ t('tickets-cycle-burndown-days-remaining', { count: daysRemaining }) }}
           </div>
         </div>
@@ -243,7 +243,7 @@ function categoryPct(count: number): number {
       </div>
 
       <!-- Frozen-snapshot timestamp -->
-      <p v-if="variant === 'full' && isFrozen && stats.frozen_at" class="text-[11px] text-tertiary italic">
+      <p v-if="variant === 'full' && isFrozen && stats.frozen_at" class="text-2xs text-tertiary italic">
         {{ t('tickets-cycle-burndown-snapshot-frozen', { date: formatDateTime(stats.frozen_at) }) }}
       </p>
     </div>

--- a/frontend/src/components/cycles/CycleListRow.vue
+++ b/frontend/src/components/cycles/CycleListRow.vue
@@ -109,18 +109,18 @@ const stateTone = computed<StatusPillTone>(() =>
       <button
         v-if="cycle.state === 'planned'"
         type="button"
-        class="text-[11px] text-secondary hover:text-primary px-2 py-1 rounded hover:bg-surface-alt focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+        class="text-2xs text-secondary hover:text-primary px-2 py-1 rounded hover:bg-surface-alt focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
         @click="emit('promote')"
       >{{ t('project-cycles-action-promote') }}</button>
       <button
         v-if="cycle.state === 'active'"
         type="button"
-        class="text-[11px] text-secondary hover:text-primary px-2 py-1 rounded hover:bg-surface-alt focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+        class="text-2xs text-secondary hover:text-primary px-2 py-1 rounded hover:bg-surface-alt focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
         @click="emit('complete')"
       >{{ t('project-cycles-action-complete') }}</button>
       <button
         type="button"
-        class="text-[11px] text-tertiary hover:text-status-error px-2 py-1 rounded hover:bg-surface-alt focus:outline-none focus-visible:ring-2 focus-visible:ring-status-error"
+        class="text-2xs text-tertiary hover:text-status-error px-2 py-1 rounded hover:bg-surface-alt focus:outline-none focus-visible:ring-2 focus-visible:ring-status-error"
         @click="emit('archive')"
       >{{ t('project-cycles-action-archive') }}</button>
     </div>

--- a/frontend/src/components/documentationComponents/CollectionBrowser.vue
+++ b/frontend/src/components/documentationComponents/CollectionBrowser.vue
@@ -169,15 +169,15 @@ onMounted(loadCollections)
        width, so the ledger degrades gracefully in a narrow main column. -->
   <section class="@container bg-surface rounded-xl border border-default overflow-hidden">
     <header class="flex items-center gap-2 px-3 h-9 border-b border-default bg-surface-alt">
-      <h2 class="text-[13px] font-semibold text-primary tracking-tight truncate flex-1">
+      <h2 class="text-xs-plus font-semibold text-primary tracking-tight truncate flex-1">
         {{ $t('docs-index-library-heading') }}
       </h2>
-      <span v-if="collections.length > 0" class="text-[11px] text-tertiary tabular-nums">
+      <span v-if="collections.length > 0" class="text-2xs text-tertiary tabular-nums">
         {{ $t('docs-index-library-count', { count: collections.length }) }}
       </span>
       <button
         type="button"
-        class="text-[11px] font-medium text-accent hover:underline whitespace-nowrap"
+        class="text-2xs font-medium text-accent hover:underline whitespace-nowrap"
         @click="emit('create')"
       >
         {{ $t('docs-collection-browser-new') }}
@@ -232,7 +232,7 @@ onMounted(loadCollections)
             </RouterLink>
             <span
               v-if="!collection.is_public"
-              class="shrink-0 inline-flex items-center gap-1 self-center text-[11px] text-tertiary border border-subtle rounded-md px-1.5 py-px bg-surface-alt"
+              class="shrink-0 inline-flex items-center gap-1 self-center text-2xs text-tertiary border border-subtle rounded-md px-1.5 py-px bg-surface-alt"
             >
               <Icon name="lock" size="xs" class="text-status-warning/80" aria-hidden="true" />
               {{ audienceLabel(collection) }}
@@ -276,7 +276,7 @@ onMounted(loadCollections)
           </div>
         </div>
 
-        <div class="flex flex-col items-end gap-1 shrink-0 text-[11px] text-tertiary whitespace-nowrap">
+        <div class="flex flex-col items-end gap-1 shrink-0 text-2xs text-tertiary whitespace-nowrap">
           <span class="font-medium text-secondary tabular-nums">
             {{ $t('docs-collection-browser-pages', { count: collection.page_count }) }}
           </span>
@@ -287,7 +287,7 @@ onMounted(loadCollections)
       </li>
     </ul>
 
-    <p v-else class="text-[13px] text-tertiary px-4 py-3">
+    <p v-else class="text-xs-plus text-tertiary px-4 py-3">
       {{ $t('docs-collection-browser-empty') }}
     </p>
   </section>

--- a/frontend/src/components/documentationComponents/CollectionManager.vue
+++ b/frontend/src/components/documentationComponents/CollectionManager.vue
@@ -102,7 +102,7 @@ onMounted(async () => {
         </div>
 
         <!-- System/Restricted badge -->
-        <span v-if="collection.is_system" class="text-[10px] px-1.5 py-0.5 rounded bg-surface-hover text-tertiary flex-shrink-0">
+        <span v-if="collection.is_system" class="text-3xs px-1.5 py-0.5 rounded bg-surface-hover text-tertiary flex-shrink-0">
           {{ $t('docs-collection-manager-system-badge') }}
         </span>
       </button>

--- a/frontend/src/components/documentationComponents/CollectionModal.vue
+++ b/frontend/src/components/documentationComponents/CollectionModal.vue
@@ -415,12 +415,12 @@ function handleSubmit() {
       <!-- Access -->
       <div class="flex flex-col gap-2 pt-1 border-t border-subtle">
         <div class="flex items-center justify-between gap-2 min-h-5">
-          <span class="text-[10px] font-semibold uppercase tracking-wide text-tertiary">
+          <span class="text-3xs font-semibold uppercase tracking-wide text-tertiary">
             {{ $t('docs-create-collection-access-heading') }}
           </span>
           <span
             v-if="isPublic"
-            class="text-[11px] text-status-success shrink-0"
+            class="text-2xs text-status-success shrink-0"
           >
             {{ $t('collection-badge-public') }}
           </span>
@@ -449,7 +449,7 @@ function handleSubmit() {
           >
             {{ $t('docs-edit-collection-hide-titles-label') }}
           </label>
-          <p class="text-[11px] leading-snug text-tertiary">
+          <p class="text-2xs leading-snug text-tertiary">
             {{ $t('docs-edit-collection-hide-titles-help') }}
           </p>
         </div>
@@ -472,7 +472,7 @@ function handleSubmit() {
           >
             {{ $t('docs-edit-collection-require-verification-label') }}
           </label>
-          <p class="text-[11px] leading-snug text-tertiary">
+          <p class="text-2xs leading-snug text-tertiary">
             {{ $t('docs-edit-collection-require-verification-help') }}
           </p>
         </div>

--- a/frontend/src/components/documentationComponents/CollectionTreeItem.vue
+++ b/frontend/src/components/documentationComponents/CollectionTreeItem.vue
@@ -55,7 +55,7 @@ const hasOverride = computed(() => props.overridePageIds?.has(props.node.id) ?? 
       <!-- Child count badge (on hover) -->
       <span
         v-if="hasChildren"
-        class="flex-shrink-0 text-[10px] text-tertiary ml-1.5 tabular-nums opacity-0 group-hover:opacity-100 transition-opacity"
+        class="flex-shrink-0 text-3xs text-tertiary ml-1.5 tabular-nums opacity-0 group-hover:opacity-100 transition-opacity"
       >
         {{ node.children.length }}
       </span>
@@ -63,7 +63,7 @@ const hasOverride = computed(() => props.overridePageIds?.has(props.node.id) ?? 
       <!-- Draft badge -->
       <span
         v-if="node.status === 'draft'"
-        class="flex-shrink-0 text-[9px] px-1.5 py-0.5 rounded-full bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300 font-medium ml-1.5"
+        class="flex-shrink-0 text-4xs px-1.5 py-0.5 rounded-full bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300 font-medium ml-1.5"
       >
         {{ $t('docs-collection-tree-item-draft') }}
       </span>

--- a/frontend/src/components/documentationComponents/DocumentAuthorBadge.vue
+++ b/frontend/src/components/documentationComponents/DocumentAuthorBadge.vue
@@ -159,19 +159,19 @@ async function unverify() {
         <span class="text-tertiary">{{ $t('docs-author-badge-verification') }}</span>
         <span
           v-if="state === 'fresh'"
-          class="inline-flex items-center gap-1 text-[10px] font-medium uppercase tracking-wide text-emerald-700 dark:text-emerald-400"
+          class="inline-flex items-center gap-1 text-3xs font-medium uppercase tracking-wide text-emerald-700 dark:text-emerald-400"
         >
           <Icon name="check" size="xs" />
           {{ $t('docs-author-badge-state-verified') }}
         </span>
         <span
           v-else-if="state === 'stale'"
-          class="inline-flex items-center gap-1 text-[10px] font-medium uppercase tracking-wide text-amber-700 dark:text-amber-400"
+          class="inline-flex items-center gap-1 text-3xs font-medium uppercase tracking-wide text-amber-700 dark:text-amber-400"
         >
           <Icon name="warning" size="xs" />
           {{ $t('docs-author-badge-state-stale') }}
         </span>
-        <span v-else class="text-[10px] uppercase tracking-wide text-tertiary">
+        <span v-else class="text-3xs uppercase tracking-wide text-tertiary">
           {{ $t('docs-author-badge-state-never') }}
         </span>
       </div>

--- a/frontend/src/components/documentationComponents/DocumentationHubRow.vue
+++ b/frontend/src/components/documentationComponents/DocumentationHubRow.vue
@@ -62,7 +62,7 @@ const fullTime = computed(() =>
     >
       {{ glyph || '📄' }}
     </span>
-    <span class="truncate min-w-0 flex-1 text-[13px] leading-snug text-primary group-hover:text-accent transition-colors">
+    <span class="truncate min-w-0 flex-1 text-xs-plus leading-snug text-primary group-hover:text-accent transition-colors">
       {{ label }}
     </span>
 
@@ -84,19 +84,19 @@ const fullTime = computed(() =>
         <span class="sr-only" :class="{ 'sm:hidden': !compact }">{{ author.name }}</span>
         <span
           v-if="!compact"
-          class="hidden sm:inline truncate max-w-[8rem] text-[11px] leading-none text-tertiary"
+          class="hidden sm:inline truncate max-w-[8rem] text-2xs leading-none text-tertiary"
         >
           {{ author.name }}
         </span>
       </template>
       <span
         v-if="!compact && author?.name && fullTime"
-        class="hidden sm:inline text-[11px] text-tertiary/60 shrink-0"
+        class="hidden sm:inline text-2xs text-tertiary/60 shrink-0"
         aria-hidden="true"
       >·</span>
       <span
         v-if="compactTime"
-        class="text-[11px] leading-none text-tertiary whitespace-nowrap tabular-nums shrink-0"
+        class="text-2xs leading-none text-tertiary whitespace-nowrap tabular-nums shrink-0"
         :class="{ 'sm:hidden': !compact }"
         :title="fullTime"
       >
@@ -104,7 +104,7 @@ const fullTime = computed(() =>
       </span>
       <span
         v-if="!compact && fullTime"
-        class="hidden sm:inline text-[11px] leading-none text-tertiary whitespace-nowrap tabular-nums shrink-0"
+        class="hidden sm:inline text-2xs leading-none text-tertiary whitespace-nowrap tabular-nums shrink-0"
       >
         {{ fullTime }}
       </span>
@@ -113,7 +113,7 @@ const fullTime = computed(() =>
     <!-- Plain meta string -->
     <span
       v-else-if="meta"
-      class="shrink-0 text-[11px] leading-none text-tertiary whitespace-nowrap tabular-nums"
+      class="shrink-0 text-2xs leading-none text-tertiary whitespace-nowrap tabular-nums"
     >
       {{ meta }}
     </span>

--- a/frontend/src/components/documentationComponents/DocumentationIndexToolbar.vue
+++ b/frontend/src/components/documentationComponents/DocumentationIndexToolbar.vue
@@ -199,8 +199,8 @@ onMounted(() => {
         @click="openDocSearch"
       >
         <Icon name="search" size="sm" aria-hidden="true" />
-        <span class="text-[13px] truncate flex-1 text-left">{{ $t('docs-index-toolbar-search-placeholder') }}</span>
-        <kbd class="hidden sm:inline-flex items-center text-[11px] px-1.5 py-px rounded border border-default bg-surface text-tertiary">⌘K</kbd>
+        <span class="text-xs-plus truncate flex-1 text-left">{{ $t('docs-index-toolbar-search-placeholder') }}</span>
+        <kbd class="hidden sm:inline-flex items-center text-2xs px-1.5 py-px rounded border border-default bg-surface text-tertiary">⌘K</kbd>
       </button>
 
       <Button

--- a/frontend/src/components/documentationComponents/DocumentationNav.vue
+++ b/frontend/src/components/documentationComponents/DocumentationNav.vue
@@ -1246,7 +1246,7 @@ defineExpose({ reloadSidebar });
           <Icon name="star" />
         </span>
         <span class="flex-1 truncate min-w-0 ml-1 font-medium">{{ $t('docs-nav-starred') }}</span>
-        <span class="flex-shrink-0 text-[10px] text-tertiary ml-1">{{ starredPages.length }}</span>
+        <span class="flex-shrink-0 text-3xs text-tertiary ml-1">{{ starredPages.length }}</span>
       </div>
 
       <!-- Starred Pages List (collapsible) -->

--- a/frontend/src/components/documentationComponents/DocumentationNavItem.vue
+++ b/frontend/src/components/documentationComponents/DocumentationNavItem.vue
@@ -206,7 +206,7 @@ const handleDrop = (event: DragEvent) => {
 
       <!-- Page Title -->
       <span class="flex-1 truncate min-w-0 ml-1">{{ page.title }}</span>
-      <span v-if="page.status === 'draft'" class="text-[9px] px-1 py-0.5 rounded bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300 flex-shrink-0 ml-1">{{ $t('docs-nav-item-draft') }}</span>
+      <span v-if="page.status === 'draft'" class="text-4xs px-1 py-0.5 rounded bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300 flex-shrink-0 ml-1">{{ $t('docs-nav-item-draft') }}</span>
 
       <!-- Hover affordances: same primitive collections use, so
            the row vocabulary stays consistent. The decorative

--- a/frontend/src/components/documentationComponents/MoveDocumentModal.vue
+++ b/frontend/src/components/documentationComponents/MoveDocumentModal.vue
@@ -154,7 +154,7 @@ onMounted(async () => {
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />
             </svg>
             <span class="flex-1">{{ $t('docs-move-root-label') }}</span>
-            <span v-if="isCurrentLocation(null)" class="text-[10px] px-1.5 py-0.5 rounded bg-surface-alt text-tertiary">{{ $t('docs-move-current-badge') }}</span>
+            <span v-if="isCurrentLocation(null)" class="text-3xs px-1.5 py-0.5 rounded bg-surface-alt text-tertiary">{{ $t('docs-move-current-badge') }}</span>
           </button>
 
           <!-- Pages -->
@@ -176,7 +176,7 @@ onMounted(async () => {
           >
             <span class="text-sm flex-shrink-0">{{ fp.icon || '📄' }}</span>
             <span class="flex-1 truncate">{{ fp.title }}</span>
-            <span v-if="isCurrentLocation(fp.id)" class="text-[10px] px-1.5 py-0.5 rounded bg-surface-alt text-tertiary flex-shrink-0">{{ $t('docs-move-current-badge') }}</span>
+            <span v-if="isCurrentLocation(fp.id)" class="text-3xs px-1.5 py-0.5 rounded bg-surface-alt text-tertiary flex-shrink-0">{{ $t('docs-move-current-badge') }}</span>
           </button>
 
           <!-- Empty state -->

--- a/frontend/src/components/documentationComponents/PageTicketLinksPanel.vue
+++ b/frontend/src/components/documentationComponents/PageTicketLinksPanel.vue
@@ -102,7 +102,7 @@ function categoryLabel(category: WorkflowStateCategory | null | undefined): stri
         <h3 class="text-xs font-semibold uppercase tracking-wide text-tertiary">
           {{ $t('docs-page-tickets-heading') }}
         </h3>
-        <span v-if="hasAny" class="text-[11px] text-tertiary">
+        <span v-if="hasAny" class="text-2xs text-tertiary">
           {{ links.length }}
         </span>
       </div>
@@ -127,7 +127,7 @@ function categoryLabel(category: WorkflowStateCategory | null | undefined): stri
     <template v-else>
       <!-- Resolved group: tickets this doc answered. -->
       <div v-if="grouped.resolves.length > 0" class="flex flex-col gap-1">
-        <p class="text-[10px] uppercase tracking-wide text-tertiary mt-1">
+        <p class="text-3xs uppercase tracking-wide text-tertiary mt-1">
           {{ $t('docs-page-tickets-resolved-heading') }}
         </p>
         <ul class="flex flex-col gap-0.5">
@@ -140,7 +140,7 @@ function categoryLabel(category: WorkflowStateCategory | null | undefined): stri
               <span class="flex-1 truncate">{{ link.ticket_title || $t('docs-page-tickets-fallback-title', { id: link.ticket_id }) }}</span>
               <span
                 v-if="link.ticket_category"
-                class="text-[10px] px-1.5 py-0.5 rounded-full"
+                class="text-3xs px-1.5 py-0.5 rounded-full"
                 :class="categoryClass(link.ticket_category)"
               >
                 {{ categoryLabel(link.ticket_category) }}
@@ -161,7 +161,7 @@ function categoryLabel(category: WorkflowStateCategory | null | undefined): stri
 
       <!-- References group: tickets that just point at this doc. -->
       <div v-if="grouped.references.length > 0" class="flex flex-col gap-1">
-        <p class="text-[10px] uppercase tracking-wide text-tertiary mt-1">
+        <p class="text-3xs uppercase tracking-wide text-tertiary mt-1">
           {{ $t('docs-page-tickets-referenced-heading') }}
         </p>
         <ul class="flex flex-col gap-0.5">
@@ -174,7 +174,7 @@ function categoryLabel(category: WorkflowStateCategory | null | undefined): stri
               <span class="flex-1 truncate">{{ link.ticket_title || $t('docs-page-tickets-fallback-title', { id: link.ticket_id }) }}</span>
               <span
                 v-if="link.ticket_category"
-                class="text-[10px] px-1.5 py-0.5 rounded-full"
+                class="text-3xs px-1.5 py-0.5 rounded-full"
                 :class="categoryClass(link.ticket_category)"
               >
                 {{ categoryLabel(link.ticket_category) }}

--- a/frontend/src/components/projectComponents/ProjectViewHeader.vue
+++ b/frontend/src/components/projectComponents/ProjectViewHeader.vue
@@ -110,7 +110,7 @@ async function confirmDelete(): Promise<void> {
          site header (PageHeader), inline-editable there. -->
     <div v-if="project" class="flex items-center gap-2 min-w-0">
       <span
-        class="shrink-0 text-[10px] uppercase tracking-wide font-semibold rounded px-1.5 py-0.5 bg-surface-hover text-tertiary leading-none"
+        class="shrink-0 text-3xs uppercase tracking-wide font-semibold rounded px-1.5 py-0.5 bg-surface-hover text-tertiary leading-none"
       >{{ $t(`project-actions-status-${project.status}`) }}</span>
       <span
         v-if="subtitle"

--- a/frontend/src/components/settings/UserDevicesCard.vue
+++ b/frontend/src/components/settings/UserDevicesCard.vue
@@ -35,7 +35,7 @@ defineProps<{
             <p class="text-sm text-primary truncate group-hover:text-accent transition-colors">
               {{ d.name }}
             </p>
-            <p class="mt-0.5 text-[11px] text-tertiary truncate">
+            <p class="mt-0.5 text-2xs text-tertiary truncate">
               {{ [d.manufacturer, d.model].filter(Boolean).join(' ') || $t('user-profile-asset-manufacturer-unknown') }}<template v-if="d.asset_tag && d.asset_tag !== d.name"> &middot; {{ d.asset_tag }}</template>
             </p>
           </div>

--- a/frontend/src/components/settings/UserEmailsCard.vue
+++ b/frontend/src/components/settings/UserEmailsCard.vue
@@ -206,7 +206,7 @@ watch(() => props.userUuid, () => {
               class="flex-shrink-0"
             />
           </div>
-          <div class="mt-0.5 text-[11px] text-tertiary truncate">
+          <div class="mt-0.5 text-2xs text-tertiary truncate">
             <span class="capitalize">{{ email.email_type || $t('settings-emails-type-personal') }}</span>
             <template v-if="email.source"> &middot; <span class="capitalize">{{ email.source }}</span></template>
           </div>

--- a/frontend/src/components/sla/SlaExplainPopover.vue
+++ b/frontend/src/components/sla/SlaExplainPopover.vue
@@ -129,7 +129,7 @@ const anchorDescriptor = computed(() => ({
     @close="emit('close')"
   >
     <header class="flex items-center justify-between">
-      <h3 class="text-[11px] uppercase tracking-wider font-semibold text-tertiary">
+      <h3 class="text-2xs uppercase tracking-wider font-semibold text-tertiary">
         {{ t('sla-explain-title') }}
       </h3>
     </header>
@@ -153,7 +153,7 @@ const anchorDescriptor = computed(() => ({
             <span class="font-semibold text-primary truncate">{{ explain.policy.name }}</span>
             <span
               v-if="explain.policy.is_default"
-              class="text-[10px] uppercase tracking-wide font-semibold text-tertiary"
+              class="text-3xs uppercase tracking-wide font-semibold text-tertiary"
             >
               {{ t('sla-explain-default-badge') }}
             </span>
@@ -170,7 +170,7 @@ const anchorDescriptor = computed(() => ({
         </div>
 
         <div v-if="explain.policy.calendar" class="flex flex-col gap-0.5">
-          <span class="text-[10px] uppercase tracking-wider font-semibold text-tertiary">
+          <span class="text-3xs uppercase tracking-wider font-semibold text-tertiary">
             {{ t('sla-explain-calendar-label') }}
           </span>
           <span class="text-secondary">
@@ -180,7 +180,7 @@ const anchorDescriptor = computed(() => ({
         </div>
 
         <div class="flex flex-col gap-0.5">
-          <span class="text-[10px] uppercase tracking-wider font-semibold text-tertiary">
+          <span class="text-3xs uppercase tracking-wider font-semibold text-tertiary">
             {{ t('sla-explain-targets-label') }}
           </span>
           <span class="text-secondary tabular-nums">
@@ -195,7 +195,7 @@ const anchorDescriptor = computed(() => ({
       </template>
 
       <div class="flex flex-col gap-0.5 pt-2 border-t border-subtle">
-        <span class="text-[10px] uppercase tracking-wider font-semibold text-tertiary">
+        <span class="text-3xs uppercase tracking-wider font-semibold text-tertiary">
           {{ t('sla-explain-state-label') }}
         </span>
         <span class="text-secondary">

--- a/frontend/src/components/ticketComponents/AttachmentPreview.vue
+++ b/frontend/src/components/ticketComponents/AttachmentPreview.vue
@@ -390,7 +390,7 @@ const generatePdfThumbnail = async () => {
     />
     <div v-else class="w-full h-full flex flex-col items-center justify-center gap-1 p-1 text-center">
       <Icon :name="attachmentType === 'pdf' ? 'book' : attachmentType === 'video' ? 'eye' : 'paperclip'" class="w-5 h-5 text-tertiary" />
-      <span class="text-[10px] text-tertiary leading-tight line-clamp-2 break-all">{{ getDisplayName(attachment.name) }}</span>
+      <span class="text-3xs text-tertiary leading-tight line-clamp-2 break-all">{{ getDisplayName(attachment.name) }}</span>
     </div>
     <div v-if="isPending" class="absolute inset-0 z-20 flex items-center justify-center bg-surface/40 pointer-events-none">
       <Spinner />

--- a/frontend/src/components/ticketComponents/CommentContent.vue
+++ b/frontend/src/components/ticketComponents/CommentContent.vue
@@ -90,7 +90,7 @@ so a printed ticket carries the full archival record, not the summary.
       :href="rawSourceUrl"
       target="_blank"
       rel="noopener noreferrer"
-      class="self-start text-[11px] text-tertiary hover:text-secondary underline-offset-2 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-status-info rounded"
+      class="self-start text-2xs text-tertiary hover:text-secondary underline-offset-2 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-status-info rounded"
       :title="$t('ticket-comments-show-original-title')"
     >
       {{ $t('ticket-comments-show-original') }}

--- a/frontend/src/components/ticketComponents/CommentsAndAttachments.vue
+++ b/frontend/src/components/ticketComponents/CommentsAndAttachments.vue
@@ -804,14 +804,14 @@ const handlePastedFiles = async (files: File[]) => {
                                         </span>
                                         <span
                                             v-if="comment.is_internal"
-                                            class="inline-flex items-center gap-1 px-1 py-0.5 rounded text-[11px] font-medium bg-status-warning-muted text-status-warning flex-shrink-0"
+                                            class="inline-flex items-center gap-1 px-1 py-0.5 rounded text-2xs font-medium bg-status-warning-muted text-status-warning flex-shrink-0"
                                         >
                                             <Icon name="lock" class="w-3 h-3" />
                                             {{ $t('ticket-comments-badge-internal') }}
                                         </span>
                                         <span
                                             v-if="comment.channel_metadata?.forwarded_by_user_uuid"
-                                            class="inline-flex items-center px-1 py-0.5 rounded text-[10px] font-semibold uppercase tracking-wide bg-accent-muted text-accent flex-shrink-0"
+                                            class="inline-flex items-center px-1 py-0.5 rounded text-3xs font-semibold uppercase tracking-wide bg-accent-muted text-accent flex-shrink-0"
                                             :title="$t('ticket-comments-badge-forwarded-title')"
                                         >
                                             {{ $t('ticket-comments-badge-forwarded') }}
@@ -913,7 +913,7 @@ const handlePastedFiles = async (files: File[]) => {
                                             </span>
                                             <span
                                                 v-if="comment.is_internal"
-                                                class="inline-flex items-center gap-1 px-1 py-0.5 rounded text-[11px] font-medium bg-status-warning-muted text-status-warning flex-shrink-0"
+                                                class="inline-flex items-center gap-1 px-1 py-0.5 rounded text-2xs font-medium bg-status-warning-muted text-status-warning flex-shrink-0"
                                             >
                                                 <Icon name="lock" class="w-3 h-3" />
                                                 {{ $t('ticket-comments-badge-internal') }}
@@ -974,7 +974,7 @@ const handlePastedFiles = async (files: File[]) => {
                                              defeats the point of showing it. -->
                                         <span
                                             v-if="comment.channel_metadata?.forwarded_by_user_uuid"
-                                            class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-semibold uppercase tracking-wide bg-accent-muted text-accent flex-shrink-0"
+                                            class="inline-flex items-center px-1.5 py-0.5 rounded text-3xs font-semibold uppercase tracking-wide bg-accent-muted text-accent flex-shrink-0"
                                             :title="$t('ticket-comments-badge-forwarded-title')"
                                         >
                                             {{ $t('ticket-comments-badge-forwarded') }}

--- a/frontend/src/components/ticketComponents/CustomDropdown.vue
+++ b/frontend/src/components/ticketComponents/CustomDropdown.vue
@@ -140,7 +140,7 @@ const glyphSize = computed(() => (props.compact ? 12 : 14))
         <span
           class="truncate"
           :class="[
-            compact ? 'text-[11px] leading-tight' : 'text-sm',
+            compact ? 'text-2xs leading-tight' : 'text-sm',
             isEmptySelection ? 'text-tertiary' : compact && type === 'priority' ? 'font-medium' : 'text-primary font-medium',
           ]"
         >{{ selectedOption?.label || placeholder || $t('ticket-chip-dropdown-select') }}</span>
@@ -183,7 +183,7 @@ const glyphSize = computed(() => (props.compact ? 12 : 14))
         <template v-for="option in options" :key="option.value">
           <div
             v-if="option.disabled"
-            class="px-3 pt-2 pb-1 text-[10px] uppercase tracking-wide text-tertiary font-semibold select-none"
+            class="px-3 pt-2 pb-1 text-3xs uppercase tracking-wide text-tertiary font-semibold select-none"
           >
             {{ option.label }}
           </div>

--- a/frontend/src/components/ticketComponents/EmailHtmlBody.vue
+++ b/frontend/src/components/ticketComponents/EmailHtmlBody.vue
@@ -58,7 +58,7 @@ render is more useful than a fitting one.
       >
         {{ expanded ? t('tickets-email-html-show-less') : t('tickets-email-html-show-full') }}
       </button>
-      <span v-if="hasOverflowed && !expanded" class="text-[11px] text-tertiary">
+      <span v-if="hasOverflowed && !expanded" class="text-2xs text-tertiary">
         {{ t('tickets-email-html-scaled', { pct: Math.round(activeScale * 100) }) }}
       </span>
     </div>

--- a/frontend/src/components/ticketComponents/MergedInField.vue
+++ b/frontend/src/components/ticketComponents/MergedInField.vue
@@ -33,7 +33,7 @@ const sourceIds = computed<number[]>(() => {
         v-for="id in sourceIds"
         :key="id"
         :to="`/tickets/${id}`"
-        class="inline-flex items-center px-2 py-0.5 rounded text-[11px] font-medium border border-subtle bg-surface-alt text-secondary hover:text-primary hover:border-default transition-colors"
+        class="inline-flex items-center px-2 py-0.5 rounded text-2xs font-medium border border-subtle bg-surface-alt text-secondary hover:text-primary hover:border-default transition-colors"
       >
         #{{ id }}
       </RouterLink>

--- a/frontend/src/components/ticketComponents/PropertyChip.vue
+++ b/frontend/src/components/ticketComponents/PropertyChip.vue
@@ -38,7 +38,7 @@ const removeAriaLabel = computed(() => props.removeTitle || t('ticket-chip-remov
     :is="to ? RouterLink : 'span'"
     :to="to"
     :title="title || label"
-    class="print-chip inline-flex items-center gap-1 pl-2 pr-1 py-0.5 rounded text-[11px] font-medium bg-surface-alt text-secondary hover:text-primary hover:bg-surface-hover transition-colors max-w-full"
+    class="print-chip inline-flex items-center gap-1 pl-2 pr-1 py-0.5 rounded text-2xs font-medium bg-surface-alt text-secondary hover:text-primary hover:bg-surface-hover transition-colors max-w-full"
     :class="{ 'opacity-60': loading }"
   >
     <slot name="leading" />

--- a/frontend/src/components/ticketComponents/TicketActivity.vue
+++ b/frontend/src/components/ticketComponents/TicketActivity.vue
@@ -603,7 +603,7 @@ const hiddenRowCount = computed(() =>
             />
             <span
               v-else
-              class="inline-flex items-center justify-center w-5 h-5 rounded-full bg-surface-alt text-tertiary text-[9px] mt-0.5 shrink-0"
+              class="inline-flex items-center justify-center w-5 h-5 rounded-full bg-surface-alt text-tertiary text-4xs mt-0.5 shrink-0"
               :title="actorFor(item.events[0]).title ?? undefined"
             >sys</span>
 
@@ -666,19 +666,19 @@ const hiddenRowCount = computed(() =>
           </template>
           <span
             v-else-if="actorFor(item.events[0]).kind === 'email'"
-            class="inline-flex items-center justify-center w-5 h-5 rounded-full bg-status-info-bg text-status-info-border text-[10px] mt-0.5 shrink-0"
+            class="inline-flex items-center justify-center w-5 h-5 rounded-full bg-status-info-bg text-status-info-border text-3xs mt-0.5 shrink-0"
             :title="actorFor(item.events[0]).title ?? undefined"
             :aria-label="t('ticket-activity-actor-email-aria')"
           >@</span>
           <span
             v-else-if="actorFor(item.events[0]).kind === 'portal'"
-            class="inline-flex items-center justify-center w-5 h-5 rounded-full bg-surface-alt text-tertiary text-[9px] mt-0.5 shrink-0"
+            class="inline-flex items-center justify-center w-5 h-5 rounded-full bg-surface-alt text-tertiary text-4xs mt-0.5 shrink-0"
             :title="actorFor(item.events[0]).title ?? undefined"
             :aria-label="t('ticket-activity-actor-portal-aria')"
           >www</span>
           <span
             v-else
-            class="inline-flex items-center justify-center w-5 h-5 rounded-full bg-surface-alt text-tertiary text-[9px] mt-0.5 shrink-0"
+            class="inline-flex items-center justify-center w-5 h-5 rounded-full bg-surface-alt text-tertiary text-4xs mt-0.5 shrink-0"
             :title="actorFor(item.events[0]).title ?? undefined"
           >sys</span>
 

--- a/frontend/src/components/ticketComponents/TicketDetails.vue
+++ b/frontend/src/components/ticketComponents/TicketDetails.vue
@@ -978,7 +978,7 @@ watchEffect(async () => {
                     v-if="canSelfAssign && !selectedAssignee"
                     @click="toggleSelfAssign"
                     type="button"
-                    class="text-[11px] font-medium px-2 h-6 rounded text-accent hover:bg-accent-muted transition-colors"
+                    class="text-2xs font-medium px-2 h-6 rounded text-accent hover:bg-accent-muted transition-colors"
                     :title="t('ticket-detail-claim-title')"
                   >
                     {{ t('ticket-detail-claim') }}
@@ -1065,7 +1065,7 @@ watchEffect(async () => {
               <!-- Remove SLA for this ticket (revealed on row hover). -->
               <button
                 type="button"
-                class="text-[11px] text-tertiary hover:text-status-error transition-colors opacity-0 group-hover:opacity-100 focus-visible:opacity-100"
+                class="text-2xs text-tertiary hover:text-status-error transition-colors opacity-0 group-hover:opacity-100 focus-visible:opacity-100"
                 :title="t('ticket-detail-sla-remove-title')"
                 @click="emit('update:slaOverride', 'none')"
               >
@@ -1113,7 +1113,7 @@ watchEffect(async () => {
               <span class="text-tertiary italic">{{ t('ticket-detail-sla-removed') }}</span>
               <button
                 type="button"
-                class="text-[11px] text-tertiary hover:text-accent transition-colors"
+                class="text-2xs text-tertiary hover:text-accent transition-colors"
                 @click="emit('update:slaOverride', 'auto')"
               >
                 {{ t('ticket-detail-sla-restore') }}
@@ -1264,7 +1264,7 @@ watchEffect(async () => {
             <span class="text-tertiary font-medium">{{ t('ticket-detail-cycle-label') }}</span>
             <button
               type="button"
-              class="inline-flex items-center gap-1.5 px-2 py-0.5 rounded text-[11px] font-medium bg-accent-muted text-accent hover:bg-accent/20 transition-colors"
+              class="inline-flex items-center gap-1.5 px-2 py-0.5 rounded text-2xs font-medium bg-accent-muted text-accent hover:bg-accent/20 transition-colors"
               :title="t('ticket-detail-cycle-tooltip', { name: ticket.cycle.name, state: ticket.cycle.state })"
               @click="openCycle"
             >
@@ -1374,7 +1374,7 @@ watchEffect(async () => {
                 <button
                   v-if="(props.internalComments?.length ?? 0) > 0"
                   type="button"
-                  class="inline-flex items-center gap-1 px-2 h-6 rounded text-[11px] font-medium text-status-warning hover:bg-status-warning-muted transition-colors"
+                  class="inline-flex items-center gap-1 px-2 h-6 rounded text-2xs font-medium text-status-warning hover:bg-status-warning-muted transition-colors"
                   :title="t('ticket-detail-resolution-draft-from-notes-title', { count: props.internalComments?.length ?? 0 })"
                   @click="draftResolutionFromInternalNotes"
                 >
@@ -1386,7 +1386,7 @@ watchEffect(async () => {
                 </button>
                 <span
                   v-if="isTerminalState"
-                  class="text-[10px] font-semibold text-status-closed"
+                  class="text-3xs font-semibold text-status-closed"
                 >{{ t('ticket-detail-resolution-closed') }}</span>
               </div>
             </div>
@@ -1425,7 +1425,7 @@ watchEffect(async () => {
                  triage; the absolute timestamp lives in the line's
                  `title` for forensic reads on hover. -->
             <div
-              class="flex items-center gap-1.5 text-[11px] text-tertiary whitespace-nowrap"
+              class="flex items-center gap-1.5 text-2xs text-tertiary whitespace-nowrap"
               :title="createdDate"
             >
               <UserAvatar
@@ -1445,7 +1445,7 @@ watchEffect(async () => {
             <!-- Updated row. No actor data available today
                  (would need a `modified_by` column to byline). -->
             <div
-              class="flex items-center gap-1.5 text-[11px] text-tertiary whitespace-nowrap"
+              class="flex items-center gap-1.5 text-2xs text-tertiary whitespace-nowrap"
               :title="modifiedDate"
             >
               <span>{{ t('ticket-detail-audit-modified') }}</span>
@@ -1456,7 +1456,7 @@ watchEffect(async () => {
             <!-- Closed row (only for terminal-state tickets). -->
             <div
               v-if="ticket.closed_at"
-              class="flex items-center gap-1.5 text-[11px] text-tertiary whitespace-nowrap"
+              class="flex items-center gap-1.5 text-2xs text-tertiary whitespace-nowrap"
               :title="closedDateLabel"
             >
               <UserAvatar

--- a/frontend/src/components/ticketComponents/TicketGapFlag.vue
+++ b/frontend/src/components/ticketComponents/TicketGapFlag.vue
@@ -50,7 +50,7 @@ async function unflag() {
       </p>
       <RouterLink
         :to="`/documentation/gaps/${gap.id}`"
-        class="text-[11px] text-status-warning hover:underline"
+        class="text-2xs text-status-warning hover:underline"
       >
         {{ t('ticket-chip-gap-view-queue') }}
       </RouterLink>
@@ -58,7 +58,7 @@ async function unflag() {
     <button
       type="button"
       :disabled="isWorking"
-      class="flex-shrink-0 text-[11px] text-tertiary hover:text-status-error transition-colors disabled:opacity-50"
+      class="flex-shrink-0 text-2xs text-tertiary hover:text-status-error transition-colors disabled:opacity-50"
       :title="t('ticket-chip-gap-remove-flag')"
       @click="unflag"
     >

--- a/frontend/src/components/ticketComponents/TicketLinkedTicketsField.vue
+++ b/frontend/src/components/ticketComponents/TicketLinkedTicketsField.vue
@@ -45,7 +45,7 @@ const hasContent = computed(
   >
     <span
       v-if="showDropAffordance || isDropTarget"
-      class="inline-flex items-center gap-1 px-2 py-0.5 rounded text-[11px] font-medium border border-dashed transition-colors"
+      class="inline-flex items-center gap-1 px-2 py-0.5 rounded text-2xs font-medium border border-dashed transition-colors"
       :class="isDropTarget
         ? 'border-accent bg-accent/10 text-accent'
         : 'border-accent/40 text-accent/70'"

--- a/frontend/src/components/ticketComponents/TicketTagsField.vue
+++ b/frontend/src/components/ticketComponents/TicketTagsField.vue
@@ -209,7 +209,7 @@ function chipClass(tag: Tag): string {
       <span
         v-for="tag in attachedTags"
         :key="tag.id"
-        class="inline-flex items-center gap-1 pl-2 pr-1 py-0.5 rounded text-[11px] font-medium"
+        class="inline-flex items-center gap-1 pl-2 pr-1 py-0.5 rounded text-2xs font-medium"
         :class="chipClass(tag)"
         :title="tag.description || tag.name"
       >
@@ -277,7 +277,7 @@ function chipClass(tag: Tag): string {
       </button>
       <button
         type="button"
-        class="text-[11px] text-tertiary hover:text-primary px-2 py-1 self-end"
+        class="text-2xs text-tertiary hover:text-primary px-2 py-1 self-end"
         @click="closePicker"
       >{{ t('ticket-field-tags-done') }}</button>
     </div>

--- a/frontend/src/components/ticketComponents/TicketWatchersField.vue
+++ b/frontend/src/components/ticketComponents/TicketWatchersField.vue
@@ -179,7 +179,7 @@ watch(isWatching, (watching) => {
           />
           <span
             v-if="overflowCount > 0"
-            class="inline-flex items-center justify-center h-5 min-w-[1.25rem] px-1 rounded-full bg-surface-alt text-tertiary text-[10px] font-medium"
+            class="inline-flex items-center justify-center h-5 min-w-[1.25rem] px-1 rounded-full bg-surface-alt text-tertiary text-3xs font-medium"
             :title="t('ticket-field-watchers-overflow-title', { count: overflowCount })"
           >+{{ overflowCount }}</span>
         </div>
@@ -195,7 +195,7 @@ watch(isWatching, (watching) => {
              accessibility primitive. -->
         <button
           type="button"
-          class="inline-flex items-center gap-1 px-2 h-6 rounded text-[11px] font-medium transition-colors"
+          class="inline-flex items-center gap-1 px-2 h-6 rounded text-2xs font-medium transition-colors"
           :class="isWatching
             ? 'text-accent hover:bg-accent-muted'
             : 'text-tertiary hover:text-primary hover:bg-surface-hover'"
@@ -249,7 +249,7 @@ watch(isWatching, (watching) => {
         >
           <span class="flex flex-col">
             <span class="text-xs text-primary">{{ t('ticket-field-watchers-notify-internal') }}</span>
-            <span class="text-[10px] text-tertiary">{{ t('ticket-field-watchers-notify-internal-hint') }}</span>
+            <span class="text-3xs text-tertiary">{{ t('ticket-field-watchers-notify-internal-hint') }}</span>
           </span>
           <Icon
             v-if="notifyOnInternalNotes"
@@ -265,7 +265,7 @@ watch(isWatching, (watching) => {
         </button>
         <p
           v-if="prefError"
-          class="px-2 py-1 text-[10px] text-status-error"
+          class="px-2 py-1 text-3xs text-status-error"
           role="alert"
         >
           {{ prefError }}

--- a/frontend/src/components/ticketComponents/UserPicker.vue
+++ b/frontend/src/components/ticketComponents/UserPicker.vue
@@ -443,7 +443,7 @@ const sectionStarts = computed(() => {
           spellcheck="false"
           :placeholder="placeholder || (type === 'assignee' ? $t('ticket-picker-user-placeholder-assignee') : $t('ticket-picker-user-placeholder-requester'))"
           class="w-full bg-transparent text-secondary placeholder-tertiary focus:outline-none leading-tight"
-          :class="compact ? 'text-[11px] py-0' : 'text-sm py-1'"
+          :class="compact ? 'text-2xs py-0' : 'text-sm py-1'"
           @focus="onFocus"
           @keydown="onKeydown"
         />
@@ -489,7 +489,7 @@ const sectionStarts = computed(() => {
                 <li
                   v-if="sectionStarts[row.id]"
                   role="presentation"
-                  class="px-3 pt-2 pb-1 text-[10px] font-semibold uppercase tracking-wider text-tertiary select-none"
+                  class="px-3 pt-2 pb-1 text-3xs font-semibold uppercase tracking-wider text-tertiary select-none"
                 >
                   {{ sectionLabel(row.section) }}
                 </li>
@@ -517,11 +517,11 @@ const sectionStarts = computed(() => {
                     :clickable="false"
                   />
                   <div class="flex-1 min-w-0">
-                    <div class="text-[13px] text-primary truncate">
+                    <div class="text-xs-plus text-primary truncate">
                       {{ row.user.name
                       }}<span v-if="row.section === 'you'" class="text-tertiary font-normal"> {{ $t('ticket-picker-user-you-suffix') }}</span>
                     </div>
-                    <div v-if="row.user.email" class="text-[11px] text-tertiary truncate">
+                    <div v-if="row.user.email" class="text-2xs text-tertiary truncate">
                       {{ row.user.email }}
                     </div>
                   </div>
@@ -586,7 +586,7 @@ const sectionStarts = computed(() => {
           <li
             v-if="sectionStarts[row.id]"
             role="presentation"
-            class="px-4 pt-3 pb-1 text-[10px] font-semibold uppercase tracking-wider text-tertiary select-none"
+            class="px-4 pt-3 pb-1 text-3xs font-semibold uppercase tracking-wider text-tertiary select-none"
           >
             {{ sectionLabel(row.section) }}
           </li>

--- a/frontend/src/components/views/AddFilterMenu.vue
+++ b/frontend/src/components/views/AddFilterMenu.vue
@@ -194,7 +194,7 @@ const stageMeta = computed<{ label: string; kind: FacetKind } | null>(() => {
     <button
       ref="triggerRef"
       type="button"
-      class="inline-flex items-center gap-1 text-[11px] px-2 h-6 rounded-md border border-dashed transition-colors"
+      class="inline-flex items-center gap-1 text-2xs px-2 h-6 rounded-md border border-dashed transition-colors"
       :class="open
         ? 'border-default bg-surface-hover text-primary'
         : 'text-tertiary hover:text-primary border-subtle hover:border-default hover:bg-surface-hover'"

--- a/frontend/src/components/views/ColumnPickerMenu.vue
+++ b/frontend/src/components/views/ColumnPickerMenu.vue
@@ -46,7 +46,7 @@ const hiddenCount = computed<number>(
     <button
       ref="triggerRef"
       type="button"
-      class="inline-flex items-center gap-1 text-[11px] px-2 h-6 rounded-md border transition-colors text-tertiary hover:text-primary border-subtle hover:border-default hover:bg-surface-hover"
+      class="inline-flex items-center gap-1 text-2xs px-2 h-6 rounded-md border transition-colors text-tertiary hover:text-primary border-subtle hover:border-default hover:bg-surface-hover"
       :aria-expanded="open"
       aria-haspopup="menu"
       @click="open = !open"
@@ -56,7 +56,7 @@ const hiddenCount = computed<number>(
            glance whether columns are tucked away. -->
       <span
         v-if="hiddenCount > 0"
-        class="text-[10px] text-tertiary"
+        class="text-3xs text-tertiary"
       >{{ hiddenCount }}</span>
       <Icon name="chevronDown" class="w-3 h-3 opacity-70" />
     </button>
@@ -100,7 +100,7 @@ const hiddenCount = computed<number>(
       <footer class="border-t border-subtle px-3 py-1.5 flex items-center justify-end">
         <button
           type="button"
-          class="text-[11px] text-tertiary hover:text-primary"
+          class="text-2xs text-tertiary hover:text-primary"
           @click="emit('reset'); open = false"
         >{{ $t('views-column-picker-reset') }}</button>
       </footer>

--- a/frontend/src/components/views/DisplayMenu.vue
+++ b/frontend/src/components/views/DisplayMenu.vue
@@ -122,7 +122,7 @@ const groupOptions = computed<ReadonlyArray<{ value: GroupBy; label: string }>>(
       <div class="py-2">
         <!-- Grouping -->
         <section class="px-3 pb-2">
-          <h3 class="text-[10px] uppercase tracking-wide font-semibold text-tertiary mb-1.5">
+          <h3 class="text-3xs uppercase tracking-wide font-semibold text-tertiary mb-1.5">
             {{ $t('views-display-menu-grouping') }}
           </h3>
           <div class="grid grid-cols-3 gap-1">
@@ -130,7 +130,7 @@ const groupOptions = computed<ReadonlyArray<{ value: GroupBy; label: string }>>(
               v-for="opt in groupOptions"
               :key="opt.value"
               type="button"
-              class="text-[11px] px-2 py-1 rounded transition-colors text-center"
+              class="text-2xs px-2 py-1 rounded transition-colors text-center"
               :class="groupBy === opt.value
                 ? 'bg-accent/10 text-accent font-medium'
                 : 'text-secondary hover:bg-surface-hover'"
@@ -142,7 +142,7 @@ const groupOptions = computed<ReadonlyArray<{ value: GroupBy; label: string }>>(
 
         <!-- Density -->
         <section class="px-3 pb-2 border-t border-subtle pt-2">
-          <h3 class="text-[10px] uppercase tracking-wide font-semibold text-tertiary mb-1.5">
+          <h3 class="text-3xs uppercase tracking-wide font-semibold text-tertiary mb-1.5">
             {{ $t('views-display-menu-density') }}
           </h3>
           <div
@@ -154,7 +154,7 @@ const groupOptions = computed<ReadonlyArray<{ value: GroupBy; label: string }>>(
               v-for="opt in densityOptions"
               :key="opt.value"
               type="button"
-              class="flex-1 text-[11px] px-2 py-1 transition-colors"
+              class="flex-1 text-2xs px-2 py-1 transition-colors"
               :class="density === opt.value
                 ? 'bg-accent/10 text-accent font-medium'
                 : 'text-secondary hover:bg-surface-hover'"
@@ -166,7 +166,7 @@ const groupOptions = computed<ReadonlyArray<{ value: GroupBy; label: string }>>(
 
         <!-- Properties -->
         <section class="border-t border-subtle pt-2">
-          <h3 class="text-[10px] uppercase tracking-wide font-semibold text-tertiary px-3 mb-1">
+          <h3 class="text-3xs uppercase tracking-wide font-semibold text-tertiary px-3 mb-1">
             {{ $t('views-display-menu-properties') }}
           </h3>
           <div class="max-h-[20rem] overflow-y-auto">
@@ -194,7 +194,7 @@ const groupOptions = computed<ReadonlyArray<{ value: GroupBy; label: string }>>(
                 <span class="block text-xs text-primary">
                   {{ col.label === '#' ? $t('views-display-menu-column-ticket-id') : $t(col.labelKey) }}
                 </span>
-                <span class="block text-[10px] text-tertiary truncate">
+                <span class="block text-3xs text-tertiary truncate">
                   {{ $t(col.descriptionKey) }}
                 </span>
               </span>
@@ -213,7 +213,7 @@ const groupOptions = computed<ReadonlyArray<{ value: GroupBy; label: string }>>(
              you can find it when you need it. -->
         <button
           type="button"
-          class="inline-flex items-center gap-1 text-[11px] text-tertiary hover:text-primary px-1.5 py-0.5 rounded hover:bg-surface-hover transition-colors"
+          class="inline-flex items-center gap-1 text-2xs text-tertiary hover:text-primary px-1.5 py-0.5 rounded hover:bg-surface-hover transition-colors"
           @click="emit('reset')"
           :title="$t('views-display-menu-reset-tooltip')"
         >
@@ -223,7 +223,7 @@ const groupOptions = computed<ReadonlyArray<{ value: GroupBy; label: string }>>(
         <button
           v-if="canSaveToView"
           type="button"
-          class="text-[11px] font-medium px-2 py-1 rounded bg-accent text-on-accent disabled:opacity-50 disabled:cursor-not-allowed"
+          class="text-2xs font-medium px-2 py-1 rounded bg-accent text-on-accent disabled:opacity-50 disabled:cursor-not-allowed"
           :disabled="!layoutDirty"
           @click="emit('save')"
         >{{ $t('views-display-menu-save-to-view') }}</button>

--- a/frontend/src/components/views/FilterPill.vue
+++ b/frontend/src/components/views/FilterPill.vue
@@ -76,7 +76,7 @@ function onRemove(e: MouseEvent): void {
   <div class="inline-flex">
     <div
       ref="triggerRef"
-      class="inline-flex items-center h-6 rounded-md border border-accent/40 bg-accent/10 text-accent text-[11px] overflow-hidden"
+      class="inline-flex items-center h-6 rounded-md border border-accent/40 bg-accent/10 text-accent text-2xs overflow-hidden"
     >
       <button
         type="button"

--- a/frontend/src/components/views/FilterValueList.vue
+++ b/frontend/src/components/views/FilterValueList.vue
@@ -206,7 +206,7 @@ watch(
         <span
           v-if="opt.hint"
           :class="[
-            'text-[10px] text-tertiary truncate min-w-0',
+            'text-3xs text-tertiary truncate min-w-0',
             opt.swatchClass ? 'col-start-3' : 'col-start-2',
           ]"
         >{{ opt.hint }}</span>
@@ -218,7 +218,7 @@ watch(
     >
       <button
         type="button"
-        class="text-[11px] text-tertiary hover:text-primary"
+        class="text-2xs text-tertiary hover:text-primary"
         @click="emit('clear')"
       >{{ $t('views-filter-value-clear') }}</button>
     </footer>

--- a/frontend/src/components/views/GroupByMenu.vue
+++ b/frontend/src/components/views/GroupByMenu.vue
@@ -67,7 +67,7 @@ function pick(key: string): void {
       ref="triggerRef"
       type="button"
       :class="[
-        'inline-flex items-center gap-1 text-[11px] px-2 h-6 rounded-md border transition-colors',
+        'inline-flex items-center gap-1 text-2xs px-2 h-6 rounded-md border transition-colors',
         isActive
           ? 'border-accent/40 bg-accent/10 text-accent'
           : 'text-tertiary hover:text-primary border-subtle hover:border-default hover:bg-surface-hover',

--- a/frontend/src/components/views/ListViewToolbar.vue
+++ b/frontend/src/components/views/ListViewToolbar.vue
@@ -85,7 +85,7 @@ const activeCount = computed(() => {
     />
     <button
       type="button"
-      class="inline-flex items-center text-[11px] px-2 h-6 rounded-md border border-dashed border-subtle text-tertiary hover:text-primary hover:border-default hover:bg-surface-hover transition-colors"
+      class="inline-flex items-center text-2xs px-2 h-6 rounded-md border border-dashed border-subtle text-tertiary hover:text-primary hover:border-default hover:bg-surface-hover transition-colors"
       :title="$t('views-save-trigger')"
       @click="emit('save-as')"
     >
@@ -104,7 +104,7 @@ const activeCount = computed(() => {
     {{ $t('list-mobile-filter-group-title') }}
     <span
       v-if="activeCount > 0"
-      class="inline-flex items-center justify-center min-w-[18px] h-[18px] px-1 rounded-full bg-accent text-on-accent text-[11px] font-semibold tabular-nums"
+      class="inline-flex items-center justify-center min-w-[18px] h-[18px] px-1 rounded-full bg-accent text-on-accent text-2xs font-semibold tabular-nums"
     >
       {{ activeCount }}
     </span>

--- a/frontend/src/components/views/TicketPreviewPane.vue
+++ b/frontend/src/components/views/TicketPreviewPane.vue
@@ -198,8 +198,8 @@ async function updateDueDate(iso: string | null): Promise<void> {
       <p class="text-sm font-medium text-secondary mb-2">{{ $t('views-ticket-preview-empty-title') }}</p>
       <p class="text-xs leading-relaxed max-w-[16rem]">
         {{ $t('views-ticket-preview-empty-prefix') }}
-        <kbd class="text-[10px] font-mono px-1.5 py-0.5 bg-surface-hover rounded border border-subtle">↑</kbd>
-        <kbd class="text-[10px] font-mono px-1.5 py-0.5 bg-surface-hover rounded border border-subtle ml-1">↓</kbd>
+        <kbd class="text-3xs font-mono px-1.5 py-0.5 bg-surface-hover rounded border border-subtle">↑</kbd>
+        <kbd class="text-3xs font-mono px-1.5 py-0.5 bg-surface-hover rounded border border-subtle ml-1">↓</kbd>
         {{ $t('views-ticket-preview-empty-suffix') }}
       </p>
     </div>
@@ -213,7 +213,7 @@ async function updateDueDate(iso: string | null): Promise<void> {
         <header
           class="flex items-center gap-2 px-4 h-9 border-b border-subtle/60 shrink-0 min-w-0"
         >
-          <span class="text-tertiary font-mono text-[11px] tabular-nums shrink-0">#{{ card.id }}</span>
+          <span class="text-tertiary font-mono text-2xs tabular-nums shrink-0">#{{ card.id }}</span>
           <span class="text-tertiary/50 shrink-0" aria-hidden="true">·</span>
           <div class="min-w-0 flex-1">
             <CustomDropdown
@@ -228,7 +228,7 @@ async function updateDueDate(iso: string | null): Promise<void> {
           </div>
           <button
             type="button"
-            class="inline-flex items-center gap-1 text-[11px] text-secondary hover:text-primary px-2 h-7 rounded-md hover:bg-surface-hover transition-colors"
+            class="inline-flex items-center gap-1 text-2xs text-secondary hover:text-primary px-2 h-7 rounded-md hover:bg-surface-hover transition-colors"
             @click="onOpen"
           >
             {{ $t('views-ticket-preview-open') }}
@@ -275,7 +275,7 @@ async function updateDueDate(iso: string | null): Promise<void> {
               </span>
               <span
                 v-if="slaState"
-                class="inline-flex items-center gap-1 text-[10px] font-medium px-1.5 h-6 rounded-md border border-subtle transition-colors duration-200"
+                class="inline-flex items-center gap-1 text-3xs font-medium px-1.5 h-6 rounded-md border border-subtle transition-colors duration-200"
                 :class="slaState.toneClass"
               >
                 <Icon name="clock" class="w-3 h-3" />
@@ -283,7 +283,7 @@ async function updateDueDate(iso: string | null): Promise<void> {
               </span>
               <span
                 v-if="card.kb_gap_signal && card.kb_gap_signal !== 'none'"
-                class="inline-flex items-center gap-1 text-[10px] font-semibold uppercase tracking-wide px-1.5 h-6 rounded-md"
+                class="inline-flex items-center gap-1 text-3xs font-semibold uppercase tracking-wide px-1.5 h-6 rounded-md"
                 :class="card.kb_gap_signal === 'strong'
                   ? 'bg-amber-500/15 text-amber-700 dark:text-amber-300'
                   : 'bg-surface-hover text-secondary'"
@@ -293,7 +293,7 @@ async function updateDueDate(iso: string | null): Promise<void> {
               </span>
               <span
                 v-if="card.recurrence_rule"
-                class="inline-flex items-center gap-1 text-[10px] font-semibold uppercase tracking-wide px-1.5 h-6 rounded-md bg-violet-500/12 text-violet-700 dark:text-violet-300"
+                class="inline-flex items-center gap-1 text-3xs font-semibold uppercase tracking-wide px-1.5 h-6 rounded-md bg-violet-500/12 text-violet-700 dark:text-violet-300"
                 :title="card.recurrence_rule"
               >
                 <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" class="w-3 h-3">
@@ -307,7 +307,7 @@ async function updateDueDate(iso: string | null): Promise<void> {
 
           <!-- PROPERTIES -->
           <section class="px-4 pt-3 pb-3 border-t border-subtle/60">
-            <h3 class="text-[10px] uppercase tracking-wider font-semibold text-tertiary mb-2">
+            <h3 class="text-3xs uppercase tracking-wider font-semibold text-tertiary mb-2">
               {{ $t('views-ticket-preview-properties') }}
             </h3>
             <div class="flex flex-col gap-2 text-xs">
@@ -381,7 +381,7 @@ async function updateDueDate(iso: string | null): Promise<void> {
                what it is). The bar gives peripheral urgency; the
                detail line carries the precise time + target. -->
           <section v-if="slaRows.length > 0" class="px-4 pt-3 pb-3 border-t border-subtle/60 flex flex-col gap-2.5">
-            <h3 class="text-[10px] uppercase tracking-wider font-semibold text-tertiary">
+            <h3 class="text-3xs uppercase tracking-wider font-semibold text-tertiary">
               {{ $t('views-ticket-preview-sla') }}
             </h3>
             <div v-for="row in slaRows" :key="row.labelKey ?? 'single'" class="flex flex-col gap-1.5">
@@ -402,7 +402,7 @@ async function updateDueDate(iso: string | null): Promise<void> {
                   :style="{ width: `${row.state.fraction * 100}%` }"
                 />
               </div>
-              <p class="text-[11px] text-tertiary">{{ row.state.detail }}</p>
+              <p class="text-2xs text-tertiary">{{ row.state.detail }}</p>
             </div>
           </section>
 
@@ -414,7 +414,7 @@ async function updateDueDate(iso: string | null): Promise<void> {
                component on both gives them identical rendered
                size, which inline-SVG mixed with Icon does not. -->
           <section class="px-4 pt-3 pb-3 border-t border-subtle/60">
-            <h3 class="text-[10px] uppercase tracking-wider font-semibold text-tertiary mb-2">
+            <h3 class="text-3xs uppercase tracking-wider font-semibold text-tertiary mb-2">
               {{ $t('views-ticket-preview-activity') }}
             </h3>
             <div class="flex flex-col gap-2 text-xs">
@@ -442,7 +442,7 @@ async function updateDueDate(iso: string | null): Promise<void> {
             v-if="card.affected_devices && card.affected_devices.count > 0"
             class="px-4 pt-3 pb-3 border-t border-subtle/60"
           >
-            <h3 class="text-[10px] uppercase tracking-wider font-semibold text-tertiary mb-2">
+            <h3 class="text-3xs uppercase tracking-wider font-semibold text-tertiary mb-2">
               {{ $t('views-ticket-preview-affected-devices') }}
             </h3>
             <div class="text-xs text-secondary flex items-center gap-2">
@@ -452,7 +452,7 @@ async function updateDueDate(iso: string | null): Promise<void> {
               </span>
               <span
                 v-if="card.affected_devices.count > 1"
-                class="text-tertiary text-[11px] tabular-nums shrink-0"
+                class="text-tertiary text-2xs tabular-nums shrink-0"
               >{{ $t('views-ticket-preview-more-devices', { count: card.affected_devices.count - 1 }) }}</span>
             </div>
           </section>

--- a/frontend/src/components/views/TicketRow.vue
+++ b/frontend/src/components/views/TicketRow.vue
@@ -233,7 +233,7 @@ function recurrenceLabel(rule: string | null | undefined): string {
       :style="colStyle(col)"
     >
       <template v-if="col.id === 'id'">
-        <span class="text-tertiary font-mono text-[11px] tabular-nums">#{{ card.id }}</span>
+        <span class="text-tertiary font-mono text-2xs tabular-nums">#{{ card.id }}</span>
       </template>
 
       <template v-else-if="col.id === 'title'">
@@ -257,12 +257,12 @@ function recurrenceLabel(rule: string | null | undefined): string {
           >↻</span>
           <span
             v-if="card.sla?.breached"
-            class="text-[10px] font-semibold uppercase tracking-wide text-rose-600 dark:text-rose-400 shrink-0"
+            class="text-3xs font-semibold uppercase tracking-wide text-rose-600 dark:text-rose-400 shrink-0"
             :title="$t('views-ticket-row-sla-breached-tooltip')"
           >{{ $t('views-ticket-row-sla-badge') }}</span>
           <span
             v-if="card.spam_suspected"
-            class="text-[10px] font-medium uppercase tracking-wide px-1.5 py-0.5 rounded bg-amber-500/15 text-amber-700 dark:text-amber-400 shrink-0"
+            class="text-3xs font-medium uppercase tracking-wide px-1.5 py-0.5 rounded bg-amber-500/15 text-amber-700 dark:text-amber-400 shrink-0"
             :title="$t('views-ticket-row-spam-tooltip')"
           >{{ $t('views-ticket-row-spam-badge') }}</span>
         </div>
@@ -313,7 +313,7 @@ function recurrenceLabel(rule: string | null | undefined): string {
       <template v-else-if="col.id === 'category'">
         <span
           v-if="card.category_id != null"
-          class="text-[11px] text-secondary bg-surface-hover rounded px-1.5 py-0.5"
+          class="text-2xs text-secondary bg-surface-hover rounded px-1.5 py-0.5"
         >#{{ card.category_id }}</span>
         <span v-else class="text-xs text-tertiary">-</span>
       </template>
@@ -321,7 +321,7 @@ function recurrenceLabel(rule: string | null | undefined): string {
       <template v-else-if="col.id === 'cycle'">
         <span
           v-if="card.cycle_id != null"
-          class="text-[11px] text-accent bg-accent/10 rounded px-1.5 py-0.5"
+          class="text-2xs text-accent bg-accent/10 rounded px-1.5 py-0.5"
           :title="$t('views-ticket-row-cycle-tooltip')"
         >{{ $t('views-ticket-row-cycle-label', { id: card.cycle_id }) }}</span>
         <span v-else class="text-xs text-tertiary">-</span>
@@ -329,7 +329,7 @@ function recurrenceLabel(rule: string | null | undefined): string {
 
       <template v-else-if="col.id === 'due_date'">
         <span
-          class="text-[11px] tabular-nums"
+          class="text-2xs tabular-nums"
           :class="card.due_date ? 'text-secondary' : 'text-tertiary'"
           :title="card.due_date ? formatDateTime(card.due_date) : $t('views-ticket-row-no-due-date')"
         >{{ shortDate(card.due_date) }}</span>
@@ -337,14 +337,14 @@ function recurrenceLabel(rule: string | null | undefined): string {
 
       <template v-else-if="col.id === 'last_activity'">
         <span
-          class="text-[11px] text-tertiary tabular-nums"
+          class="text-2xs text-tertiary tabular-nums"
           :title="formatDateTime(card.last_activity_at)"
         >{{ relativeTime(card.last_activity_at) }}</span>
       </template>
 
       <template v-else-if="col.id === 'created_at'">
         <span
-          class="text-[11px] text-tertiary tabular-nums"
+          class="text-2xs text-tertiary tabular-nums"
           :title="formatDateTime(card.created_at)"
         >{{ relativeTime(card.created_at) }}</span>
       </template>
@@ -352,7 +352,7 @@ function recurrenceLabel(rule: string | null | undefined): string {
       <template v-else-if="col.id === 'sla'">
         <span
           v-if="card.sla"
-          class="inline-flex items-center gap-1 text-[11px] tabular-nums transition-colors duration-200"
+          class="inline-flex items-center gap-1 text-2xs tabular-nums transition-colors duration-200"
           :class="slaToneClass(card)"
           :title="slaTitle(card)"
         >
@@ -365,7 +365,7 @@ function recurrenceLabel(rule: string | null | undefined): string {
       <template v-else-if="col.id === 'kb_gap'">
         <span
           v-if="card.kb_gap_signal && card.kb_gap_signal !== 'none'"
-          class="text-[10px] font-semibold uppercase tracking-wide rounded px-1.5 py-0.5"
+          class="text-3xs font-semibold uppercase tracking-wide rounded px-1.5 py-0.5"
           :class="card.kb_gap_signal === 'strong'
             ? 'bg-amber-500/20 text-amber-700 dark:text-amber-300'
             : 'bg-surface-hover text-secondary'"
@@ -377,7 +377,7 @@ function recurrenceLabel(rule: string | null | undefined): string {
       <template v-else-if="col.id === 'devices'">
         <span
           v-if="card.affected_devices && card.affected_devices.count > 0"
-          class="text-[11px] text-secondary tabular-nums inline-flex items-center gap-1"
+          class="text-2xs text-secondary tabular-nums inline-flex items-center gap-1"
           :title="card.affected_devices.first?.name ?? $t('views-ticket-row-devices-count', { count: card.affected_devices.count })"
         >
           <Icon name="device" class="w-3 h-3" />
@@ -389,7 +389,7 @@ function recurrenceLabel(rule: string | null | undefined): string {
       <template v-else-if="col.id === 'recurrence'">
         <span
           v-if="card.recurrence_rule"
-          class="text-[10px] font-medium rounded px-1.5 py-0.5 bg-violet-500/15 text-violet-700 dark:text-violet-300"
+          class="text-3xs font-medium rounded px-1.5 py-0.5 bg-violet-500/15 text-violet-700 dark:text-violet-300"
           :title="card.recurrence_rule"
         >{{ recurrenceLabel(card.recurrence_rule) }}</span>
         <span v-else class="text-xs text-tertiary">-</span>

--- a/frontend/src/components/views/TicketsBulkBar.vue
+++ b/frontend/src/components/views/TicketsBulkBar.vue
@@ -253,7 +253,7 @@ function runPluginBulkAction(reg: { pluginUuid: string; componentName: string })
         @close="statusOpen = false"
       >
         <div v-for="group in statusGroups" :key="group.label">
-          <div class="px-3 pt-2 pb-1 text-[10px] font-semibold text-tertiary tracking-wide uppercase">
+          <div class="px-3 pt-2 pb-1 text-3xs font-semibold text-tertiary tracking-wide uppercase">
             {{ group.label }}
           </div>
           <button

--- a/frontend/src/components/views/TicketsCardList.vue
+++ b/frontend/src/components/views/TicketsCardList.vue
@@ -96,10 +96,10 @@ function onContextMenu(id: number, event: MouseEvent): void {
           <!-- Top line: id + title. Title takes whatever width
                remains; truncates on overflow. -->
           <div class="flex items-center gap-2 min-w-0">
-            <span class="text-[11px] font-mono tabular-nums text-tertiary shrink-0">#{{ card.id }}</span>
+            <span class="text-2xs font-mono tabular-nums text-tertiary shrink-0">#{{ card.id }}</span>
             <span
               v-if="inlinePriorityClass(card.priority)"
-              class="text-[11px] leading-none font-bold shrink-0"
+              class="text-2xs leading-none font-bold shrink-0"
               :class="inlinePriorityClass(card.priority)!"
               :title="`Priority: ${card.priority}`"
             >!</span>
@@ -114,7 +114,7 @@ function onContextMenu(id: number, event: MouseEvent): void {
             >{{ card.title }}</span>
             <span
               v-if="card.sla?.breached"
-              class="ml-auto text-[10px] font-semibold uppercase tracking-wide text-rose-600 dark:text-rose-400 shrink-0"
+              class="ml-auto text-3xs font-semibold uppercase tracking-wide text-rose-600 dark:text-rose-400 shrink-0"
               :title="$t('ticket-list-sla-breached-title')"
             >SLA</span>
           </div>

--- a/frontend/src/components/views/TicketsHeader.vue
+++ b/frontend/src/components/views/TicketsHeader.vue
@@ -431,7 +431,7 @@ defineExpose({ openAddFilter })
       />
       <button
         type="button"
-        class="text-[11px] text-tertiary hover:text-primary px-2 h-6 rounded-md hover:bg-surface-hover transition-colors"
+        class="text-2xs text-tertiary hover:text-primary px-2 h-6 rounded-md hover:bg-surface-hover transition-colors"
         :title="$t('ticket-list-save-view-title')"
         @click="emit('save-as-view')"
       >

--- a/frontend/src/components/views/TicketsTable.vue
+++ b/frontend/src/components/views/TicketsTable.vue
@@ -200,7 +200,7 @@ const grouped = computed<boolean>(() => props.buckets.length > 0)
           <th
             v-for="col in visibleColumns"
             :key="col.id"
-            class="relative text-left text-[10px] font-semibold text-tertiary uppercase tracking-wider border-b border-subtle bg-surface select-none p-0"
+            class="relative text-left text-3xs font-semibold text-tertiary uppercase tracking-wider border-b border-subtle bg-surface select-none p-0"
             :class="[
               `col-${col.id}`,
               col.align === 'center' && 'text-center',
@@ -241,7 +241,7 @@ const grouped = computed<boolean>(() => props.buckets.length > 0)
               @dragend="layout.onDragEnd"
             >
               <span>{{ $t(col.labelKey) }}</span>
-              <span v-if="sortField === col.sortKey" class="text-[10px] leading-none" aria-hidden="true">
+              <span v-if="sortField === col.sortKey" class="text-3xs leading-none" aria-hidden="true">
                 {{ sortDir === 'asc' ? '↑' : '↓' }}
               </span>
             </button>
@@ -328,7 +328,7 @@ const grouped = computed<boolean>(() => props.buckets.length > 0)
                     :class="isCollapsed(bucket.key) && '-rotate-90'"
                   />
                   <span class="text-xs font-semibold text-primary">{{ bucket.label }}</span>
-                  <span class="text-[11px] text-tertiary tabular-nums">{{ bucket.cards.length }}</span>
+                  <span class="text-2xs text-tertiary tabular-nums">{{ bucket.cards.length }}</span>
                 </div>
               </td>
             </tr>

--- a/frontend/src/components/views/UserCell.vue
+++ b/frontend/src/components/views/UserCell.vue
@@ -78,11 +78,11 @@ const avatarSrc = computed<string | null>(
       />
       <span
         v-else-if="status === 'resolved'"
-        class="truncate text-[11px] text-secondary"
+        class="truncate text-2xs text-secondary"
       >{{ userName }}</span>
       <span
         v-else
-        class="text-[11px] text-tertiary italic shrink-0"
+        class="text-2xs text-tertiary italic shrink-0"
         :title="t('user-cell-missing-tooltip')"
       >{{ t('user-cell-unknown') }}</span>
     </template>

--- a/frontend/src/sync/views/CalendarBoard.vue
+++ b/frontend/src/sync/views/CalendarBoard.vue
@@ -265,7 +265,7 @@ watch(grid, (cells) => {
         <h2 class="text-sm font-semibold text-primary ml-2 tabular-nums">{{ monthLabel }}</h2>
       </div>
       <div class="flex items-center gap-3">
-        <span class="text-[10px] uppercase tracking-wide text-tertiary">{{ t('calendar-anchor-label') }}</span>
+        <span class="text-3xs uppercase tracking-wide text-tertiary">{{ t('calendar-anchor-label') }}</span>
         <BaseDropdown
           :model-value="dateField"
           :options="anchorOptions"
@@ -282,7 +282,7 @@ watch(grid, (cells) => {
     <div class="flex-1 min-h-0 hidden md:grid" style="grid-template-columns: 1fr 12rem">
       <section class="min-h-0 flex flex-col">
         <!-- Weekday header -->
-        <div class="grid grid-cols-7 text-[10px] uppercase tracking-wide font-semibold text-tertiary bg-surface border-b border-subtle">
+        <div class="grid grid-cols-7 text-3xs uppercase tracking-wide font-semibold text-tertiary bg-surface border-b border-subtle">
           <div
             v-for="label in WEEKDAY_LABELS"
             :key="label"
@@ -308,7 +308,7 @@ watch(grid, (cells) => {
                  charge of the cell's vertical space. -->
             <div class="flex items-center justify-between gap-1">
               <span
-                class="text-[11px] font-medium tabular-nums"
+                class="text-2xs font-medium tabular-nums"
                 :class="{
                   'text-on-accent bg-accent rounded-full inline-flex items-center justify-center w-5 h-5': cell.isToday,
                   'text-secondary': !cell.isToday && cell.inMonth,
@@ -328,7 +328,7 @@ watch(grid, (cells) => {
                 />
                 <span
                   v-if="overlaysFor(cell).length > 3"
-                  class="text-[9px] text-tertiary tabular-nums"
+                  class="text-4xs text-tertiary tabular-nums"
                 >+{{ overlaysFor(cell).length - 3 }}</span>
               </div>
             </div>
@@ -336,7 +336,7 @@ watch(grid, (cells) => {
             <article
               v-for="card in cardsFor(cell)"
               :key="card.id"
-              class="bg-surface rounded border border-default hover:border-strong px-1.5 py-1 cursor-pointer text-[11px] flex items-center gap-1.5 truncate"
+              class="bg-surface rounded border border-default hover:border-strong px-1.5 py-1 cursor-pointer text-2xs flex items-center gap-1.5 truncate"
               @click="open(card.id)"
             >
               <PriorityIndicator
@@ -353,7 +353,7 @@ watch(grid, (cells) => {
       <!-- Undated rail -->
       <aside class="border-l border-subtle bg-surface flex flex-col min-h-0">
         <header class="px-3 py-2 border-b border-subtle">
-          <h3 class="text-[10px] uppercase tracking-wide font-semibold text-tertiary">
+          <h3 class="text-3xs uppercase tracking-wide font-semibold text-tertiary">
             No date ({{ undatedCards.length }})
           </h3>
         </header>
@@ -372,11 +372,11 @@ watch(grid, (cells) => {
               />
               <span class="text-primary line-clamp-2 flex-1">{{ card.title }}</span>
             </div>
-            <span class="text-[10px] text-tertiary">#{{ card.id }}</span>
+            <span class="text-3xs text-tertiary">#{{ card.id }}</span>
           </article>
           <p
             v-if="undatedCards.length === 0"
-            class="text-[11px] text-tertiary italic text-center mt-4"
+            class="text-2xs text-tertiary italic text-center mt-4"
           >Every ticket has a date.</p>
         </div>
       </aside>
@@ -388,7 +388,7 @@ watch(grid, (cells) => {
     <div class="flex-1 min-h-0 md:hidden overflow-y-auto flex flex-col">
       <section v-for="day in agendaDays" :key="day.date.toISOString()" class="flex flex-col">
         <h3
-          class="sticky top-0 z-10 bg-app px-3 py-1.5 text-[11px] font-semibold uppercase tracking-wide border-b border-subtle"
+          class="sticky top-0 z-10 bg-app px-3 py-1.5 text-2xs font-semibold uppercase tracking-wide border-b border-subtle"
           :class="day.isToday ? 'text-accent' : 'text-tertiary'"
         >{{ agendaDayLabel(day.date) }}</h3>
         <div class="flex flex-col gap-1.5 px-3 py-2">
@@ -404,14 +404,14 @@ watch(grid, (cells) => {
               size="xs"
             />
             <span class="text-primary truncate flex-1">{{ card.title }}</span>
-            <span class="text-[10px] text-tertiary tabular-nums shrink-0">#{{ card.id }}</span>
+            <span class="text-3xs text-tertiary tabular-nums shrink-0">#{{ card.id }}</span>
           </article>
         </div>
       </section>
 
       <!-- Undated bucket -->
       <section v-if="undatedCards.length > 0" class="flex flex-col">
-        <h3 class="sticky top-0 z-10 bg-app px-3 py-1.5 text-[11px] font-semibold uppercase tracking-wide text-tertiary border-b border-subtle">
+        <h3 class="sticky top-0 z-10 bg-app px-3 py-1.5 text-2xs font-semibold uppercase tracking-wide text-tertiary border-b border-subtle">
           No date ({{ undatedCards.length }})
         </h3>
         <div class="flex flex-col gap-1.5 px-3 py-2">
@@ -427,7 +427,7 @@ watch(grid, (cells) => {
               size="xs"
             />
             <span class="text-primary truncate flex-1">{{ card.title }}</span>
-            <span class="text-[10px] text-tertiary tabular-nums shrink-0">#{{ card.id }}</span>
+            <span class="text-3xs text-tertiary tabular-nums shrink-0">#{{ card.id }}</span>
           </article>
         </div>
       </section>

--- a/frontend/src/sync/views/KanbanBoard.vue
+++ b/frontend/src/sync/views/KanbanBoard.vue
@@ -919,7 +919,7 @@ function affectedDevicesTooltip(card: CardData): string {
             </h3>
           </div>
           <div class="flex items-center gap-1 shrink-0">
-            <span class="text-[10px] text-tertiary tabular-nums leading-none">{{ lane.totalCards }}</span>
+            <span class="text-3xs text-tertiary tabular-nums leading-none">{{ lane.totalCards }}</span>
           </div>
         </header>
         <!-- Bottom pad — scrolls away with the top pad. -->
@@ -938,7 +938,7 @@ function affectedDevicesTooltip(card: CardData): string {
         >
           <header
             v-if="secondaryGroupBy"
-            class="kanban-sublane-header flex items-center justify-between px-2 py-0.5 text-[10px] uppercase tracking-wide font-semibold text-tertiary bg-surface border-b border-subtle sticky z-10 shrink-0"
+            class="kanban-sublane-header flex items-center justify-between px-2 py-0.5 text-3xs uppercase tracking-wide font-semibold text-tertiary bg-surface border-b border-subtle sticky z-10 shrink-0"
           >
             <span class="truncate">{{ sublane.label }}</span>
             <span class="tabular-nums">{{ sublane.cards.length }}</span>
@@ -972,7 +972,7 @@ function affectedDevicesTooltip(card: CardData): string {
                      tooltip — the colour does the talking; full
                      countdown text lives in the detail view. -->
                 <div class="flex items-start justify-between gap-1.5 mb-1">
-                  <h4 class="text-[13px] font-medium text-primary line-clamp-2 flex-1 inline-flex items-baseline gap-1">
+                  <h4 class="text-xs-plus font-medium text-primary line-clamp-2 flex-1 inline-flex items-baseline gap-1">
                     <span
                       v-if="card.recurrence_rule"
                       class="text-tertiary text-xs shrink-0"
@@ -1011,7 +1011,7 @@ function affectedDevicesTooltip(card: CardData): string {
                 >
                   <span
                     v-if="card.kb_gap_signal && card.kb_gap_signal !== 'none'"
-                    class="text-[10px] font-medium rounded px-1.5 py-0.5 inline-flex items-center gap-1"
+                    class="text-3xs font-medium rounded px-1.5 py-0.5 inline-flex items-center gap-1"
                     :class="kbGapClass(card.kb_gap_signal)"
                     :title="`${card.kb_gap_signal} knowledge gap signal`"
                   >
@@ -1020,7 +1020,7 @@ function affectedDevicesTooltip(card: CardData): string {
                   </span>
                   <span
                     v-if="card.affected_devices && card.affected_devices.count > 0"
-                    class="text-[10px] font-medium rounded px-1.5 py-0.5 bg-surface-hover text-secondary inline-flex items-center gap-1"
+                    class="text-3xs font-medium rounded px-1.5 py-0.5 bg-surface-hover text-secondary inline-flex items-center gap-1"
                     :title="affectedDevicesTooltip(card)"
                   >
                     <span aria-hidden="true">▢</span>
@@ -1029,7 +1029,7 @@ function affectedDevicesTooltip(card: CardData): string {
                 </div>
 
                 <!-- Meta row -->
-                <div class="flex items-center justify-between text-[11px] text-tertiary">
+                <div class="flex items-center justify-between text-2xs text-tertiary">
                   <span class="font-mono">#{{ card.id }}</span>
                   <UserAvatar
                     v-if="card.assignee_uuid"
@@ -1046,7 +1046,7 @@ function affectedDevicesTooltip(card: CardData): string {
                      will move on the next drag. -->
                 <span
                   v-if="isSelected(card.id) && selectedIds.size > 1"
-                  class="absolute top-1 right-1 text-[10px] uppercase tracking-wide font-semibold text-accent bg-accent/10 rounded px-1.5 py-0.5"
+                  class="absolute top-1 right-1 text-3xs uppercase tracking-wide font-semibold text-accent bg-accent/10 rounded px-1.5 py-0.5"
                 >
                   {{ selectedIds.size }} selected
                 </span>
@@ -1058,7 +1058,7 @@ function affectedDevicesTooltip(card: CardData): string {
                    accent while a card is dragged over it. -->
               <div
                 v-if="sublane.cards.length === 0"
-                class="flex items-center justify-center text-[11px] italic border-2 rounded-lg min-h-12 transition-colors"
+                class="flex items-center justify-center text-2xs italic border-2 rounded-lg min-h-12 transition-colors"
                 :class="
                   isLaneHovered(sublane.id)
                     ? 'border-accent bg-accent-muted text-accent font-medium'
@@ -1087,7 +1087,7 @@ function affectedDevicesTooltip(card: CardData): string {
                 :ref="(el) => focusQuickAdd(el as Element | null)"
                 v-model="quickAddTitle"
                 type="text"
-                class="w-full text-[13px] rounded-md border border-default bg-surface px-2 py-1 text-primary placeholder:text-tertiary focus:outline-none focus:ring-2 focus:ring-accent"
+                class="w-full text-xs-plus rounded-md border border-default bg-surface px-2 py-1 text-primary placeholder:text-tertiary focus:outline-none focus:ring-2 focus:ring-accent"
                 :placeholder="projectId != null ? t('kanban-composer-placeholder') : t('kanban-quick-add-placeholder')"
                 @keydown.enter.prevent="commitQuickAdd(lane)"
                 @keydown.down.prevent="quickAddNav(1)"
@@ -1106,7 +1106,7 @@ function affectedDevicesTooltip(card: CardData): string {
                 <button
                   v-if="quickAddCanCreate"
                   type="button"
-                  class="w-full flex items-center gap-1.5 px-2 py-1.5 text-left text-[13px] text-primary"
+                  class="w-full flex items-center gap-1.5 px-2 py-1.5 text-left text-xs-plus text-primary"
                   :class="isCreateHighlighted ? 'bg-accent-muted' : 'hover:bg-surface-hover'"
                   @mousedown.prevent="submitQuickAdd(lane)"
                 >
@@ -1116,7 +1116,7 @@ function affectedDevicesTooltip(card: CardData): string {
 
                 <div
                   v-if="quickAddMatches.length > 0"
-                  class="px-2 pt-1 pb-0.5 text-[10px] uppercase tracking-wide text-tertiary border-t border-subtle"
+                  class="px-2 pt-1 pb-0.5 text-3xs uppercase tracking-wide text-tertiary border-t border-subtle"
                 >
                   {{ quickAddTitle.trim() ? t('kanban-composer-existing') : t('kanban-composer-recent') }}
                 </div>
@@ -1124,7 +1124,7 @@ function affectedDevicesTooltip(card: CardData): string {
                   v-for="(match, i) in quickAddMatches"
                   :key="match.id"
                   type="button"
-                  class="w-full flex items-center gap-1.5 px-2 py-1.5 text-left text-[13px]"
+                  class="w-full flex items-center gap-1.5 px-2 py-1.5 text-left text-xs-plus"
                   :class="isMatchHighlighted(i) ? 'bg-accent-muted' : 'hover:bg-surface-hover'"
                   @mousedown.prevent="addExisting(lane, match.id)"
                 >
@@ -1137,7 +1137,7 @@ function affectedDevicesTooltip(card: CardData): string {
             <button
               v-else
               type="button"
-              class="w-full flex items-center gap-1.5 rounded-md px-2 py-1.5 text-left text-[13px] text-tertiary hover:text-primary hover:bg-surface-hover transition-colors"
+              class="w-full flex items-center gap-1.5 rounded-md px-2 py-1.5 text-left text-xs-plus text-tertiary hover:text-primary hover:bg-surface-hover transition-colors"
               :aria-label="t('kanban-quick-add-aria', { column: lane.label })"
               @click.stop="openQuickAdd(lane.id)"
             >
@@ -1186,7 +1186,7 @@ function affectedDevicesTooltip(card: CardData): string {
 
           <div
             v-if="quickAddMatches.length > 0"
-            class="px-3 pt-3 pb-1 text-[11px] uppercase tracking-wide text-tertiary"
+            class="px-3 pt-3 pb-1 text-2xs uppercase tracking-wide text-tertiary"
           >
             {{ quickAddTitle.trim() ? t('kanban-composer-existing') : t('kanban-composer-recent') }}
           </div>
@@ -1198,7 +1198,7 @@ function affectedDevicesTooltip(card: CardData): string {
             class="w-full flex items-center gap-2.5 px-3 min-h-[52px] py-2 text-left border-b border-subtle active:bg-surface-hover"
             @click="sheetAddExisting(match.id)"
           >
-            <span class="text-tertiary tabular-nums shrink-0 text-[13px]">#{{ match.id }}</span>
+            <span class="text-tertiary tabular-nums shrink-0 text-xs-plus">#{{ match.id }}</span>
             <span class="flex-1 min-w-0 truncate text-[15px] text-primary">{{ match.title }}</span>
             <PriorityIndicator
               v-if="match.priority && match.priority !== 'none'"

--- a/frontend/src/sync/views/gantt/GanttBarHoverCard.vue
+++ b/frontend/src/sync/views/gantt/GanttBarHoverCard.vue
@@ -48,7 +48,7 @@ const blockedBy = computed(() => props.card.relation_counts?.blocked_by ?? 0)
 <template>
   <div class="w-64 p-3 flex flex-col gap-2 text-left">
     <div class="flex items-center justify-between gap-2">
-      <span class="font-mono text-[11px] text-tertiary">#{{ card.id }}</span>
+      <span class="font-mono text-2xs text-tertiary">#{{ card.id }}</span>
       <StatusPill :label="card.workflow_state.name" :tone="statusTone" size="xs" />
     </div>
 
@@ -79,7 +79,7 @@ const blockedBy = computed(() => props.card.relation_counts?.blocked_by ?? 0)
       </div>
     </div>
 
-    <p v-if="resizable" class="text-[11px] text-tertiary border-t border-subtle/60 pt-1.5">
+    <p v-if="resizable" class="text-2xs text-tertiary border-t border-subtle/60 pt-1.5">
       {{ t('gantt-hover-reschedule-hint') }}
     </p>
   </div>

--- a/frontend/src/sync/views/gantt/GanttBoard.vue
+++ b/frontend/src/sync/views/gantt/GanttBoard.vue
@@ -757,7 +757,7 @@ function open(card: CardData): void {
         </div>
         <!-- Secondary band (month / quarter spans). -->
         <div
-          class="relative h-6 text-[11px] uppercase tracking-wide font-semibold text-tertiary border-b border-subtle/60"
+          class="relative h-6 text-2xs uppercase tracking-wide font-semibold text-tertiary border-b border-subtle/60"
         >
           <div
             v-for="b in secondaryBands"
@@ -769,7 +769,7 @@ function open(card: CardData): void {
         <!-- Primary tick row (day / week), with a labelled Today pill
              anchored on the today line. -->
         <div
-          class="relative h-6 text-[11px] tabular-nums text-tertiary"
+          class="relative h-6 text-2xs tabular-nums text-tertiary"
           :class="cycleBands.length > 0 ? 'border-b border-subtle/60' : ''"
         >
           <div
@@ -780,7 +780,7 @@ function open(card: CardData): void {
           >{{ tick.label }}</div>
           <span
             v-if="todayInRange"
-            class="absolute top-1/2 -translate-y-1/2 -translate-x-1/2 z-10 rounded-full bg-accent px-1.5 py-px text-[11px] leading-4 font-semibold text-on-accent whitespace-nowrap pointer-events-none"
+            class="absolute top-1/2 -translate-y-1/2 -translate-x-1/2 z-10 rounded-full bg-accent px-1.5 py-px text-2xs leading-4 font-semibold text-on-accent whitespace-nowrap pointer-events-none"
             :style="{ left: `${todayX}px` }"
           >{{ t('gantt-today') }}</span>
         </div>
@@ -789,7 +789,7 @@ function open(card: CardData): void {
           <div
             v-for="band in cycleBands"
             :key="band.key"
-            class="absolute top-0 bottom-0 flex items-center px-2 border-l border-r text-[11px] font-medium truncate"
+            class="absolute top-0 bottom-0 flex items-center px-2 border-l border-r text-2xs font-medium truncate"
             :class="cycleStripClass(band.state)"
             :style="{ left: `${band.left}px`, width: `${band.width}px` }"
             :title="band.label"
@@ -952,7 +952,7 @@ function open(card: CardData): void {
             }"
           ></div>
           <span
-            class="absolute -translate-x-1/2 rounded-md bg-surface border border-default shadow-sm px-1.5 py-0.5 text-[11px] tabular-nums text-primary whitespace-nowrap pointer-events-none z-20"
+            class="absolute -translate-x-1/2 rounded-md bg-surface border border-default shadow-sm px-1.5 py-0.5 text-2xs tabular-nums text-primary whitespace-nowrap pointer-events-none z-20"
             :style="{
               left: `${dragChrome.chipX}px`,
               top: `${Math.max(0, dragChrome.y - 22)}px`,
@@ -1060,7 +1060,7 @@ function open(card: CardData): void {
             ></span>
             <span
               v-if="row.width >= LABEL_MIN_PX"
-              class="relative z-[1] px-1.5 text-[11px] text-primary truncate"
+              class="relative z-[1] px-1.5 text-2xs text-primary truncate"
             >
               {{ row.card.title }}
             </span>
@@ -1093,7 +1093,7 @@ function open(card: CardData): void {
                instead of truncating into nothing (industry idiom). -->
           <span
             v-if="row.width < LABEL_MIN_PX"
-            class="absolute text-[11px] text-secondary whitespace-nowrap pointer-events-none"
+            class="absolute text-2xs text-secondary whitespace-nowrap pointer-events-none"
             :style="{
               left: `${row.left + Math.max(MIN_BAR_PX, row.width - 4) + 6}px`,
               top: `${row.y + BAR_INSET_Y}px`,

--- a/frontend/src/sync/views/gantt/VerticalTimeline.vue
+++ b/frontend/src/sync/views/gantt/VerticalTimeline.vue
@@ -492,7 +492,7 @@ function onResize(el: HTMLElement | null): void {
           <!-- Pinned: the ruler is the reference for everything on the canvas,
                so panning across concurrency must not take it off-screen. -->
           <span
-            class="sticky left-0 z-20 w-11 shrink-0 pl-1 py-0.5 bg-surface text-[10px] tabular-nums leading-none"
+            class="sticky left-0 z-20 w-11 shrink-0 pl-1 py-0.5 bg-surface text-3xs tabular-nums leading-none"
             :class="tick.strong ? 'text-secondary' : 'text-tertiary'"
           >{{ tick.label }}</span>
           <span
@@ -515,7 +515,7 @@ function onResize(el: HTMLElement | null): void {
           }"
         >
           <span
-            class="sticky left-12 inline-block max-w-full truncate rounded px-1.5 py-0.5 text-[10px] font-medium border"
+            class="sticky left-12 inline-block max-w-full truncate rounded px-1.5 py-0.5 text-3xs font-medium border"
             :class="cycleStripClass(band.state)"
             :title="band.label"
           >{{ band.label }}</span>
@@ -547,7 +547,7 @@ function onResize(el: HTMLElement | null): void {
         <!-- Live date chip while moving. -->
         <div
           v-if="dragGhost"
-          class="absolute z-30 pointer-events-none rounded-full bg-accent px-1.5 py-px text-[10px] font-semibold text-on-accent tabular-nums whitespace-nowrap"
+          class="absolute z-30 pointer-events-none rounded-full bg-accent px-1.5 py-px text-3xs font-semibold text-on-accent tabular-nums whitespace-nowrap"
           :style="{
             top: `${dragGhost.chipTop}px`,
             left: `${dragGhost.chipLeft}px`,
@@ -578,15 +578,15 @@ function onResize(el: HTMLElement | null): void {
           <template v-if="fidelity(blockHeight(p)) === 'full'">
             <div class="px-1.5 py-1 flex flex-col gap-1 h-full">
               <div class="flex items-center gap-1">
-                <span class="text-[10px] tabular-nums text-tertiary">#{{ p.item.card.id }}</span>
+                <span class="text-3xs tabular-nums text-tertiary">#{{ p.item.card.id }}</span>
                 <PriorityIndicator
                   v-if="p.item.card.priority !== 'none'"
                   :priority="(p.item.card.priority === 'urgent' ? 'high' : p.item.card.priority) as 'low' | 'medium' | 'high'"
                   size="xs"
                 />
               </div>
-              <span class="text-[11px] leading-tight text-primary line-clamp-3">{{ p.item.card.title }}</span>
-              <span class="text-[10px] text-tertiary tabular-nums whitespace-nowrap">{{ dateLabel(p.item) }}</span>
+              <span class="text-2xs leading-tight text-primary line-clamp-3">{{ p.item.card.title }}</span>
+              <span class="text-3xs text-tertiary tabular-nums whitespace-nowrap">{{ dateLabel(p.item) }}</span>
               <UserAvatar
                 v-if="p.item.card.assignee_uuid"
                 :uuid="p.item.card.assignee_uuid"
@@ -600,16 +600,16 @@ function onResize(el: HTMLElement | null): void {
 
           <template v-else-if="fidelity(blockHeight(p)) === 'compact'">
             <div class="px-1.5 py-1 h-full flex flex-col gap-0.5">
-              <span class="text-[10px] tabular-nums text-tertiary">#{{ p.item.card.id }}</span>
-              <span class="block text-[11px] leading-tight text-primary line-clamp-4">{{ p.item.card.title }}</span>
-              <span class="mt-auto text-[10px] text-tertiary tabular-nums whitespace-nowrap">{{ dateLabel(p.item) }}</span>
+              <span class="text-3xs tabular-nums text-tertiary">#{{ p.item.card.id }}</span>
+              <span class="block text-2xs leading-tight text-primary line-clamp-4">{{ p.item.card.title }}</span>
+              <span class="mt-auto text-3xs text-tertiary tabular-nums whitespace-nowrap">{{ dateLabel(p.item) }}</span>
             </div>
           </template>
 
           <!-- Mark. Too small in one axis or both to letter, so it carries the
                id only and stays tappable rather than clipping text mid-word. -->
           <template v-else>
-            <span class="flex items-center justify-center w-full h-full bg-accent/15 text-[10px] tabular-nums text-secondary">
+            <span class="flex items-center justify-center w-full h-full bg-accent/15 text-3xs tabular-nums text-secondary">
               #{{ p.item.card.id }}
             </span>
           </template>
@@ -620,7 +620,7 @@ function onResize(el: HTMLElement | null): void {
     <!-- Tickets with no due date have no position on a time axis, so they sit
          outside the canvas rather than being given a fabricated one. -->
     <div v-if="unscheduled.length > 0" class="shrink-0 border-t border-default bg-surface-alt">
-      <div class="px-3 pt-2 pb-1 text-[11px] uppercase tracking-wide text-tertiary">
+      <div class="px-3 pt-2 pb-1 text-2xs uppercase tracking-wide text-tertiary">
         {{ t('gantt-unscheduled', { count: unscheduled.length }) }}
       </div>
       <button
@@ -630,8 +630,8 @@ function onResize(el: HTMLElement | null): void {
         class="w-full flex items-center gap-2 px-3 min-h-[44px] text-left border-t border-subtle active:bg-surface-hover"
         @click="onCardClick?.(card.id)"
       >
-        <span class="text-[11px] tabular-nums text-tertiary shrink-0">#{{ card.id }}</span>
-        <span class="flex-1 min-w-0 truncate text-[13px] text-primary">{{ card.title }}</span>
+        <span class="text-2xs tabular-nums text-tertiary shrink-0">#{{ card.id }}</span>
+        <span class="flex-1 min-w-0 truncate text-xs-plus text-primary">{{ card.title }}</span>
       </button>
     </div>
   </div>

--- a/frontend/src/views/AdminIndexView.vue
+++ b/frontend/src/views/AdminIndexView.vue
@@ -63,7 +63,7 @@ const filteredGroups = computed(() =>
       <!-- Grouped sections -->
       <div class="flex flex-col gap-5">
         <div v-for="group in filteredGroups" :key="group.labelKey">
-          <h2 class="text-[11px] font-semibold uppercase tracking-wider text-tertiary mb-2 px-1">
+          <h2 class="text-2xs font-semibold uppercase tracking-wider text-tertiary mb-2 px-1">
             {{ $t(group.labelKey) }}
           </h2>
           <div class="bg-surface border border-default rounded-xl overflow-hidden divide-y divide-default">

--- a/frontend/src/views/AssetsListView.vue
+++ b/frontend/src/views/AssetsListView.vue
@@ -635,7 +635,7 @@ async function exportAssetsCsv(scope?: 'history') {
           </div>
           <button
             type="button"
-            class="inline-flex items-center text-[11px] px-2 h-6 rounded-md border border-default text-secondary hover:text-primary hover:bg-surface-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-transparent disabled:hover:text-secondary"
+            class="inline-flex items-center text-2xs px-2 h-6 rounded-md border border-default text-secondary hover:text-primary hover:bg-surface-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-transparent disabled:hover:text-secondary"
             :title="listView.page.totalItems.value === 0 ? $t('assets-list-export-empty') : $t('assets-list-export-csv')"
             :disabled="listView.page.totalItems.value === 0"
             @click="exportAssetsCsv()"
@@ -644,7 +644,7 @@ async function exportAssetsCsv(scope?: 'history') {
           </button>
           <button
             type="button"
-            class="inline-flex items-center text-[11px] px-2 h-6 rounded-md border border-default text-secondary hover:text-primary hover:bg-surface-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-transparent disabled:hover:text-secondary"
+            class="inline-flex items-center text-2xs px-2 h-6 rounded-md border border-default text-secondary hover:text-primary hover:bg-surface-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-transparent disabled:hover:text-secondary"
             :title="listView.page.totalItems.value === 0 ? $t('assets-list-export-empty') : $t('assets-list-export-history')"
             :disabled="listView.page.totalItems.value === 0"
             @click="exportAssetsCsv('history')"
@@ -713,11 +713,11 @@ async function exportAssetsCsv(scope?: 'history') {
                 :style="{ backgroundColor: group.color || 'var(--color-text-tertiary)' }"
                 :title="group.name"
               />
-              <span v-if="item.groups.length > 3" class="text-[10px] text-tertiary">+{{ item.groups.length - 3 }}</span>
+              <span v-if="item.groups.length > 3" class="text-3xs text-tertiary">+{{ item.groups.length - 3 }}</span>
             </div>
             <span
               v-if="isLowStock(item)"
-              class="text-[10px] px-1.5 py-0.5 rounded-full bg-status-warning/15 text-status-warning whitespace-nowrap font-medium flex-shrink-0"
+              class="text-3xs px-1.5 py-0.5 rounded-full bg-status-warning/15 text-status-warning whitespace-nowrap font-medium flex-shrink-0"
               :title="$t('assets-list-low-stock-tooltip', { quantity: item.quantity ?? '', unit: item.unit ?? '', threshold: item.low_stock_threshold ?? '' })"
             >
               {{ $t('assets-list-low-stock-badge') }}

--- a/frontend/src/views/BrandingSettingsView.vue
+++ b/frontend/src/views/BrandingSettingsView.vue
@@ -362,9 +362,9 @@ async function confirmDeleteBrandingImage(): Promise<void> {
               />
               <p class="text-xs text-tertiary">
                 {{ $t('admin-branding-signature-default-variables-hint') }}
-                <code class="text-[10px] bg-surface-alt px-1 rounded">&#123;&#123;tech_name&#125;&#125;</code>,
-                <code class="text-[10px] bg-surface-alt px-1 rounded">&#123;&#123;tech_email&#125;&#125;</code>,
-                <code class="text-[10px] bg-surface-alt px-1 rounded">&#123;&#123;app_name&#125;&#125;</code>
+                <code class="text-3xs bg-surface-alt px-1 rounded">&#123;&#123;tech_name&#125;&#125;</code>,
+                <code class="text-3xs bg-surface-alt px-1 rounded">&#123;&#123;tech_email&#125;&#125;</code>,
+                <code class="text-3xs bg-surface-alt px-1 rounded">&#123;&#123;app_name&#125;&#125;</code>
               </p>
             </div>
 

--- a/frontend/src/views/ChannelsEmailSettingsView.vue
+++ b/frontend/src/views/ChannelsEmailSettingsView.vue
@@ -299,11 +299,11 @@
             />
             <p class="text-xs text-tertiary">
               {{ $t('admin-channels-email-auto-ack-variables-hint') }}
-              <code class="text-[10px] bg-surface-alt px-1 rounded">&#123;&#123;ticket_id&#125;&#125;</code>,
-              <code class="text-[10px] bg-surface-alt px-1 rounded">&#123;&#123;ticket_title&#125;&#125;</code>,
-              <code class="text-[10px] bg-surface-alt px-1 rounded">&#123;&#123;customer_name&#125;&#125;</code>,
-              <code class="text-[10px] bg-surface-alt px-1 rounded">&#123;&#123;customer_first_name&#125;&#125;</code>,
-              <code class="text-[10px] bg-surface-alt px-1 rounded">&#123;&#123;app_name&#125;&#125;</code>
+              <code class="text-3xs bg-surface-alt px-1 rounded">&#123;&#123;ticket_id&#125;&#125;</code>,
+              <code class="text-3xs bg-surface-alt px-1 rounded">&#123;&#123;ticket_title&#125;&#125;</code>,
+              <code class="text-3xs bg-surface-alt px-1 rounded">&#123;&#123;customer_name&#125;&#125;</code>,
+              <code class="text-3xs bg-surface-alt px-1 rounded">&#123;&#123;customer_first_name&#125;&#125;</code>,
+              <code class="text-3xs bg-surface-alt px-1 rounded">&#123;&#123;app_name&#125;&#125;</code>
             </p>
           </div>
 

--- a/frontend/src/views/CollectionView.vue
+++ b/frontend/src/views/CollectionView.vue
@@ -420,14 +420,14 @@ const deleteModalTitle = computed(() =>
               <span
                 v-for="group in override.groups"
                 :key="'g-' + group.id"
-                class="text-[10px] px-1.5 py-0.5 rounded-full bg-accent/10 text-accent flex-shrink-0"
+                class="text-3xs px-1.5 py-0.5 rounded-full bg-accent/10 text-accent flex-shrink-0"
               >
                 {{ group.name }}
               </span>
               <span
                 v-for="user in (override.users || [])"
                 :key="'u-' + user.uuid"
-                class="text-[10px] px-1.5 py-0.5 rounded-full bg-blue-500/10 text-blue-600 dark:text-blue-400 flex-shrink-0"
+                class="text-3xs px-1.5 py-0.5 rounded-full bg-blue-500/10 text-blue-600 dark:text-blue-400 flex-shrink-0"
               >
                 {{ user.name }}
               </span>

--- a/frontend/src/views/DataImportView.vue
+++ b/frontend/src/views/DataImportView.vue
@@ -82,7 +82,7 @@ const statusBadges = computed<Record<string, { text: string; class: string }>>((
             <div class="flex items-center gap-2">
               <h3 class="text-sm font-medium text-primary">{{ $t(item.titleKey) }}</h3>
               <span
-                class="px-1.5 py-0.5 text-[11px] font-medium rounded-full"
+                class="px-1.5 py-0.5 text-2xs font-medium rounded-full"
                 :class="statusBadges[item.status]?.class"
               >
                 {{ statusBadges[item.status]?.text }}

--- a/frontend/src/views/DocumentView.vue
+++ b/frontend/src/views/DocumentView.vue
@@ -721,8 +721,8 @@ watch(documentObj, (newDocument) => {
                 <!-- Metadata -->
                 <div class="flex flex-wrap items-center gap-x-3 gap-y-2 text-xs text-tertiary">
                   <!-- Status Badge -->
-                  <span v-if="document.status === 'draft'" class="text-[10px] px-1.5 py-0.5 rounded bg-status-warning-muted text-status-warning font-medium">{{ $t('doc-detail-status-draft') }}</span>
-                  <span v-else-if="document.status === 'archived'" class="text-[10px] px-1.5 py-0.5 rounded bg-surface-alt text-secondary font-medium">{{ $t('doc-detail-status-archived') }}</span>
+                  <span v-if="document.status === 'draft'" class="text-3xs px-1.5 py-0.5 rounded bg-status-warning-muted text-status-warning font-medium">{{ $t('doc-detail-status-draft') }}</span>
+                  <span v-else-if="document.status === 'archived'" class="text-3xs px-1.5 py-0.5 rounded bg-surface-alt text-secondary font-medium">{{ $t('doc-detail-status-archived') }}</span>
 
                   <!--
                     Verification status chip — sits next to the
@@ -738,7 +738,7 @@ watch(documentObj, (newDocument) => {
                   <button
                     v-if="document.created_by && document.requires_verification && !document.verified_at"
                     type="button"
-                    class="text-[10px] px-1.5 py-0.5 rounded font-medium bg-accent/10 text-accent hover:bg-accent/20 transition-colors flex items-center gap-1"
+                    class="text-3xs px-1.5 py-0.5 rounded font-medium bg-accent/10 text-accent hover:bg-accent/20 transition-colors flex items-center gap-1"
                     :title="$t('doc-detail-needs-verification-title')"
                     @click="verificationOpen = true"
                   >
@@ -748,7 +748,7 @@ watch(documentObj, (newDocument) => {
                   <button
                     v-else-if="document.is_stale"
                     type="button"
-                    class="text-[10px] px-1.5 py-0.5 rounded font-medium bg-status-warning-muted text-status-warning hover:bg-status-warning/25 transition-colors flex items-center gap-1 animate-pulse"
+                    class="text-3xs px-1.5 py-0.5 rounded font-medium bg-status-warning-muted text-status-warning hover:bg-status-warning/25 transition-colors flex items-center gap-1 animate-pulse"
                     :title="$t('doc-detail-verification-stale-title')"
                     @click="verificationOpen = true"
                   >

--- a/frontend/src/views/DocumentationGapsView.vue
+++ b/frontend/src/views/DocumentationGapsView.vue
@@ -224,14 +224,14 @@ function signalLabel(signal: KnowledgeGapSignal): string {
           <button
             type="button"
             :disabled="detectMutation.asyncStatus.value === 'loading'"
-            class="text-[11px] px-2 py-1 rounded-md bg-surface-alt hover:bg-surface-hover text-secondary hover:text-primary transition-colors disabled:opacity-50 flex items-center gap-1.5"
+            class="text-2xs px-2 py-1 rounded-md bg-surface-alt hover:bg-surface-hover text-secondary hover:text-primary transition-colors disabled:opacity-50 flex items-center gap-1.5"
             @click="runDetection"
           >
             <Icon name="search" size="xs" />
             <span v-if="detectMutation.asyncStatus.value === 'loading'">{{ $t('docs-gaps-refreshing') }}&hellip;</span>
             <span v-else>{{ $t('docs-gaps-refresh') }}</span>
           </button>
-          <span v-if="detectMessage" class="text-[11px] text-tertiary truncate">
+          <span v-if="detectMessage" class="text-2xs text-tertiary truncate">
             {{ detectMessage }}
           </span>
         </div>
@@ -255,13 +255,13 @@ function signalLabel(signal: KnowledgeGapSignal): string {
                   {{ gap.title }}
                 </p>
                 <span
-                  class="flex-shrink-0 text-[10px] px-1.5 py-0.5 rounded bg-surface text-tertiary"
+                  class="flex-shrink-0 text-3xs px-1.5 py-0.5 rounded bg-surface text-tertiary"
                   :title="$t('docs-gaps-impact-tooltip', { count: gap.impact_score, label: impactLabel(gap.title) })"
                 >
                   {{ gap.impact_score }}&nbsp;{{ impactLabel(gap.title) }}
                 </span>
               </div>
-              <div class="flex items-center justify-between gap-2 text-[11px] text-tertiary">
+              <div class="flex items-center justify-between gap-2 text-2xs text-tertiary">
                 <span>{{ $t('docs-gaps-signal-count', { count: gap.evidence_count }) }}</span>
                 <span v-if="gap.last_evidence_at">
                   {{ formatRelativeTime(gap.last_evidence_at) }}
@@ -307,7 +307,7 @@ function signalLabel(signal: KnowledgeGapSignal): string {
               <p v-if="selectedGap.description" class="text-sm text-secondary mt-2">
                 {{ selectedGap.description }}
               </p>
-              <div class="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px] text-tertiary">
+              <div class="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-2xs text-tertiary">
                 <span>{{ $t('docs-gaps-status-label') }} <span class="text-secondary">{{ selectedGap.status }}</span></span>
                 <span>
                   <span class="text-secondary">{{ selectedGap.impact_score }}</span>
@@ -342,10 +342,10 @@ function signalLabel(signal: KnowledgeGapSignal): string {
                 <Icon name="ticket" class="flex-shrink-0 mt-0.5 text-tertiary" />
                 <div class="flex-1 min-w-0">
                   <div class="flex items-center justify-between gap-2 mb-1">
-                    <span class="text-[10px] uppercase tracking-wide text-tertiary">
+                    <span class="text-3xs uppercase tracking-wide text-tertiary">
                       {{ signalLabel(signal) }}
                     </span>
-                    <span class="text-[10px] text-tertiary">
+                    <span class="text-3xs text-tertiary">
                       {{ formatRelativeTime(signal.detected_at) }}
                     </span>
                   </div>
@@ -390,7 +390,7 @@ function signalLabel(signal: KnowledgeGapSignal): string {
                     </ul>
                     <p
                       v-if="(clusterPayload(signal).member_count ?? 0) > (clusterPayload(signal).sample_titles?.length ?? 0)"
-                      class="text-[11px] text-tertiary mt-1"
+                      class="text-2xs text-tertiary mt-1"
                     >
                       &hellip; {{ $t('docs-gaps-cluster-more', { count: (clusterPayload(signal).member_count ?? 0) - (clusterPayload(signal).sample_titles?.length ?? 0) }) }}
                     </p>
@@ -408,7 +408,7 @@ function signalLabel(signal: KnowledgeGapSignal): string {
                     >
                       📄 {{ staleDocPayload(signal).page_title ?? $t('docs-gaps-stale-untitled') }}
                     </RouterLink>
-                    <p class="text-[11px] text-tertiary mt-1">
+                    <p class="text-2xs text-tertiary mt-1">
                       <template v-if="staleDocPayload(signal).verified_at">
                         <span class="text-secondary">
                           {{ $t('docs-gaps-stale-verified', { time: formatRelativeTime(staleDocPayload(signal).verified_at!) }) }}
@@ -426,7 +426,7 @@ function signalLabel(signal: KnowledgeGapSignal): string {
                     </p>
                     <p
                       v-if="(staleDocPayload(signal).recent_ticket_ids?.length ?? 0) > 0"
-                      class="text-[11px] text-tertiary mt-1"
+                      class="text-2xs text-tertiary mt-1"
                     >
                       <span class="text-secondary">{{ staleDocPayload(signal).recent_ticket_ids!.length }}</span>
                       {{ $t('docs-gaps-stale-recent-tickets', { count: staleDocPayload(signal).recent_ticket_ids!.length }) }}
@@ -442,7 +442,7 @@ function signalLabel(signal: KnowledgeGapSignal): string {
                         </template>
                       </span>
                     </p>
-                    <p class="text-[11px] text-tertiary mt-1 italic">
+                    <p class="text-2xs text-tertiary mt-1 italic">
                       {{ $t('docs-gaps-stale-auto-dismiss') }}
                     </p>
                   </template>
@@ -454,7 +454,7 @@ function signalLabel(signal: KnowledgeGapSignal): string {
                     <p class="text-sm text-primary">
                       "{{ failedSearchPayload(signal).query_sample ?? signal.source_ref }}"
                     </p>
-                    <p class="text-[11px] text-tertiary mt-1">
+                    <p class="text-2xs text-tertiary mt-1">
                       {{ $t('docs-gaps-failed-search-count', { count: failedSearchPayload(signal).count ?? 0 }) }}
                       <template v-if="failedSearchPayload(signal).first_seen && failedSearchPayload(signal).last_seen">
                         &middot; {{ $t('docs-gaps-failed-search-range', { first: formatRelativeTime(failedSearchPayload(signal).first_seen!), last: formatRelativeTime(failedSearchPayload(signal).last_seen!) }) }}
@@ -486,7 +486,7 @@ function signalLabel(signal: KnowledgeGapSignal): string {
                        provenance, not as the headline. -->
                   <p
                     v-if="signal.detected_by_user"
-                    class="text-[11px] text-tertiary mt-1"
+                    class="text-2xs text-tertiary mt-1"
                   >
                     {{ $t('docs-gaps-flagged-by', { name: signal.detected_by_user.name }) }}
                   </p>

--- a/frontend/src/views/DocumentationIndexView.vue
+++ b/frontend/src/views/DocumentationIndexView.vue
@@ -196,7 +196,7 @@ usePageCreateAction(handleCreatePage)
               <span class="font-medium text-primary">{{ $t('docs-index-drafts-strip-count', { count: uncollectedCount }) }}</span>
               {{ $t('docs-index-drafts-strip-suffix') }}
             </span>
-            <span class="ml-auto text-[11px] font-medium text-accent group-hover:underline whitespace-nowrap">
+            <span class="ml-auto text-2xs font-medium text-accent group-hover:underline whitespace-nowrap">
               {{ $t('docs-index-drafts-strip-review') }}
             </span>
           </RouterLink>
@@ -209,22 +209,22 @@ usePageCreateAction(handleCreatePage)
             <template #headerActions>
               <span
                 v-if="attentionCount > 0"
-                class="inline-flex items-center h-[18px] px-1.5 rounded-full bg-status-warning-muted text-amber-700 text-[11px] font-semibold tabular-nums"
+                class="inline-flex items-center h-[18px] px-1.5 rounded-full bg-status-warning-muted text-amber-700 text-2xs font-semibold tabular-nums"
               >
                 {{ attentionCount }}
               </span>
             </template>
 
-            <p v-if="gapsLoading && attentionCount === 0" class="px-3 py-2.5 text-[13px] text-tertiary">
+            <p v-if="gapsLoading && attentionCount === 0" class="px-3 py-2.5 text-xs-plus text-tertiary">
               {{ $t('docs-index-gaps-loading') }}
             </p>
-            <p v-else-if="attentionCount === 0" class="px-3 py-2.5 text-[13px] text-tertiary">
+            <p v-else-if="attentionCount === 0" class="px-3 py-2.5 text-xs-plus text-tertiary">
               {{ $t('docs-index-attention-empty') }}
             </p>
 
             <template v-else>
               <template v-if="visibleGaps.length > 0">
-                <p class="px-3 pt-2 pb-1 text-[11px] font-semibold text-tertiary uppercase tracking-wide">
+                <p class="px-3 pt-2 pb-1 text-2xs font-semibold text-tertiary uppercase tracking-wide">
                   {{ $t('docs-index-gaps-heading') }}
                 </p>
                 <ul class="flex flex-col px-1.5">
@@ -234,10 +234,10 @@ usePageCreateAction(handleCreatePage)
                       class="group flex items-center gap-2 py-1.5 px-1.5 rounded hover:bg-surface-hover transition-colors"
                     >
                       <Icon name="warning" size="xs" class="shrink-0 text-status-warning" aria-hidden="true" />
-                      <span class="truncate min-w-0 flex-1 text-[13px] leading-snug text-primary group-hover:text-accent transition-colors">
+                      <span class="truncate min-w-0 flex-1 text-xs-plus leading-snug text-primary group-hover:text-accent transition-colors">
                         {{ gap.title }}
                       </span>
-                      <span class="shrink-0 text-[10px] px-1.5 py-0.5 rounded bg-surface-alt text-tertiary tabular-nums whitespace-nowrap">
+                      <span class="shrink-0 text-3xs px-1.5 py-0.5 rounded bg-surface-alt text-tertiary tabular-nums whitespace-nowrap">
                         {{ gapImpactLabel(gap) }}
                       </span>
                     </RouterLink>
@@ -247,7 +247,7 @@ usePageCreateAction(handleCreatePage)
 
               <template v-if="verificationAttention.length > 0">
                 <p
-                  class="px-3 pt-2 pb-1 text-[11px] font-semibold text-tertiary uppercase tracking-wide"
+                  class="px-3 pt-2 pb-1 text-2xs font-semibold text-tertiary uppercase tracking-wide"
                   :class="{ 'border-t border-subtle mt-1': visibleGaps.length > 0 }"
                 >
                   {{ $t('docs-index-attention-verification') }}
@@ -261,10 +261,10 @@ usePageCreateAction(handleCreatePage)
                       <span class="shrink-0 w-4 text-center text-sm leading-none opacity-80" aria-hidden="true">
                         {{ page.icon || '📄' }}
                       </span>
-                      <span class="truncate min-w-0 flex-1 text-[13px] leading-snug text-primary group-hover:text-accent transition-colors">
+                      <span class="truncate min-w-0 flex-1 text-xs-plus leading-snug text-primary group-hover:text-accent transition-colors">
                         {{ page.title }}
                       </span>
-                      <span class="shrink-0 text-[11px] text-amber-700 whitespace-nowrap">
+                      <span class="shrink-0 text-2xs text-amber-700 whitespace-nowrap">
                         {{ verificationMeta(page) }}
                       </span>
                     </RouterLink>
@@ -273,10 +273,10 @@ usePageCreateAction(handleCreatePage)
               </template>
 
               <div class="flex items-center justify-between px-3 py-2 border-t border-default bg-surface-alt/50">
-                <RouterLink to="/documentation/gaps" class="text-[11px] font-medium text-accent hover:underline">
+                <RouterLink to="/documentation/gaps" class="text-2xs font-medium text-accent hover:underline">
                   {{ $t('docs-index-attention-gaps-link') }}
                 </RouterLink>
-                <span class="text-[11px] text-tertiary tabular-nums">
+                <span class="text-2xs text-tertiary tabular-nums">
                   {{ $t('docs-index-attention-totals', { gaps: gapCount, stale: verificationCount }) }}
                 </span>
               </div>
@@ -295,7 +295,7 @@ usePageCreateAction(handleCreatePage)
                 />
               </li>
             </ul>
-            <p v-else class="px-2 py-1.5 text-[13px] text-tertiary">
+            <p v-else class="px-2 py-1.5 text-xs-plus text-tertiary">
               {{ $t('docs-index-no-recent-activity') }}
             </p>
           </SectionCard>
@@ -305,7 +305,7 @@ usePageCreateAction(handleCreatePage)
             <template #headerActions>
               <span
                 v-if="visibleStarred.length > 0"
-                class="text-[11px] text-tertiary tabular-nums font-normal"
+                class="text-2xs text-tertiary tabular-nums font-normal"
               >
                 {{ starredPages.length }}
               </span>
@@ -320,7 +320,7 @@ usePageCreateAction(handleCreatePage)
                 />
               </li>
             </ul>
-            <p v-else class="px-2 py-1.5 text-[13px] text-tertiary">
+            <p v-else class="px-2 py-1.5 text-xs-plus text-tertiary">
               {{ $t('docs-index-starred-hint') }}
             </p>
           </SectionCard>

--- a/frontend/src/views/EmailSettingsView.vue
+++ b/frontend/src/views/EmailSettingsView.vue
@@ -413,8 +413,8 @@ const getRequiredEnvVars = () => [
           />
           <p class="text-xs text-tertiary">
             {{ $t('admin-email-security-note-variables-hint') }}
-            <code class="text-[10px] bg-surface-alt px-1 rounded">&#123;&#123;brand_name&#125;&#125;</code>,
-            <code class="text-[10px] bg-surface-alt px-1 rounded">&#123;&#123;domain&#125;&#125;</code>
+            <code class="text-3xs bg-surface-alt px-1 rounded">&#123;&#123;brand_name&#125;&#125;</code>,
+            <code class="text-3xs bg-surface-alt px-1 rounded">&#123;&#123;domain&#125;&#125;</code>
           </p>
         </div>
 

--- a/frontend/src/views/NotificationInboxView.vue
+++ b/frontend/src/views/NotificationInboxView.vue
@@ -413,7 +413,7 @@ onBeforeUnmount(() => {
             {{ tab.label }}
             <span
               v-if="tab.value === 'unread' && unreadCount > 0"
-              class="rounded-full bg-accent/15 px-1.5 py-0.5 text-[11px] font-semibold leading-none text-accent"
+              class="rounded-full bg-accent/15 px-1.5 py-0.5 text-2xs font-semibold leading-none text-accent"
             >
               {{ unreadCount > 99 ? '99+' : unreadCount }}
             </span>
@@ -562,7 +562,7 @@ onBeforeUnmount(() => {
               class="border-b border-default last:border-b-0"
             >
               <h2
-                class="sticky top-0 z-[5] bg-surface/95 px-4 py-1.5 text-[11px] font-semibold uppercase tracking-wide text-tertiary backdrop-blur"
+                class="sticky top-0 z-[5] bg-surface/95 px-4 py-1.5 text-2xs font-semibold uppercase tracking-wide text-tertiary backdrop-blur"
               >
                 {{ group.label }}
               </h2>

--- a/frontend/src/views/ProfileSettingsView.vue
+++ b/frontend/src/views/ProfileSettingsView.vue
@@ -619,7 +619,7 @@ const cancelDelete = () => {
               <template #headerActions>
                 <router-link
                   to="/admin/groups"
-                  class="text-[11px] font-medium text-accent hover:underline whitespace-nowrap inline-flex items-center gap-1"
+                  class="text-2xs font-medium text-accent hover:underline whitespace-nowrap inline-flex items-center gap-1"
                 >
                   <Icon name="settings" size="xs" />
                   Manage Groups
@@ -728,7 +728,7 @@ const cancelDelete = () => {
               </template>
               <template #title>{{ t('user-settings-account-setup-title') }}</template>
               <template #headerActions>
-                <span class="text-[11px] px-2 py-0.5 bg-status-warning/20 text-status-warning rounded-full font-medium">{{ t('user-settings-account-setup-pending') }}</span>
+                <span class="text-2xs px-2 py-0.5 bg-status-warning/20 text-status-warning rounded-full font-medium">{{ t('user-settings-account-setup-pending') }}</span>
               </template>
 
               <div>

--- a/frontend/src/views/ProjectCyclesView.vue
+++ b/frontend/src/views/ProjectCyclesView.vue
@@ -380,7 +380,7 @@ async function onMoveMenuSelect(id: string): Promise<void> {
                      group header, so rows don't repeat it. -->
                 <div class="flex flex-col @container">
                   <div v-for="group in activeCycleGroups" :key="group.category">
-                    <div class="px-3 py-1.5 text-[11px] uppercase tracking-wide font-semibold text-tertiary bg-surface-alt border-b border-subtle/50">
+                    <div class="px-3 py-1.5 text-2xs uppercase tracking-wide font-semibold text-tertiary bg-surface-alt border-b border-subtle/50">
                       {{ group.label }} <span class="text-tertiary">({{ group.tickets.length }})</span>
                     </div>
                     <div
@@ -447,7 +447,7 @@ async function onMoveMenuSelect(id: string): Promise<void> {
               <section v-if="upcomingCycles.length > 0" class="flex flex-col gap-2">
                 <div class="flex items-center gap-2 px-0.5">
                   <h2 class="text-sm font-semibold text-primary">{{ $t('project-cycles-upcoming-title') }}</h2>
-                  <span class="text-[11px] text-tertiary tabular-nums">{{ upcomingCycles.length }}</span>
+                  <span class="text-2xs text-tertiary tabular-nums">{{ upcomingCycles.length }}</span>
                 </div>
                 <div class="hidden sm:flex flex-col @container bg-surface border border-default rounded-lg p-1.5">
                   <CycleListRow
@@ -481,7 +481,7 @@ async function onMoveMenuSelect(id: string): Promise<void> {
               <section v-if="completedCycles.length > 0" class="flex flex-col gap-2">
                 <div class="flex items-center gap-2 px-0.5">
                   <h2 class="text-sm font-semibold text-primary">{{ $t('project-cycles-completed-title') }}</h2>
-                  <span class="text-[11px] text-tertiary tabular-nums">{{ completedCycles.length }}</span>
+                  <span class="text-2xs text-tertiary tabular-nums">{{ completedCycles.length }}</span>
                 </div>
                 <div class="hidden sm:flex flex-col @container bg-surface border border-default rounded-lg p-1.5">
                   <CycleListRow
@@ -513,7 +513,7 @@ async function onMoveMenuSelect(id: string): Promise<void> {
     <!-- Create cycle -->
     <Modal :show="showCreate" :title="$t('project-cycles-create-title')" size="sm" @close="showCreate = false">
       <form class="flex flex-col gap-3" @submit.prevent="createCycle">
-        <p v-if="velocity != null" class="text-[11px] text-tertiary">
+        <p v-if="velocity != null" class="text-2xs text-tertiary">
           {{ $t('project-cycles-velocity-hint', { count: velocity }) }}
         </p>
         <label class="flex flex-col gap-1 text-xs text-secondary">

--- a/frontend/src/views/ProjectsView.vue
+++ b/frontend/src/views/ProjectsView.vue
@@ -425,7 +425,7 @@ function handleProjectContextMenuSelect(actionId: string): void {
           </template>
 
           <template #cell-updated="{ item }">
-            <span v-if="item.updated_at" class="text-[11px] text-tertiary tabular-nums">
+            <span v-if="item.updated_at" class="text-2xs text-tertiary tabular-nums">
               {{ formatCompactRelativeTime(item.updated_at) }}
             </span>
           </template>

--- a/frontend/src/views/SlaAdminView.vue
+++ b/frontend/src/views/SlaAdminView.vue
@@ -678,7 +678,7 @@ const clockStartOptions = computed(() => [
           <template #headerActions>
             <button
               type="button"
-              class="inline-flex items-center gap-1 text-[11px] font-medium text-accent hover:underline"
+              class="inline-flex items-center gap-1 text-2xs font-medium text-accent hover:underline"
               @click="openCreateCalendar"
             >
               <Icon name="add" class="w-3 h-3" />
@@ -708,7 +708,7 @@ const clockStartOptions = computed(() => [
                     <button
                       v-if="cal.is_default"
                       type="button"
-                      class="text-[10px] uppercase tracking-wide font-semibold text-accent border border-accent/40 bg-accent/10 rounded px-1.5 py-0.5 hover:bg-accent/15 transition-colors"
+                      class="text-3xs uppercase tracking-wide font-semibold text-accent border border-accent/40 bg-accent/10 rounded px-1.5 py-0.5 hover:bg-accent/15 transition-colors"
                       @click="toggleCalendarDefault(cal)"
                     >
                       {{ $t('admin-sla-default-badge') }}
@@ -755,7 +755,7 @@ const clockStartOptions = computed(() => [
           <template #headerActions>
             <button
               type="button"
-              class="inline-flex items-center gap-1 text-[11px] font-medium text-accent hover:underline"
+              class="inline-flex items-center gap-1 text-2xs font-medium text-accent hover:underline"
               @click="openCreatePolicy"
             >
               <Icon name="add" class="w-3 h-3" />
@@ -837,7 +837,7 @@ const clockStartOptions = computed(() => [
                     <button
                       v-if="p.is_default"
                       type="button"
-                      class="text-[10px] uppercase tracking-wide font-semibold text-accent border border-accent/40 bg-accent/10 rounded px-1.5 py-0.5 hover:bg-accent/15 transition-colors"
+                      class="text-3xs uppercase tracking-wide font-semibold text-accent border border-accent/40 bg-accent/10 rounded px-1.5 py-0.5 hover:bg-accent/15 transition-colors"
                       @click="togglePolicyDefault(p)"
                     >
                       {{ $t('admin-sla-default-badge') }}
@@ -938,7 +938,7 @@ const clockStartOptions = computed(() => [
         <div v-if="editingCalendar" class="flex flex-col gap-2 pt-2 border-t border-subtle">
           <div class="flex items-center justify-between gap-3">
             <span :class="FIELD_LABEL_CLASS">{{ $t('admin-sla-field-holidays') }}</span>
-            <div class="flex items-center gap-2 text-[11px] text-tertiary">
+            <div class="flex items-center gap-2 text-2xs text-tertiary">
               <span>{{ $t('admin-sla-holiday-import-label') }}</span>
               <BaseDropdown
                 :model-value="importChoice"
@@ -951,7 +951,7 @@ const clockStartOptions = computed(() => [
           </div>
           <p
             v-if="importSummary"
-            class="text-[11px] text-accent bg-accent/10 border border-accent/30 rounded px-2 py-1"
+            class="text-2xs text-accent bg-accent/10 border border-accent/30 rounded px-2 py-1"
             role="status"
           >
             {{ importSummary }}
@@ -968,7 +968,7 @@ const clockStartOptions = computed(() => [
               <span class="font-mono tabular-nums text-primary">{{ h.date }}</span>
               <span
                 v-if="h.recurrence === 'annual'"
-                class="text-[10px] uppercase tracking-wide font-semibold text-accent border border-accent/40 bg-accent/10 rounded px-1.5 py-0.5"
+                class="text-3xs uppercase tracking-wide font-semibold text-accent border border-accent/40 bg-accent/10 rounded px-1.5 py-0.5"
               >
                 {{ $t('admin-sla-holiday-annual-badge') }}
               </span>
@@ -983,13 +983,13 @@ const clockStartOptions = computed(() => [
               </button>
             </li>
           </ul>
-          <p v-else class="text-[11px] text-tertiary italic">
+          <p v-else class="text-2xs text-tertiary italic">
             {{ $t('admin-sla-holidays-empty-hint') }}
           </p>
           <div class="flex flex-col gap-2">
             <div class="flex flex-wrap items-end gap-2">
               <label class="flex flex-col gap-1">
-                <span class="text-[10px] uppercase tracking-wide font-medium text-tertiary">
+                <span class="text-3xs uppercase tracking-wide font-medium text-tertiary">
                   {{ $t('admin-sla-holiday-date') }}
                 </span>
                 <DatePicker
@@ -999,7 +999,7 @@ const clockStartOptions = computed(() => [
                 />
               </label>
               <label class="flex flex-col gap-1 flex-1 min-w-[12rem]">
-                <span class="text-[10px] uppercase tracking-wide font-medium text-tertiary">
+                <span class="text-3xs uppercase tracking-wide font-medium text-tertiary">
                   {{ $t('admin-sla-holiday-label') }}
                 </span>
                 <input
@@ -1062,7 +1062,7 @@ const clockStartOptions = computed(() => [
         <!-- Conditions: which tickets does this policy match? -->
         <fieldset class="flex flex-col gap-2">
           <legend
-            class="text-[11px] font-medium text-tertiary uppercase tracking-wide mb-1"
+            class="text-2xs font-medium text-tertiary uppercase tracking-wide mb-1"
           >
             {{ $t('admin-sla-form-conditions-heading') }}
           </legend>
@@ -1101,14 +1101,14 @@ const clockStartOptions = computed(() => [
             :label="$t('admin-sla-field-no-sla')"
             @update:model-value="(v: boolean) => (policyDraft.no_sla = v)"
           />
-          <p class="text-[11px] text-tertiary pl-6">{{ $t('admin-sla-field-no-sla-hint') }}</p>
+          <p class="text-2xs text-tertiary pl-6">{{ $t('admin-sla-field-no-sla-hint') }}</p>
         </div>
 
         <!-- Targets: what the engine computes for each match. Irrelevant (and
              hidden) for a No-SLA policy. -->
         <fieldset v-if="!policyDraft.no_sla" class="flex flex-col gap-2">
           <legend
-            class="text-[11px] font-medium text-tertiary uppercase tracking-wide mb-1"
+            class="text-2xs font-medium text-tertiary uppercase tracking-wide mb-1"
           >
             {{ $t('admin-sla-form-targets-heading') }}
           </legend>
@@ -1145,7 +1145,7 @@ const clockStartOptions = computed(() => [
               size="sm"
               @update:model-value="(v) => (policyDraft.clock_start = String(v))"
             />
-            <p class="text-[11px] text-tertiary">{{ $t('admin-sla-field-clock-start-hint') }}</p>
+            <p class="text-2xs text-tertiary">{{ $t('admin-sla-field-clock-start-hint') }}</p>
           </div>
         </fieldset>
 

--- a/frontend/src/views/admin/AdminAuditView.vue
+++ b/frontend/src/views/admin/AdminAuditView.vue
@@ -504,7 +504,7 @@ function clearFilters() {
           <th
             scope="colgroup"
             colspan="5"
-            class="pt-4 pb-1 pl-2 text-left text-[10px] font-semibold uppercase tracking-wide text-tertiary"
+            class="pt-4 pb-1 pl-2 text-left text-3xs font-semibold uppercase tracking-wide text-tertiary"
           >
             {{ group.label }}
           </th>
@@ -541,7 +541,7 @@ function clearFilters() {
                   {{ entry.severity }}
                 </span>
               </div>
-              <code class="font-mono text-[11px] text-tertiary">{{ entry.event_type }}</code>
+              <code class="font-mono text-2xs text-tertiary">{{ entry.event_type }}</code>
             </td>
 
             <td class="py-2 align-top">

--- a/frontend/src/views/admin/AdminWorkspacesView.vue
+++ b/frontend/src/views/admin/AdminWorkspacesView.vue
@@ -363,7 +363,7 @@ const deleteTypeToConfirmLabel = computed(() => {
                   </td>
                   <td class="px-3 py-2">
                     <span
-                      class="text-[10px] uppercase tracking-wide font-semibold rounded px-1.5 py-0.5"
+                      class="text-3xs uppercase tracking-wide font-semibold rounded px-1.5 py-0.5"
                       :class="
                         ws.archived_at
                           ? 'text-secondary border border-default bg-surface-alt'

--- a/frontend/src/views/admin/EmailQueueView.vue
+++ b/frontend/src/views/admin/EmailQueueView.vue
@@ -335,7 +335,7 @@ const deadTotal = computed(
                the upstream diagnostic so a hover reveals "why". -->
           <span
             v-if="row.bounced_at"
-            class="text-[10px] font-semibold uppercase tracking-wide px-2 py-0.5 rounded bg-red-500/10 text-red-700 dark:text-red-400"
+            class="text-3xs font-semibold uppercase tracking-wide px-2 py-0.5 rounded bg-red-500/10 text-red-700 dark:text-red-400"
             :title="row.bounce_diagnostic
               ? t('admin-email-queue-bounced-with-diagnostic', { diagnostic: row.bounce_diagnostic })
               : t('admin-email-queue-bounced-no-diagnostic')"

--- a/frontend/src/views/admin/EmailSuppressionsView.vue
+++ b/frontend/src/views/admin/EmailSuppressionsView.vue
@@ -217,7 +217,7 @@ function formatDateTime(iso: string): string {
                 class="rounded border border-default bg-surface px-3 py-2 flex items-center gap-3"
             >
                 <span
-                    class="text-[10px] font-semibold uppercase tracking-wide px-2 py-0.5 rounded"
+                    class="text-3xs font-semibold uppercase tracking-wide px-2 py-0.5 rounded"
                     :class="toneFor(row.reason)"
                 >
                     {{ reasonLabel(row.reason) }}

--- a/frontend/src/views/admin/WorkflowStatesView.vue
+++ b/frontend/src/views/admin/WorkflowStatesView.vue
@@ -255,7 +255,7 @@ onMounted(() => {
             />
             <span
               v-if="state.is_default"
-              class="text-[10px] uppercase tracking-wide font-semibold text-accent border border-accent/40 bg-accent/10 rounded px-1.5 py-0.5"
+              class="text-3xs uppercase tracking-wide font-semibold text-accent border border-accent/40 bg-accent/10 rounded px-1.5 py-0.5"
             >
               {{ $t('admin-workflow-states-default-badge') }}
             </span>

--- a/frontend/src/views/dashboard/ChannelHealthWidget.vue
+++ b/frontend/src/views/dashboard/ChannelHealthWidget.vue
@@ -81,10 +81,10 @@ function polledLabel(at: string | null | undefined): string {
         />
         <div class="flex-1 min-w-0">
           <p class="text-sm text-primary truncate">{{ c.name }}</p>
-          <p class="mt-0.5 text-[11px] text-tertiary truncate">
+          <p class="mt-0.5 text-2xs text-tertiary truncate">
             {{ c.provider }} · {{ polledLabel(c.last_polled_at) }}
           </p>
-          <p v-if="lastError(c)" class="mt-0.5 text-[11px] text-status-error truncate">
+          <p v-if="lastError(c)" class="mt-0.5 text-2xs text-status-error truncate">
             {{ lastError(c) }}
           </p>
         </div>

--- a/frontend/src/views/dashboard/DashboardWidgetShell.vue
+++ b/frontend/src/views/dashboard/DashboardWidgetShell.vue
@@ -448,7 +448,7 @@ function sizeCodeToSpan(code: string): WidgetSpan | null {
       ]"
       @pointerdown="onHeaderPointerDown"
     >
-      <h2 class="text-[13px] font-semibold text-primary truncate tracking-tight">{{ title }}</h2>
+      <h2 class="text-xs-plus font-semibold text-primary truncate tracking-tight">{{ title }}</h2>
 
       <!-- Optional inline count badge next to the title (e.g. "12"
            assigned tickets). Renders as a pill: h-5, rounded, mono
@@ -465,7 +465,7 @@ function sizeCodeToSpan(code: string): WidgetSpan | null {
       <router-link
         v-if="actionTo && !editMode"
         :to="actionTo"
-        class="text-[11px] font-medium text-accent hover:underline whitespace-nowrap"
+        class="text-2xs font-medium text-accent hover:underline whitespace-nowrap"
       >
         {{ actionLabelText }} →
       </router-link>

--- a/frontend/src/views/dashboard/KnowledgeGapsWidget.vue
+++ b/frontend/src/views/dashboard/KnowledgeGapsWidget.vue
@@ -74,7 +74,7 @@ function signalCount(count: number): string {
           <Icon name="warning" class="text-amber-500 flex-shrink-0 mt-0.5" />
           <div class="flex-1 min-w-0">
             <p class="text-sm text-primary truncate">{{ item.title }}</p>
-            <div class="text-[11px] text-tertiary mt-0.5 flex items-center gap-2">
+            <div class="text-2xs text-tertiary mt-0.5 flex items-center gap-2">
               <span>{{ signalCount(item.evidenceCount) }}</span>
               <span v-if="item.lastEvidenceAt" class="text-subtle">&middot;</span>
               <span v-if="item.lastEvidenceAt">
@@ -83,7 +83,7 @@ function signalCount(count: number): string {
             </div>
           </div>
           <span
-            class="flex-shrink-0 text-[10px] px-1.5 py-0.5 rounded bg-surface-alt text-tertiary"
+            class="flex-shrink-0 text-3xs px-1.5 py-0.5 rounded bg-surface-alt text-tertiary"
             :title="impactTooltip(item)"
           >
             {{ impactBadge(item) }}

--- a/frontend/src/views/dashboard/KpiRail.vue
+++ b/frontend/src/views/dashboard/KpiRail.vue
@@ -48,7 +48,7 @@ defineProps<{
         </span>
         <span class="flex-1 min-h-0" aria-hidden="true" />
         <span
-          class="shrink-0 text-[10px] font-medium uppercase tracking-wider text-tertiary truncate max-w-full"
+          class="shrink-0 text-3xs font-medium uppercase tracking-wider text-tertiary truncate max-w-full"
         >
           {{ stat.label }}
         </span>

--- a/frontend/src/views/dashboard/MyAssetsWidget.vue
+++ b/frontend/src/views/dashboard/MyAssetsWidget.vue
@@ -62,7 +62,7 @@ const errorMessage = computed(() =>
           class="block px-4 py-2 hover:bg-surface-hover transition-colors group"
         >
           <p class="text-sm text-primary truncate group-hover:text-accent transition-colors">{{ d.name }}</p>
-          <p class="mt-0.5 text-[11px] text-tertiary truncate">
+          <p class="mt-0.5 text-2xs text-tertiary truncate">
             {{ d.model || t('dashboard-my-assets-unknown-model') }}<template v-if="d.attributes?.hostname"> · {{ d.attributes.hostname }}</template>
           </p>
         </router-link>

--- a/frontend/src/views/dashboard/charts/ContributionHeatmapPlot.vue
+++ b/frontend/src/views/dashboard/charts/ContributionHeatmapPlot.vue
@@ -89,7 +89,7 @@ function tooltipDetails(day: ContributionDay) {
 <template>
   <div class="flex flex-1 min-h-0 h-full w-full gap-1.5 px-1 py-1">
     <div
-      class="grid grid-rows-7 shrink-0 w-7 h-full text-[9px] leading-none text-tertiary tabular-nums"
+      class="grid grid-rows-7 shrink-0 w-7 h-full text-4xs leading-none text-tertiary tabular-nums"
       aria-hidden="true"
     >
       <span

--- a/frontend/src/views/dashboard/charts/Heatmap.vue
+++ b/frontend/src/views/dashboard/charts/Heatmap.vue
@@ -93,7 +93,7 @@ function cellAlpha(dow: number, hour: number): number {
         props.viewUuid ? 'transition-colors hover:bg-surface-hover rounded' : '',
       ]"
     >
-      <div class="grid grid-cols-[2rem_repeat(24,minmax(0,1fr))] gap-px text-[9px] text-tertiary">
+      <div class="grid grid-cols-[2rem_repeat(24,minmax(0,1fr))] gap-px text-4xs text-tertiary">
         <span aria-hidden="true" />
         <span
           v-for="h in HOUR_LABELS"
@@ -108,7 +108,7 @@ function cellAlpha(dow: number, hour: number): number {
         :key="`row-${dow}`"
         class="grid grid-cols-[2rem_repeat(24,minmax(0,1fr))] gap-px"
       >
-        <span class="text-[10px] text-tertiary self-center">{{ label }}</span>
+        <span class="text-3xs text-tertiary self-center">{{ label }}</span>
         <span
           v-for="h in HOUR_LABELS"
           :key="`c-${dow}-${h}`"

--- a/frontend/src/views/dashboard/charts/KpiTile.vue
+++ b/frontend/src/views/dashboard/charts/KpiTile.vue
@@ -165,7 +165,7 @@ const drillTo = computed(() => {
     <div
       v-if="deltaSign && deltaPctDisplay"
       :class="[
-        'flex items-center gap-1 text-[11px] font-medium tabular-nums',
+        'flex items-center gap-1 text-2xs font-medium tabular-nums',
         deltaSign === 'up' ? 'text-status-success' : '',
         deltaSign === 'down' ? 'text-status-error' : '',
         deltaSign === 'flat' ? 'text-tertiary' : '',

--- a/frontend/src/views/dashboard/charts/VolumeKpiRail.vue
+++ b/frontend/src/views/dashboard/charts/VolumeKpiRail.vue
@@ -47,14 +47,14 @@ defineProps<{
         </span>
         <span
           v-if="stat.snapshot && stat.snapshotLabel"
-          class="text-[10px] font-medium uppercase tracking-wide text-tertiary truncate"
+          class="text-3xs font-medium uppercase tracking-wide text-tertiary truncate"
         >
           {{ stat.snapshotLabel }}
         </span>
         <span
           v-else-if="stat.deltaSign && stat.deltaPctDisplay"
           :class="[
-            'inline-flex items-center gap-0.5 text-[10px] sm:text-[11px] font-medium tabular-nums truncate',
+            'inline-flex items-center gap-0.5 text-3xs sm:text-2xs font-medium tabular-nums truncate',
             stat.deltaSign === 'up' ? 'text-status-success' : '',
             stat.deltaSign === 'down' ? 'text-status-error' : '',
             stat.deltaSign === 'flat' ? 'text-tertiary' : '',
@@ -78,7 +78,7 @@ defineProps<{
         />
       </div>
 
-      <span class="shrink-0 text-[10px] font-medium uppercase tracking-wider text-tertiary truncate">
+      <span class="shrink-0 text-3xs font-medium uppercase tracking-wider text-tertiary truncate">
         {{ stat.label }}
       </span>
     </router-link>

--- a/frontend/src/views/dashboard/chrome/TimeRangeChipCluster.vue
+++ b/frontend/src/views/dashboard/chrome/TimeRangeChipCluster.vue
@@ -131,7 +131,7 @@ function applyCustom(): void {
       <div class="border-t border-default my-1" />
 
       <div class="px-2 py-1 flex flex-col gap-2">
-        <span class="text-[11px] uppercase tracking-wide text-tertiary font-medium">
+        <span class="text-2xs uppercase tracking-wide text-tertiary font-medium">
           {{ t('dashboard-time-range-custom') }}
         </span>
         <DatePicker

--- a/frontend/src/views/public/GuestTicketSubmitView.vue
+++ b/frontend/src/views/public/GuestTicketSubmitView.vue
@@ -218,7 +218,7 @@
             <span class="text-xs text-secondary">
               {{ uploading ? t('guest-submit-attachments-uploading') : t('guest-submit-attachments-pick') }}
             </span>
-            <span class="text-[11px] text-tertiary">
+            <span class="text-2xs text-tertiary">
               {{ t('guest-submit-attachments-hint', { size: MAX_SIZE_MB }) }}
             </span>
           </label>
@@ -235,7 +235,7 @@
               <Icon name="paperclip" class="shrink-0 text-tertiary" />
               <div class="flex-1 min-w-0 flex flex-col">
                 <span class="text-xs text-primary truncate">{{ att.name }}</span>
-                <span class="text-[11px] text-tertiary">{{ formatSize(att.size) }}</span>
+                <span class="text-2xs text-tertiary">{{ formatSize(att.size) }}</span>
               </div>
               <Button
                 variant="ghost-danger"


### PR DESCRIPTION
Phase 1 of tablet scaling work. A refactor with **no rendering change** — it makes the type system scalable, which nothing after this works without.

### The problem

348 call sites across 102 components wrote their font size as an arbitrary value: `text-[11px]` (171), `text-[10px]` (136), `text-[13px]` (23), `text-[9px]` (18).

Arbitrary px bypasses every scaling mechanism there is:

- **It ignores the root font size.** A user who raises their browser or OS text size gets nothing from those 348 sites. That is a WCAG 1.4.4 (Resize Text, AA) failure — text is meant to scale to 200% — not a cosmetic issue.
- **It renders far smaller on a dense display.** The Boox Tab Ultra reports 936 CSS px across a ~6.2″ panel, roughly 151 CSS px per inch against a desktop monitor's 96. An `11px` label lands near 5.5pt there.

The tablet problem and the accessibility problem are the same problem, and this is the fix for both.

### What this does

Adds four `@theme` tokens in rem and replaces every call site mechanically:

| was | now | rem | computes to |
|---|---|---|---|
| `text-[11px]` | `text-2xs` | 0.6875rem | 11px |
| `text-[10px]` | `text-3xs` | 0.625rem | 10px |
| `text-[9px]` | `text-4xs` | 0.5625rem | 9px |
| `text-[13px]` | `text-xs-plus` | 0.8125rem | 13px |

**Strictly 1:1.** Each token computes to exactly the pixel value it replaces at the default 16px root, so nothing renders differently today. Borders and hairlines stay in px on purpose — those should *not* grow with type.

No `--line-height` is defined on the tokens: the arbitrary values they replace set `font-size` only, so adding one would change layout rather than preserve it.

`text-xs-plus` sits between Tailwind's `xs` (12px) and `sm` (14px), a gap with no conventional name, hence the explicit one.

### Verification

Type-check, lint and build all clean. I also confirmed in the built CSS that each utility emits a real rule rather than silently generating nothing — a token that produces no class would fall back to inherited sizing and look almost right, which is exactly the failure mode that bit the push boot line earlier today.

```
.text-2xs{font-size:var(--text-2xs)
.text-3xs{font-size:var(--text-3xs)
.text-4xs{font-size:var(--text-4xs)
.text-xs-plus{font-size:var(--text-xs-plus)
```

### Follow-ups, deliberately not here

- **Phase 2:** one context-driven root scale, keyed on `pointer: coarse` plus viewport rather than on platform, so iPad, Android and a tablet browser all benefit and it composes with user font preferences.
- **Scale rationalisation:** six type sizes below 15px (9/10/11/12/13/14) is drift, not a scale. Consolidating is better design but changes appearance, so it needs a human eye on the result and does not belong in a no-op refactor.

https://claude.ai/code/session_01KZdfqh5Fiqj27tPTBNNVbx