### PR TITLE
Enforce API-token scope in the auth funnel, not in a wrap

### DIFF
--- a/backend/src/middleware/api_token.rs
+++ b/backend/src/middleware/api_token.rs
@@ -315,6 +315,19 @@ async fn finalize<B: MessageBody>(
     next: Next<B>,
     claims: Claims,
 ) -> Result<ServiceResponse<B>, Error> {
+    // Scope enforcement runs here, at the one point every authenticated
+    // request passes, rather than in a middleware each new scope has to
+    // remember to stack alongside the auth wrap. `/api/collaboration` is what
+    // forgetting looked like: it wrapped `dual_auth_middleware` but not the
+    // scope middleware, so a narrowed token reached
+    // `POST /api/collaboration/token` and traded itself for an unrestricted
+    // `collab` JWT. The policy already returned `Full` for that path; it was
+    // simply never asked.
+    if !crate::middleware::token_scope::claims_may_call(&claims, req.method(), req.path()) {
+        return Err(actix_web::error::ErrorForbidden(
+            "API token scope does not permit this request",
+        ));
+    }
     request_context::populate(&req, &claims);
     req.extensions_mut().insert(claims);
     next.call(req).await

--- a/backend/src/middleware/token_scope.rs
+++ b/backend/src/middleware/token_scope.rs
@@ -1,13 +1,15 @@
 //! API token scope enforcement.
 //!
 //! This module owns the route policy that maps an incoming request to
-//! the scope it requires, plus (step 3) the middleware that enforces it
-//! against a narrowed token's `ScopeSet`.
+//! the scope it requires, plus the predicate that enforces it against a
+//! narrowed token's `ScopeSet`. The predicate is called from
+//! `api_token::finalize`, so every authenticated request is checked at one
+//! point instead of wherever a wrap happens to be stacked.
 //!
 //! Design:
 //!   * `full` credentials (every cookie session and every un-narrowed
-//!     token) short-circuit in the middleware and never reach this
-//!     policy. Only deliberately-narrowed API tokens are constrained.
+//!     token) short-circuit before this policy is consulted. Only
+//!     deliberately-narrowed API tokens are constrained.
 //!   * The policy returns a `ScopeRequirement`. Anything not explicitly
 //!     mapped defaults to `Full`, which a narrowed token can never
 //!     satisfy, so a new or cross-cutting route fail-closes rather than
@@ -15,11 +17,7 @@
 //!   * Scope is a second, orthogonal layer: the handler's existing role
 //!     gate still runs. A request must pass both.
 
-use actix_web::body::MessageBody;
-use actix_web::dev::{ServiceRequest, ServiceResponse};
 use actix_web::http::Method;
-use actix_web::middleware::Next;
-use actix_web::{Error, HttpMessage};
 
 use crate::models::Claims;
 use crate::utils::scopes::{Action, Domain, ScopeSet};
@@ -160,34 +158,22 @@ fn action_for(method: &Method, rest: &str) -> Action {
 /// pass both layers. (The control-plane provisioning surface is a
 /// separate scope with its own EdDSA-JWT auth, not an api_token, so it
 /// never reaches this middleware.)
-pub async fn token_scope_middleware(
-    req: ServiceRequest,
-    next: Next<impl MessageBody>,
-) -> Result<ServiceResponse<impl MessageBody>, Error> {
-    if scope_allows(&req) {
-        next.call(req).await
-    } else {
-        Err(actix_web::error::ErrorForbidden(
-            "API token scope does not permit this request",
-        ))
-    }
-}
-
-/// Whether the request's credential scope permits it. Borrow-scoped so
-/// the extensions borrow is dropped before the async `next.call`.
-fn scope_allows(req: &ServiceRequest) -> bool {
-    let ext = req.extensions();
-    let claims = match ext.get::<Claims>() {
-        // No claims: the auth layer already rejected, or this isn't an
-        // authenticated scope. Nothing for us to enforce.
-        None => return true,
-        Some(c) => c,
-    };
+/// Whether a credential's scope permits this request.
+///
+/// Enforcement is called from `api_token::finalize`, the one point every
+/// authenticated request passes, rather than from a middleware a new scope
+/// has to remember to stack. It used to be a wrap, stacked on `/api` and
+/// `/api/files` and nowhere else; `/api/collaboration` is registered as its
+/// own top-level scope with only the auth wrap, so a deliberately narrowed
+/// token reached `POST /api/collaboration/token` and traded itself for an
+/// unrestricted `collab` JWT. Nothing had to be wrong for that to happen,
+/// only forgotten, which is the argument for the funnel over the wrap.
+pub fn claims_may_call(claims: &Claims, method: &Method, path: &str) -> bool {
     // Cookie sessions and un-narrowed tokens carry `full`.
     if claims.scope == "full" {
         return true;
     }
-    match required_scope(req.method(), req.path()) {
+    match required_scope(method, path) {
         ScopeRequirement::Any => true,
         ScopeRequirement::Full => false,
         ScopeRequirement::Capability(domain, action) => {
@@ -203,6 +189,67 @@ mod tests {
 
     fn req(method: Method, path: &str) -> ScopeRequirement {
         required_scope(&method, path)
+    }
+
+    fn claims_scoped(scope: &str) -> Claims {
+        Claims {
+            sub: uuid::Uuid::new_v4().to_string(),
+            name: "Token".to_string(),
+            email: String::new(),
+            platform_role: "user".to_string(),
+            scope: scope.to_string(),
+            sid: None,
+            workspace_uuid: None,
+            exp: 0,
+            iat: 0,
+        }
+    }
+
+    /// The bypass this enforcement point exists to close. `/api/collaboration`
+    /// is its own top-level scope carrying only the auth wrap, so while
+    /// enforcement was a separate middleware stacked on `/api` and
+    /// `/api/files`, a token narrowed to something harmless reached
+    /// `POST /api/collaboration/token` and traded itself for an unrestricted
+    /// `collab` JWT, and from there a read/write socket on every document its
+    /// owner could see.
+    #[test]
+    fn a_narrowed_token_cannot_mint_a_collab_credential() {
+        let narrow = claims_scoped("notifications:read");
+        assert!(
+            !claims_may_call(&narrow, &Method::POST, "/api/collaboration/token"),
+            "a narrowed token must not mint a collab credential"
+        );
+        assert!(
+            !claims_may_call(&narrow, &Method::GET, "/api/collaboration/article/abc"),
+            "nor read a document body through the same unmapped tree"
+        );
+    }
+
+    #[test]
+    fn full_credentials_are_unaffected() {
+        let full = claims_scoped("full");
+        // Cookie sessions and un-narrowed tokens carry `full`; every path,
+        // mapped or not, must stay open to them or this move would have
+        // logged out the whole product.
+        for path in [
+            "/api/collaboration/token",
+            "/api/tickets/5",
+            "/api/files/tickets/x.png",
+            "/api/some/route/added/tomorrow",
+        ] {
+            assert!(
+                claims_may_call(&full, &Method::GET, path),
+                "full credential refused at {path}"
+            );
+            assert!(claims_may_call(&full, &Method::POST, path));
+        }
+    }
+
+    #[test]
+    fn a_narrowed_token_still_reaches_what_it_was_scoped_for() {
+        let reader = claims_scoped("tickets:read");
+        assert!(claims_may_call(&reader, &Method::GET, "/api/tickets/5"));
+        assert!(!claims_may_call(&reader, &Method::POST, "/api/tickets"));
     }
 
     #[test]
@@ -437,13 +484,36 @@ mod enforcement_tests {
         }
     }
 
-    /// Drive a request through an app wrapped only in the scope
-    /// middleware; the default handler returns 200, so the status is the
-    /// middleware's decision (200 allow / 403 deny).
+    /// Mirrors what `api_token::finalize` does with the predicate, so these
+    /// end-to-end cases keep testing enforcement after it moved out of a
+    /// middleware of its own. Claims absent means the real funnel was never
+    /// reached, which is an allow here for the same reason it was before.
+    async fn scope_gate(
+        req: actix_web::dev::ServiceRequest,
+        next: actix_web::middleware::Next<impl actix_web::body::MessageBody>,
+    ) -> Result<actix_web::dev::ServiceResponse<impl actix_web::body::MessageBody>, actix_web::Error>
+    {
+        let allowed = req
+            .extensions()
+            .get::<Claims>()
+            .map(|c| claims_may_call(c, req.method(), req.path()))
+            .unwrap_or(true);
+        if allowed {
+            next.call(req).await
+        } else {
+            Err(actix_web::error::ErrorForbidden(
+                "API token scope does not permit this request",
+            ))
+        }
+    }
+
+    /// Drive a request through an app wrapped only in the scope gate; the
+    /// default handler returns 200, so the status is the gate's decision
+    /// (200 allow / 403 deny).
     async fn status_for(scope: Option<&str>, method: Method, path: &str) -> StatusCode {
         let app = actix_test::init_service(
             App::new()
-                .wrap(from_fn(token_scope_middleware))
+                .wrap(from_fn(scope_gate))
                 .default_service(web::to(|| async { HttpResponse::Ok().finish() })),
         )
         .await;
@@ -477,7 +547,9 @@ mod enforcement_tests {
 
     #[actix_web::test]
     async fn session_with_no_claims_passes_through() {
-        // Defensive: if dual_auth didn't insert claims, we don't block.
+        // Defensive: enforcement now lives inside the auth funnel, which only
+        // runs with claims in hand. A request that somehow arrives without
+        // them was never authenticated, so it is not ours to block.
         assert_eq!(
             status_for(None, Method::POST, "/api/tickets").await,
             StatusCode::OK

--- a/backend/src/startup.rs
+++ b/backend/src/startup.rs
@@ -798,12 +798,10 @@ pub fn configure_app(
             )
 
             // Authenticated, workspace-scoped tenant file serving. Its own
-            // scope so the wrap stack matches the main /api scope: dual_auth
-            // (cookie or Bearer + workspace-membership gate) registered last so
-            // it runs first and puts Claims in extensions, then token_scope
-            // enforces API-token scopes. These routes map to `Full`, so a
-            // narrowed token 403s here instead of slipping past scope
-            // enforcement (they used to sit outside any scope-wrapped tree).
+            // scope carrying dual_auth (cookie or Bearer + workspace-membership
+            // gate). API-token scopes are enforced inside the auth funnel
+            // itself, so they cover this tree without a second wrap; these
+            // routes map to `Full`, and a narrowed token 403s here.
             // The handlers add a per-ticket/asset visibility check via
             // TenantConn so a caller only reads files it can see in its own
             // workspace. Registered before the main /api scope so /api/files/*
@@ -811,9 +809,6 @@ pub fn configure_app(
             // so the `{filename:.*}` tail can't swallow it.
             .service(
                 web::scope("/api/files")
-                    .wrap(actix_web::middleware::from_fn(
-                        crate::middleware::token_scope::token_scope_middleware,
-                    ))
                     .wrap(actix_web::middleware::from_fn(crate::middleware::dual_auth_middleware))
                     .route("/tickets/{ticket_id}/notes/{filename:.*}", web::get().to(crate::handlers::serve_ticket_note_image))
                     .route("/tickets/{filename:.*}", web::get().to(crate::handlers::serve_ticket_file))
@@ -921,15 +916,10 @@ pub fn configure_app(
                     // this does not throttle long-lived connections. See
                     // security-audit-2026-06.
                     .wrap(RateLimiter::default())
-                    // Enforce API-token scopes. Registered before (so it
-                    // runs after) dual_auth, which puts Claims in
-                    // extensions. Cookie sessions and un-narrowed tokens
-                    // carry `full` and short-circuit; platform tokens are
-                    // exempt; a narrowed token must satisfy the route's
-                    // required scope.
-                    .wrap(actix_web::middleware::from_fn(
-                        crate::middleware::token_scope::token_scope_middleware,
-                    ))
+                    // Cookie or Bearer or `nsk_` API token. The funnel behind
+                    // this also enforces API-token scopes, so a narrowed token
+                    // must satisfy the route's required scope; cookie sessions
+                    // and un-narrowed tokens carry `full` and short-circuit.
                     .wrap(actix_web::middleware::from_fn(crate::middleware::dual_auth_middleware))
 
                     // Authentication Provider management (admin only) - simplified for environment-based config
@@ -1068,9 +1058,8 @@ pub fn configure_app(
                     .configure(crate::handlers::files::config)
 
                     // Collab-document image upload. Deliberately here rather
-                    // than under /api/collaboration: that scope carries
-                    // neither the rate limiter nor token-scope enforcement,
-                    // and a 10MB multipart write needs both.
+                    // than under /api/collaboration: that scope carries no rate
+                    // limiter, and a 10MB multipart write needs one.
                     .configure(crate::handlers::collab_images::config)
 
                     // ===== SSE / SEARCH / NOTIFICATIONS / BUG REPORTS =====


### PR DESCRIPTION
Scope enforcement was a middleware, stacked on `/api` and `/api/files`. `/api/collaboration` is registered as its own top-level scope carrying only `dual_auth_middleware`, so the policy was never asked there.

Worth being precise about the failure: the policy already had the right answer. `required_scope` returns `Full` for anything unmapped, and nothing under `collaboration` is mapped, so a narrowed token was always meant to be refused. Nothing was misconfigured. The check simply wasn't reached, because pairing two wraps correctly is something a new scope has to remember to do.

What that cost: a token deliberately narrowed to something harmless reached `POST /api/collaboration/token`, which mints a `collab` connection JWT from the caller's identity alone, and `ws_handler` accepts exactly that JWT. So a `notifications:read` token handed to a third-party integration converted into Yjs read *and write* on every document its owner could open, plus the revision-history and restore routes on the same tree.

## The change

Move the check into `api_token::finalize`, the one point every authenticated request passes, and delete both wraps. `scope_allows` becomes `claims_may_call`, taking the claims directly rather than digging them back out of extensions. About sixty lines net.

## Why this is safe to move

Only three auth wraps funnel through `finalize`:

| Scope | Before | After |
|---|---|---|
| `/api` | enforced by the wrap | enforced in the funnel, unchanged |
| `/api/files` | enforced by the wrap | enforced in the funnel, unchanged |
| `/api/collaboration` | **not enforced** | enforced |

The portal and platform-token middlewares insert their own context and never call `finalize`. That one is worth stating explicitly rather than assuming: portal sessions carry `PORTAL_SCOPE`, not `full`, so had they passed through this point the entire customer portal would have started 403ing.

Connection tokens (`sse` / `collab`) don't carry `full` either, so I checked whether any client presents one to the collaboration REST tree. Every collab REST call goes through `apiClient` on the cookie or bearer session; the connection token is only ever used to open the socket.

## Tests

The module had eleven end-to-end enforcement tests driving a request through the middleware. They are ported onto a six-line shim mirroring what `finalize` now does, rather than dropped along with the middleware they drove. All 23 tests in the module pass.

Added one pinning the specific bypass: a `notifications:read` token can neither mint a collab credential nor read a document body through that tree. Plus a check that `full` credentials still reach every path, mapped or not, since that is the property whose failure would have been loudest.

Local: `cargo fmt` clean, `cargo clippy --all-targets` with no new warnings, `cargo test` 1935 passed / 0 failed.

https://claude.ai/code/session_017iEcp3fFMB594JYRZxcQ5H