### PR TITLE
Gate the Graph integration, the doc export, and page ticket links

### DIFF
--- a/backend/src/handlers/documentation.rs
+++ b/backend/src/handlers/documentation.rs
@@ -469,37 +469,56 @@ fn to_page_response(
 /// Mirrors the standalone list_page_tickets handler so callers can
 /// choose between embed (one round trip) and a separate fetch
 /// (cheaper for views that don't always want it).
+/// Title + workflow category for each linked ticket the caller may actually see.
+///
+/// Both the page-response embed and the links endpoint hydrate the same rows,
+/// and both used to hydrate every linked ticket regardless of whether the
+/// caller could open it, so a documentation page could name and categorise
+/// tickets outside the caller's visibility. Filtering through
+/// `visible_tickets_query` here means neither caller can forget it, and an
+/// invisible ticket resolves to `None` and renders untitled, which is the
+/// shape both call sites already handled for an unhydratable id.
+fn linked_ticket_meta(
+    conn: &mut DbConnection,
+    ticket_ids: &[i32],
+    ctx: &crate::repository::ticket_visibility::VisibilityContext,
+) -> Result<
+    std::collections::HashMap<i32, (String, crate::models::WorkflowStateCategory)>,
+    diesel::result::Error,
+> {
+    use crate::schema::tickets;
+    use diesel::prelude::*;
+    if ticket_ids.is_empty() {
+        return Ok(Default::default());
+    }
+    let rows: Vec<(i32, String, i32)> =
+        crate::repository::ticket_visibility::visible_tickets_query(ctx)
+            .filter(tickets::id.eq_any(ticket_ids))
+            .select((tickets::id, tickets::title, tickets::workflow_state_id))
+            .load(conn)?;
+    Ok(rows
+        .into_iter()
+        .map(|(id, title, ws_id)| {
+            let cat = crate::repository::workflow_states::category_of(conn, ws_id)
+                .ok()
+                .flatten()
+                .unwrap_or(crate::models::WorkflowStateCategory::Backlog);
+            (id, (title, cat))
+        })
+        .collect())
+}
+
 fn embed_page_tickets(
     response: &mut DocumentationPageResponse,
     conn: &mut DbConnection,
+    ctx: &crate::repository::ticket_visibility::VisibilityContext,
 ) -> Result<(), String> {
     let links = repository::documentation_page_tickets::links_for_page(conn, response.id)
         .map_err(|e| format!("Failed to load page<->ticket links: {e:?}"))?;
 
-    use crate::schema::tickets;
-    use diesel::prelude::*;
     let ticket_ids: Vec<i32> = links.iter().map(|l| l.ticket_id).collect();
-    let tickets_meta: std::collections::HashMap<
-        i32,
-        (String, crate::models::WorkflowStateCategory),
-    > = if ticket_ids.is_empty() {
-        Default::default()
-    } else {
-        let rows: Vec<(i32, String, i32)> = tickets::table
-            .filter(tickets::id.eq_any(&ticket_ids))
-            .select((tickets::id, tickets::title, tickets::workflow_state_id))
-            .load(conn)
-            .map_err(|e| format!("Failed to hydrate tickets: {e:?}"))?;
-        rows.into_iter()
-            .map(|(id, title, ws_id)| {
-                let cat = crate::repository::workflow_states::category_of(conn, ws_id)
-                    .ok()
-                    .flatten()
-                    .unwrap_or(crate::models::WorkflowStateCategory::Backlog);
-                (id, (title, cat))
-            })
-            .collect()
-    };
+    let tickets_meta = linked_ticket_meta(conn, &ticket_ids, ctx)
+        .map_err(|e| format!("Failed to hydrate tickets: {e:?}"))?;
 
     let embed: Vec<DocumentationPageTicketEmbed> = links
         .into_iter()
@@ -600,6 +619,7 @@ pub async fn get_documentation_page(
     let want_tickets = embed_includes(&query.embed, "tickets");
     let is_admin_user = auth.is_workspace_admin();
     let user_uuid = auth.user_uuid;
+    let ticket_ctx = crate::repository::ticket_visibility::VisibilityContext::from_auth(&auth);
 
     let outcome = tc.run(|conn| {
         let page = match repository::get_documentation_page(page_id, conn) {
@@ -618,7 +638,7 @@ pub async fn get_documentation_page(
         response.requires_verification =
             repository::page_requires_verification(conn, response.id).unwrap_or(false);
         if want_tickets {
-            if let Err(e) = embed_page_tickets(&mut response, conn) {
+            if let Err(e) = embed_page_tickets(&mut response, conn, &ticket_ctx) {
                 return Ok(PageLoadOutcome::EmbedFailed(e));
             }
         }
@@ -650,6 +670,7 @@ pub async fn get_documentation_page_by_slug(
     let want_tickets = embed_includes(&query.embed, "tickets");
     let is_admin_user = auth.is_workspace_admin();
     let user_uuid = auth.user_uuid;
+    let ticket_ctx = crate::repository::ticket_visibility::VisibilityContext::from_auth(&auth);
 
     let outcome = tc.run(|conn| {
         let page = match repository::get_documentation_page_by_slug(&page_slug, conn) {
@@ -668,7 +689,7 @@ pub async fn get_documentation_page_by_slug(
         response.requires_verification =
             repository::page_requires_verification(conn, response.id).unwrap_or(false);
         if want_tickets {
-            if let Err(e) = embed_page_tickets(&mut response, conn) {
+            if let Err(e) = embed_page_tickets(&mut response, conn, &ticket_ctx) {
                 return Ok(PageLoadOutcome::EmbedFailed(e));
             }
         }
@@ -1579,23 +1600,37 @@ enum MarkdownOutcome {
 // Export a single documentation page as Markdown
 pub async fn export_page_as_markdown(
     req: actix_web::HttpRequest,
+    auth: AuthContext,
     mut tc: TenantConn,
     page_id: web::Path<i32>,
 ) -> impl Responder {
     let id = page_id.into_inner();
     let locale = crate::utils::locale::request_locale(&req);
+    // The same audience gates the page itself and every page it embeds. Reading
+    // a page through the export used to skip the ACL that `get_documentation_page`
+    // applies, on the page and on its embeds alike.
+    let audience = repository::PageAudience::User {
+        user_uuid: auth.user_uuid,
+        is_admin: auth.is_workspace_admin(),
+    };
 
     let outcome = tc.run(|conn| {
         let page = match repository::get_documentation_page(id, conn) {
             Ok(p) => p,
             Err(_) => return Ok(MarkdownOutcome::NotFound),
         };
+        if !audience.can_read(conn, page.id) {
+            // Same shape as the page read: an inaccessible page is absent, not
+            // forbidden, so the export does not confirm that the id exists.
+            return Ok(MarkdownOutcome::NotFound);
+        }
         let markdown = match resolve_yjs_document(&page, conn) {
             Some(doc_bytes) => {
                 let mut visited = std::collections::HashSet::new();
+                let mut resolver = utils::markdown_export::EmbedResolver { conn, audience };
                 utils::markdown_export::yjs_to_markdown_with_embeds(
                     &doc_bytes,
-                    conn,
+                    &mut resolver,
                     &mut visited,
                     Some(page.uuid),
                     0,
@@ -2192,38 +2227,28 @@ pub struct CreatePageTicketLinkRequest {
 pub async fn list_page_tickets(
     mut tc: TenantConn,
     path: web::Path<i32>,
-    _auth: AuthContext,
+    auth: AuthContext,
 ) -> impl Responder {
     let page_id = path.into_inner();
+    // The links belong to the page, so the page's own ACL decides who may read
+    // them; `auth` was taken and then ignored here, which let any member list
+    // the tickets attached to a page they cannot open.
+    let audience = repository::PageAudience::User {
+        user_uuid: auth.user_uuid,
+        is_admin: auth.is_workspace_admin(),
+    };
+    let ticket_ctx = crate::repository::ticket_visibility::VisibilityContext::from_auth(&auth);
 
     let result = tc.run(|conn| {
+        if !audience.can_read(conn, page_id) {
+            return Ok(Vec::new());
+        }
         let links = repository::documentation_page_tickets::links_for_page(conn, page_id)?;
 
-        // Hydrate ticket title + status in one query rather than N+1.
-        use crate::schema::tickets;
-        use diesel::prelude::*;
+        // Hydrate ticket title + status in one query rather than N+1, filtered
+        // to the tickets this caller may see.
         let ticket_ids: Vec<i32> = links.iter().map(|l| l.ticket_id).collect();
-        let tickets_meta: std::collections::HashMap<
-            i32,
-            (String, crate::models::WorkflowStateCategory),
-        > = if ticket_ids.is_empty() {
-            Default::default()
-        } else {
-            let rows: Vec<(i32, String, i32)> = tickets::table
-                .filter(tickets::id.eq_any(&ticket_ids))
-                .select((tickets::id, tickets::title, tickets::workflow_state_id))
-                .load(conn)
-                .unwrap_or_default();
-            rows.into_iter()
-                .map(|(id, title, ws_id)| {
-                    let cat = crate::repository::workflow_states::category_of(conn, ws_id)
-                        .ok()
-                        .flatten()
-                        .unwrap_or(crate::models::WorkflowStateCategory::Backlog);
-                    (id, (title, cat))
-                })
-                .collect()
-        };
+        let tickets_meta = linked_ticket_meta(conn, &ticket_ids, &ticket_ctx)?;
 
         let responses: Vec<PageTicketLinkResponse> = links
             .into_iter()

--- a/backend/src/handlers/msgraph_integration.rs
+++ b/backend/src/handlers/msgraph_integration.rs
@@ -712,11 +712,18 @@ pub async fn get_sync_progress_endpoint(
         Ok(c) => c,
         Err(e) => return e,
     };
-    // Extract claims from cookie auth middleware
-    let _claims = match req.extensions().get::<crate::models::Claims>() {
-        Some(claims) => claims.clone(),
-        None => return errors::unauthorized("Authentication required"),
-    };
+    // The Entra/Intune integration runs on the org's own app credentials, so
+    // its state, its configuration and its running sync sessions are workspace-
+    // admin only, matching `trigger_sync` below and the Graph proxy in
+    // `microsoft_graph.rs`. Being a member of the workspace was the whole check
+    // here before, which let any member read the connection's configuration,
+    // probe the live connection, and cancel an admin's directory sync.
+    let _claims =
+        match crate::utils::rbac::require_workspace_role(&req, crate::models::WorkspaceRole::Admin)
+        {
+            Ok(c) => c,
+            Err(resp) => return resp,
+        };
 
     let session_id = path.into_inner();
 
@@ -735,11 +742,18 @@ pub async fn get_active_syncs(
         Ok(c) => c,
         Err(e) => return e,
     };
-    // Extract claims from cookie auth middleware
-    let _claims = match req.extensions().get::<crate::models::Claims>() {
-        Some(claims) => claims.clone(),
-        None => return errors::unauthorized("Authentication required"),
-    };
+    // The Entra/Intune integration runs on the org's own app credentials, so
+    // its state, its configuration and its running sync sessions are workspace-
+    // admin only, matching `trigger_sync` below and the Graph proxy in
+    // `microsoft_graph.rs`. Being a member of the workspace was the whole check
+    // here before, which let any member read the connection's configuration,
+    // probe the live connection, and cancel an admin's directory sync.
+    let _claims =
+        match crate::utils::rbac::require_workspace_role(&req, crate::models::WorkspaceRole::Admin)
+        {
+            Ok(c) => c,
+            Err(resp) => return resp,
+        };
 
     if let Ok(progress_map) = SYNC_PROGRESS.lock() {
         let active_syncs: Vec<SyncProgressState> = progress_map
@@ -771,11 +785,18 @@ pub async fn get_last_sync(
         Ok(c) => c,
         Err(e) => return e,
     };
-    // Extract claims from cookie auth middleware
-    let _claims = match req.extensions().get::<crate::models::Claims>() {
-        Some(claims) => claims.clone(),
-        None => return errors::unauthorized("Authentication required"),
-    };
+    // The Entra/Intune integration runs on the org's own app credentials, so
+    // its state, its configuration and its running sync sessions are workspace-
+    // admin only, matching `trigger_sync` below and the Graph proxy in
+    // `microsoft_graph.rs`. Being a member of the workspace was the whole check
+    // here before, which let any member read the connection's configuration,
+    // probe the live connection, and cancel an admin's directory sync.
+    let _claims =
+        match crate::utils::rbac::require_workspace_role(&req, crate::models::WorkspaceRole::Admin)
+        {
+            Ok(c) => c,
+            Err(resp) => return resp,
+        };
 
     // Try to get from database first (persistent storage)
     match sync_history_repo::get_last_completed_sync(&mut conn) {
@@ -834,11 +855,18 @@ pub async fn cancel_sync_session(
         Ok(c) => c,
         Err(e) => return e,
     };
-    // Extract claims from cookie auth middleware
-    let _claims = match req.extensions().get::<crate::models::Claims>() {
-        Some(claims) => claims.clone(),
-        None => return errors::unauthorized("Authentication required"),
-    };
+    // The Entra/Intune integration runs on the org's own app credentials, so
+    // its state, its configuration and its running sync sessions are workspace-
+    // admin only, matching `trigger_sync` below and the Graph proxy in
+    // `microsoft_graph.rs`. Being a member of the workspace was the whole check
+    // here before, which let any member read the connection's configuration,
+    // probe the live connection, and cancel an admin's directory sync.
+    let _claims =
+        match crate::utils::rbac::require_workspace_role(&req, crate::models::WorkspaceRole::Admin)
+        {
+            Ok(c) => c,
+            Err(resp) => return resp,
+        };
 
     let session_id = path.into_inner();
 
@@ -871,11 +899,18 @@ pub async fn cancel_sync_session(
 
 /// Validate Microsoft Graph configuration
 pub async fn get_config_validation(req: actix_web::HttpRequest) -> impl Responder {
-    // Extract claims from cookie auth middleware
-    let _claims = match req.extensions().get::<crate::models::Claims>() {
-        Some(claims) => claims.clone(),
-        None => return errors::unauthorized("Authentication required"),
-    };
+    // The Entra/Intune integration runs on the org's own app credentials, so
+    // its state, its configuration and its running sync sessions are workspace-
+    // admin only, matching `trigger_sync` below and the Graph proxy in
+    // `microsoft_graph.rs`. Being a member of the workspace was the whole check
+    // here before, which let any member read the connection's configuration,
+    // probe the live connection, and cancel an admin's directory sync.
+    let _claims =
+        match crate::utils::rbac::require_workspace_role(&req, crate::models::WorkspaceRole::Admin)
+        {
+            Ok(c) => c,
+            Err(resp) => return resp,
+        };
 
     let mut missing_fields = Vec::new();
 
@@ -930,11 +965,18 @@ pub async fn get_connection_status(
         Ok(c) => c,
         Err(e) => return e,
     };
-    // Extract claims from cookie auth middleware
-    let _claims = match req.extensions().get::<crate::models::Claims>() {
-        Some(claims) => claims.clone(),
-        None => return errors::unauthorized("Authentication required"),
-    };
+    // The Entra/Intune integration runs on the org's own app credentials, so
+    // its state, its configuration and its running sync sessions are workspace-
+    // admin only, matching `trigger_sync` below and the Graph proxy in
+    // `microsoft_graph.rs`. Being a member of the workspace was the whole check
+    // here before, which let any member read the connection's configuration,
+    // probe the live connection, and cancel an admin's directory sync.
+    let _claims =
+        match crate::utils::rbac::require_workspace_role(&req, crate::models::WorkspaceRole::Admin)
+        {
+            Ok(c) => c,
+            Err(resp) => return resp,
+        };
 
     // Check if Microsoft is configured via environment variables
     let microsoft_configured = config_utils::get_microsoft_client_id().is_ok()
@@ -1012,11 +1054,18 @@ pub async fn get_connection_status(
 
 /// Test Microsoft Graph connection
 pub async fn test_connection(req: actix_web::HttpRequest) -> impl Responder {
-    // Extract claims from cookie auth middleware
-    let _claims = match req.extensions().get::<crate::models::Claims>() {
-        Some(claims) => claims.clone(),
-        None => return errors::unauthorized("Authentication required"),
-    };
+    // The Entra/Intune integration runs on the org's own app credentials, so
+    // its state, its configuration and its running sync sessions are workspace-
+    // admin only, matching `trigger_sync` below and the Graph proxy in
+    // `microsoft_graph.rs`. Being a member of the workspace was the whole check
+    // here before, which let any member read the connection's configuration,
+    // probe the live connection, and cancel an admin's directory sync.
+    let _claims =
+        match crate::utils::rbac::require_workspace_role(&req, crate::models::WorkspaceRole::Admin)
+        {
+            Ok(c) => c,
+            Err(resp) => return resp,
+        };
 
     tracing::info!("🔬 Testing Microsoft Graph connection");
 
@@ -5064,11 +5113,18 @@ pub async fn get_entra_object_id(
         Ok(c) => c,
         Err(e) => return e,
     };
-    // Extract claims from cookie auth middleware
-    let _claims = match req.extensions().get::<crate::models::Claims>() {
-        Some(claims) => claims.clone(),
-        None => return errors::unauthorized("Authentication required"),
-    };
+    // The Entra/Intune integration runs on the org's own app credentials, so
+    // its state, its configuration and its running sync sessions are workspace-
+    // admin only, matching `trigger_sync` below and the Graph proxy in
+    // `microsoft_graph.rs`. Being a member of the workspace was the whole check
+    // here before, which let any member read the connection's configuration,
+    // probe the live connection, and cancel an admin's directory sync.
+    let _claims =
+        match crate::utils::rbac::require_workspace_role(&req, crate::models::WorkspaceRole::Admin)
+        {
+            Ok(c) => c,
+            Err(resp) => return resp,
+        };
 
     // Get Microsoft provider
     let provider = match get_default_microsoft_provider() {

--- a/backend/src/repository/documentation.rs
+++ b/backend/src/repository/documentation.rs
@@ -938,6 +938,43 @@ pub fn set_page_visibility(
     })
 }
 
+/// Who a page render is for, so the ACL can travel with a recursion.
+///
+/// The markdown exporter follows `embedded_document` nodes, and a page the
+/// caller may read can embed one they may not. Checking only the top-level
+/// page therefore checks the wrong thing. Carrying the audience down the
+/// recursion means every page the output contains is checked, once, by the
+/// same predicate the ordinary page read uses.
+///
+/// The comment-side analogue is `ticket_visibility::CommentAudience`.
+#[derive(Clone, Copy)]
+pub enum PageAudience {
+    /// A specific caller. Every page is filtered by [`can_user_access_page`].
+    User {
+        user_uuid: uuid::Uuid,
+        is_admin: bool,
+    },
+    /// No filtering, for callers that have already established authority over
+    /// the whole export (nothing uses this yet; it exists so a future system
+    /// exporter has to say so rather than pass a borrowed user).
+    Unrestricted,
+}
+
+impl PageAudience {
+    /// Fails closed: a lookup error reads as "not accessible", matching the
+    /// handlers, which turn a visibility-check failure into a refusal rather
+    /// than falling through to the content.
+    pub fn can_read(&self, conn: &mut DbConnection, page_id: i32) -> bool {
+        match self {
+            PageAudience::Unrestricted => true,
+            PageAudience::User {
+                user_uuid,
+                is_admin,
+            } => can_user_access_page(conn, page_id, user_uuid, *is_admin).unwrap_or(false),
+        }
+    }
+}
+
 /// Check whether a single user can access a page.
 /// Logic: admin → true; page has override → check page groups + user;
 ///        else inherit from collections (no collections = public,

--- a/backend/src/utils/markdown_export.rs
+++ b/backend/src/utils/markdown_export.rs
@@ -9,6 +9,7 @@ use yrs::{
 
 use crate::db::DbConnection;
 use crate::repository;
+use crate::repository::PageAudience;
 use crate::utils::i18n;
 
 const MAX_EMBED_DEPTH: usize = 10;
@@ -58,10 +59,34 @@ pub fn yjs_to_markdown(yjs_document: &[u8]) -> Option<String> {
     }
 }
 
+/// Everything needed to follow an `embedded_document` node: the connection to
+/// read the embedded page with, and who the export is for.
+///
+/// They are bundled rather than passed separately because they must not be
+/// separable. A page the caller may read can embed one they may not, so an
+/// exporter holding a connection but no audience would silently render content
+/// past the ACL. Requiring both to resolve an embed makes that a type error
+/// rather than a discipline.
+pub struct EmbedResolver<'a> {
+    pub conn: &'a mut DbConnection,
+    pub audience: PageAudience,
+}
+
+impl EmbedResolver<'_> {
+    /// Reborrow for a recursive call. `Option<&mut _>` is not `Copy`, and
+    /// `as_deref_mut` does not apply to a plain struct.
+    fn reborrow(&mut self) -> EmbedResolver<'_> {
+        EmbedResolver {
+            conn: self.conn,
+            audience: self.audience,
+        }
+    }
+}
+
 /// Convert a Yjs document to Markdown with recursive embed resolution
 pub fn yjs_to_markdown_with_embeds(
     yjs_document: &[u8],
-    conn: &mut DbConnection,
+    resolver: &mut EmbedResolver<'_>,
     visited: &mut HashSet<Uuid>,
     current_uuid: Option<Uuid>,
     depth: usize,
@@ -112,7 +137,7 @@ pub fn yjs_to_markdown_with_embeds(
 
     let mut output = String::new();
     for child in fragment.children(&txn) {
-        let block = node_to_markdown_with_embeds(&child, &txn, 0, conn, visited, depth, locale);
+        let block = node_to_markdown_with_embeds(&child, &txn, 0, resolver, visited, depth, locale);
         if !block.is_empty() {
             output.push_str(&block);
             output.push('\n');
@@ -159,7 +184,7 @@ fn node_to_markdown_with_embeds(
     node: &XmlOut,
     txn: &yrs::Transaction,
     list_depth: usize,
-    conn: &mut DbConnection,
+    resolver: &mut EmbedResolver<'_>,
     visited: &mut HashSet<Uuid>,
     embed_depth: usize,
     locale: &LanguageIdentifier,
@@ -173,7 +198,7 @@ fn node_to_markdown_with_embeds(
                 elem,
                 txn,
                 list_depth,
-                Some(conn),
+                Some(resolver.reborrow()),
                 visited,
                 embed_depth,
                 Some(locale),
@@ -186,7 +211,7 @@ fn node_to_markdown_with_embeds(
                     &child,
                     txn,
                     list_depth,
-                    conn,
+                    resolver,
                     visited,
                     embed_depth,
                     locale,
@@ -207,7 +232,7 @@ fn element_to_markdown(
     elem: &yrs::XmlElementRef,
     txn: &yrs::Transaction,
     list_depth: usize,
-    mut conn: Option<&mut DbConnection>,
+    mut resolver: Option<EmbedResolver<'_>>,
     visited: &mut HashSet<Uuid>,
     embed_depth: usize,
     locale: Option<&LanguageIdentifier>,
@@ -240,7 +265,7 @@ fn element_to_markdown(
                 elem,
                 txn,
                 list_depth,
-                conn.as_deref_mut(),
+                resolver.as_mut().map(EmbedResolver::reborrow),
                 visited,
                 embed_depth,
                 locale,
@@ -262,7 +287,7 @@ fn element_to_markdown(
                             li,
                             txn,
                             list_depth,
-                            conn.as_deref_mut(),
+                            resolver.as_mut().map(EmbedResolver::reborrow),
                             visited,
                             embed_depth,
                             locale,
@@ -284,7 +309,7 @@ fn element_to_markdown(
                             li,
                             txn,
                             list_depth,
-                            conn.as_deref_mut(),
+                            resolver.as_mut().map(EmbedResolver::reborrow),
                             visited,
                             embed_depth,
                             locale,
@@ -340,10 +365,20 @@ fn element_to_markdown(
                 .map(|v| v.to_string(txn))
                 .unwrap_or(untitled_fallback);
 
-            if let Some(conn) = conn {
+            if let Some(mut resolver) = resolver {
                 if let (Ok(uuid), Some(loc)) = (Uuid::parse_str(&doc_uuid_str), locale) {
                     if embed_depth < MAX_EMBED_DEPTH && !visited.contains(&uuid) {
-                        if let Ok(page) = repository::get_documentation_page_by_uuid(&uuid, conn) {
+                        let conn = &mut *resolver.conn;
+                        // An embedded page carries its own ACL. Read it only if
+                        // this export's audience may read it; otherwise fall
+                        // through to the reference fallback below, which prints
+                        // the title the embedding document already contains and
+                        // none of the embedded content.
+                        let readable = repository::get_documentation_page_by_uuid(&uuid, conn)
+                            .ok()
+                            .filter(|page| resolver.audience.can_read(resolver.conn, page.id));
+                        if let Some(page) = readable {
+                            let conn = &mut *resolver.conn;
                             let yjs_doc = page.yjs_document.as_ref()
                                 .cloned()
                                 .or_else(|| {
@@ -357,7 +392,7 @@ fn element_to_markdown(
                             if let Some(doc_bytes) = yjs_doc {
                                 if let Some(content) = yjs_to_markdown_with_embeds(
                                     &doc_bytes,
-                                    conn,
+                                    &mut resolver,
                                     visited,
                                     Some(uuid),
                                     embed_depth + 1,
@@ -514,7 +549,7 @@ fn collect_block_children(
     elem: &yrs::XmlElementRef,
     txn: &yrs::Transaction,
     list_depth: usize,
-    mut conn: Option<&mut DbConnection>,
+    mut resolver: Option<EmbedResolver<'_>>,
     visited: &mut HashSet<Uuid>,
     embed_depth: usize,
     locale: Option<&LanguageIdentifier>,
@@ -529,7 +564,7 @@ fn collect_block_children(
                     child_elem,
                     txn,
                     list_depth,
-                    conn.as_deref_mut(),
+                    resolver.as_mut().map(EmbedResolver::reborrow),
                     visited,
                     embed_depth,
                     locale,
@@ -555,7 +590,7 @@ fn collect_list_item_content(
     li: &yrs::XmlElementRef,
     txn: &yrs::Transaction,
     list_depth: usize,
-    mut conn: Option<&mut DbConnection>,
+    mut resolver: Option<EmbedResolver<'_>>,
     visited: &mut HashSet<Uuid>,
     embed_depth: usize,
     locale: Option<&LanguageIdentifier>,
@@ -575,7 +610,7 @@ fn collect_list_item_content(
                     child_elem,
                     txn,
                     list_depth + 1,
-                    conn.as_deref_mut(),
+                    resolver.as_mut().map(EmbedResolver::reborrow),
                     visited,
                     embed_depth,
                     locale,
@@ -586,7 +621,7 @@ fn collect_list_item_content(
                     child_elem,
                     txn,
                     list_depth,
-                    conn.as_deref_mut(),
+                    resolver.as_mut().map(EmbedResolver::reborrow),
                     visited,
                     embed_depth,
                     locale,

--- a/backend/tests/documentation_export_acl.rs
+++ b/backend/tests/documentation_export_acl.rs
@@ -1,0 +1,193 @@
+//! Documentation export honours the page ACL, on the page and on its embeds.
+//!
+//! `export_page_as_markdown` used to read a page and follow every
+//! `embedded_document` node in it without consulting
+//! `can_user_access_page`, which the ordinary page read does consult. The
+//! interesting half is the embed: a page the caller may read can embed one
+//! they may not, so checking only the top-level page checks the wrong thing.
+//!
+//! These drive `yjs_to_markdown_with_embeds` directly, the way
+//! `portal_session` drives the portal primitives, because that function is
+//! where the audience travels with the recursion.
+
+#![allow(clippy::expect_used)]
+
+use diesel::prelude::*;
+use yrs::types::xml::XmlIn;
+use yrs::{Doc, ReadTxn, Transact, WriteTxn, XmlElementPrelim, XmlFragment};
+
+use backend::db::DbConnection;
+use backend::models::{DocumentationStatus, NewDocumentationPage, User};
+use backend::repository::PageAudience;
+use backend::utils::markdown_export::{yjs_to_markdown_with_embeds, EmbedResolver};
+
+mod common;
+
+/// A y-prosemirror fragment holding `text`, built by the converter the app
+/// itself uses so the fixture cannot drift from the real document shape.
+fn page_body(text: &str) -> Vec<u8> {
+    backend::services::seed::markdown_to_yjs(text).expect("build body")
+}
+
+/// A fragment that embeds `child_uuid`, the shape the editor writes.
+fn page_embedding(child_uuid: uuid::Uuid, child_title: &str) -> Vec<u8> {
+    let doc = Doc::new();
+    let fragment = {
+        let mut txn = doc.transact_mut();
+        txn.get_or_insert_xml_fragment("prosemirror")
+    };
+    {
+        let mut txn = doc.transact_mut();
+        let mut embed = XmlElementPrelim::new("embedded_document", Vec::<XmlIn>::new());
+        embed
+            .attributes
+            .insert("documentUuid".into(), child_uuid.to_string());
+        embed
+            .attributes
+            .insert("documentTitle".into(), child_title.to_string());
+        fragment.push_back(&mut txn, embed);
+    }
+    let txn = doc.transact();
+    txn.encode_state_as_update_v1(&yrs::StateVector::default())
+}
+
+fn insert_page(
+    conn: &mut DbConnection,
+    author: &User,
+    title: &str,
+    slug: &str,
+    body: Vec<u8>,
+) -> backend::models::DocumentationPage {
+    use backend::schema::documentation_pages;
+    let new = NewDocumentationPage {
+        uuid: uuid::Uuid::new_v4(),
+        title: title.to_string(),
+        slug: slug.to_string(),
+        icon: None,
+        cover_image: None,
+        status: DocumentationStatus::Published,
+        created_by: author.uuid,
+        last_edited_by: author.uuid,
+        parent_id: None,
+        display_order: None,
+        is_public: false,
+        is_template: false,
+        yjs_state_vector: None,
+        yjs_document: Some(body),
+        yjs_client_id: None,
+        has_unsaved_changes: false,
+    };
+    diesel::insert_into(documentation_pages::table)
+        .values(&new)
+        .get_result(conn)
+        .expect("insert page")
+}
+
+/// Give the page an explicit visibility override naming somebody else, which
+/// is the cheapest way to make `can_user_access_page` say no: any override at
+/// all switches the page from "inherit" to "listed users and groups only".
+fn restrict_page_to(conn: &mut DbConnection, page_id: i32, workspace_id: i32, grantee: uuid::Uuid) {
+    use backend::schema::documentation_page_visibility as v;
+    diesel::insert_into(v::table)
+        .values((
+            v::page_id.eq(page_id),
+            v::user_uuid.eq(Some(grantee)),
+            v::workspace_id.eq(workspace_id),
+        ))
+        .execute(conn)
+        .expect("restrict page");
+}
+
+struct Fixture {
+    parent_body: Vec<u8>,
+    secret_title: String,
+    secret_text: String,
+    reader: uuid::Uuid,
+}
+
+fn setup(conn: &mut DbConnection, slug: &str) -> Fixture {
+    let workspace_id = common::mint_workspace(conn, slug, slug);
+    backend::sync::session::pin_workspace(conn, workspace_id).expect("pin");
+    let author = common::insert_user(conn, "Doc Author");
+    let reader = common::insert_user(conn, "Doc Reader");
+    let other = common::insert_user(conn, "Someone Else");
+
+    let secret_text = "the embedded secret".to_string();
+    let secret = insert_page(
+        conn,
+        &author,
+        "Secret Page",
+        &format!("{slug}-secret"),
+        page_body(&secret_text),
+    );
+    restrict_page_to(conn, secret.id, workspace_id, other.uuid);
+
+    let parent_body = page_embedding(secret.uuid, "Secret Page");
+    Fixture {
+        parent_body,
+        secret_title: "Secret Page".to_string(),
+        secret_text,
+        reader: reader.uuid,
+    }
+}
+
+fn render(conn: &mut DbConnection, body: &[u8], audience: PageAudience) -> String {
+    let mut visited = std::collections::HashSet::new();
+    let locale: unic_langid::LanguageIdentifier = "en-US".parse().expect("locale");
+    let mut resolver = EmbedResolver { conn, audience };
+    yjs_to_markdown_with_embeds(body, &mut resolver, &mut visited, None, 0, &locale)
+        .unwrap_or_default()
+}
+
+#[test]
+fn an_export_omits_an_embedded_page_the_reader_cannot_open() {
+    common::ensure_test_keyring();
+    let test_db = common::TestDb::new();
+    let pool = test_db.pool_with_size(2);
+    let mut conn = pool.get().expect("conn");
+    let f = setup(&mut conn, "acme-embed-denied");
+
+    let out = render(
+        &mut conn,
+        &f.parent_body,
+        PageAudience::User {
+            user_uuid: f.reader,
+            is_admin: false,
+        },
+    );
+
+    assert!(
+        !out.contains(&f.secret_text),
+        "an embedded page outside the reader's ACL must not be rendered: {out}"
+    );
+    assert!(
+        out.contains(&f.secret_title),
+        "the fallback reference still names the page, which the embedding \
+         document already contained: {out}"
+    );
+}
+
+#[test]
+fn an_export_includes_an_embedded_page_the_reader_can_open() {
+    common::ensure_test_keyring();
+    let test_db = common::TestDb::new();
+    let pool = test_db.pool_with_size(2);
+    let mut conn = pool.get().expect("conn");
+    let f = setup(&mut conn, "acme-embed-allowed");
+
+    // Same document, same fixture, admin audience: proves the omission above
+    // is the ACL talking and not the embed machinery failing to resolve.
+    let out = render(
+        &mut conn,
+        &f.parent_body,
+        PageAudience::User {
+            user_uuid: f.reader,
+            is_admin: true,
+        },
+    );
+
+    assert!(
+        out.contains(&f.secret_text),
+        "an admin's export must still resolve the embed: {out}"
+    );
+}

--- a/backend/tests/integration_routes_require_admin.rs
+++ b/backend/tests/integration_routes_require_admin.rs
@@ -1,0 +1,68 @@
+//! Every route on the Entra/Intune integration is workspace-admin only.
+//!
+//! The integration runs on the organisation's own Graph app credentials, so
+//! reading its configuration, probing the live connection, or cancelling a
+//! running directory sync are all admin actions. Eight of these handlers used
+//! to check only that the caller was authenticated, which made them member-
+//! reachable while the sibling Graph proxy in `microsoft_graph.rs` required
+//! admin for the same credentials.
+//!
+//! Asserted at the source rather than over HTTP: the gate itself
+//! (`require_workspace_role`) needs a resolved workspace and a membership row,
+//! and what regresses in practice is a ninth handler being added with the weak
+//! check copied from its neighbours.
+
+use std::fs;
+use std::path::PathBuf;
+
+use regex::Regex;
+
+/// Bare authentication: claims are read out of the request extensions and
+/// nothing further is asked. Correct for a self-service route, wrong for every
+/// route in these two modules.
+const BARE_AUTH: &str = "req.extensions().get::<crate::models::Claims>()";
+
+#[test]
+fn graph_integration_handlers_require_workspace_admin() {
+    let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let mut offenders: Vec<String> = Vec::new();
+    let routed =
+        Regex::new(r"web::(?:get|post|put|patch|delete)\(\)\.to\((\w+)\)").expect("route regex");
+
+    for module in ["msgraph_integration.rs", "microsoft_graph.rs"] {
+        let path = manifest.join("src/handlers").join(module);
+        let src = fs::read_to_string(&path).expect("read module");
+        // Drop the test module, which may legitimately build bare claims.
+        let src = src.split("#[cfg(test)]").next().unwrap_or(&src).to_string();
+
+        let handlers: Vec<String> = routed
+            .captures_iter(&src)
+            .map(|c| c[1].to_string())
+            .collect();
+        assert!(
+            !handlers.is_empty(),
+            "{module}: found no routes; the scanner has drifted from the config fn"
+        );
+
+        for name in handlers {
+            let Some(start) = src.find(&format!("fn {name}(")) else {
+                continue;
+            };
+            let body = &src[start..];
+            let end = body.find("\n}\n").map(|i| i + 2).unwrap_or(body.len());
+            let body = &body[..end];
+            if body.contains(BARE_AUTH) && !body.contains("require_workspace_role") {
+                offenders.push(format!("{module}::{name}"));
+            }
+        }
+    }
+
+    assert!(
+        offenders.is_empty(),
+        "These Graph integration handlers gate on being authenticated rather than \
+         on being a workspace admin, though they act through the organisation's \
+         Graph credentials:\n  {}\n\nAdd:\n  \
+         crate::utils::rbac::require_workspace_role(&req, crate::models::WorkspaceRole::Admin)",
+        offenders.join("\n  ")
+    );
+}


### PR DESCRIPTION
Three routes that read past their own authorization. Two of them shared a root cause, so the fix is one shared helper rather than three patches.

## Graph integration: authenticated was doing the work of admin

`microsoft_graph.rs` requires workspace admin to proxy Graph, with the reason stated inline: the proxy runs on the organisation's own app credentials. Eight handlers in `msgraph_integration.rs` run on those same credentials but checked only that the caller was authenticated, so any workspace member could read the integration's configuration, probe the live connection, and cancel an admin's running directory sync.

All eight carried a byte-identical bare-auth block, replaced with the `require_workspace_role` call that `trigger_sync` already uses a few hundred lines away.

## Documentation export skipped the page ACL, and its embeds

`export_page_as_markdown` never called `can_user_access_page`, which the ordinary page read does call. The top-level page was the smaller half of it: the exporter follows `embedded_document` nodes, and a page the caller may read can embed one they may not, so checking only the entry page checks the wrong thing.

`PageAudience` now travels with the recursion. It is bundled with the connection into an `EmbedResolver` rather than passed alongside it, because the two must not be separable: an exporter holding a connection but no audience would silently render past the ACL. That makes it a type error instead of a discipline, and it shrinks the signatures rather than growing them.

An embedded page the caller cannot open falls through to the existing reference fallback, which prints the title the embedding document already contained and none of the content.

## Page ticket links listed tickets the caller cannot see

`list_page_tickets` took `AuthContext` and ignored it (`_auth`), so any member could list the tickets attached to a page they cannot open. It and `embed_page_tickets` also hydrated ticket titles and categories through the same unfiltered query, naming tickets outside the caller's visibility. Both now go through one `linked_ticket_meta` that filters via `visible_tickets_query`, so neither can forget it and an invisible ticket renders untitled exactly as an unresolvable id already did.

## Tests

`documentation_export_acl.rs` runs the same fixture twice: a non-admin reader must not see the embedded page's content, and an admin must. The pair is its own mutation check, since the second test fails if the omission were the embed machinery rather than the ACL.

`integration_routes_require_admin.rs` asserts the invariant at the source for both Graph modules, because what regresses in practice is a ninth handler copying the weak check from its neighbours. Mutation-checked: reverting one handler's gate turns it red.

Local: `cargo fmt` clean, `cargo clippy --all-targets` with no new warnings in touched files, `cargo test` 1935 passed / 0 failed.

https://claude.ai/code/session_017iEcp3fFMB594JYRZxcQ5H