### PR TITLE
Let the brand follow the auth column

### DIFF
--- a/frontend/src/components/auth/AuthLayout.vue
+++ b/frontend/src/components/auth/AuthLayout.vue
@@ -72,7 +72,12 @@ const heroStyle = computed(() => ({
       <div
         class="mx-auto flex min-h-full w-full max-w-[28rem] flex-col gap-10 px-6 pb-10 pt-[calc(2.5rem+env(safe-area-inset-top))] sm:px-10 lg:max-w-none lg:px-16 lg:pb-14 lg:pt-[calc(3.5rem+env(safe-area-inset-top))]"
       >
-        <div class="w-fit">
+        <!-- The brand follows the column, and the column follows the hero:
+             centred while the column is centred, back in its corner once the
+             hero returns at lg and anchors the panel left. A mark that stays
+             left while the column centres reads as misaligned, because it is
+             two alignment decisions disagreeing on one screen. -->
+        <div class="w-fit self-center lg:self-start">
           <slot name="logo">
             <LogoIcon class="h-9 w-auto text-accent" :aria-label="$t('nav-logo-alt')" />
           </slot>
@@ -84,7 +89,10 @@ const heroStyle = computed(() => ({
           </div>
         </div>
 
-        <p v-if="$slots.footer" class="text-xs leading-relaxed text-tertiary">
+        <p
+          v-if="$slots.footer"
+          class="text-center text-xs leading-relaxed text-tertiary lg:text-left"
+        >
           <slot name="footer" />
         </p>
 
@@ -96,7 +104,7 @@ const heroStyle = computed(() => ({
         <button
           v-if="showSwitchServer"
           type="button"
-          class="w-fit text-sm text-secondary underline underline-offset-2 hover:text-primary pointer-coarse:min-h-11"
+          class="w-fit self-center text-sm text-secondary underline underline-offset-2 hover:text-primary lg:self-start pointer-coarse:min-h-11"
           @click="returnToConnect"
         >
           {{ $t('connect-switch-server') }}

--- a/frontend/src/views/ConnectServerView.vue
+++ b/frontend/src/views/ConnectServerView.vue
@@ -64,7 +64,7 @@ async function connectSelfHosted() {
     <template #hero-subtitle>{{ $t('connect-hero-subtitle') }}</template>
 
     <div class="flex flex-col gap-8">
-      <div>
+      <div class="text-center lg:text-left">
         <h1 class="text-2xl font-semibold text-primary">{{ $t('connect-title') }}</h1>
         <p class="mt-2 text-sm text-secondary">{{ $t('connect-subtitle') }}</p>
       </div>
@@ -93,7 +93,7 @@ async function connectSelfHosted() {
         <!-- Someone with no account at all has nothing to type into either
              option above, and the app cannot create one for them. Hand them
              off to the website rather than leaving the screen a dead end. -->
-        <div class="flex flex-col items-center gap-1">
+        <div class="flex flex-col items-center gap-1 lg:items-start">
           <p class="text-sm text-secondary">{{ $t('connect-no-account') }}</p>
           <button
             type="button"

--- a/frontend/src/views/LoginView.vue
+++ b/frontend/src/views/LoginView.vue
@@ -720,7 +720,7 @@ const handleOidcLogoutClick = async () => {
 
       <!-- Login Form -->
       <form v-else-if="!ssoOnly" @submit.prevent="handleLogin" class="flex flex-col gap-5">
-        <header class="flex flex-col gap-1.5">
+        <header class="flex flex-col gap-1.5 text-center lg:text-left">
           <h1 class="text-2xl sm:text-3xl font-semibold tracking-tight text-primary">
             {{ $t('login-title') }}
           </h1>
@@ -900,7 +900,7 @@ const handleOidcLogoutClick = async () => {
            path. onMounted auto-initiates the redirect; this is the visible
            state during it, with a manual fallback if it was blocked. -->
       <div v-else class="flex flex-col gap-5">
-        <header class="flex flex-col gap-1.5">
+        <header class="flex flex-col gap-1.5 text-center lg:text-left">
           <h1 class="text-2xl sm:text-3xl font-semibold tracking-tight text-primary">
             {{ $t('login-title') }}
           </h1>

--- a/frontend/src/views/MFASetupView.vue
+++ b/frontend/src/views/MFASetupView.vue
@@ -6,7 +6,7 @@
 
     <div class="flex flex-col gap-6">
       <!-- Header -->
-      <header class="flex flex-col gap-1.5">
+      <header class="flex flex-col gap-1.5 text-center lg:text-left">
         <h1 class="text-2xl sm:text-3xl font-semibold tracking-tight text-primary">
           {{ headerTitle }}
         </h1>

--- a/frontend/src/views/NoWorkspaceAccessView.vue
+++ b/frontend/src/views/NoWorkspaceAccessView.vue
@@ -34,7 +34,7 @@ async function signOut() {
 <template>
   <AuthLayout>
     <div class="flex flex-col gap-6">
-      <div class="flex flex-col gap-2">
+      <div class="flex flex-col gap-2 text-center lg:text-left">
         <h1 class="text-2xl sm:text-3xl font-semibold tracking-tight text-primary">
           {{ $t('no-workspace-access-title') }}
         </h1>

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -322,7 +322,7 @@ onUnmounted(() => {
     </template>
 
     <div class="flex flex-col gap-6">
-      <header class="flex flex-col gap-1.5">
+      <header class="flex flex-col gap-1.5 text-center lg:text-left">
         <h1 class="text-2xl sm:text-3xl font-semibold tracking-tight text-primary">
           {{ $t('onboarding-welcome-title') }}
         </h1>


### PR DESCRIPTION
Implements the layout spec approved for the sign-in and onboarding screens. **Alignment only** — nothing moves in the DOM, no breakpoint is added.

### The problem

Capping the auth column (#314) centred it on tablet, but the logo stayed on the column's *left edge* — so it landed neither in a corner nor in the middle. Two alignment decisions disagreeing on one screen, which is precisely how it read.

### The rule

> **The brand follows the column. The column follows the hero.**

Below `lg` there is no hero, the column centres, and the mark, headings and links centre with it. At `lg` the hero returns, the panel anchors left, and they go back to the corner.

`lg` already means "the hero fits", so reusing it for alignment adds no new concept to hold.

### What stays left, and why

**Form fields keep their hard left edge.** They are *scanned*, and they are already full-width, so their edges align either way. A mark, a heading and a single link are not scanned as a list, so centring them costs nothing.

### The alternative I rejected

Pinning the mark to the viewport corner and centring only the form. It puts two alignments on one screen, and on a large tablet it strands the mark alone in empty ground, far from the content it labels.

### Scope

| | Below `lg` | `lg` and up |
|---|---|---|
| Logo | centred | column's left edge |
| Heading & subtitle | centred | left |
| Inputs & buttons | full width — unchanged | full width — unchanged |
| Footer, "Switch server", sign-up link | centred | left |

Six headers across five views (`LoginView` has two states), plus the three elements `AuthLayout` owns.

### Note on the dependency

This uses `self-*` and `text-align`, **not** auto margins — deliberately, so it does not depend on #315. But the *column itself* still centres via `mx-auto`, which is inert until #315 lands. Merged alone, this gives correctly-centred chrome inside a column still pinned left. **#315 first.**

Type-check, lint and build clean. Device verification of the combined result is pending — the tablet dropped off both USB and Tailscale before I could measure it.

https://claude.ai/code/session_01KZdfqh5Fiqj27tPTBNNVbx