### PR TITLE
Put the global reset in a layer so margin utilities work again

### DIFF
--- a/frontend/src/assets/main.css
+++ b/frontend/src/assets/main.css
@@ -16,11 +16,21 @@
   font-display: swap;
 }
 
-*,
-*::before,
-*::after {
-  box-sizing: border-box;
-  margin: 0;
+/* Unlayered CSS beats anything inside an @layer, regardless of specificity.
+   This reset used to sit outside every layer, so `margin: 0` here silently
+   overrode Tailwind's margin utilities -- which live in @layer utilities --
+   across the whole app. Every m* class was inert: `mt-4` computed to 0px,
+   `mx-auto` never centred anything. It went unnoticed because this codebase
+   reaches for flex + gap rather than margins, and `gap` was unaffected.
+   Tailwind's own preflight does exactly this in @layer base; matching it lets
+   utilities win again. */
+@layer base {
+  *,
+  *::before,
+  *::after {
+    box-sizing: border-box;
+    margin: 0;
+  }
 }
 
 /* ============================================


### PR DESCRIPTION
**Every margin utility in the application has been inert.** Found while chasing a left-aligned auth column on a tablet; the cause turned out to be app-wide and affects web equally.

### The bug

`main.css` opened with a reset **outside every `@layer`**:

```css
*, *::before, *::after { box-sizing: border-box; margin: 0; }
```

Unlayered CSS beats layered CSS regardless of specificity, and Tailwind 4 emits utilities into `@layer utilities`. So this `margin: 0` won against every `m*` class in the codebase.

Measured in the running app before the change:

```
mt-4     0px    (expected 16px)
mb-5     0px    (expected 20px)
mx-auto  0px    (never centred anything)
gap-4   18px    (unaffected — which is why nobody noticed)
```

A freshly created `<div class="ml-auto">` computed `margin-left: 0px` too, so this was never specific to one component.

It survived because this codebase reaches for `flex` + `gap` rather than margins. Where a margin *was* written it quietly did nothing, and layouts were tuned around its absence.

### The fix

Move the reset into `@layer base`, which is exactly where Tailwind's own preflight puts the identical rule. Utilities can then win.

### Why this is not optional

The auth-column centring merged in #314 uses `ml-auto`/`mr-auto`, so **it cannot work until this lands** — the connect and onboarding screens are left-aligned on `main` right now. Verified on device after this change:

```
sectionWidth 936   columnWidth 504   leftGap 216   rightGap 216   CENTRED
mt-4 → 18px   mb-5 → 22.5px      (16 and 20 scaled by the 1.125 touch factor)
```

### Risk — please read before merging

**Margins now take effect for the first time, everywhere.** Any `mt-*`, `mb-*`, `mx-auto` written in good faith over the life of the project starts applying. The sidebar logo's `mb-5` alone gains 22.5px it never had.

That is simultaneously the point of the change and its danger: it is a one-line fix with app-wide visual consequences. It wants a deliberate look at the **web** app, not only the tablet, which is why it is split out of the tablet PR rather than riding along with it.

If the shift turns out to be disruptive, the narrow alternative is to leave the reset unlayered and centre that one column with flex instead — worse as engineering, but contained.

https://claude.ai/code/session_01KZdfqh5Fiqj27tPTBNNVbx