### PR TITLE
Editor images from the menu and camera, and a revision restore that actually reverts

### DIFF
--- a/backend/src/handlers/collaboration.rs
+++ b/backend/src/handlers/collaboration.rs
@@ -88,51 +88,30 @@ fn new_server_doc(doc_id: &str) -> Doc {
     doc
 }
 
-/// Rebuild a collaborative document from a stored revision snapshot and
-/// make it the live document: swap it into `app_state`, flag it for
-/// persistence, and broadcast the restored state to connected clients.
+/// Validate that a stored revision can be restored, without touching the live
+/// document.
 ///
-/// yrs updates merge (a union of operations, never a delete), so a
-/// revision can't be reverted in place. The idiomatic restore is to
-/// rebuild a fresh doc from the revision's full-state snapshot
-/// (`encode_state_as_update_v1(&StateVector::default())`, the format
-/// every revision stores) and replace the live one. Already-open
-/// editors merge the broadcast like any update; a hard revert there
-/// relies on the client reloading after a restore.
-async fn restore_revision_snapshot(
-    app_state: &YjsAppState,
-    doc_id: &str,
-    workspace_id: i32,
-    doc_type: DocumentType,
-    snapshot: &[u8],
-) -> Result<(), HttpResponse> {
-    let update = Update::decode_v1(snapshot).map_err(|e| {
-        error!(doc_id, error = ?e, "Error decoding revision snapshot");
-        errors::internal("Error decoding revision")
-    })?;
-
-    let doc = new_server_doc(doc_id);
-    {
-        let mut txn = doc.transact_mut();
-        txn.apply_update(update).map_err(|e| {
-            error!(doc_id, error = ?e, "Error applying revision snapshot");
-            errors::internal("Error applying revision")
-        })?;
-    }
-
-    let full_state = doc
-        .transact()
-        .encode_state_as_update_v1(&StateVector::default());
-
-    app_state
-        .replace_document(doc_id, doc, workspace_id, doc_type)
-        .await;
-    app_state.mark_document_changed(doc_id).await;
-
-    use yrs::sync::{Message, SyncMessage};
-    let restored = Message::Sync(SyncMessage::Update(full_state)).encode_v1();
-    app_state.broadcast(doc_id, "", &restored).await;
-
+/// The content revert deliberately happens on the client, not here. A Yjs
+/// update is a set of operations that is commutative, associative and
+/// idempotent: applying one adds changes to a document but never removes or
+/// reverts existing content. A revision snapshot is this document's own history
+/// at an earlier point, so every connected client already holds every operation
+/// in it. Replaying it, or swapping in a document rebuilt from it and
+/// broadcasting that, is a guaranteed no-op on the clients and reverts nothing.
+///
+/// A revert has to be expressed as new operations. The editor does that in one
+/// ProseMirror transaction on the live view (see
+/// `frontend/src/components/editor/restoreRevision.ts`), which y-prosemirror
+/// translates into the delete and insert operations that reach every peer over
+/// the WebSocket, and which persist through the normal update path. That also
+/// keeps the restore on the machine that owns the room, undoable, and free of
+/// the stale `Arc<Awareness>` that swapping the document left open sessions
+/// holding.
+///
+/// So this endpoint stays the permission gate and the audit point: it proves
+/// the revision decodes before reporting success, and does nothing else.
+fn validate_revision_snapshot(snapshot: &[u8]) -> Result<(), HttpResponse> {
+    Update::decode_v1(snapshot).map_err(|_| errors::internal("Error decoding revision"))?;
     Ok(())
 }
 
@@ -1843,44 +1822,6 @@ impl YjsAppState {
         }
     }
 
-    /// Replace the document with a new one (used for restoring revisions)
-    /// This creates a new Awareness with the new Doc and replaces the existing one
-    async fn replace_document(
-        &self,
-        doc_id: &str,
-        new_doc: Doc,
-        workspace_id: i32,
-        doc_type: DocumentType,
-    ) {
-        let mut documents = self.documents.write().await;
-
-        // Create new Awareness with the new Doc
-        let awareness = Awareness::new(new_doc);
-
-        // Initialize awareness with basic server info
-        let local_state = r#"{"server": true, "name": "Server"}"#;
-        let _ = awareness.set_local_state(local_state);
-
-        let awareness = Arc::new(awareness);
-
-        if let Some(doc_state) = documents.get_mut(doc_id) {
-            // Replace the awareness with the new one
-            doc_state.awareness = Arc::clone(&awareness);
-            doc_state.mark_changed();
-            info!(doc_id = %doc_id, "Replaced document with restored revision");
-        } else {
-            // Document doesn't exist in memory, create it. Restore runs
-            // on the owning machine but doesn't carry the claim fence
-            // here, so the snapshot writes unconditionally (None); the
-            // explicit admin restore is not the stale-owner case fencing
-            // guards against.
-            let doc_state =
-                DocumentState::new(Arc::clone(&awareness), workspace_id, None, doc_type);
-            documents.insert(doc_id.to_string(), doc_state);
-            info!(doc_id = %doc_id, "Created new document from restored revision");
-        }
-    }
-
     // Track contributor for version history
     async fn add_contributor(&self, doc_id: &str, user_uuid: Uuid) {
         let mut documents = self.documents.write().await;
@@ -3531,8 +3472,6 @@ pub async fn get_ticket_revision(
 pub async fn restore_ticket_revision(
     path: web::Path<(i32, i32)>,
     mut tc: TenantConn,
-    ws: crate::extractors::WorkspaceContext,
-    app_state: web::Data<YjsAppState>,
     auth: AuthContext,
 ) -> HttpResponse {
     let (ticket_id, revision_number) = path.into_inner();
@@ -3559,26 +3498,20 @@ pub async fn restore_ticket_revision(
         Err(_) => return errors::not_found_msg("Revision not found"),
     };
 
-    // Build the same workspace-namespaced, UUID-keyed doc_id the clients
-    // connect with, so the restore targets the live room (not a phantom
-    // integer-keyed doc no session is attached to).
-    let doc_id = match tc.run(|conn| crate::repository::tickets::uuid_by_id(conn, ticket_id)) {
-        Ok(Some(uuid)) => format!("ws-{}_ticket-{}", ws.workspace_uuid, uuid),
-        _ => return errors::not_found_msg("Ticket not found"),
-    };
-    if let Err(resp) = restore_revision_snapshot(
-        &app_state,
-        &doc_id,
-        ws.workspace_id,
-        DocumentType::Ticket(ticket_id),
-        &revision.yjs_document_content,
-    )
-    .await
-    {
+    if let Err(resp) = validate_revision_snapshot(&revision.yjs_document_content) {
+        error!(
+            ticket_id,
+            revision_number, "Revision snapshot failed to decode"
+        );
         return resp;
     }
 
-    info!(ticket_id, revision_number, "Restored ticket to revision");
+    // The client applies the revert; this endpoint only authorised it, so it
+    // cannot report whether the revert landed.
+    info!(
+        ticket_id,
+        revision_number, "Authorised ticket revision restore"
+    );
     HttpResponse::Ok().json(json!({
         "success": true,
         "message": format!("Restored to revision {revision_number}"),
@@ -3644,8 +3577,6 @@ pub async fn get_doc_revision(
 pub async fn restore_doc_revision(
     path: web::Path<(i32, i32)>,
     mut tc: TenantConn,
-    ws: crate::extractors::WorkspaceContext,
-    app_state: web::Data<YjsAppState>,
     auth: AuthContext,
 ) -> HttpResponse {
     let (doc_id, revision_number) = path.into_inner();
@@ -3661,28 +3592,17 @@ pub async fn restore_doc_revision(
         Err(_) => return errors::not_found_msg("Revision not found"),
     };
 
-    // Build the same workspace-namespaced, UUID-keyed doc_id the clients
-    // connect with, so the restore targets the live room.
-    let doc_id_str =
-        match tc.run(|conn| crate::repository::documentation::page_uuid_by_id(conn, doc_id)) {
-            Ok(Some(uuid)) => format!("ws-{}_doc-{}", ws.workspace_uuid, uuid),
-            _ => return errors::not_found_msg("Page not found"),
-        };
-    if let Err(resp) = restore_revision_snapshot(
-        &app_state,
-        &doc_id_str,
-        ws.workspace_id,
-        DocumentType::Documentation(doc_id),
-        &revision.yjs_document_snapshot,
-    )
-    .await
-    {
+    if let Err(resp) = validate_revision_snapshot(&revision.yjs_document_snapshot) {
+        error!(
+            doc_id,
+            revision_number, "Revision snapshot failed to decode"
+        );
         return resp;
     }
 
     info!(
         doc_id,
-        revision_number, "Restored documentation page to revision"
+        revision_number, "Authorised documentation revision restore"
     );
     HttpResponse::Ok().json(json!({
         "success": true,

--- a/frontend/src/components/CollaborativeEditor.vue
+++ b/frontend/src/components/CollaborativeEditor.vue
@@ -74,7 +74,7 @@ import {
     emDash,
     ellipsis,
 } from "prosemirror-inputrules";
-import { createImageUploadPlugin } from "./editor/imageUploadPlugin";
+import { createImageUploadPlugin, insertImageFiles } from "./editor/imageUploadPlugin";
 import { ImageNodeView } from "./editor/imageNodeView";
 import { parseCollabDocId } from "@nosdesk/core/utils/collabDocId";
 import { EditorImageUploadError } from "@/services/editorImageService";
@@ -134,6 +134,36 @@ const toast = useToastStore();
 // A failed paste used to vanish silently: the plugin calls preventDefault and
 // then only logged. Each failure mode gets its own message because they have
 // different fixes (save the page, pick a smaller image, retry).
+// Shared by the paste/drop plugin and the insert-menu pickers, so a picked
+// image takes exactly the same path as a pasted one.
+const imageUploadOptions = () => ({
+    docId: props.docId,
+    uploadingLabel: (filename: string) => t('editor-image-uploading', { name: filename }),
+    onUploadStart: () => log.debug('Image upload started'),
+    onUploadEnd: () => log.debug('Image upload completed'),
+    onUploadError: handleImageUploadError,
+});
+
+const imagePickerRef = ref<HTMLInputElement | null>(null);
+const cameraPickerRef = ref<HTMLInputElement | null>(null);
+
+// `capture` is honoured by mobile browsers and ignored on desktop, so the
+// entry is only offered where it does something.
+const supportsCameraCapture = 'capture' in document.createElement('input');
+
+const onImagesPicked = (event: Event) => {
+    const input = event.target as HTMLInputElement;
+    const view = editorView;
+    if (view) {
+        // Focus first: the click moved focus to the menu, and the insert reads
+        // the editor's current selection.
+        view.focus();
+        insertImageFiles(view, input.files, imageUploadOptions());
+    }
+    // Reset so picking the same file twice still fires `change`.
+    input.value = '';
+};
+
 const handleImageUploadError = (error: unknown, file: { name: string }) => {
     log.error("Image upload failed:", error);
     const code = error instanceof EditorImageUploadError ? error.code : "upload-failed";
@@ -936,13 +966,7 @@ const initEditor = async () => {
                     dropCursor(), // Shows cursor when dragging
                     createTicketDropIndicatorPlugin(), // Shows drop indicator for ticket cards
                     // NOTE: gapCursor() removed - causes null reference errors with empty Yjs documents
-                    createImageUploadPlugin({
-                        docId: props.docId,
-                        uploadingLabel: (filename: string) => t('editor-image-uploading', { name: filename }),
-                        onUploadStart: () => log.debug('Image upload started'),
-                        onUploadEnd: () => log.debug('Image upload completed'),
-                        onUploadError: handleImageUploadError,
-                    }),
+                    createImageUploadPlugin(imageUploadOptions()),
                     syntaxHighlightPlugin,
                     createMentionViewPlugin(),
                     twemojiPlugin,
@@ -2273,9 +2297,54 @@ defineExpose({
                         >
                             {{ $t('editor-insert-menu-embed-document') }}
                         </button>
+                        <button
+                            @click="
+                                showInsertMenu = false;
+                                imagePickerRef?.click();
+                            "
+                            class="dropdown-item"
+                            role="menuitem"
+                        >
+                            {{ $t('editor-insert-menu-image') }}
+                        </button>
+                        <button
+                            v-if="supportsCameraCapture"
+                            @click="
+                                showInsertMenu = false;
+                                cameraPickerRef?.click();
+                            "
+                            class="dropdown-item"
+                            role="menuitem"
+                        >
+                            {{ $t('editor-insert-menu-take-photo') }}
+                        </button>
                     </div>
                 </Teleport>
             </div>
+
+            <!-- Image sources. Hidden inputs rather than a native plugin: the
+                 picker already offers Gallery / Camera / Files on Android and
+                 Photo Library / Take Photo / Files on iOS, and the same markup
+                 works on the web. `capture` asks for the camera directly, which
+                 matters for a helpdesk: photographing a device or an error on a
+                 screen is the common case. Desktop browsers ignore `capture`,
+                 so that entry is hidden where there is no touch input. -->
+            <input
+                ref="imagePickerRef"
+                type="file"
+                accept="image/*"
+                multiple
+                class="hidden"
+                @change="onImagesPicked"
+            />
+            <input
+                ref="cameraPickerRef"
+                type="file"
+                accept="image/*"
+                capture="environment"
+                class="hidden"
+                @change="onImagesPicked"
+            />
 
             <div class="toolbar-divider"></div>
 

--- a/frontend/src/components/CollaborativeEditor.vue
+++ b/frontend/src/components/CollaborativeEditor.vue
@@ -36,6 +36,7 @@ import {
 } from "./editor/linkTooltipPlugin";
 import { createTicketLinkPlugin, setTicketNavigationHandler } from "./editor/ticketLinkPlugin";
 import { mountRevisionView, decodeRevisionBytes, type RevisionViewHandle } from "./editor/revisionView";
+import { restoreRevisionIntoView } from './editor/restoreRevision';
 import { createEmbeddedDocumentPlugin, setDocumentNavigationHandler } from "./editor/embeddedDocumentPlugin";
 import DocumentPicker from "./editor/DocumentPicker.vue";
 import apiClient from "@nosdesk/core/apiClient";
@@ -1912,10 +1913,6 @@ function exitRevisionView() {
 //   revision_no  -> fetch that revision's Yjs snapshot, swap editor
 //                   into read-only mode showing the historical doc
 //
-// Endpoint differs by surface: tickets vs documentation share the
-// same response shape (ArticleRevisionDetail) but live under
-// different paths. We pick based on docId prefix — same heuristic
-// the rest of the editor uses.
 const handleRevisionSelect = async (revisionNumber: number | null) => {
     if (revisionNumber === null) {
         log.info("Exiting revision view");
@@ -1929,34 +1926,68 @@ const handleRevisionSelect = async (revisionNumber: number | null) => {
 
     log.info(`User selected revision ${revisionNumber}`);
     try {
-        const id = props.resourceId;
-        let endpoint: string | null = null;
-        if (id && id > 0) {
-            if (docKind.value === 'ticket') {
-                endpoint = `/collaboration/tickets/${id}/revisions/${revisionNumber}`;
-            } else if (docKind.value === 'doc') {
-                endpoint = `/collaboration/docs/${id}/revisions/${revisionNumber}`;
-            }
-        }
-        if (!endpoint) {
-            log.error(`Unable to derive revision endpoint for docId=${props.docId}`);
-            return;
-        }
-        const response = await apiClient.get<{
-            revision_number: number;
-            yjs_document_content: string;
-        }>(endpoint);
-        viewSnapshot(response.data);
+        const snapshot = await fetchRevision(revisionNumber);
+        if (snapshot) viewSnapshot(snapshot);
     } catch (error) {
         log.error(`Failed to load revision ${revisionNumber}:`, error);
     }
 };
 
-// Handle revision restoration
-const handleRevisionRestored = (revisionNumber: number) => {
-    log.info(`Revision ${revisionNumber} restored successfully`);
+// Endpoint differs by surface: tickets and documentation share the response
+// shape (ArticleRevisionDetail) but live under different paths. We pick based
+// on docId prefix, the same heuristic the rest of the editor uses.
+async function fetchRevision(revisionNumber: number) {
+    const id = props.resourceId;
+    let endpoint: string | null = null;
+    if (id && id > 0) {
+        if (docKind.value === 'ticket') {
+            endpoint = `/collaboration/tickets/${id}/revisions/${revisionNumber}`;
+        } else if (docKind.value === 'doc') {
+            endpoint = `/collaboration/docs/${id}/revisions/${revisionNumber}`;
+        }
+    }
+    if (!endpoint) {
+        log.error(`Unable to derive revision endpoint for docId=${props.docId}`);
+        return null;
+    }
+    const response = await apiClient.get<{
+        revision_number: number;
+        yjs_document_content: string;
+    }>(endpoint);
+    return response.data;
+}
+
+// Handle revision restoration.
+//
+// The revert happens here, on the live view, not on the server: a Yjs update
+// only ever adds operations, so the revision's own history (which every client
+// already has) cannot roll anything back. Replacing the content in a local
+// transaction produces the delete and insert operations that do, and
+// ySyncPlugin carries them to every peer. See editor/restoreRevision.ts.
+const handleRevisionRestored = async (revisionNumber: number) => {
     showRevisionHistory.value = false;
-    // The backend broadcast will update all clients automatically
+    if (!editorView) {
+        log.error(`Cannot restore revision ${revisionNumber}: no editor view`);
+        return;
+    }
+    // Drop the read-only overlay first, or the revert happens under a snapshot
+    // that is still covering the document and nothing appears to have changed.
+    exitRevisionView();
+    try {
+        const snapshot = await fetchRevision(revisionNumber);
+        if (!snapshot) return;
+        const changed = restoreRevisionIntoView(
+            editorView,
+            decodeRevisionBytes(snapshot.yjs_document_content),
+        );
+        log.info(
+            changed
+                ? `Restored revision ${revisionNumber}`
+                : `Revision ${revisionNumber} matches the current document; nothing to restore`,
+        );
+    } catch (error) {
+        log.error(`Failed to restore revision ${revisionNumber}:`, error);
+    }
 };
 
 /**
@@ -1980,6 +2011,9 @@ function getTextContent(): string {
 // Expose methods and state for parent components
 defineExpose({
     viewSnapshot,
+    // Hosts that own their own revision list (DocumentView) delegate the
+    // restore here, because the revert is a transaction on the live view.
+    restoreRevision: handleRevisionRestored,
     exitRevisionView,
     isViewingRevision,
     currentRevisionNumber,

--- a/frontend/src/components/editor/imageAttrs.spec.ts
+++ b/frontend/src/components/editor/imageAttrs.spec.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, afterEach } from 'vitest'
 import { DOMParser, DOMSerializer } from 'prosemirror-model'
+import { configureAssetUrl } from '@nosdesk/core/transport'
 import { schema } from './schema'
 
 /**
@@ -66,5 +67,49 @@ describe('image resize/adjust attrs', () => {
     const attrs = parseImage(el)
     expect(attrs.width).toBe(240)
     expect(attrs.align).toBeNull()
+  })
+})
+
+/**
+ * On the app the rendered `src` is platform-specific (the webview cannot load a
+ * relative `/api/...` URL, so it goes through the asset proxy scheme), while the
+ * stored `src` must stay relative: the document is shared, and a paste inside
+ * the app re-enters through parseDOM. Writing a `nosdesk-asset://` URL into Yjs
+ * would break that image for the web and every other client, permanently.
+ */
+describe('image src under an asset resolver', () => {
+  const PREFIX = 'http://nosdesk-asset.localhost'
+
+  afterEach(() => {
+    configureAssetUrl(
+      (path) => path,
+      (url) => url
+    )
+  })
+
+  it('renders through the resolver but stores the portable path', () => {
+    configureAssetUrl(
+      (path) => (path.startsWith('/') ? `${PREFIX}${path}` : path),
+      (url) => url.replace(/^(?:nosdesk-asset:\/\/localhost|http:\/\/nosdesk-asset\.localhost)/, '')
+    )
+    const stored = '/api/files/collab/doc/abc/def_image.png'
+
+    const el = serializeImage({ src: stored })
+    expect(el.getAttribute('src')).toBe(`${PREFIX}${stored}`)
+
+    // The round trip a copy/paste performs.
+    expect(parseImage(el).src).toBe(stored)
+  })
+
+  it('leaves an absolute external src alone in both directions', () => {
+    configureAssetUrl(
+      (path) => (path.startsWith('/') ? `${PREFIX}${path}` : path),
+      (url) => url.replace(/^(?:nosdesk-asset:\/\/localhost|http:\/\/nosdesk-asset\.localhost)/, '')
+    )
+    const external = 'https://example.com/logo.png'
+
+    const el = serializeImage({ src: external })
+    expect(el.getAttribute('src')).toBe(external)
+    expect(parseImage(el).src).toBe(external)
   })
 })

--- a/frontend/src/components/editor/imageNodeView.ts
+++ b/frontend/src/components/editor/imageNodeView.ts
@@ -23,6 +23,7 @@
 import type { Node as PMNode } from 'prosemirror-model';
 import { NodeSelection } from 'prosemirror-state';
 import type { EditorView, NodeView } from 'prosemirror-view';
+import { assetUrl } from '@nosdesk/core/transport';
 
 const MIN_WIDTH_PX = 60;
 
@@ -162,7 +163,13 @@ export class ImageNodeView implements NodeView {
       width: number | null;
       align: Align | null;
     };
-    if (this.img.getAttribute('src') !== src) this.img.setAttribute('src', src);
+    // `src` is stored relative (`/api/files/collab/...`) so the document stays
+    // portable. In the app a relative URL resolves against the webview origin,
+    // which serves the bundled SPA and has no `/api`, so the load fails
+    // silently with naturalWidth 0. `assetUrl` rewrites it to the proxied
+    // scheme; identity on the web.
+    const renderSrc = assetUrl(src);
+    if (this.img.getAttribute('src') !== renderSrc) this.img.setAttribute('src', renderSrc);
     if (alt) this.img.setAttribute('alt', alt);
     else this.img.removeAttribute('alt');
     if (title) this.img.setAttribute('title', title);

--- a/frontend/src/components/editor/imageUploadPlugin.ts
+++ b/frontend/src/components/editor/imageUploadPlugin.ts
@@ -84,6 +84,10 @@ function placeholderWidget(pos: number, pending: PendingUpload): Decoration {
     () => {
       const el = document.createElement('span');
       el.className = 'image-upload-placeholder';
+      // Without this the widget is part of the editable region, and an IME
+      // (Android's especially) can compose into it, committing the placeholder
+      // label into the document as real text.
+      el.contentEditable = 'false';
       const spinner = document.createElement('span');
       spinner.className = 'image-upload-spinner';
       const label = document.createElement('span');
@@ -302,6 +306,34 @@ function stripDataURLImages(slice: Slice, state: EditorState): Slice {
 
   const content = scrub(slice.content);
   return found ? new Slice(content, slice.openStart, slice.openEnd) : slice;
+}
+
+/**
+ * Insert images from a UI control (file picker, camera) at the current
+ * selection, on the same path paste and drop already take: placeholder widget,
+ * upload, then swap in the real node, preserving order across a batch.
+ *
+ * Exported because paste and drop were the only ways in, which on a touch
+ * device means there was effectively no way in at all: drag-and-drop between
+ * apps barely exists there, and pasting an image into a contenteditable is
+ * inconsistent in Android's WebView.
+ *
+ * Takes `options` explicitly rather than reaching into plugin state, so the
+ * caller passes the same object it gave `createImageUploadPlugin`.
+ */
+export function insertImageFiles(
+  view: EditorView,
+  list: FileList | null | undefined,
+  options: ImageUploadPluginOptions
+): void {
+  const files = imageFilesFrom(list);
+  if (!files.length) return;
+  void uploadBatch(
+    view,
+    files.map((file) => ({ file, alt: file.name })),
+    view.state.selection.from,
+    options
+  );
 }
 
 export function createImageUploadPlugin(options: ImageUploadPluginOptions): Plugin {

--- a/frontend/src/components/editor/restoreRevision.spec.ts
+++ b/frontend/src/components/editor/restoreRevision.spec.ts
@@ -1,0 +1,98 @@
+/**
+ * Why restoring a revision has to be a transaction on the live document.
+ *
+ * The previous implementation rebuilt a document from the revision snapshot on
+ * the server and broadcast its full state. That could never work: a Yjs update
+ * is a set of operations that is commutative, associative and idempotent, and a
+ * revision snapshot holds this document's own earlier history, so every client
+ * already has every operation in it. The first test pins that fact, because it
+ * is the reason the endpoint reported success while nothing changed on screen.
+ *
+ * The rest assert the replacement behaviour: the revert reaches the shared Yjs
+ * state (so peers converge) and survives the edits made after the revision.
+ */
+import { describe, expect, it } from 'vitest'
+import { EditorState } from 'prosemirror-state'
+import { EditorView } from 'prosemirror-view'
+import * as Y from 'yjs'
+import { initProseMirrorDoc, ySyncPlugin } from 'y-prosemirror'
+
+import { schema } from './schema'
+import { restoreRevisionIntoView } from './restoreRevision'
+
+/** A live editor: Y.Doc + bound EditorView, as the app builds it. */
+function makeLiveEditor() {
+  const ydoc = new Y.Doc({ gc: false })
+  const fragment = ydoc.getXmlFragment('prosemirror')
+  const mount = document.createElement('div')
+  document.body.appendChild(mount)
+
+  const { doc, mapping } = initProseMirrorDoc(fragment, schema)
+  const view = new EditorView(mount, {
+    state: EditorState.create({ doc, schema, plugins: [ySyncPlugin(fragment, { mapping })] }),
+  })
+  return { ydoc, view, mount }
+}
+
+function appendParagraph(view: EditorView, text: string) {
+  const { state } = view
+  const node = state.schema.nodes.paragraph.create(null, state.schema.text(text))
+  view.dispatch(state.tr.insert(state.doc.content.size, node))
+}
+
+const textOf = (view: EditorView) => view.state.doc.textBetween(0, view.state.doc.content.size, ' ')
+
+/** The bytes a revision stores: a full v1 update of the document at that time. */
+const snapshot = (ydoc: Y.Doc) => Y.encodeStateAsUpdate(ydoc)
+
+describe('restoreRevisionIntoView', () => {
+  it('cannot be done by replaying the snapshot, which is what the server used to broadcast', () => {
+    const { ydoc, view } = makeLiveEditor()
+    appendParagraph(view, 'first')
+    const revision = snapshot(ydoc)
+    appendParagraph(view, 'second')
+
+    // Exactly what the old restore sent to every client.
+    Y.applyUpdate(ydoc, revision)
+
+    expect(textOf(view)).toContain('second')
+  })
+
+  it('reverts the live document to the revision', () => {
+    const { ydoc, view } = makeLiveEditor()
+    appendParagraph(view, 'first')
+    const revision = snapshot(ydoc)
+    appendParagraph(view, 'second')
+
+    expect(restoreRevisionIntoView(view, revision)).toBe(true)
+
+    expect(textOf(view)).toContain('first')
+    expect(textOf(view)).not.toContain('second')
+    void ydoc
+  })
+
+  it('writes the revert into the shared Yjs state, so peers converge', () => {
+    const { ydoc, view } = makeLiveEditor()
+    appendParagraph(view, 'first')
+    const revision = snapshot(ydoc)
+    appendParagraph(view, 'second')
+
+    const peer = new Y.Doc({ gc: false })
+    Y.applyUpdate(peer, Y.encodeStateAsUpdate(ydoc))
+    expect(peer.getXmlFragment('prosemirror').toString()).toContain('second')
+
+    restoreRevisionIntoView(view, revision)
+    Y.applyUpdate(peer, Y.encodeStateAsUpdate(ydoc))
+
+    const peerText = peer.getXmlFragment('prosemirror').toString()
+    expect(peerText).toContain('first')
+    expect(peerText).not.toContain('second')
+  })
+
+  it('reports no change when the document already matches the revision', () => {
+    const { ydoc, view } = makeLiveEditor()
+    appendParagraph(view, 'first')
+
+    expect(restoreRevisionIntoView(view, snapshot(ydoc))).toBe(false)
+  })
+})

--- a/frontend/src/components/editor/restoreRevision.ts
+++ b/frontend/src/components/editor/restoreRevision.ts
@@ -1,0 +1,62 @@
+/**
+ * Restore a stored revision into the live collaborative document.
+ *
+ * A Yjs update can only add operations. They are commutative, associative and
+ * idempotent, so applying one never removes or reverts existing content. A
+ * revision snapshot is this document's own history at an earlier point, which
+ * every open client already holds, so replaying it against the live document is
+ * a guaranteed no-op and cannot roll anything back.
+ *
+ * A revert therefore has to be expressed as new operations. We rebuild the
+ * target ProseMirror document from the snapshot and replace the live content
+ * with it in a single transaction. `ySyncPlugin` translates that into the
+ * delete and insert operations that carry the revert to every peer over the
+ * existing connection, and the change joins the undo stack like any other edit.
+ */
+import { Fragment, type Node as PMNode, type Schema } from 'prosemirror-model';
+import type { EditorView } from 'prosemirror-view';
+import * as Y from 'yjs';
+import { initProseMirrorDoc } from 'y-prosemirror';
+
+/** The Yjs root a Nosdesk collaborative document lives under. */
+const ROOT_FRAGMENT = 'prosemirror';
+
+/**
+ * Materialise a revision's full Yjs v1 update as a detached ProseMirror
+ * document. The scratch doc exists only to be read, so it is always destroyed.
+ */
+export function revisionToProseMirrorDoc(schema: Schema, updateBytes: Uint8Array): PMNode {
+  const scratchDoc = new Y.Doc();
+  try {
+    Y.applyUpdate(scratchDoc, updateBytes);
+    const { doc } = initProseMirrorDoc(scratchDoc.getXmlFragment(ROOT_FRAGMENT), schema);
+    return doc;
+  } finally {
+    scratchDoc.destroy();
+  }
+}
+
+/**
+ * Replace the live document's content with the revision's.
+ *
+ * Returns false when the document already matches the revision, so callers can
+ * tell "restored" from "nothing to do" rather than reporting a change that
+ * never happened.
+ */
+export function restoreRevisionIntoView(view: EditorView, updateBytes: Uint8Array): boolean {
+  const { schema } = view.state;
+  const target = revisionToProseMirrorDoc(schema, updateBytes);
+
+  // The schema requires at least one block, so an empty revision restores to a
+  // single empty paragraph rather than an invalid document.
+  const content =
+    target.content.size > 0 ? target.content : Fragment.from(schema.nodes.paragraph.create());
+
+  // ProseMirror does not diff, so a replace always counts as a change. Compare
+  // the content instead: dispatching a no-op replace would rewrite the whole
+  // document as Yjs deletes and inserts, churning every peer for nothing.
+  if (view.state.doc.content.eq(content)) return false;
+
+  view.dispatch(view.state.tr.replaceWith(0, view.state.doc.content.size, content));
+  return true;
+}

--- a/frontend/src/components/editor/schema.ts
+++ b/frontend/src/components/editor/schema.ts
@@ -1,4 +1,5 @@
 import { Schema } from 'prosemirror-model';
+import { assetUrl, assetPath } from '@nosdesk/core/transport';
 import type { NodeSpec, MarkSpec, DOMOutputSpec } from 'prosemirror-model';
 
 const brDOM: DOMOutputSpec = ['br'];
@@ -155,7 +156,11 @@ export const nodes: {[key: string]: NodeSpec} = {
             : null;
         const align = dom.getAttribute('data-align');
         return {
-          src: dom.getAttribute('src'),
+          // Store the portable path, never this platform's rendered URL: a
+          // paste inside the app re-enters here, and a `nosdesk-asset://` src
+          // written into the shared document would break that image for every
+          // other client.
+          src: assetPath(dom.getAttribute('src') ?? ''),
           title: dom.getAttribute('title'),
           alt: dom.getAttribute('alt'),
           width,
@@ -165,7 +170,7 @@ export const nodes: {[key: string]: NodeSpec} = {
     }],
     toDOM(node) {
       const domAttrs: Record<string, string> = {
-        src: node.attrs.src,
+        src: assetUrl(node.attrs.src),
         title: node.attrs.title,
         alt: node.attrs.alt
       };

--- a/frontend/src/views/DocumentView.vue
+++ b/frontend/src/views/DocumentView.vue
@@ -276,8 +276,10 @@ const handleCloseInsights = () => {
   docPanel.close()
 }
 
-const handleRevisionRestored = () => {
-  fetchContent()
+const handleRevisionRestored = async (revisionNumber: number) => {
+  // The editor owns the revert: it is a transaction on the live ProseMirror
+  // view, which ySyncPlugin turns into the operations that reach every peer.
+  await editorRef.value?.restoreRevision(revisionNumber)
 }
 
 // Delete handler

--- a/i18n/locales/en-US/main.ftl
+++ b/i18n/locales/en-US/main.ftl
@@ -3426,6 +3426,8 @@ editor-insert-menu-blockquote = Blockquote
 editor-insert-menu-code-block = Code Block
 editor-insert-menu-link = Link
 editor-insert-menu-embed-document = Embed Document
+editor-insert-menu-image = Image
+editor-insert-menu-take-photo = Take Photo
 
 # Editor: code block language prompt (CollaborativeEditor)
 editor-code-block-language-prompt = Enter language for syntax highlighting (optional):

--- a/i18n/locales/fr-FR/main.ftl
+++ b/i18n/locales/fr-FR/main.ftl
@@ -3291,6 +3291,8 @@ editor-insert-menu-blockquote = Citation
 editor-insert-menu-code-block = Bloc de code
 editor-insert-menu-link = Lien
 editor-insert-menu-embed-document = Intégrer un document
+editor-insert-menu-image = Image
+editor-insert-menu-take-photo = Prendre une photo
 
 # Éditeur : invite de langage du bloc de code (CollaborativeEditor)
 editor-code-block-language-prompt = Langage pour la coloration syntaxique (facultatif) :

--- a/i18n/locales/nl-NL/main.ftl
+++ b/i18n/locales/nl-NL/main.ftl
@@ -3282,6 +3282,8 @@ editor-insert-menu-blockquote = Citaat
 editor-insert-menu-code-block = Codeblok
 editor-insert-menu-link = Link
 editor-insert-menu-embed-document = Document insluiten
+editor-insert-menu-image = Afbeelding
+editor-insert-menu-take-photo = Foto maken
 
 # Editor: prompt voor codeblok-taal (CollaborativeEditor)
 editor-code-block-language-prompt = Taal voor syntaxisaccentuering (optioneel):

--- a/mobile/src/transport.ts
+++ b/mobile/src/transport.ts
@@ -40,7 +40,12 @@ const ASSET_SCHEME_PREFIX = /android/i.test(navigator.userAgent)
   ? 'http://nosdesk-asset.localhost'
   : 'nosdesk-asset://localhost'
 
-configureAssetUrl((path) => (path.startsWith('/') ? `${ASSET_SCHEME_PREFIX}${path}` : path))
+configureAssetUrl(
+  (path) => (path.startsWith('/') ? `${ASSET_SCHEME_PREFIX}${path}` : path),
+  // The inverse. Both prefixes are stripped, not just this platform's, so an
+  // iOS-authored paste normalises correctly on Android and the reverse.
+  (url) => url.replace(/^(?:nosdesk-asset:\/\/localhost|http:\/\/nosdesk-asset\.localhost)/, '')
+)
 
 /**
  * Push the current bearer + API origin to the Rust asset proxy so it can

--- a/packages/core/src/transport.ts
+++ b/packages/core/src/transport.ts
@@ -130,11 +130,29 @@ export function collabWsBaseUrl(): string {
  * mobile/src-tauri/src/asset_proxy.rs.
  */
 let assetUrlResolver: (path: string) => string = (path) => path
+let assetPathResolver: (url: string) => string = (url) => url
 
-export function configureAssetUrl(resolver: (path: string) => string): void {
+/**
+ * `resolver` maps a stored path to something this platform can load.
+ * `reverse` maps it back, and matters more than it looks: an editor image's
+ * `src` is rendered through `assetUrl`, and anything that re-reads rendered DOM
+ * (clipboard paste, `parseDOM`) must recover the stored form. Writing a
+ * platform-specific URL into a shared document would break that image for every
+ * other client, permanently.
+ */
+export function configureAssetUrl(
+  resolver: (path: string) => string,
+  reverse?: (url: string) => string
+): void {
   assetUrlResolver = resolver
+  if (reverse) assetPathResolver = reverse
 }
 
 export function assetUrl(path: string): string {
   return assetUrlResolver(path)
+}
+
+/** Inverse of [`assetUrl`]: the portable path to store in a document. */
+export function assetPath(url: string): string {
+  return assetPathResolver(url)
 }


### PR DESCRIPTION
Two editor changes that came out of testing on the Boox tablet.

## Images

Images stored as relative paths did not render inside the mobile webview, where files load over `nosdesk-asset://`. The node view and the schema's `toDOM` now resolve sources through the transport's asset resolver, with `assetPath()` as the inverse for `parseDOM`.

There was also no way to insert an image except by pasting. The insert menu gains "Image" and "Take photo", backed by hidden file inputs. The native picker already offers Gallery / Camera / Files on Android and Photo Library / Take Photo / Files on iOS, so no plugin is needed. `capture` asks for the camera directly, which is the common case for a helpdesk (photographing a device or an error on a screen), and desktop browsers ignore it, so that entry is hidden where there is no touch input.

The upload placeholder is now `contentEditable = 'false'`. Without it the widget sits in the editable region and an IME (Android's especially) can compose into it, which is why "Uploading" was appearing in documents as real text.

## Revision restore

Restoring reported success while nothing changed on screen.

The server rebuilt a document from the revision snapshot and broadcast its full state. That cannot revert anything. Yjs updates are commutative, associative and idempotent, so applying one adds operations but never removes content, and a revision snapshot is the document's own history at an earlier point. Every connected client already holds every operation in it, so the broadcast was a guaranteed no-op. The old code's own comment conceded it, saying a hard revert "relies on the client reloading after a restore", and nothing triggered that reload.

A revert has to be expressed as new operations. The editor now rebuilds the target document from the snapshot and replaces the live content in a single ProseMirror transaction; y-prosemirror turns that into the delete and insert operations that reach every peer over the existing connection. It persists through the normal update path, joins the undo stack, and runs on the machine that owns the room, closing an affinity gap where neither restore handler called `route()`.

`replace_document` is deleted rather than fixed. Its only caller was this path, and it swapped the `Arc<Awareness>` in the document map while open WebSocket sessions kept the one they captured at connect, leaving them editing a document no longer being persisted. The endpoints keep the permission gate and now only prove the revision decodes, so their log lines say they authorised a restore rather than performed one.

Two further fixes found while wiring it up: nothing exited the read-only overlay on restore, so the revert would have happened under a snapshot still covering the document; and `replaceWith` always reports `docChanged`, so restoring the revision already on screen would have rewritten the whole document as Yjs operations for nothing. That guard is a structural content compare now.

### Tests

`restoreRevision.spec.ts` opens with the proof that the old design could not work: it replays the revision update into the live document exactly as the server did, and asserts the post-revision text is still there. The rest cover the revert, convergence to a second `Y.Doc` peer, and the no-change case.

Backend suite green (all `test result: ok`, including the 1796-test lib run), `tracing_field_allowlist_lint` 7 passed, `cargo fmt --check` clean, `npm run type-check` exit 0, 19 editor tests.

Not yet verified: two-tab acceptance, which is next on staging.

https://claude.ai/code/session_017iEcp3fFMB594JYRZxcQ5H