### PR TITLE
Soft-remove workspace memberships

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -1681,9 +1681,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
-version = "0.10.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",

--- a/backend/migrations/2026-09-09-000002_workspace_members_removed_at/down.sql
+++ b/backend/migrations/2026-09-09-000002_workspace_members_removed_at/down.sql
@@ -1,0 +1,37 @@
+-- Drop the soft-removed rows: with the column gone they would read as active
+-- memberships, which is worse than losing them.
+DELETE FROM workspace_members WHERE removed_at IS NOT NULL;
+
+DROP INDEX IF EXISTS workspace_members_active_idx;
+ALTER TABLE workspace_members DROP COLUMN removed_at;
+
+CREATE OR REPLACE FUNCTION public.enforce_workspace_seat_limit() RETURNS trigger
+    LANGUAGE plpgsql SECURITY DEFINER
+    SET search_path TO 'pg_catalog', 'public'
+    AS $$
+DECLARE
+    lim INTEGER;
+    staff_count INTEGER;
+BEGIN
+    IF NEW.role NOT IN ('owner', 'admin', 'agent') THEN
+        RETURN NEW;
+    END IF;
+    IF TG_OP = 'UPDATE' AND OLD.role IN ('owner', 'admin', 'agent') THEN
+        RETURN NEW;
+    END IF;
+    SELECT seat_limit INTO lim FROM workspaces WHERE id = NEW.workspace_id;
+    IF lim IS NULL THEN
+        RETURN NEW;
+    END IF;
+    SELECT count(*) INTO staff_count
+        FROM workspace_members
+        WHERE workspace_id = NEW.workspace_id
+          AND role IN ('owner', 'admin', 'agent')
+          AND user_uuid <> NEW.user_uuid;
+    IF staff_count >= lim THEN
+        RAISE EXCEPTION 'workspace % staff seat limit (%) reached', NEW.workspace_id, lim
+            USING ERRCODE = 'check_violation', CONSTRAINT = 'workspace_seat_limit';
+    END IF;
+    RETURN NEW;
+END;
+$$;

--- a/backend/migrations/2026-09-09-000002_workspace_members_removed_at/up.sql
+++ b/backend/migrations/2026-09-09-000002_workspace_members_removed_at/up.sql
@@ -1,0 +1,80 @@
+-- Soft-remove workspace memberships.
+--
+-- `remove_membership` hard-deleted the row, which makes membership-joined
+-- identity resolution impossible: everyone who ever left renders as an unknown
+-- user on their historical tickets, comments and audit entries. Keep the row
+-- and mark it instead.
+--
+-- No backfill: every existing row is an active membership, which is exactly
+-- what NULL means here. Adding a nullable column with no default is a
+-- metadata-only change in Postgres, so no row rewrite and no audit-trigger
+-- storm (the hazard that requires DISABLE TRIGGER on audited tables).
+ALTER TABLE workspace_members ADD COLUMN removed_at TIMESTAMPTZ;
+
+COMMENT ON COLUMN workspace_members.removed_at IS
+    'When the membership was revoked. NULL means active. Identity resolution '
+    'reads rows regardless; every role, permission and seat-counting read must '
+    'filter removed_at IS NULL.';
+
+-- Finding a removed member is a rare, targeted read; finding the active ones
+-- is on the hot path for every request that resolves a role.
+CREATE INDEX IF NOT EXISTS workspace_members_active_idx
+    ON workspace_members (workspace_id, user_uuid)
+    WHERE removed_at IS NULL;
+
+-- The seat-limit trigger needs two changes, not one.
+--
+-- 1. The staff count must ignore removed members, or a revoked staff member
+--    keeps consuming a licensed seat forever.
+--
+-- 2. The UPDATE short-circuit gains the same condition. This one is
+--    defence-in-depth rather than a live fix, and the distinction is worth
+--    recording. The short-circuit reads "an UPDATE that keeps a staff role
+--    consumes no new seat", which was true when the only way to leave was
+--    DELETE; under soft-remove, re-activating a removed staff member is an
+--    UPDATE whose OLD.role is still staff, so it looks like a bypass. It is
+--    not, today: re-activation happens through `add_membership`'s
+--    ON CONFLICT DO UPDATE, and Postgres fires BEFORE INSERT *and then*
+--    BEFORE UPDATE for a conflicting upsert (verified, not assumed), so the
+--    INSERT pass runs the full count and refuses. The condition matters the
+--    moment anyone writes a direct `UPDATE ... SET removed_at = NULL`, where
+--    the UPDATE pass would be the only check, and it costs nothing now.
+CREATE OR REPLACE FUNCTION public.enforce_workspace_seat_limit() RETURNS trigger
+    LANGUAGE plpgsql SECURITY DEFINER
+    SET search_path TO 'pg_catalog', 'public'
+    AS $$
+DECLARE
+    lim INTEGER;
+    staff_count INTEGER;
+BEGIN
+    IF NEW.role NOT IN ('owner', 'admin', 'agent') THEN
+        RETURN NEW;
+    END IF;
+    -- A removed member consumes nothing, so removing one never needs a check.
+    IF NEW.removed_at IS NOT NULL THEN
+        RETURN NEW;
+    END IF;
+    -- An UPDATE that keeps an ALREADY-ACTIVE staff role consumes no new seat.
+    -- Re-activating a removed one does, and falls through to the count below.
+    IF TG_OP = 'UPDATE'
+       AND OLD.role IN ('owner', 'admin', 'agent')
+       AND OLD.removed_at IS NULL THEN
+        RETURN NEW;
+    END IF;
+    SELECT seat_limit INTO lim FROM workspaces WHERE id = NEW.workspace_id;
+    IF lim IS NULL THEN
+        RETURN NEW;
+    END IF;
+    SELECT count(*) INTO staff_count
+        FROM workspace_members
+        WHERE workspace_id = NEW.workspace_id
+          AND role IN ('owner', 'admin', 'agent')
+          AND removed_at IS NULL
+          AND user_uuid <> NEW.user_uuid;
+    IF staff_count >= lim THEN
+        RAISE EXCEPTION 'workspace % staff seat limit (%) reached', NEW.workspace_id, lim
+            USING ERRCODE = 'check_violation', CONSTRAINT = 'workspace_seat_limit';
+    END IF;
+    RETURN NEW;
+END;
+$$;

--- a/backend/src/handlers/asset_audits.rs
+++ b/backend/src/handlers/asset_audits.rs
@@ -220,7 +220,8 @@ fn inventory_alert_recipients(conn: &mut crate::db::DbConnection) -> Vec<uuid::U
                         >(
                             "NULLIF(current_setting('app.workspace_id', true), '')::int",
                         )))
-                        .filter(workspace_members::role.eq_any(vec!["owner", "admin", "agent"])),
+                        .filter(workspace_members::role.eq_any(vec!["owner", "admin", "agent"]))
+                        .filter(workspace_members::removed_at.is_null()),
                 )),
         )
         .select(users::uuid)

--- a/backend/src/handlers/asset_usage.rs
+++ b/backend/src/handlers/asset_usage.rs
@@ -306,7 +306,8 @@ fn inventory_alert_recipients(conn: &mut crate::db::DbConnection) -> Vec<uuid::U
                         >(
                             "NULLIF(current_setting('app.workspace_id', true), '')::int",
                         )))
-                        .filter(workspace_members::role.eq_any(vec!["owner", "admin", "agent"])),
+                        .filter(workspace_members::role.eq_any(vec!["owner", "admin", "agent"]))
+                        .filter(workspace_members::removed_at.is_null()),
                 )),
         )
         .select(users::uuid)

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -790,7 +790,8 @@ pub async fn add_comment_to_ticket(
                                                 .filter(
                                                     workspace_members::role
                                                         .eq_any(vec!["owner", "admin", "agent"]),
-                                                ),
+                                                )
+                                                .filter(workspace_members::removed_at.is_null()),
                                         ),
                                     ),
                                 )

--- a/backend/src/handlers/users.rs
+++ b/backend/src/handlers/users.rs
@@ -2282,13 +2282,15 @@ pub async fn update_user_by_uuid(
                 }
                 let guard = tc.run(|conn| {
                     diesel::sql_query(
+                        // Removed admins must not prop up the count, or the
+                        // last real admin could be demoted behind their ghost.
                         "SELECT \
                            (SELECT COUNT(*) FROM workspace_members \
                               WHERE workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::int \
-                                AND role = 'admin') AS admin_count, \
+                                AND role = 'admin' AND removed_at IS NULL) AS admin_count, \
                            EXISTS(SELECT 1 FROM workspace_members \
                               WHERE workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::int \
-                                AND user_uuid = $1 AND role = 'admin') AS target_is_admin",
+                                AND user_uuid = $1 AND role = 'admin' AND removed_at IS NULL) AS target_is_admin",
                     )
                     .bind::<diesel::sql_types::Uuid, _>(user_uuid_parsed)
                     .get_result::<AdminGuard>(conn)

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -191,6 +191,11 @@ pub struct WorkspaceMember {
     pub role: String,
     pub invited_at: DateTime<Utc>,
     pub accepted_at: Option<DateTime<Utc>>,
+    /// When the membership was revoked; `None` means active. The row is kept
+    /// so historical actors still resolve to a name. Every role, permission
+    /// and seat-counting read must filter on this; only identity resolution
+    /// may ignore it.
+    pub removed_at: Option<DateTime<Utc>>,
 }
 
 /// invited the bug where a user could accidentally promote a view

--- a/backend/src/repository/comments.rs
+++ b/backend/src/repository/comments.rs
@@ -242,7 +242,8 @@ pub fn create_comment_with_annotation(
                                     .filter(
                                         crate::schema::workspace_members::role
                                             .eq_any(vec!["owner", "admin", "agent"]),
-                                    ),
+                                    )
+                                    .filter(crate::schema::workspace_members::removed_at.is_null()),
                             ),
                         ),
                     ),

--- a/backend/src/repository/user_helpers.rs
+++ b/backend/src/repository/user_helpers.rs
@@ -17,6 +17,7 @@ pub fn workspace_role(conn: &mut DbConnection, user_uuid: Uuid) -> Option<Worksp
     use crate::schema::workspace_members;
     workspace_members::table
         .filter(workspace_members::user_uuid.eq(user_uuid))
+        .filter(workspace_members::removed_at.is_null())
         .select(workspace_members::role)
         .first::<String>(conn)
         .ok()
@@ -34,6 +35,7 @@ pub fn workspace_roles_batch(
     use crate::schema::workspace_members;
     workspace_members::table
         .filter(workspace_members::user_uuid.eq_any(user_uuids))
+        .filter(workspace_members::removed_at.is_null())
         .select((workspace_members::user_uuid, workspace_members::role))
         .load::<(Uuid, String)>(conn)
         .unwrap_or_default()
@@ -548,6 +550,7 @@ pub fn get_users_with_primary_emails(
         workspace_members::table
             .filter(workspace_members::workspace_id.eq(workspace_id))
             .filter(workspace_members::user_uuid.eq_any(&user_uuids))
+            .filter(workspace_members::removed_at.is_null())
             .select((workspace_members::user_uuid, workspace_members::role))
             .load::<(Uuid, String)>(conn)
             .unwrap_or_default()

--- a/backend/src/repository/users.rs
+++ b/backend/src/repository/users.rs
@@ -156,7 +156,8 @@ fn requester_sql(workspace_id: i32) -> String {
     format!(
         "(users.platform_role = 'user' \
          AND COALESCE((SELECT role FROM workspace_members \
-                       WHERE workspace_id = {workspace_id} AND user_uuid = users.uuid), \
+                       WHERE workspace_id = {workspace_id} AND user_uuid = users.uuid \
+                       AND removed_at IS NULL), \
                       'member') = 'member')"
     )
 }
@@ -228,7 +229,8 @@ pub fn get_paginated_users(
                     parts.push(format!(
                         "(users.platform_role = 'platform_admin' \
                          OR (SELECT role FROM workspace_members \
-                             WHERE workspace_id = {workspace_id} AND user_uuid = users.uuid) \
+                             WHERE workspace_id = {workspace_id} AND user_uuid = users.uuid \
+                       AND removed_at IS NULL) \
                             IN ('owner', 'admin'))"
                     ));
                     any = true;
@@ -237,7 +239,8 @@ pub fn get_paginated_users(
                     parts.push(format!(
                         "(users.platform_role <> 'platform_admin' \
                          AND (SELECT role FROM workspace_members \
-                              WHERE workspace_id = {workspace_id} AND user_uuid = users.uuid) \
+                              WHERE workspace_id = {workspace_id} AND user_uuid = users.uuid \
+                       AND removed_at IS NULL) \
                              = 'agent')"
                     ));
                     any = true;
@@ -246,7 +249,8 @@ pub fn get_paginated_users(
                     parts.push(format!(
                         "(users.platform_role <> 'platform_admin' \
                          AND COALESCE((SELECT role FROM workspace_members \
-                                       WHERE workspace_id = {workspace_id} AND user_uuid = users.uuid), \
+                                       WHERE workspace_id = {workspace_id} AND user_uuid = users.uuid \
+                       AND removed_at IS NULL), \
                                       'member') = 'member')"
                     ));
                     any = true;
@@ -282,10 +286,12 @@ pub fn get_paginated_users(
         "CASE \
         WHEN users.platform_role = 'platform_admin' THEN 0 \
         WHEN (SELECT role FROM workspace_members \
-              WHERE workspace_id = {workspace_id} AND user_uuid = users.uuid) \
+              WHERE workspace_id = {workspace_id} AND user_uuid = users.uuid \
+                       AND removed_at IS NULL) \
              IN ('owner', 'admin') THEN 1 \
         WHEN (SELECT role FROM workspace_members \
-              WHERE workspace_id = {workspace_id} AND user_uuid = users.uuid) \
+              WHERE workspace_id = {workspace_id} AND user_uuid = users.uuid \
+                       AND removed_at IS NULL) \
              = 'agent' THEN 2 \
         ELSE 3 END"
     );
@@ -887,7 +893,8 @@ pub fn set_user_roles(
     diesel::update(
         workspace_members::table
             .filter(workspace_members::workspace_id.eq(workspace_id))
-            .filter(workspace_members::user_uuid.eq(user_uuid)),
+            .filter(workspace_members::user_uuid.eq(user_uuid))
+            .filter(workspace_members::removed_at.is_null()),
     )
     .set(workspace_members::role.eq(workspace_role))
     .execute(conn)?;

--- a/backend/src/repository/workspaces.rs
+++ b/backend/src/repository/workspaces.rs
@@ -54,6 +54,7 @@ pub fn user_is_staff_anywhere(conn: &mut DbConnection, user_uuid: Uuid) -> Query
     let n: i64 = workspace_members::table
         .filter(workspace_members::user_uuid.eq(user_uuid))
         .filter(workspace_members::role.eq_any(STAFF_ROLES))
+        .filter(workspace_members::removed_at.is_null())
         .select(count_star())
         .get_result(conn)?;
     Ok(n > 0)
@@ -275,6 +276,7 @@ pub fn membership(
     workspace_members::table
         .filter(workspace_members::workspace_id.eq(workspace_id))
         .filter(workspace_members::user_uuid.eq(user_uuid))
+        .filter(workspace_members::removed_at.is_null())
         .first(conn)
         .optional()
 }
@@ -324,10 +326,20 @@ pub fn add_membership(
     // which has a pending-invite step. The email-invite path creates
     // its membership via create_user_with_email and leaves accepted_at
     // NULL until accept_invitation stamps it.
+    //
+    // `DO NOTHING` was right when removal deleted the row: a conflict could
+    // only mean "already an active member". Under soft-remove the row survives,
+    // so a conflict is ambiguous and DO NOTHING would silently leave a removed
+    // person removed while reporting nothing added. Re-activate instead, and
+    // keep the old behaviour for the still-active case with the WHERE clause.
+    // The re-activation is an UPDATE, so it goes through the seat-limit
+    // trigger, which is why that trigger had to learn about `removed_at` too.
     let rows = diesel::sql_query(
         "INSERT INTO workspace_members (workspace_id, user_uuid, role, accepted_at) \
          VALUES ($1, $2, $3, now()) \
-         ON CONFLICT (workspace_id, user_uuid) DO NOTHING",
+         ON CONFLICT (workspace_id, user_uuid) DO UPDATE \
+           SET removed_at = NULL, role = EXCLUDED.role, accepted_at = now() \
+         WHERE workspace_members.removed_at IS NOT NULL",
     )
     .bind::<diesel::sql_types::Integer, _>(workspace_id)
     .bind::<diesel::sql_types::Uuid, _>(user_uuid)
@@ -417,6 +429,7 @@ pub fn count_staff_members(conn: &mut DbConnection, workspace_id: i32) -> QueryR
     workspace_members::table
         .filter(workspace_members::workspace_id.eq(workspace_id))
         .filter(workspace_members::role.eq_any(STAFF_ROLES))
+        .filter(workspace_members::removed_at.is_null())
         .count()
         .get_result(conn)
 }
@@ -504,6 +517,7 @@ pub fn set_notification_push_detail(
 pub fn primary_workspace_for_user(conn: &mut DbConnection, user_uuid: Uuid) -> QueryResult<i32> {
     workspace_members::table
         .filter(workspace_members::user_uuid.eq(user_uuid))
+        .filter(workspace_members::removed_at.is_null())
         .order(workspace_members::workspace_id.asc())
         .select(workspace_members::workspace_id)
         .first::<i32>(conn)
@@ -685,6 +699,7 @@ pub fn list_memberships_for_user(
     workspace_members::table
         .inner_join(workspaces::table.on(workspaces::id.eq(workspace_members::workspace_id)))
         .filter(workspace_members::user_uuid.eq(user_uuid))
+        .filter(workspace_members::removed_at.is_null())
         .filter(workspaces::archived_at.is_null())
         .order(workspaces::id.asc())
         .select((WorkspaceMember::as_select(), Workspace::as_select()))
@@ -723,6 +738,7 @@ pub fn list_workspace_members(
 ) -> QueryResult<Vec<WorkspaceMember>> {
     workspace_members::table
         .filter(workspace_members::workspace_id.eq(workspace_id))
+        .filter(workspace_members::removed_at.is_null())
         .order(workspace_members::user_uuid.asc())
         .load(conn)
 }
@@ -735,6 +751,7 @@ pub fn count_workspace_owners(conn: &mut DbConnection, workspace_id: i32) -> Que
     workspace_members::table
         .filter(workspace_members::workspace_id.eq(workspace_id))
         .filter(workspace_members::role.eq("owner"))
+        .filter(workspace_members::removed_at.is_null())
         .count()
         .get_result(conn)
 }
@@ -768,6 +785,7 @@ pub fn remove_membership(
     let existing = workspace_members::table
         .filter(workspace_members::workspace_id.eq(workspace_id))
         .filter(workspace_members::user_uuid.eq(user_uuid))
+        .filter(workspace_members::removed_at.is_null())
         .first::<WorkspaceMember>(conn)
         .optional()?;
     let row = match existing {
@@ -786,11 +804,16 @@ pub fn remove_membership(
         }
     }
 
-    diesel::delete(
+    // Stamp rather than delete. The row is what lets a former member's name
+    // still render on the tickets, comments and audit entries they left behind;
+    // deleting it turned every one of those into an unknown user.
+    diesel::update(
         workspace_members::table
             .filter(workspace_members::workspace_id.eq(workspace_id))
-            .filter(workspace_members::user_uuid.eq(user_uuid)),
+            .filter(workspace_members::user_uuid.eq(user_uuid))
+            .filter(workspace_members::removed_at.is_null()),
     )
+    .set(workspace_members::removed_at.eq(chrono::Utc::now()))
     .execute(conn)?;
     Ok(RemoveMembershipOutcome::Removed)
 }
@@ -820,6 +843,7 @@ pub fn get_membership_role(
     workspace_members::table
         .filter(workspace_members::workspace_id.eq(workspace_id))
         .filter(workspace_members::user_uuid.eq(user_uuid))
+        .filter(workspace_members::removed_at.is_null())
         .select(workspace_members::role)
         .first::<String>(conn)
         .optional()
@@ -834,7 +858,8 @@ pub fn mark_memberships_accepted(conn: &mut DbConnection, user_uuid: Uuid) -> Qu
     diesel::update(
         workspace_members::table
             .filter(workspace_members::user_uuid.eq(user_uuid))
-            .filter(workspace_members::accepted_at.is_null()),
+            .filter(workspace_members::accepted_at.is_null())
+            .filter(workspace_members::removed_at.is_null()),
     )
     .set(workspace_members::accepted_at.eq(chrono::Utc::now()))
     .execute(conn)
@@ -857,6 +882,7 @@ pub fn update_membership_role(
     let existing = workspace_members::table
         .filter(workspace_members::workspace_id.eq(workspace_id))
         .filter(workspace_members::user_uuid.eq(user_uuid))
+        .filter(workspace_members::removed_at.is_null())
         .first::<WorkspaceMember>(conn)
         .optional()?;
     let row = match existing {
@@ -880,7 +906,8 @@ pub fn update_membership_role(
     let updated = diesel::update(
         workspace_members::table
             .filter(workspace_members::workspace_id.eq(workspace_id))
-            .filter(workspace_members::user_uuid.eq(user_uuid)),
+            .filter(workspace_members::user_uuid.eq(user_uuid))
+            .filter(workspace_members::removed_at.is_null()),
     )
     .set(workspace_members::role.eq(new_role))
     .get_result::<WorkspaceMember>(conn)?;
@@ -1593,7 +1620,7 @@ mod tests {
         let ops: Vec<&str> = rows.iter().map(|r| r.op.as_str()).collect();
         assert_eq!(
             ops,
-            vec!["I", "U", "D"],
+            vec!["I", "U", "U"],
             "one audit row per mutation, in order"
         );
         for r in &rows {
@@ -1606,6 +1633,19 @@ mod tests {
             rows[1].changed.as_deref().unwrap_or("").contains("role"),
             "role-change row should list role in changed_cols: {:?}",
             rows[1].changed
+        );
+        // Removal is the third 'U', not a 'D': memberships are soft-removed so
+        // a former member's name still resolves on what they left behind. The
+        // audit trail is strictly better for it, since a delete destroyed the
+        // evidence that the person was ever a member.
+        assert!(
+            rows[2]
+                .changed
+                .as_deref()
+                .unwrap_or("")
+                .contains("removed_at"),
+            "removal row should list removed_at in changed_cols: {:?}",
+            rows[2].changed
         );
     }
 

--- a/backend/src/schema.rs
+++ b/backend/src/schema.rs
@@ -2181,6 +2181,7 @@ diesel::table! {
         role -> Varchar,
         invited_at -> Timestamptz,
         accepted_at -> Nullable<Timestamptz>,
+        removed_at -> Nullable<Timestamptz>,
     }
 }
 

--- a/backend/src/services/avatar_thumbnails.rs
+++ b/backend/src/services/avatar_thumbnails.rs
@@ -98,7 +98,8 @@ pub async fn backfill_thumbnails(
     let rows: Vec<AvatarRow> = match diesel::sql_query(
         "SELECT u.uuid::text AS uuid_str, u.avatar_url, u.avatar_thumb, \
                 (SELECT wm.workspace_id FROM workspace_members wm \
-                 WHERE wm.user_uuid = u.uuid ORDER BY wm.workspace_id LIMIT 1) AS workspace_id \
+                 WHERE wm.user_uuid = u.uuid AND wm.removed_at IS NULL \
+                 ORDER BY wm.workspace_id LIMIT 1) AS workspace_id \
          FROM users u WHERE u.avatar_url IS NOT NULL",
     )
     .load(conn)

--- a/backend/src/services/search/indexer.rs
+++ b/backend/src/services/search/indexer.rs
@@ -468,6 +468,9 @@ pub fn rebuild_index(
     // its full workspace set as multi-valued workspace_id terms. A user with
     // no memberships gets an empty set and is unreachable (fail-closed).
     let all_memberships: Vec<(uuid::Uuid, i32)> = workspace_members::table
+        // A removed member must stop being searchable in that workspace; the
+        // row survives only so their name still resolves on old records.
+        .filter(workspace_members::removed_at.is_null())
         .select((
             workspace_members::user_uuid,
             workspace_members::workspace_id,

--- a/backend/src/services/workspace_export.rs
+++ b/backend/src/services/workspace_export.rs
@@ -261,6 +261,9 @@ fn load_workspace_meta(
         #[diesel(sql_type = Text)]
         user_uuid: String,
     }
+    // members-any-status: an export must round-trip history, and historical rows
+    // reference people who have since been removed; dropping them would fail the
+    // enforced user FK on import.
     let members: Vec<UuidRow> = sql_query(
         "SELECT user_uuid::text AS user_uuid FROM workspace_members WHERE workspace_id = $1 \
          ORDER BY user_uuid",
@@ -319,6 +322,7 @@ pub fn collect_workspace_rows(
     // who was removed from membership or was never a member (external requester);
     // omitting them would fail the enforced user FK on import. Each referencing
     // column lives on a workspace-scoped table, so every subquery is scoped by $1.
+    // members-any-status: as above, and the comment block above says so already.
     let mut union_parts =
         vec!["SELECT user_uuid FROM workspace_members WHERE workspace_id = $1".to_string()];
     for (tbl, col) in user_referencing_columns(conn)? {

--- a/backend/tests/workspace_member_soft_remove.rs
+++ b/backend/tests/workspace_member_soft_remove.rs
@@ -1,0 +1,262 @@
+//! Soft-removed memberships: the row survives, the access does not.
+//!
+//! `remove_membership` stamps `removed_at` instead of deleting, so a former
+//! colleague's name still resolves on the tickets and comments they left
+//! behind. Everything else must behave as if the row were gone, and the
+//! re-invite path has to work, since a conflicting row now always exists.
+
+#![allow(clippy::expect_used)]
+
+use diesel::prelude::*;
+
+use backend::db::DbConnection;
+use backend::repository::workspaces::{
+    add_membership, count_staff_members, membership, remove_membership, AddMembershipOutcome,
+    RemoveMembershipOutcome, SeatWriteAuthority,
+};
+use backend::sync::actor::ActorContext;
+use backend::sync::session::with_actor_context;
+
+mod common;
+
+fn try_as_actor<T>(
+    conn: &mut DbConnection,
+    workspace_id: i32,
+    user: uuid::Uuid,
+    f: impl FnOnce(&mut DbConnection) -> QueryResult<T>,
+) -> QueryResult<T> {
+    let actor = ActorContext::user(user, None).with_workspace(workspace_id);
+    with_actor_context::<_, diesel::result::Error>(conn, &actor, f)
+}
+
+fn as_actor<T>(
+    conn: &mut DbConnection,
+    workspace_id: i32,
+    user: uuid::Uuid,
+    f: impl FnOnce(&mut DbConnection) -> QueryResult<T>,
+) -> T {
+    try_as_actor(conn, workspace_id, user, f).expect("actor txn")
+}
+
+/// Whether adding this member succeeded. The seat-limit trigger raises, which
+/// aborts the transaction, so the error has to propagate out of the actor
+/// wrapper for the rollback to happen; swallowing it inside leaves the
+/// connection poisoned for every later statement.
+fn try_add_staff(conn: &mut DbConnection, workspace_id: i32, user: uuid::Uuid) -> bool {
+    try_as_actor(conn, workspace_id, user, |c| {
+        add_membership(
+            c,
+            workspace_id,
+            user,
+            "agent",
+            SeatWriteAuthority::ControlPlane,
+        )
+    })
+    .is_ok()
+}
+
+/// The raw row, ignoring `removed_at`, which is what identity resolution does.
+fn row_exists(conn: &mut DbConnection, workspace_id: i32, user: uuid::Uuid) -> bool {
+    use backend::schema::workspace_members as wm;
+    diesel::select(diesel::dsl::exists(
+        wm::table
+            .filter(wm::workspace_id.eq(workspace_id))
+            .filter(wm::user_uuid.eq(user)),
+    ))
+    .get_result(conn)
+    .expect("row exists")
+}
+
+fn set_seat_limit(conn: &mut DbConnection, workspace_id: i32, limit: i32) {
+    use backend::schema::workspaces;
+    diesel::update(workspaces::table.filter(workspaces::id.eq(workspace_id)))
+        .set(workspaces::seat_limit.eq(limit))
+        .execute(conn)
+        .expect("set seat limit");
+}
+
+#[test]
+fn removal_keeps_the_row_but_ends_the_membership() {
+    common::ensure_test_keyring();
+    let test_db = common::TestDb::new();
+    let pool = test_db.pool_with_size(2);
+    let mut conn = pool.get().expect("conn");
+
+    let ws = common::mint_workspace(&mut conn, "acme-soft-remove", "Acme Soft Remove");
+    let leaver = common::insert_user(&mut conn, "The Leaver");
+
+    as_actor(&mut conn, ws, leaver.uuid, |c| {
+        add_membership(
+            c,
+            ws,
+            leaver.uuid,
+            "agent",
+            SeatWriteAuthority::ControlPlane,
+        )?;
+        Ok(())
+    });
+    assert!(
+        as_actor(&mut conn, ws, leaver.uuid, |c| membership(
+            c,
+            ws,
+            leaver.uuid
+        ))
+        .is_some(),
+        "precondition: an active membership"
+    );
+
+    let outcome = as_actor(&mut conn, ws, leaver.uuid, |c| {
+        remove_membership(c, ws, leaver.uuid, SeatWriteAuthority::ControlPlane)
+    });
+    assert!(matches!(outcome, RemoveMembershipOutcome::Removed));
+
+    assert!(
+        as_actor(&mut conn, ws, leaver.uuid, |c| membership(
+            c,
+            ws,
+            leaver.uuid
+        ))
+        .is_none(),
+        "a removed member must not resolve as a member"
+    );
+    assert!(
+        row_exists(&mut conn, ws, leaver.uuid),
+        "but the row must survive, or their name vanishes from everything they touched"
+    );
+}
+
+#[test]
+fn a_removed_staff_member_frees_their_seat() {
+    common::ensure_test_keyring();
+    let test_db = common::TestDb::new();
+    let pool = test_db.pool_with_size(2);
+    let mut conn = pool.get().expect("conn");
+
+    let ws = common::mint_workspace(&mut conn, "acme-seat-freed", "Acme Seat Freed");
+    let first = common::insert_user(&mut conn, "First Agent");
+    let second = common::insert_user(&mut conn, "Second Agent");
+
+    as_actor(&mut conn, ws, first.uuid, |c| {
+        add_membership(c, ws, first.uuid, "agent", SeatWriteAuthority::ControlPlane)?;
+        Ok(())
+    });
+    set_seat_limit(&mut conn, ws, 1);
+
+    // The seat is taken, so a second agent is refused.
+    assert!(
+        !try_add_staff(&mut conn, ws, second.uuid),
+        "precondition: the seat cap is enforced"
+    );
+
+    as_actor(&mut conn, ws, first.uuid, |c| {
+        remove_membership(c, ws, first.uuid, SeatWriteAuthority::ControlPlane)
+    });
+    assert_eq!(
+        as_actor(&mut conn, ws, first.uuid, |c| count_staff_members(c, ws)),
+        0,
+        "a removed staff member must stop consuming a licensed seat"
+    );
+
+    assert!(
+        try_add_staff(&mut conn, ws, second.uuid),
+        "and the freed seat must be usable"
+    );
+}
+
+#[test]
+fn re_adding_a_removed_member_restores_them() {
+    common::ensure_test_keyring();
+    let test_db = common::TestDb::new();
+    let pool = test_db.pool_with_size(2);
+    let mut conn = pool.get().expect("conn");
+
+    let ws = common::mint_workspace(&mut conn, "acme-rejoin", "Acme Rejoin");
+    let returner = common::insert_user(&mut conn, "The Returner");
+
+    as_actor(&mut conn, ws, returner.uuid, |c| {
+        add_membership(
+            c,
+            ws,
+            returner.uuid,
+            "agent",
+            SeatWriteAuthority::ControlPlane,
+        )?;
+        Ok(())
+    });
+    as_actor(&mut conn, ws, returner.uuid, |c| {
+        remove_membership(c, ws, returner.uuid, SeatWriteAuthority::ControlPlane)
+    });
+
+    // The row still exists, so the insert conflicts. Under the old
+    // `ON CONFLICT DO NOTHING` this silently left them removed.
+    let outcome = as_actor(&mut conn, ws, returner.uuid, |c| {
+        add_membership(
+            c,
+            ws,
+            returner.uuid,
+            "agent",
+            SeatWriteAuthority::ControlPlane,
+        )
+    });
+    assert!(matches!(outcome, AddMembershipOutcome::Added(n) if n == 1));
+    assert!(
+        as_actor(&mut conn, ws, returner.uuid, |c| membership(
+            c,
+            ws,
+            returner.uuid
+        ))
+        .is_some(),
+        "re-adding a removed member must make them a member again"
+    );
+}
+
+/// Re-invites are hires. Removing a staff member frees their seat, so coming
+/// back has to compete for one like anyone else, or a workspace could cycle
+/// people through removal and re-adding to exceed its licence.
+///
+/// Worth knowing which mechanism enforces this. Re-activation runs through
+/// `add_membership`'s `ON CONFLICT DO UPDATE`, and a conflicting upsert fires
+/// BEFORE INSERT and then BEFORE UPDATE, so the seat check refuses on the
+/// INSERT pass. The `OLD.removed_at IS NULL` condition added to the trigger's
+/// UPDATE short-circuit is defence-in-depth for a future direct
+/// `UPDATE ... SET removed_at = NULL`, and this test passes with or without
+/// it; it is the behaviour that is pinned here, not that clause.
+#[test]
+fn re_adding_a_removed_staff_member_still_respects_the_seat_cap() {
+    common::ensure_test_keyring();
+    let test_db = common::TestDb::new();
+    let pool = test_db.pool_with_size(2);
+    let mut conn = pool.get().expect("conn");
+
+    let ws = common::mint_workspace(&mut conn, "acme-rejoin-cap", "Acme Rejoin Cap");
+    let leaver = common::insert_user(&mut conn, "Departed Agent");
+    let replacement = common::insert_user(&mut conn, "Replacement Agent");
+
+    as_actor(&mut conn, ws, leaver.uuid, |c| {
+        add_membership(
+            c,
+            ws,
+            leaver.uuid,
+            "agent",
+            SeatWriteAuthority::ControlPlane,
+        )?;
+        Ok(())
+    });
+    set_seat_limit(&mut conn, ws, 1);
+
+    // They leave, and the one seat is given to somebody else.
+    as_actor(&mut conn, ws, leaver.uuid, |c| {
+        remove_membership(c, ws, leaver.uuid, SeatWriteAuthority::ControlPlane)
+    });
+    assert!(
+        try_add_staff(&mut conn, ws, replacement.uuid),
+        "the freed seat goes to the replacement"
+    );
+
+    // Now the leaver comes back. The seat is gone, so this must be refused.
+    assert!(
+        !try_add_staff(&mut conn, ws, leaver.uuid),
+        "re-activating a removed staff member consumes a seat and must be capped \
+         like any other hire"
+    );
+}

--- a/backend/tests/workspace_members_active_filter_lint.rs
+++ b/backend/tests/workspace_members_active_filter_lint.rs
@@ -1,0 +1,129 @@
+//! Lint: a read of `workspace_members` says whether it wants active members.
+//!
+//! `workspace_members` rows outlive the membership. `remove_membership` stamps
+//! `removed_at` rather than deleting, because the row is what lets a former
+//! colleague's name still render on the tickets, comments and audit entries
+//! they left behind. That makes every read ambiguous in a way it was not
+//! before:
+//!
+//! - **Role, permission and seat reads** must filter `removed_at IS NULL`.
+//!   Forgetting leaves a removed member holding their role, or consuming a
+//!   licensed seat forever.
+//! - **Identity resolution** must NOT filter, or the history the column exists
+//!   to preserve renders as an unknown user again.
+//!
+//! Both are one-line changes and neither fails loudly, so the mistake is
+//! invisible in review and in production. This makes the choice explicit.
+//!
+//! ## Escape hatch
+//!
+//! A read that deliberately spans removed members carries, on the line above
+//! the query or its enclosing `pub fn`:
+//!
+//! ```ignore
+//! // members-any-status: <why this read includes removed members>
+//! ```
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use regex::Regex;
+
+/// Files whose `workspace_members` use is not a tenant read at all.
+const SKIP: &[&str] = &["schema.rs", "test_helpers.rs"];
+
+/// Everything from the first `#[cfg(test)]` onward. Test modules build and tear
+/// down membership rows directly, which is not the behaviour under review;
+/// the other lints in this directory drop them the same way.
+fn strip_test_modules(src: &str) -> &str {
+    match src.find("#[cfg(test)]") {
+        Some(i) => &src[..i],
+        None => src,
+    }
+}
+
+const MARKER: &str = "members-any-status:";
+
+#[derive(Debug)]
+struct Violation {
+    relpath: String,
+    line: usize,
+    snippet: String,
+}
+
+fn scan(root: &Path, out: &mut Vec<Violation>) {
+    let table_re = Regex::new(r"workspace_members::table|FROM workspace_members").expect("re");
+    // The filter can be Diesel or raw SQL, and may sit several lines below the
+    // table reference, so the window is the query, not the line.
+    let filtered_re = Regex::new(r"removed_at\s*(?:\.is_null\(\)|IS NULL)").expect("re");
+
+    for entry in walkdir::WalkDir::new(root)
+        .into_iter()
+        .filter_map(Result::ok)
+        .filter(|e| e.path().extension().and_then(|s| s.to_str()) == Some("rs"))
+    {
+        let path = entry.path();
+        let name = path.file_name().and_then(|s| s.to_str()).unwrap_or("");
+        if SKIP.contains(&name) {
+            continue;
+        }
+        let Ok(src) = fs::read_to_string(path) else {
+            continue;
+        };
+        let lines: Vec<&str> = strip_test_modules(&src).lines().collect();
+        for (i, line) in lines.iter().enumerate() {
+            if !table_re.is_match(line) {
+                continue;
+            }
+            // A query is at most ~18 lines here; look that far for the filter.
+            let end = (i + 18).min(lines.len());
+            let window = lines[i..end].join("\n");
+            if filtered_re.is_match(&window) {
+                continue;
+            }
+            // The marker may be above the query or above its enclosing fn.
+            let back = i.saturating_sub(25);
+            if lines[back..i].iter().any(|l| l.contains(MARKER)) {
+                continue;
+            }
+            out.push(Violation {
+                relpath: path
+                    .strip_prefix(root.parent().unwrap_or(root))
+                    .unwrap_or(path)
+                    .to_string_lossy()
+                    .replace('\\', "/"),
+                line: i + 1,
+                snippet: line.trim().chars().take(70).collect(),
+            });
+        }
+    }
+}
+
+#[test]
+fn workspace_members_reads_state_whether_they_want_active_members() {
+    let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let src_root = manifest.join("src");
+    assert!(src_root.exists());
+
+    let mut violations = Vec::new();
+    scan(&src_root, &mut violations);
+
+    if !violations.is_empty() {
+        let mut msg = String::from(
+            "\nThese reads of `workspace_members` neither filter `removed_at IS NULL`\n\
+             nor say that they mean to include removed members.\n\n\
+             A removed membership row still exists, so an unfiltered role, permission\n\
+             or seat read silently treats a removed person as a current one.\n\n\
+             Add `.filter(workspace_members::removed_at.is_null())` (or `AND removed_at\n\
+             IS NULL` in raw SQL), or, if the read genuinely spans removed members —\n\
+             identity resolution for historical records is the reason this column\n\
+             exists — put this directly above the query or its enclosing fn:\n\n  \
+             // members-any-status: <why>\n\n\
+             Sites:\n\n",
+        );
+        for v in &violations {
+            msg.push_str(&format!("  {}:{}  {}\n", v.relpath, v.line, v.snippet));
+        }
+        panic!("{msg}");
+    }
+}


### PR DESCRIPTION
Prerequisite for membership-joined identity resolution. `remove_membership` hard-deleted the row, so join-scoping a user lookup would make everyone who ever left the workspace render as an unknown user on the tickets, comments and audit entries they left behind. That is a visible regression, not a theoretical one, so the column has to land first.

## The ambiguity this introduces

A `workspace_members` row now outlives the membership, which splits every read in two:

- **Role, permission and seat reads** must filter `removed_at IS NULL`. Forgetting leaves a removed member holding their role, or consuming a licensed seat forever.
- **Identity resolution** must *not* filter, or the history the column exists to preserve renders as an unknown user again.

Both are one-line changes and neither fails loudly, so `workspace_members_active_filter_lint` makes the choice explicit. A read that deliberately spans removed members carries `// members-any-status: <why>`.

## The lint paid for itself immediately

I swept the readers by grepping `workspace_members::table`. The lint also matches `FROM workspace_members`, and found **seven sites I had missed**, all raw SQL or an unusual shape. One was a real bug:

> The last-admin guard in `handlers/users.rs` counts workspace admins to refuse demoting the final one. Unfiltered, a *removed* admin props up that count, and the last real admin can be demoted behind their ghost.

Also caught: a role write that could re-grant a role to a removed member, search indexing that kept them findable in a workspace they had left, and avatar-thumbnail audit attribution pointing at a workspace they were no longer in. Both `workspace_export` reads legitimately span removed members, since an import must satisfy the enforced user FK for historical rows, so they carry markers.

## Re-invites

`add_membership` used `ON CONFLICT DO NOTHING`, which was right when a conflict could only mean "already an active member". The row now survives removal, so a conflict is ambiguous and DO NOTHING would have silently left a returning member removed while reporting nothing added. It re-activates instead, with a `WHERE removed_at IS NOT NULL` clause preserving the old behaviour for the still-active case.

## The seat trigger, and a correction

The staff count now ignores removed members, or a revoked staff member consumes a licensed seat forever. That half is load-bearing: reverting it fails two tests.

The UPDATE short-circuit also gains `OLD.removed_at IS NULL`, and I want to be accurate about that one. I expected it to be a live seat-limit bypass, on the reasoning that re-activating a removed staff member is an UPDATE whose `OLD.role` is still staff. The mutation test disproved it: reverting the clause, the test still passed. A conflicting `ON CONFLICT DO UPDATE` fires BEFORE INSERT *and then* BEFORE UPDATE (verified with a probe table, not assumed), so the seat check already refuses on the INSERT pass. The clause is kept as defence-in-depth, because it becomes the only check the moment anyone writes a direct `UPDATE ... SET removed_at = NULL`. The migration comment and the test say so rather than claiming a fix.

## Migration notes

No backfill: every existing row is an active membership, which is what NULL means. Adding a nullable column with no default is metadata-only in Postgres, so there is no row rewrite and no audit-trigger storm, which is the hazard that normally requires the DISABLE TRIGGER treatment on an audited table. The RLS policy is workspace-isolation only with no status condition, so removed rows keep returning to the identity resolver unchanged.

One behavioural change: removal is audited as `'U'` with `removed_at` in `changed_cols` rather than `'D'`. That is better for audit, since a delete destroyed the evidence that the person was ever a member. `membership_changes_are_audit_logged` is updated and now also asserts which column changed, so the test pins why it is a `'U'`.

Local: `cargo fmt` clean, `cargo clippy --all-targets` with no new warnings, `cargo test` 1937 passed / 0 failed.

https://claude.ai/code/session_017iEcp3fFMB594JYRZxcQ5H