### PR TITLE
Scope identity and contact reads to the people you can see

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -1681,9 +1681,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
-version = "0.10.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",

--- a/backend/migrations/2026-09-09-000002_workspace_members_removed_at/down.sql
+++ b/backend/migrations/2026-09-09-000002_workspace_members_removed_at/down.sql
@@ -1,0 +1,37 @@
+-- Drop the soft-removed rows: with the column gone they would read as active
+-- memberships, which is worse than losing them.
+DELETE FROM workspace_members WHERE removed_at IS NOT NULL;
+
+DROP INDEX IF EXISTS workspace_members_active_idx;
+ALTER TABLE workspace_members DROP COLUMN removed_at;
+
+CREATE OR REPLACE FUNCTION public.enforce_workspace_seat_limit() RETURNS trigger
+    LANGUAGE plpgsql SECURITY DEFINER
+    SET search_path TO 'pg_catalog', 'public'
+    AS $$
+DECLARE
+    lim INTEGER;
+    staff_count INTEGER;
+BEGIN
+    IF NEW.role NOT IN ('owner', 'admin', 'agent') THEN
+        RETURN NEW;
+    END IF;
+    IF TG_OP = 'UPDATE' AND OLD.role IN ('owner', 'admin', 'agent') THEN
+        RETURN NEW;
+    END IF;
+    SELECT seat_limit INTO lim FROM workspaces WHERE id = NEW.workspace_id;
+    IF lim IS NULL THEN
+        RETURN NEW;
+    END IF;
+    SELECT count(*) INTO staff_count
+        FROM workspace_members
+        WHERE workspace_id = NEW.workspace_id
+          AND role IN ('owner', 'admin', 'agent')
+          AND user_uuid <> NEW.user_uuid;
+    IF staff_count >= lim THEN
+        RAISE EXCEPTION 'workspace % staff seat limit (%) reached', NEW.workspace_id, lim
+            USING ERRCODE = 'check_violation', CONSTRAINT = 'workspace_seat_limit';
+    END IF;
+    RETURN NEW;
+END;
+$$;

--- a/backend/migrations/2026-09-09-000002_workspace_members_removed_at/up.sql
+++ b/backend/migrations/2026-09-09-000002_workspace_members_removed_at/up.sql
@@ -1,0 +1,80 @@
+-- Soft-remove workspace memberships.
+--
+-- `remove_membership` hard-deleted the row, which makes membership-joined
+-- identity resolution impossible: everyone who ever left renders as an unknown
+-- user on their historical tickets, comments and audit entries. Keep the row
+-- and mark it instead.
+--
+-- No backfill: every existing row is an active membership, which is exactly
+-- what NULL means here. Adding a nullable column with no default is a
+-- metadata-only change in Postgres, so no row rewrite and no audit-trigger
+-- storm (the hazard that requires DISABLE TRIGGER on audited tables).
+ALTER TABLE workspace_members ADD COLUMN removed_at TIMESTAMPTZ;
+
+COMMENT ON COLUMN workspace_members.removed_at IS
+    'When the membership was revoked. NULL means active. Identity resolution '
+    'reads rows regardless; every role, permission and seat-counting read must '
+    'filter removed_at IS NULL.';
+
+-- Finding a removed member is a rare, targeted read; finding the active ones
+-- is on the hot path for every request that resolves a role.
+CREATE INDEX IF NOT EXISTS workspace_members_active_idx
+    ON workspace_members (workspace_id, user_uuid)
+    WHERE removed_at IS NULL;
+
+-- The seat-limit trigger needs two changes, not one.
+--
+-- 1. The staff count must ignore removed members, or a revoked staff member
+--    keeps consuming a licensed seat forever.
+--
+-- 2. The UPDATE short-circuit gains the same condition. This one is
+--    defence-in-depth rather than a live fix, and the distinction is worth
+--    recording. The short-circuit reads "an UPDATE that keeps a staff role
+--    consumes no new seat", which was true when the only way to leave was
+--    DELETE; under soft-remove, re-activating a removed staff member is an
+--    UPDATE whose OLD.role is still staff, so it looks like a bypass. It is
+--    not, today: re-activation happens through `add_membership`'s
+--    ON CONFLICT DO UPDATE, and Postgres fires BEFORE INSERT *and then*
+--    BEFORE UPDATE for a conflicting upsert (verified, not assumed), so the
+--    INSERT pass runs the full count and refuses. The condition matters the
+--    moment anyone writes a direct `UPDATE ... SET removed_at = NULL`, where
+--    the UPDATE pass would be the only check, and it costs nothing now.
+CREATE OR REPLACE FUNCTION public.enforce_workspace_seat_limit() RETURNS trigger
+    LANGUAGE plpgsql SECURITY DEFINER
+    SET search_path TO 'pg_catalog', 'public'
+    AS $$
+DECLARE
+    lim INTEGER;
+    staff_count INTEGER;
+BEGIN
+    IF NEW.role NOT IN ('owner', 'admin', 'agent') THEN
+        RETURN NEW;
+    END IF;
+    -- A removed member consumes nothing, so removing one never needs a check.
+    IF NEW.removed_at IS NOT NULL THEN
+        RETURN NEW;
+    END IF;
+    -- An UPDATE that keeps an ALREADY-ACTIVE staff role consumes no new seat.
+    -- Re-activating a removed one does, and falls through to the count below.
+    IF TG_OP = 'UPDATE'
+       AND OLD.role IN ('owner', 'admin', 'agent')
+       AND OLD.removed_at IS NULL THEN
+        RETURN NEW;
+    END IF;
+    SELECT seat_limit INTO lim FROM workspaces WHERE id = NEW.workspace_id;
+    IF lim IS NULL THEN
+        RETURN NEW;
+    END IF;
+    SELECT count(*) INTO staff_count
+        FROM workspace_members
+        WHERE workspace_id = NEW.workspace_id
+          AND role IN ('owner', 'admin', 'agent')
+          AND removed_at IS NULL
+          AND user_uuid <> NEW.user_uuid;
+    IF staff_count >= lim THEN
+        RAISE EXCEPTION 'workspace % staff seat limit (%) reached', NEW.workspace_id, lim
+            USING ERRCODE = 'check_violation', CONSTRAINT = 'workspace_seat_limit';
+    END IF;
+    RETURN NEW;
+END;
+$$;

--- a/backend/src/handlers/asset_audits.rs
+++ b/backend/src/handlers/asset_audits.rs
@@ -220,7 +220,8 @@ fn inventory_alert_recipients(conn: &mut crate::db::DbConnection) -> Vec<uuid::U
                         >(
                             "NULLIF(current_setting('app.workspace_id', true), '')::int",
                         )))
-                        .filter(workspace_members::role.eq_any(vec!["owner", "admin", "agent"])),
+                        .filter(workspace_members::role.eq_any(vec!["owner", "admin", "agent"]))
+                        .filter(workspace_members::removed_at.is_null()),
                 )),
         )
         .select(users::uuid)

--- a/backend/src/handlers/asset_usage.rs
+++ b/backend/src/handlers/asset_usage.rs
@@ -306,7 +306,8 @@ fn inventory_alert_recipients(conn: &mut crate::db::DbConnection) -> Vec<uuid::U
                         >(
                             "NULLIF(current_setting('app.workspace_id', true), '')::int",
                         )))
-                        .filter(workspace_members::role.eq_any(vec!["owner", "admin", "agent"])),
+                        .filter(workspace_members::role.eq_any(vec!["owner", "admin", "agent"]))
+                        .filter(workspace_members::removed_at.is_null()),
                 )),
         )
         .select(users::uuid)

--- a/backend/src/handlers/documentation.rs
+++ b/backend/src/handlers/documentation.rs
@@ -469,37 +469,56 @@ fn to_page_response(
 /// Mirrors the standalone list_page_tickets handler so callers can
 /// choose between embed (one round trip) and a separate fetch
 /// (cheaper for views that don't always want it).
+/// Title + workflow category for each linked ticket the caller may actually see.
+///
+/// Both the page-response embed and the links endpoint hydrate the same rows,
+/// and both used to hydrate every linked ticket regardless of whether the
+/// caller could open it, so a documentation page could name and categorise
+/// tickets outside the caller's visibility. Filtering through
+/// `visible_tickets_query` here means neither caller can forget it, and an
+/// invisible ticket resolves to `None` and renders untitled, which is the
+/// shape both call sites already handled for an unhydratable id.
+fn linked_ticket_meta(
+    conn: &mut DbConnection,
+    ticket_ids: &[i32],
+    ctx: &crate::repository::ticket_visibility::VisibilityContext,
+) -> Result<
+    std::collections::HashMap<i32, (String, crate::models::WorkflowStateCategory)>,
+    diesel::result::Error,
+> {
+    use crate::schema::tickets;
+    use diesel::prelude::*;
+    if ticket_ids.is_empty() {
+        return Ok(Default::default());
+    }
+    let rows: Vec<(i32, String, i32)> =
+        crate::repository::ticket_visibility::visible_tickets_query(ctx)
+            .filter(tickets::id.eq_any(ticket_ids))
+            .select((tickets::id, tickets::title, tickets::workflow_state_id))
+            .load(conn)?;
+    Ok(rows
+        .into_iter()
+        .map(|(id, title, ws_id)| {
+            let cat = crate::repository::workflow_states::category_of(conn, ws_id)
+                .ok()
+                .flatten()
+                .unwrap_or(crate::models::WorkflowStateCategory::Backlog);
+            (id, (title, cat))
+        })
+        .collect())
+}
+
 fn embed_page_tickets(
     response: &mut DocumentationPageResponse,
     conn: &mut DbConnection,
+    ctx: &crate::repository::ticket_visibility::VisibilityContext,
 ) -> Result<(), String> {
     let links = repository::documentation_page_tickets::links_for_page(conn, response.id)
         .map_err(|e| format!("Failed to load page<->ticket links: {e:?}"))?;
 
-    use crate::schema::tickets;
-    use diesel::prelude::*;
     let ticket_ids: Vec<i32> = links.iter().map(|l| l.ticket_id).collect();
-    let tickets_meta: std::collections::HashMap<
-        i32,
-        (String, crate::models::WorkflowStateCategory),
-    > = if ticket_ids.is_empty() {
-        Default::default()
-    } else {
-        let rows: Vec<(i32, String, i32)> = tickets::table
-            .filter(tickets::id.eq_any(&ticket_ids))
-            .select((tickets::id, tickets::title, tickets::workflow_state_id))
-            .load(conn)
-            .map_err(|e| format!("Failed to hydrate tickets: {e:?}"))?;
-        rows.into_iter()
-            .map(|(id, title, ws_id)| {
-                let cat = crate::repository::workflow_states::category_of(conn, ws_id)
-                    .ok()
-                    .flatten()
-                    .unwrap_or(crate::models::WorkflowStateCategory::Backlog);
-                (id, (title, cat))
-            })
-            .collect()
-    };
+    let tickets_meta = linked_ticket_meta(conn, &ticket_ids, ctx)
+        .map_err(|e| format!("Failed to hydrate tickets: {e:?}"))?;
 
     let embed: Vec<DocumentationPageTicketEmbed> = links
         .into_iter()
@@ -600,6 +619,7 @@ pub async fn get_documentation_page(
     let want_tickets = embed_includes(&query.embed, "tickets");
     let is_admin_user = auth.is_workspace_admin();
     let user_uuid = auth.user_uuid;
+    let ticket_ctx = crate::repository::ticket_visibility::VisibilityContext::from_auth(&auth);
 
     let outcome = tc.run(|conn| {
         let page = match repository::get_documentation_page(page_id, conn) {
@@ -618,7 +638,7 @@ pub async fn get_documentation_page(
         response.requires_verification =
             repository::page_requires_verification(conn, response.id).unwrap_or(false);
         if want_tickets {
-            if let Err(e) = embed_page_tickets(&mut response, conn) {
+            if let Err(e) = embed_page_tickets(&mut response, conn, &ticket_ctx) {
                 return Ok(PageLoadOutcome::EmbedFailed(e));
             }
         }
@@ -650,6 +670,7 @@ pub async fn get_documentation_page_by_slug(
     let want_tickets = embed_includes(&query.embed, "tickets");
     let is_admin_user = auth.is_workspace_admin();
     let user_uuid = auth.user_uuid;
+    let ticket_ctx = crate::repository::ticket_visibility::VisibilityContext::from_auth(&auth);
 
     let outcome = tc.run(|conn| {
         let page = match repository::get_documentation_page_by_slug(&page_slug, conn) {
@@ -668,7 +689,7 @@ pub async fn get_documentation_page_by_slug(
         response.requires_verification =
             repository::page_requires_verification(conn, response.id).unwrap_or(false);
         if want_tickets {
-            if let Err(e) = embed_page_tickets(&mut response, conn) {
+            if let Err(e) = embed_page_tickets(&mut response, conn, &ticket_ctx) {
                 return Ok(PageLoadOutcome::EmbedFailed(e));
             }
         }
@@ -1579,23 +1600,37 @@ enum MarkdownOutcome {
 // Export a single documentation page as Markdown
 pub async fn export_page_as_markdown(
     req: actix_web::HttpRequest,
+    auth: AuthContext,
     mut tc: TenantConn,
     page_id: web::Path<i32>,
 ) -> impl Responder {
     let id = page_id.into_inner();
     let locale = crate::utils::locale::request_locale(&req);
+    // The same audience gates the page itself and every page it embeds. Reading
+    // a page through the export used to skip the ACL that `get_documentation_page`
+    // applies, on the page and on its embeds alike.
+    let audience = repository::PageAudience::User {
+        user_uuid: auth.user_uuid,
+        is_admin: auth.is_workspace_admin(),
+    };
 
     let outcome = tc.run(|conn| {
         let page = match repository::get_documentation_page(id, conn) {
             Ok(p) => p,
             Err(_) => return Ok(MarkdownOutcome::NotFound),
         };
+        if !audience.can_read(conn, page.id) {
+            // Same shape as the page read: an inaccessible page is absent, not
+            // forbidden, so the export does not confirm that the id exists.
+            return Ok(MarkdownOutcome::NotFound);
+        }
         let markdown = match resolve_yjs_document(&page, conn) {
             Some(doc_bytes) => {
                 let mut visited = std::collections::HashSet::new();
+                let mut resolver = utils::markdown_export::EmbedResolver { conn, audience };
                 utils::markdown_export::yjs_to_markdown_with_embeds(
                     &doc_bytes,
-                    conn,
+                    &mut resolver,
                     &mut visited,
                     Some(page.uuid),
                     0,
@@ -2192,38 +2227,28 @@ pub struct CreatePageTicketLinkRequest {
 pub async fn list_page_tickets(
     mut tc: TenantConn,
     path: web::Path<i32>,
-    _auth: AuthContext,
+    auth: AuthContext,
 ) -> impl Responder {
     let page_id = path.into_inner();
+    // The links belong to the page, so the page's own ACL decides who may read
+    // them; `auth` was taken and then ignored here, which let any member list
+    // the tickets attached to a page they cannot open.
+    let audience = repository::PageAudience::User {
+        user_uuid: auth.user_uuid,
+        is_admin: auth.is_workspace_admin(),
+    };
+    let ticket_ctx = crate::repository::ticket_visibility::VisibilityContext::from_auth(&auth);
 
     let result = tc.run(|conn| {
+        if !audience.can_read(conn, page_id) {
+            return Ok(Vec::new());
+        }
         let links = repository::documentation_page_tickets::links_for_page(conn, page_id)?;
 
-        // Hydrate ticket title + status in one query rather than N+1.
-        use crate::schema::tickets;
-        use diesel::prelude::*;
+        // Hydrate ticket title + status in one query rather than N+1, filtered
+        // to the tickets this caller may see.
         let ticket_ids: Vec<i32> = links.iter().map(|l| l.ticket_id).collect();
-        let tickets_meta: std::collections::HashMap<
-            i32,
-            (String, crate::models::WorkflowStateCategory),
-        > = if ticket_ids.is_empty() {
-            Default::default()
-        } else {
-            let rows: Vec<(i32, String, i32)> = tickets::table
-                .filter(tickets::id.eq_any(&ticket_ids))
-                .select((tickets::id, tickets::title, tickets::workflow_state_id))
-                .load(conn)
-                .unwrap_or_default();
-            rows.into_iter()
-                .map(|(id, title, ws_id)| {
-                    let cat = crate::repository::workflow_states::category_of(conn, ws_id)
-                        .ok()
-                        .flatten()
-                        .unwrap_or(crate::models::WorkflowStateCategory::Backlog);
-                    (id, (title, cat))
-                })
-                .collect()
-        };
+        let tickets_meta = linked_ticket_meta(conn, &ticket_ids, &ticket_ctx)?;
 
         let responses: Vec<PageTicketLinkResponse> = links
             .into_iter()

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -790,7 +790,8 @@ pub async fn add_comment_to_ticket(
                                                 .filter(
                                                     workspace_members::role
                                                         .eq_any(vec!["owner", "admin", "agent"]),
-                                                ),
+                                                )
+                                                .filter(workspace_members::removed_at.is_null()),
                                         ),
                                     ),
                                 )

--- a/backend/src/handlers/msgraph_integration.rs
+++ b/backend/src/handlers/msgraph_integration.rs
@@ -712,11 +712,18 @@ pub async fn get_sync_progress_endpoint(
         Ok(c) => c,
         Err(e) => return e,
     };
-    // Extract claims from cookie auth middleware
-    let _claims = match req.extensions().get::<crate::models::Claims>() {
-        Some(claims) => claims.clone(),
-        None => return errors::unauthorized("Authentication required"),
-    };
+    // The Entra/Intune integration runs on the org's own app credentials, so
+    // its state, its configuration and its running sync sessions are workspace-
+    // admin only, matching `trigger_sync` below and the Graph proxy in
+    // `microsoft_graph.rs`. Being a member of the workspace was the whole check
+    // here before, which let any member read the connection's configuration,
+    // probe the live connection, and cancel an admin's directory sync.
+    let _claims =
+        match crate::utils::rbac::require_workspace_role(&req, crate::models::WorkspaceRole::Admin)
+        {
+            Ok(c) => c,
+            Err(resp) => return resp,
+        };
 
     let session_id = path.into_inner();
 
@@ -735,11 +742,18 @@ pub async fn get_active_syncs(
         Ok(c) => c,
         Err(e) => return e,
     };
-    // Extract claims from cookie auth middleware
-    let _claims = match req.extensions().get::<crate::models::Claims>() {
-        Some(claims) => claims.clone(),
-        None => return errors::unauthorized("Authentication required"),
-    };
+    // The Entra/Intune integration runs on the org's own app credentials, so
+    // its state, its configuration and its running sync sessions are workspace-
+    // admin only, matching `trigger_sync` below and the Graph proxy in
+    // `microsoft_graph.rs`. Being a member of the workspace was the whole check
+    // here before, which let any member read the connection's configuration,
+    // probe the live connection, and cancel an admin's directory sync.
+    let _claims =
+        match crate::utils::rbac::require_workspace_role(&req, crate::models::WorkspaceRole::Admin)
+        {
+            Ok(c) => c,
+            Err(resp) => return resp,
+        };
 
     if let Ok(progress_map) = SYNC_PROGRESS.lock() {
         let active_syncs: Vec<SyncProgressState> = progress_map
@@ -771,11 +785,18 @@ pub async fn get_last_sync(
         Ok(c) => c,
         Err(e) => return e,
     };
-    // Extract claims from cookie auth middleware
-    let _claims = match req.extensions().get::<crate::models::Claims>() {
-        Some(claims) => claims.clone(),
-        None => return errors::unauthorized("Authentication required"),
-    };
+    // The Entra/Intune integration runs on the org's own app credentials, so
+    // its state, its configuration and its running sync sessions are workspace-
+    // admin only, matching `trigger_sync` below and the Graph proxy in
+    // `microsoft_graph.rs`. Being a member of the workspace was the whole check
+    // here before, which let any member read the connection's configuration,
+    // probe the live connection, and cancel an admin's directory sync.
+    let _claims =
+        match crate::utils::rbac::require_workspace_role(&req, crate::models::WorkspaceRole::Admin)
+        {
+            Ok(c) => c,
+            Err(resp) => return resp,
+        };
 
     // Try to get from database first (persistent storage)
     match sync_history_repo::get_last_completed_sync(&mut conn) {
@@ -834,11 +855,18 @@ pub async fn cancel_sync_session(
         Ok(c) => c,
         Err(e) => return e,
     };
-    // Extract claims from cookie auth middleware
-    let _claims = match req.extensions().get::<crate::models::Claims>() {
-        Some(claims) => claims.clone(),
-        None => return errors::unauthorized("Authentication required"),
-    };
+    // The Entra/Intune integration runs on the org's own app credentials, so
+    // its state, its configuration and its running sync sessions are workspace-
+    // admin only, matching `trigger_sync` below and the Graph proxy in
+    // `microsoft_graph.rs`. Being a member of the workspace was the whole check
+    // here before, which let any member read the connection's configuration,
+    // probe the live connection, and cancel an admin's directory sync.
+    let _claims =
+        match crate::utils::rbac::require_workspace_role(&req, crate::models::WorkspaceRole::Admin)
+        {
+            Ok(c) => c,
+            Err(resp) => return resp,
+        };
 
     let session_id = path.into_inner();
 
@@ -871,11 +899,18 @@ pub async fn cancel_sync_session(
 
 /// Validate Microsoft Graph configuration
 pub async fn get_config_validation(req: actix_web::HttpRequest) -> impl Responder {
-    // Extract claims from cookie auth middleware
-    let _claims = match req.extensions().get::<crate::models::Claims>() {
-        Some(claims) => claims.clone(),
-        None => return errors::unauthorized("Authentication required"),
-    };
+    // The Entra/Intune integration runs on the org's own app credentials, so
+    // its state, its configuration and its running sync sessions are workspace-
+    // admin only, matching `trigger_sync` below and the Graph proxy in
+    // `microsoft_graph.rs`. Being a member of the workspace was the whole check
+    // here before, which let any member read the connection's configuration,
+    // probe the live connection, and cancel an admin's directory sync.
+    let _claims =
+        match crate::utils::rbac::require_workspace_role(&req, crate::models::WorkspaceRole::Admin)
+        {
+            Ok(c) => c,
+            Err(resp) => return resp,
+        };
 
     let mut missing_fields = Vec::new();
 
@@ -930,11 +965,18 @@ pub async fn get_connection_status(
         Ok(c) => c,
         Err(e) => return e,
     };
-    // Extract claims from cookie auth middleware
-    let _claims = match req.extensions().get::<crate::models::Claims>() {
-        Some(claims) => claims.clone(),
-        None => return errors::unauthorized("Authentication required"),
-    };
+    // The Entra/Intune integration runs on the org's own app credentials, so
+    // its state, its configuration and its running sync sessions are workspace-
+    // admin only, matching `trigger_sync` below and the Graph proxy in
+    // `microsoft_graph.rs`. Being a member of the workspace was the whole check
+    // here before, which let any member read the connection's configuration,
+    // probe the live connection, and cancel an admin's directory sync.
+    let _claims =
+        match crate::utils::rbac::require_workspace_role(&req, crate::models::WorkspaceRole::Admin)
+        {
+            Ok(c) => c,
+            Err(resp) => return resp,
+        };
 
     // Check if Microsoft is configured via environment variables
     let microsoft_configured = config_utils::get_microsoft_client_id().is_ok()
@@ -1012,11 +1054,18 @@ pub async fn get_connection_status(
 
 /// Test Microsoft Graph connection
 pub async fn test_connection(req: actix_web::HttpRequest) -> impl Responder {
-    // Extract claims from cookie auth middleware
-    let _claims = match req.extensions().get::<crate::models::Claims>() {
-        Some(claims) => claims.clone(),
-        None => return errors::unauthorized("Authentication required"),
-    };
+    // The Entra/Intune integration runs on the org's own app credentials, so
+    // its state, its configuration and its running sync sessions are workspace-
+    // admin only, matching `trigger_sync` below and the Graph proxy in
+    // `microsoft_graph.rs`. Being a member of the workspace was the whole check
+    // here before, which let any member read the connection's configuration,
+    // probe the live connection, and cancel an admin's directory sync.
+    let _claims =
+        match crate::utils::rbac::require_workspace_role(&req, crate::models::WorkspaceRole::Admin)
+        {
+            Ok(c) => c,
+            Err(resp) => return resp,
+        };
 
     tracing::info!("🔬 Testing Microsoft Graph connection");
 
@@ -5064,11 +5113,18 @@ pub async fn get_entra_object_id(
         Ok(c) => c,
         Err(e) => return e,
     };
-    // Extract claims from cookie auth middleware
-    let _claims = match req.extensions().get::<crate::models::Claims>() {
-        Some(claims) => claims.clone(),
-        None => return errors::unauthorized("Authentication required"),
-    };
+    // The Entra/Intune integration runs on the org's own app credentials, so
+    // its state, its configuration and its running sync sessions are workspace-
+    // admin only, matching `trigger_sync` below and the Graph proxy in
+    // `microsoft_graph.rs`. Being a member of the workspace was the whole check
+    // here before, which let any member read the connection's configuration,
+    // probe the live connection, and cancel an admin's directory sync.
+    let _claims =
+        match crate::utils::rbac::require_workspace_role(&req, crate::models::WorkspaceRole::Admin)
+        {
+            Ok(c) => c,
+            Err(resp) => return resp,
+        };
 
     // Get Microsoft provider
     let provider = match get_default_microsoft_provider() {

--- a/backend/src/handlers/user_contact.rs
+++ b/backend/src/handlers/user_contact.rs
@@ -20,12 +20,17 @@ use crate::models::{
 use crate::repository::user_contact as repo;
 use crate::services::custom_fields::schema as field_schema;
 
-/// Contact-mutation gate shared by the handlers: self, workspace-admin, OR an
-/// agent editing a REQUESTER (a `member`) of this workspace. Agents log and
-/// manage customers, but never edit another staff member's contact (that stays
-/// self-or-admin). Returns the forbidden response to early-return, or None when
-/// authorized.
-fn guard_contact_edit(
+/// Contact-access gate shared by every handler in this module, read and write:
+/// self, workspace-admin, OR an agent acting on a REQUESTER (a `member`) of
+/// this workspace. Agents log and manage customers, but never touch another
+/// staff member's contact details (that stays self-or-admin). Returns the
+/// forbidden response to early-return, or None when authorized.
+///
+/// The reads used to skip this, taking `AuthContext` and binding it to `_auth`,
+/// which contradicted the contract stated at the top of this module and left
+/// any workspace member able to read any other member's phone numbers and
+/// postal addresses. One gate, both directions, so they cannot drift again.
+fn guard_contact_access(
     auth: &AuthContext,
     tc: &mut TenantConn,
     user_uuid: Uuid,
@@ -206,9 +211,12 @@ fn empty_profile(user_uuid: Uuid) -> Value {
 pub async fn get_user_profile_fields(
     mut tc: TenantConn,
     params: web::Path<Uuid>,
-    _auth: AuthContext,
+    auth: AuthContext,
 ) -> impl Responder {
     let user_uuid = params.into_inner();
+    if let Some(denied) = guard_contact_access(&auth, &mut tc, user_uuid) {
+        return denied;
+    }
     match tc.run(|conn| repo::get_profile(conn, user_uuid)) {
         Ok(Some(profile)) => HttpResponse::Ok().json(profile),
         Ok(None) => HttpResponse::Ok().json(empty_profile(user_uuid)),
@@ -287,9 +295,12 @@ pub async fn set_user_profile_fields(
 pub async fn list_user_phones(
     mut tc: TenantConn,
     params: web::Path<Uuid>,
-    _auth: AuthContext,
+    auth: AuthContext,
 ) -> impl Responder {
     let user_uuid = params.into_inner();
+    if let Some(denied) = guard_contact_access(&auth, &mut tc, user_uuid) {
+        return denied;
+    }
     match tc.run(|conn| repo::list_phones(conn, user_uuid)) {
         Ok(rows) => HttpResponse::Ok().json(rows),
         Err(e) => {
@@ -306,7 +317,7 @@ pub async fn add_user_phone(
     auth: AuthContext,
 ) -> impl Responder {
     let user_uuid = params.into_inner();
-    if let Some(resp) = guard_contact_edit(&auth, &mut tc, user_uuid) {
+    if let Some(resp) = guard_contact_access(&auth, &mut tc, user_uuid) {
         return resp;
     }
     let input = body.into_inner();
@@ -326,7 +337,7 @@ pub async fn update_user_phone(
     auth: AuthContext,
 ) -> impl Responder {
     let (user_uuid, id) = params.into_inner();
-    if let Some(resp) = guard_contact_edit(&auth, &mut tc, user_uuid) {
+    if let Some(resp) = guard_contact_access(&auth, &mut tc, user_uuid) {
         return resp;
     }
     let input = body.into_inner();
@@ -350,7 +361,7 @@ pub async fn delete_user_phone(
     auth: AuthContext,
 ) -> impl Responder {
     let (user_uuid, id) = params.into_inner();
-    if let Some(resp) = guard_contact_edit(&auth, &mut tc, user_uuid) {
+    if let Some(resp) = guard_contact_access(&auth, &mut tc, user_uuid) {
         return resp;
     }
     let result = tc.run(|conn| {
@@ -373,9 +384,12 @@ pub async fn delete_user_phone(
 pub async fn list_user_addresses(
     mut tc: TenantConn,
     params: web::Path<Uuid>,
-    _auth: AuthContext,
+    auth: AuthContext,
 ) -> impl Responder {
     let user_uuid = params.into_inner();
+    if let Some(denied) = guard_contact_access(&auth, &mut tc, user_uuid) {
+        return denied;
+    }
     match tc.run(|conn| repo::list_addresses(conn, user_uuid)) {
         Ok(rows) => HttpResponse::Ok().json(rows),
         Err(e) => {
@@ -392,7 +406,7 @@ pub async fn add_user_address(
     auth: AuthContext,
 ) -> impl Responder {
     let user_uuid = params.into_inner();
-    if let Some(resp) = guard_contact_edit(&auth, &mut tc, user_uuid) {
+    if let Some(resp) = guard_contact_access(&auth, &mut tc, user_uuid) {
         return resp;
     }
     let input = body.into_inner();
@@ -412,7 +426,7 @@ pub async fn update_user_address(
     auth: AuthContext,
 ) -> impl Responder {
     let (user_uuid, id) = params.into_inner();
-    if let Some(resp) = guard_contact_edit(&auth, &mut tc, user_uuid) {
+    if let Some(resp) = guard_contact_access(&auth, &mut tc, user_uuid) {
         return resp;
     }
     let input = body.into_inner();
@@ -436,7 +450,7 @@ pub async fn delete_user_address(
     auth: AuthContext,
 ) -> impl Responder {
     let (user_uuid, id) = params.into_inner();
-    if let Some(resp) = guard_contact_edit(&auth, &mut tc, user_uuid) {
+    if let Some(resp) = guard_contact_access(&auth, &mut tc, user_uuid) {
         return resp;
     }
     let result = tc.run(|conn| {

--- a/backend/src/handlers/users.rs
+++ b/backend/src/handlers/users.rs
@@ -2282,13 +2282,15 @@ pub async fn update_user_by_uuid(
                 }
                 let guard = tc.run(|conn| {
                     diesel::sql_query(
+                        // Removed admins must not prop up the count, or the
+                        // last real admin could be demoted behind their ghost.
                         "SELECT \
                            (SELECT COUNT(*) FROM workspace_members \
                               WHERE workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::int \
-                                AND role = 'admin') AS admin_count, \
+                                AND role = 'admin' AND removed_at IS NULL) AS admin_count, \
                            EXISTS(SELECT 1 FROM workspace_members \
                               WHERE workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::int \
-                                AND user_uuid = $1 AND role = 'admin') AS target_is_admin",
+                                AND user_uuid = $1 AND role = 'admin' AND removed_at IS NULL) AS target_is_admin",
                     )
                     .bind::<diesel::sql_types::Uuid, _>(user_uuid_parsed)
                     .get_result::<AdminGuard>(conn)

--- a/backend/src/handlers/users.rs
+++ b/backend/src/handlers/users.rs
@@ -730,6 +730,7 @@ fn get_device_counts_batch(user_uuids: &[Uuid], conn: &mut DbConnection) -> Hash
 pub async fn get_user_by_uuid(
     uuid_path: web::Path<String>,
     pool: web::Data<crate::db::Pool>,
+    ws: WorkspaceContext,
     req: HttpRequest,
 ) -> impl Responder {
     let uuid_str = uuid_path.into_inner();
@@ -748,13 +749,21 @@ pub async fn get_user_by_uuid(
     // resolves under RLS (workspace_members is workspace-isolated).
     helpers::pin_request_workspace(&req, &mut conn);
 
-    match repository::get_user_by_uuid(&user_uuid_parsed, &mut conn) {
-        Ok(user) => {
+    // Resolve through the membership join, not by uuid alone. `users` has no
+    // RLS (an account spans workspaces, so there is no column to key on), and
+    // the pin above only scopes the RLS-bearing tables joined alongside it, so
+    // a bare `find(uuid)` here read any user in the deployment — name, avatar
+    // and primary email — for any authenticated member of any workspace.
+    match repository::directory::find_member(&mut conn, ws.workspace_id, user_uuid_parsed) {
+        Ok(Some(user)) => {
             // Use helper function to fetch primary email from user_emails table
             let user_response =
                 repository::user_helpers::get_user_with_primary_email(user, &mut conn);
             HttpResponse::Ok().json(user_response)
         }
+        // A stranger is indistinguishable from a missing row, so this does not
+        // become an oracle for which uuids exist in other workspaces.
+        Ok(None) => errors::not_found_msg("User not found"),
         Err(_) => errors::not_found_msg("User not found"),
     }
 }
@@ -793,7 +802,10 @@ pub async fn get_users_batch(
     // Convert to Vec for the repository function
     let uuids_vec: Vec<Uuid> = valid_uuids.into_iter().collect();
 
-    match repository::get_users_by_uuids(&uuids_vec, &mut conn) {
+    // Same membership join as the singular lookup: a batch endpoint must not
+    // become a cheaper oracle for the identities the singular one now hides.
+    // Unknown uuids are simply absent from the response.
+    match repository::directory::find_members(&mut conn, ws.workspace_id, &uuids_vec) {
         Ok(users) => {
             // Convert users to UserResponse with emails (batch fetch for efficiency)
             let user_responses = repository::user_helpers::get_users_with_primary_emails(

--- a/backend/src/middleware/api_token.rs
+++ b/backend/src/middleware/api_token.rs
@@ -315,6 +315,19 @@ async fn finalize<B: MessageBody>(
     next: Next<B>,
     claims: Claims,
 ) -> Result<ServiceResponse<B>, Error> {
+    // Scope enforcement runs here, at the one point every authenticated
+    // request passes, rather than in a middleware each new scope has to
+    // remember to stack alongside the auth wrap. `/api/collaboration` is what
+    // forgetting looked like: it wrapped `dual_auth_middleware` but not the
+    // scope middleware, so a narrowed token reached
+    // `POST /api/collaboration/token` and traded itself for an unrestricted
+    // `collab` JWT. The policy already returned `Full` for that path; it was
+    // simply never asked.
+    if !crate::middleware::token_scope::claims_may_call(&claims, req.method(), req.path()) {
+        return Err(actix_web::error::ErrorForbidden(
+            "API token scope does not permit this request",
+        ));
+    }
     request_context::populate(&req, &claims);
     req.extensions_mut().insert(claims);
     next.call(req).await

--- a/backend/src/middleware/token_scope.rs
+++ b/backend/src/middleware/token_scope.rs
@@ -1,13 +1,15 @@
 //! API token scope enforcement.
 //!
 //! This module owns the route policy that maps an incoming request to
-//! the scope it requires, plus (step 3) the middleware that enforces it
-//! against a narrowed token's `ScopeSet`.
+//! the scope it requires, plus the predicate that enforces it against a
+//! narrowed token's `ScopeSet`. The predicate is called from
+//! `api_token::finalize`, so every authenticated request is checked at one
+//! point instead of wherever a wrap happens to be stacked.
 //!
 //! Design:
 //!   * `full` credentials (every cookie session and every un-narrowed
-//!     token) short-circuit in the middleware and never reach this
-//!     policy. Only deliberately-narrowed API tokens are constrained.
+//!     token) short-circuit before this policy is consulted. Only
+//!     deliberately-narrowed API tokens are constrained.
 //!   * The policy returns a `ScopeRequirement`. Anything not explicitly
 //!     mapped defaults to `Full`, which a narrowed token can never
 //!     satisfy, so a new or cross-cutting route fail-closes rather than
@@ -15,11 +17,7 @@
 //!   * Scope is a second, orthogonal layer: the handler's existing role
 //!     gate still runs. A request must pass both.
 
-use actix_web::body::MessageBody;
-use actix_web::dev::{ServiceRequest, ServiceResponse};
 use actix_web::http::Method;
-use actix_web::middleware::Next;
-use actix_web::{Error, HttpMessage};
 
 use crate::models::Claims;
 use crate::utils::scopes::{Action, Domain, ScopeSet};
@@ -160,34 +158,22 @@ fn action_for(method: &Method, rest: &str) -> Action {
 /// pass both layers. (The control-plane provisioning surface is a
 /// separate scope with its own EdDSA-JWT auth, not an api_token, so it
 /// never reaches this middleware.)
-pub async fn token_scope_middleware(
-    req: ServiceRequest,
-    next: Next<impl MessageBody>,
-) -> Result<ServiceResponse<impl MessageBody>, Error> {
-    if scope_allows(&req) {
-        next.call(req).await
-    } else {
-        Err(actix_web::error::ErrorForbidden(
-            "API token scope does not permit this request",
-        ))
-    }
-}
-
-/// Whether the request's credential scope permits it. Borrow-scoped so
-/// the extensions borrow is dropped before the async `next.call`.
-fn scope_allows(req: &ServiceRequest) -> bool {
-    let ext = req.extensions();
-    let claims = match ext.get::<Claims>() {
-        // No claims: the auth layer already rejected, or this isn't an
-        // authenticated scope. Nothing for us to enforce.
-        None => return true,
-        Some(c) => c,
-    };
+/// Whether a credential's scope permits this request.
+///
+/// Enforcement is called from `api_token::finalize`, the one point every
+/// authenticated request passes, rather than from a middleware a new scope
+/// has to remember to stack. It used to be a wrap, stacked on `/api` and
+/// `/api/files` and nowhere else; `/api/collaboration` is registered as its
+/// own top-level scope with only the auth wrap, so a deliberately narrowed
+/// token reached `POST /api/collaboration/token` and traded itself for an
+/// unrestricted `collab` JWT. Nothing had to be wrong for that to happen,
+/// only forgotten, which is the argument for the funnel over the wrap.
+pub fn claims_may_call(claims: &Claims, method: &Method, path: &str) -> bool {
     // Cookie sessions and un-narrowed tokens carry `full`.
     if claims.scope == "full" {
         return true;
     }
-    match required_scope(req.method(), req.path()) {
+    match required_scope(method, path) {
         ScopeRequirement::Any => true,
         ScopeRequirement::Full => false,
         ScopeRequirement::Capability(domain, action) => {
@@ -203,6 +189,67 @@ mod tests {
 
     fn req(method: Method, path: &str) -> ScopeRequirement {
         required_scope(&method, path)
+    }
+
+    fn claims_scoped(scope: &str) -> Claims {
+        Claims {
+            sub: uuid::Uuid::new_v4().to_string(),
+            name: "Token".to_string(),
+            email: String::new(),
+            platform_role: "user".to_string(),
+            scope: scope.to_string(),
+            sid: None,
+            workspace_uuid: None,
+            exp: 0,
+            iat: 0,
+        }
+    }
+
+    /// The bypass this enforcement point exists to close. `/api/collaboration`
+    /// is its own top-level scope carrying only the auth wrap, so while
+    /// enforcement was a separate middleware stacked on `/api` and
+    /// `/api/files`, a token narrowed to something harmless reached
+    /// `POST /api/collaboration/token` and traded itself for an unrestricted
+    /// `collab` JWT, and from there a read/write socket on every document its
+    /// owner could see.
+    #[test]
+    fn a_narrowed_token_cannot_mint_a_collab_credential() {
+        let narrow = claims_scoped("notifications:read");
+        assert!(
+            !claims_may_call(&narrow, &Method::POST, "/api/collaboration/token"),
+            "a narrowed token must not mint a collab credential"
+        );
+        assert!(
+            !claims_may_call(&narrow, &Method::GET, "/api/collaboration/article/abc"),
+            "nor read a document body through the same unmapped tree"
+        );
+    }
+
+    #[test]
+    fn full_credentials_are_unaffected() {
+        let full = claims_scoped("full");
+        // Cookie sessions and un-narrowed tokens carry `full`; every path,
+        // mapped or not, must stay open to them or this move would have
+        // logged out the whole product.
+        for path in [
+            "/api/collaboration/token",
+            "/api/tickets/5",
+            "/api/files/tickets/x.png",
+            "/api/some/route/added/tomorrow",
+        ] {
+            assert!(
+                claims_may_call(&full, &Method::GET, path),
+                "full credential refused at {path}"
+            );
+            assert!(claims_may_call(&full, &Method::POST, path));
+        }
+    }
+
+    #[test]
+    fn a_narrowed_token_still_reaches_what_it_was_scoped_for() {
+        let reader = claims_scoped("tickets:read");
+        assert!(claims_may_call(&reader, &Method::GET, "/api/tickets/5"));
+        assert!(!claims_may_call(&reader, &Method::POST, "/api/tickets"));
     }
 
     #[test]
@@ -437,13 +484,36 @@ mod enforcement_tests {
         }
     }
 
-    /// Drive a request through an app wrapped only in the scope
-    /// middleware; the default handler returns 200, so the status is the
-    /// middleware's decision (200 allow / 403 deny).
+    /// Mirrors what `api_token::finalize` does with the predicate, so these
+    /// end-to-end cases keep testing enforcement after it moved out of a
+    /// middleware of its own. Claims absent means the real funnel was never
+    /// reached, which is an allow here for the same reason it was before.
+    async fn scope_gate(
+        req: actix_web::dev::ServiceRequest,
+        next: actix_web::middleware::Next<impl actix_web::body::MessageBody>,
+    ) -> Result<actix_web::dev::ServiceResponse<impl actix_web::body::MessageBody>, actix_web::Error>
+    {
+        let allowed = req
+            .extensions()
+            .get::<Claims>()
+            .map(|c| claims_may_call(c, req.method(), req.path()))
+            .unwrap_or(true);
+        if allowed {
+            next.call(req).await
+        } else {
+            Err(actix_web::error::ErrorForbidden(
+                "API token scope does not permit this request",
+            ))
+        }
+    }
+
+    /// Drive a request through an app wrapped only in the scope gate; the
+    /// default handler returns 200, so the status is the gate's decision
+    /// (200 allow / 403 deny).
     async fn status_for(scope: Option<&str>, method: Method, path: &str) -> StatusCode {
         let app = actix_test::init_service(
             App::new()
-                .wrap(from_fn(token_scope_middleware))
+                .wrap(from_fn(scope_gate))
                 .default_service(web::to(|| async { HttpResponse::Ok().finish() })),
         )
         .await;
@@ -477,7 +547,9 @@ mod enforcement_tests {
 
     #[actix_web::test]
     async fn session_with_no_claims_passes_through() {
-        // Defensive: if dual_auth didn't insert claims, we don't block.
+        // Defensive: enforcement now lives inside the auth funnel, which only
+        // runs with claims in hand. A request that somehow arrives without
+        // them was never authenticated, so it is not ours to block.
         assert_eq!(
             status_for(None, Method::POST, "/api/tickets").await,
             StatusCode::OK

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -191,6 +191,11 @@ pub struct WorkspaceMember {
     pub role: String,
     pub invited_at: DateTime<Utc>,
     pub accepted_at: Option<DateTime<Utc>>,
+    /// When the membership was revoked; `None` means active. The row is kept
+    /// so historical actors still resolve to a name. Every role, permission
+    /// and seat-counting read must filter on this; only identity resolution
+    /// may ignore it.
+    pub removed_at: Option<DateTime<Utc>>,
 }
 
 /// invited the bug where a user could accidentally promote a view

--- a/backend/src/repository/comments.rs
+++ b/backend/src/repository/comments.rs
@@ -242,7 +242,8 @@ pub fn create_comment_with_annotation(
                                     .filter(
                                         crate::schema::workspace_members::role
                                             .eq_any(vec!["owner", "admin", "agent"]),
-                                    ),
+                                    )
+                                    .filter(crate::schema::workspace_members::removed_at.is_null()),
                             ),
                         ),
                     ),

--- a/backend/src/repository/directory.rs
+++ b/backend/src/repository/directory.rs
@@ -1,0 +1,64 @@
+//! Identity resolution scoped by workspace membership.
+//!
+//! `users` carries no row-level security, deliberately: one account can hold
+//! memberships in several workspaces, so the table is global and RLS has no
+//! workspace column to key on. The consequence is that a uuid-keyed read of
+//! `users` is unscoped. Pinning the request's workspace does not help, because
+//! the pin constrains the RLS-bearing tables joined alongside it (the role
+//! lookup), not the identity row itself. Any authenticated member could
+//! therefore read any user in the deployment by uuid, primary email included.
+//!
+//! The scope has to come from a join. `workspace_members` is the only table
+//! that says who belongs where, so identity reads go through it.
+//!
+//! **Membership status is deliberately ignored here.** These functions resolve
+//! *who someone is*, not *what they may do*: a former colleague still has to
+//! render as a name on the tickets and comments they left behind. Everything
+//! that decides authority reads `workspace_members` with `removed_at IS NULL`
+//! instead; see `workspace_members_active_filter_lint`.
+
+use diesel::prelude::*;
+use uuid::Uuid;
+
+use crate::db::DbConnection;
+use crate::models::User;
+use crate::schema::{users, workspace_members};
+
+/// The identity of one user, if they are or ever were a member of this
+/// workspace. `Ok(None)` for a stranger, so a caller cannot tell "no such
+/// user" from "not someone you can see".
+// members-any-status: identity resolution must still name people who have left,
+// or their historical tickets and comments render as an unknown user.
+pub fn find_member(
+    conn: &mut DbConnection,
+    workspace_id: i32,
+    user_uuid: Uuid,
+) -> QueryResult<Option<User>> {
+    users::table
+        .inner_join(workspace_members::table.on(workspace_members::user_uuid.eq(users::uuid)))
+        .filter(workspace_members::workspace_id.eq(workspace_id))
+        .filter(users::uuid.eq(user_uuid))
+        .select(users::all_columns)
+        .first::<User>(conn)
+        .optional()
+}
+
+/// [`find_member`] for many uuids at once. Strangers are absent from the
+/// result rather than reported, matching the singular form: a batch lookup
+/// must not become an oracle for which uuids exist in other workspaces.
+// members-any-status: as above.
+pub fn find_members(
+    conn: &mut DbConnection,
+    workspace_id: i32,
+    user_uuids: &[Uuid],
+) -> QueryResult<Vec<User>> {
+    if user_uuids.is_empty() {
+        return Ok(Vec::new());
+    }
+    users::table
+        .inner_join(workspace_members::table.on(workspace_members::user_uuid.eq(users::uuid)))
+        .filter(workspace_members::workspace_id.eq(workspace_id))
+        .filter(users::uuid.eq_any(user_uuids))
+        .select(users::all_columns)
+        .load::<User>(conn)
+}

--- a/backend/src/repository/documentation.rs
+++ b/backend/src/repository/documentation.rs
@@ -938,6 +938,43 @@ pub fn set_page_visibility(
     })
 }
 
+/// Who a page render is for, so the ACL can travel with a recursion.
+///
+/// The markdown exporter follows `embedded_document` nodes, and a page the
+/// caller may read can embed one they may not. Checking only the top-level
+/// page therefore checks the wrong thing. Carrying the audience down the
+/// recursion means every page the output contains is checked, once, by the
+/// same predicate the ordinary page read uses.
+///
+/// The comment-side analogue is `ticket_visibility::CommentAudience`.
+#[derive(Clone, Copy)]
+pub enum PageAudience {
+    /// A specific caller. Every page is filtered by [`can_user_access_page`].
+    User {
+        user_uuid: uuid::Uuid,
+        is_admin: bool,
+    },
+    /// No filtering, for callers that have already established authority over
+    /// the whole export (nothing uses this yet; it exists so a future system
+    /// exporter has to say so rather than pass a borrowed user).
+    Unrestricted,
+}
+
+impl PageAudience {
+    /// Fails closed: a lookup error reads as "not accessible", matching the
+    /// handlers, which turn a visibility-check failure into a refusal rather
+    /// than falling through to the content.
+    pub fn can_read(&self, conn: &mut DbConnection, page_id: i32) -> bool {
+        match self {
+            PageAudience::Unrestricted => true,
+            PageAudience::User {
+                user_uuid,
+                is_admin,
+            } => can_user_access_page(conn, page_id, user_uuid, *is_admin).unwrap_or(false),
+        }
+    }
+}
+
 /// Check whether a single user can access a page.
 /// Logic: admin → true; page has override → check page groups + user;
 ///        else inherit from collections (no collections = public,

--- a/backend/src/repository/mod.rs
+++ b/backend/src/repository/mod.rs
@@ -20,6 +20,7 @@ pub mod channels;
 pub mod comments;
 pub mod cycles;
 pub mod dashboard_stats;
+pub mod directory;
 pub mod documentation;
 pub mod documentation_collections;
 pub mod documentation_page_tickets;

--- a/backend/src/repository/user_helpers.rs
+++ b/backend/src/repository/user_helpers.rs
@@ -17,6 +17,7 @@ pub fn workspace_role(conn: &mut DbConnection, user_uuid: Uuid) -> Option<Worksp
     use crate::schema::workspace_members;
     workspace_members::table
         .filter(workspace_members::user_uuid.eq(user_uuid))
+        .filter(workspace_members::removed_at.is_null())
         .select(workspace_members::role)
         .first::<String>(conn)
         .ok()
@@ -34,6 +35,7 @@ pub fn workspace_roles_batch(
     use crate::schema::workspace_members;
     workspace_members::table
         .filter(workspace_members::user_uuid.eq_any(user_uuids))
+        .filter(workspace_members::removed_at.is_null())
         .select((workspace_members::user_uuid, workspace_members::role))
         .load::<(Uuid, String)>(conn)
         .unwrap_or_default()
@@ -548,6 +550,7 @@ pub fn get_users_with_primary_emails(
         workspace_members::table
             .filter(workspace_members::workspace_id.eq(workspace_id))
             .filter(workspace_members::user_uuid.eq_any(&user_uuids))
+            .filter(workspace_members::removed_at.is_null())
             .select((workspace_members::user_uuid, workspace_members::role))
             .load::<(Uuid, String)>(conn)
             .unwrap_or_default()

--- a/backend/src/repository/users.rs
+++ b/backend/src/repository/users.rs
@@ -156,7 +156,8 @@ fn requester_sql(workspace_id: i32) -> String {
     format!(
         "(users.platform_role = 'user' \
          AND COALESCE((SELECT role FROM workspace_members \
-                       WHERE workspace_id = {workspace_id} AND user_uuid = users.uuid), \
+                       WHERE workspace_id = {workspace_id} AND user_uuid = users.uuid \
+                       AND removed_at IS NULL), \
                       'member') = 'member')"
     )
 }
@@ -228,7 +229,8 @@ pub fn get_paginated_users(
                     parts.push(format!(
                         "(users.platform_role = 'platform_admin' \
                          OR (SELECT role FROM workspace_members \
-                             WHERE workspace_id = {workspace_id} AND user_uuid = users.uuid) \
+                             WHERE workspace_id = {workspace_id} AND user_uuid = users.uuid \
+                       AND removed_at IS NULL) \
                             IN ('owner', 'admin'))"
                     ));
                     any = true;
@@ -237,7 +239,8 @@ pub fn get_paginated_users(
                     parts.push(format!(
                         "(users.platform_role <> 'platform_admin' \
                          AND (SELECT role FROM workspace_members \
-                              WHERE workspace_id = {workspace_id} AND user_uuid = users.uuid) \
+                              WHERE workspace_id = {workspace_id} AND user_uuid = users.uuid \
+                       AND removed_at IS NULL) \
                              = 'agent')"
                     ));
                     any = true;
@@ -246,7 +249,8 @@ pub fn get_paginated_users(
                     parts.push(format!(
                         "(users.platform_role <> 'platform_admin' \
                          AND COALESCE((SELECT role FROM workspace_members \
-                                       WHERE workspace_id = {workspace_id} AND user_uuid = users.uuid), \
+                                       WHERE workspace_id = {workspace_id} AND user_uuid = users.uuid \
+                       AND removed_at IS NULL), \
                                       'member') = 'member')"
                     ));
                     any = true;
@@ -282,10 +286,12 @@ pub fn get_paginated_users(
         "CASE \
         WHEN users.platform_role = 'platform_admin' THEN 0 \
         WHEN (SELECT role FROM workspace_members \
-              WHERE workspace_id = {workspace_id} AND user_uuid = users.uuid) \
+              WHERE workspace_id = {workspace_id} AND user_uuid = users.uuid \
+                       AND removed_at IS NULL) \
              IN ('owner', 'admin') THEN 1 \
         WHEN (SELECT role FROM workspace_members \
-              WHERE workspace_id = {workspace_id} AND user_uuid = users.uuid) \
+              WHERE workspace_id = {workspace_id} AND user_uuid = users.uuid \
+                       AND removed_at IS NULL) \
              = 'agent' THEN 2 \
         ELSE 3 END"
     );
@@ -887,7 +893,8 @@ pub fn set_user_roles(
     diesel::update(
         workspace_members::table
             .filter(workspace_members::workspace_id.eq(workspace_id))
-            .filter(workspace_members::user_uuid.eq(user_uuid)),
+            .filter(workspace_members::user_uuid.eq(user_uuid))
+            .filter(workspace_members::removed_at.is_null()),
     )
     .set(workspace_members::role.eq(workspace_role))
     .execute(conn)?;

--- a/backend/src/repository/workspaces.rs
+++ b/backend/src/repository/workspaces.rs
@@ -54,6 +54,7 @@ pub fn user_is_staff_anywhere(conn: &mut DbConnection, user_uuid: Uuid) -> Query
     let n: i64 = workspace_members::table
         .filter(workspace_members::user_uuid.eq(user_uuid))
         .filter(workspace_members::role.eq_any(STAFF_ROLES))
+        .filter(workspace_members::removed_at.is_null())
         .select(count_star())
         .get_result(conn)?;
     Ok(n > 0)
@@ -275,6 +276,7 @@ pub fn membership(
     workspace_members::table
         .filter(workspace_members::workspace_id.eq(workspace_id))
         .filter(workspace_members::user_uuid.eq(user_uuid))
+        .filter(workspace_members::removed_at.is_null())
         .first(conn)
         .optional()
 }
@@ -324,10 +326,20 @@ pub fn add_membership(
     // which has a pending-invite step. The email-invite path creates
     // its membership via create_user_with_email and leaves accepted_at
     // NULL until accept_invitation stamps it.
+    //
+    // `DO NOTHING` was right when removal deleted the row: a conflict could
+    // only mean "already an active member". Under soft-remove the row survives,
+    // so a conflict is ambiguous and DO NOTHING would silently leave a removed
+    // person removed while reporting nothing added. Re-activate instead, and
+    // keep the old behaviour for the still-active case with the WHERE clause.
+    // The re-activation is an UPDATE, so it goes through the seat-limit
+    // trigger, which is why that trigger had to learn about `removed_at` too.
     let rows = diesel::sql_query(
         "INSERT INTO workspace_members (workspace_id, user_uuid, role, accepted_at) \
          VALUES ($1, $2, $3, now()) \
-         ON CONFLICT (workspace_id, user_uuid) DO NOTHING",
+         ON CONFLICT (workspace_id, user_uuid) DO UPDATE \
+           SET removed_at = NULL, role = EXCLUDED.role, accepted_at = now() \
+         WHERE workspace_members.removed_at IS NOT NULL",
     )
     .bind::<diesel::sql_types::Integer, _>(workspace_id)
     .bind::<diesel::sql_types::Uuid, _>(user_uuid)
@@ -417,6 +429,7 @@ pub fn count_staff_members(conn: &mut DbConnection, workspace_id: i32) -> QueryR
     workspace_members::table
         .filter(workspace_members::workspace_id.eq(workspace_id))
         .filter(workspace_members::role.eq_any(STAFF_ROLES))
+        .filter(workspace_members::removed_at.is_null())
         .count()
         .get_result(conn)
 }
@@ -504,6 +517,7 @@ pub fn set_notification_push_detail(
 pub fn primary_workspace_for_user(conn: &mut DbConnection, user_uuid: Uuid) -> QueryResult<i32> {
     workspace_members::table
         .filter(workspace_members::user_uuid.eq(user_uuid))
+        .filter(workspace_members::removed_at.is_null())
         .order(workspace_members::workspace_id.asc())
         .select(workspace_members::workspace_id)
         .first::<i32>(conn)
@@ -685,6 +699,7 @@ pub fn list_memberships_for_user(
     workspace_members::table
         .inner_join(workspaces::table.on(workspaces::id.eq(workspace_members::workspace_id)))
         .filter(workspace_members::user_uuid.eq(user_uuid))
+        .filter(workspace_members::removed_at.is_null())
         .filter(workspaces::archived_at.is_null())
         .order(workspaces::id.asc())
         .select((WorkspaceMember::as_select(), Workspace::as_select()))
@@ -723,6 +738,7 @@ pub fn list_workspace_members(
 ) -> QueryResult<Vec<WorkspaceMember>> {
     workspace_members::table
         .filter(workspace_members::workspace_id.eq(workspace_id))
+        .filter(workspace_members::removed_at.is_null())
         .order(workspace_members::user_uuid.asc())
         .load(conn)
 }
@@ -735,6 +751,7 @@ pub fn count_workspace_owners(conn: &mut DbConnection, workspace_id: i32) -> Que
     workspace_members::table
         .filter(workspace_members::workspace_id.eq(workspace_id))
         .filter(workspace_members::role.eq("owner"))
+        .filter(workspace_members::removed_at.is_null())
         .count()
         .get_result(conn)
 }
@@ -768,6 +785,7 @@ pub fn remove_membership(
     let existing = workspace_members::table
         .filter(workspace_members::workspace_id.eq(workspace_id))
         .filter(workspace_members::user_uuid.eq(user_uuid))
+        .filter(workspace_members::removed_at.is_null())
         .first::<WorkspaceMember>(conn)
         .optional()?;
     let row = match existing {
@@ -786,11 +804,16 @@ pub fn remove_membership(
         }
     }
 
-    diesel::delete(
+    // Stamp rather than delete. The row is what lets a former member's name
+    // still render on the tickets, comments and audit entries they left behind;
+    // deleting it turned every one of those into an unknown user.
+    diesel::update(
         workspace_members::table
             .filter(workspace_members::workspace_id.eq(workspace_id))
-            .filter(workspace_members::user_uuid.eq(user_uuid)),
+            .filter(workspace_members::user_uuid.eq(user_uuid))
+            .filter(workspace_members::removed_at.is_null()),
     )
+    .set(workspace_members::removed_at.eq(chrono::Utc::now()))
     .execute(conn)?;
     Ok(RemoveMembershipOutcome::Removed)
 }
@@ -820,6 +843,7 @@ pub fn get_membership_role(
     workspace_members::table
         .filter(workspace_members::workspace_id.eq(workspace_id))
         .filter(workspace_members::user_uuid.eq(user_uuid))
+        .filter(workspace_members::removed_at.is_null())
         .select(workspace_members::role)
         .first::<String>(conn)
         .optional()
@@ -834,7 +858,8 @@ pub fn mark_memberships_accepted(conn: &mut DbConnection, user_uuid: Uuid) -> Qu
     diesel::update(
         workspace_members::table
             .filter(workspace_members::user_uuid.eq(user_uuid))
-            .filter(workspace_members::accepted_at.is_null()),
+            .filter(workspace_members::accepted_at.is_null())
+            .filter(workspace_members::removed_at.is_null()),
     )
     .set(workspace_members::accepted_at.eq(chrono::Utc::now()))
     .execute(conn)
@@ -857,6 +882,7 @@ pub fn update_membership_role(
     let existing = workspace_members::table
         .filter(workspace_members::workspace_id.eq(workspace_id))
         .filter(workspace_members::user_uuid.eq(user_uuid))
+        .filter(workspace_members::removed_at.is_null())
         .first::<WorkspaceMember>(conn)
         .optional()?;
     let row = match existing {
@@ -880,7 +906,8 @@ pub fn update_membership_role(
     let updated = diesel::update(
         workspace_members::table
             .filter(workspace_members::workspace_id.eq(workspace_id))
-            .filter(workspace_members::user_uuid.eq(user_uuid)),
+            .filter(workspace_members::user_uuid.eq(user_uuid))
+            .filter(workspace_members::removed_at.is_null()),
     )
     .set(workspace_members::role.eq(new_role))
     .get_result::<WorkspaceMember>(conn)?;
@@ -1593,7 +1620,7 @@ mod tests {
         let ops: Vec<&str> = rows.iter().map(|r| r.op.as_str()).collect();
         assert_eq!(
             ops,
-            vec!["I", "U", "D"],
+            vec!["I", "U", "U"],
             "one audit row per mutation, in order"
         );
         for r in &rows {
@@ -1606,6 +1633,19 @@ mod tests {
             rows[1].changed.as_deref().unwrap_or("").contains("role"),
             "role-change row should list role in changed_cols: {:?}",
             rows[1].changed
+        );
+        // Removal is the third 'U', not a 'D': memberships are soft-removed so
+        // a former member's name still resolves on what they left behind. The
+        // audit trail is strictly better for it, since a delete destroyed the
+        // evidence that the person was ever a member.
+        assert!(
+            rows[2]
+                .changed
+                .as_deref()
+                .unwrap_or("")
+                .contains("removed_at"),
+            "removal row should list removed_at in changed_cols: {:?}",
+            rows[2].changed
         );
     }
 

--- a/backend/src/schema.rs
+++ b/backend/src/schema.rs
@@ -2181,6 +2181,7 @@ diesel::table! {
         role -> Varchar,
         invited_at -> Timestamptz,
         accepted_at -> Nullable<Timestamptz>,
+        removed_at -> Nullable<Timestamptz>,
     }
 }
 

--- a/backend/src/services/avatar_thumbnails.rs
+++ b/backend/src/services/avatar_thumbnails.rs
@@ -98,7 +98,8 @@ pub async fn backfill_thumbnails(
     let rows: Vec<AvatarRow> = match diesel::sql_query(
         "SELECT u.uuid::text AS uuid_str, u.avatar_url, u.avatar_thumb, \
                 (SELECT wm.workspace_id FROM workspace_members wm \
-                 WHERE wm.user_uuid = u.uuid ORDER BY wm.workspace_id LIMIT 1) AS workspace_id \
+                 WHERE wm.user_uuid = u.uuid AND wm.removed_at IS NULL \
+                 ORDER BY wm.workspace_id LIMIT 1) AS workspace_id \
          FROM users u WHERE u.avatar_url IS NOT NULL",
     )
     .load(conn)

--- a/backend/src/services/search/indexer.rs
+++ b/backend/src/services/search/indexer.rs
@@ -468,6 +468,9 @@ pub fn rebuild_index(
     // its full workspace set as multi-valued workspace_id terms. A user with
     // no memberships gets an empty set and is unreachable (fail-closed).
     let all_memberships: Vec<(uuid::Uuid, i32)> = workspace_members::table
+        // A removed member must stop being searchable in that workspace; the
+        // row survives only so their name still resolves on old records.
+        .filter(workspace_members::removed_at.is_null())
         .select((
             workspace_members::user_uuid,
             workspace_members::workspace_id,

--- a/backend/src/services/workspace_export.rs
+++ b/backend/src/services/workspace_export.rs
@@ -261,6 +261,9 @@ fn load_workspace_meta(
         #[diesel(sql_type = Text)]
         user_uuid: String,
     }
+    // members-any-status: an export must round-trip history, and historical rows
+    // reference people who have since been removed; dropping them would fail the
+    // enforced user FK on import.
     let members: Vec<UuidRow> = sql_query(
         "SELECT user_uuid::text AS user_uuid FROM workspace_members WHERE workspace_id = $1 \
          ORDER BY user_uuid",
@@ -319,6 +322,7 @@ pub fn collect_workspace_rows(
     // who was removed from membership or was never a member (external requester);
     // omitting them would fail the enforced user FK on import. Each referencing
     // column lives on a workspace-scoped table, so every subquery is scoped by $1.
+    // members-any-status: as above, and the comment block above says so already.
     let mut union_parts =
         vec!["SELECT user_uuid FROM workspace_members WHERE workspace_id = $1".to_string()];
     for (tbl, col) in user_referencing_columns(conn)? {

--- a/backend/src/startup.rs
+++ b/backend/src/startup.rs
@@ -798,12 +798,10 @@ pub fn configure_app(
             )
 
             // Authenticated, workspace-scoped tenant file serving. Its own
-            // scope so the wrap stack matches the main /api scope: dual_auth
-            // (cookie or Bearer + workspace-membership gate) registered last so
-            // it runs first and puts Claims in extensions, then token_scope
-            // enforces API-token scopes. These routes map to `Full`, so a
-            // narrowed token 403s here instead of slipping past scope
-            // enforcement (they used to sit outside any scope-wrapped tree).
+            // scope carrying dual_auth (cookie or Bearer + workspace-membership
+            // gate). API-token scopes are enforced inside the auth funnel
+            // itself, so they cover this tree without a second wrap; these
+            // routes map to `Full`, and a narrowed token 403s here.
             // The handlers add a per-ticket/asset visibility check via
             // TenantConn so a caller only reads files it can see in its own
             // workspace. Registered before the main /api scope so /api/files/*
@@ -811,9 +809,6 @@ pub fn configure_app(
             // so the `{filename:.*}` tail can't swallow it.
             .service(
                 web::scope("/api/files")
-                    .wrap(actix_web::middleware::from_fn(
-                        crate::middleware::token_scope::token_scope_middleware,
-                    ))
                     .wrap(actix_web::middleware::from_fn(crate::middleware::dual_auth_middleware))
                     .route("/tickets/{ticket_id}/notes/{filename:.*}", web::get().to(crate::handlers::serve_ticket_note_image))
                     .route("/tickets/{filename:.*}", web::get().to(crate::handlers::serve_ticket_file))
@@ -921,15 +916,10 @@ pub fn configure_app(
                     // this does not throttle long-lived connections. See
                     // security-audit-2026-06.
                     .wrap(RateLimiter::default())
-                    // Enforce API-token scopes. Registered before (so it
-                    // runs after) dual_auth, which puts Claims in
-                    // extensions. Cookie sessions and un-narrowed tokens
-                    // carry `full` and short-circuit; platform tokens are
-                    // exempt; a narrowed token must satisfy the route's
-                    // required scope.
-                    .wrap(actix_web::middleware::from_fn(
-                        crate::middleware::token_scope::token_scope_middleware,
-                    ))
+                    // Cookie or Bearer or `nsk_` API token. The funnel behind
+                    // this also enforces API-token scopes, so a narrowed token
+                    // must satisfy the route's required scope; cookie sessions
+                    // and un-narrowed tokens carry `full` and short-circuit.
                     .wrap(actix_web::middleware::from_fn(crate::middleware::dual_auth_middleware))
 
                     // Authentication Provider management (admin only) - simplified for environment-based config
@@ -1068,9 +1058,8 @@ pub fn configure_app(
                     .configure(crate::handlers::files::config)
 
                     // Collab-document image upload. Deliberately here rather
-                    // than under /api/collaboration: that scope carries
-                    // neither the rate limiter nor token-scope enforcement,
-                    // and a 10MB multipart write needs both.
+                    // than under /api/collaboration: that scope carries no rate
+                    // limiter, and a 10MB multipart write needs one.
                     .configure(crate::handlers::collab_images::config)
 
                     // ===== SSE / SEARCH / NOTIFICATIONS / BUG REPORTS =====

--- a/backend/src/utils/markdown_export.rs
+++ b/backend/src/utils/markdown_export.rs
@@ -9,6 +9,7 @@ use yrs::{
 
 use crate::db::DbConnection;
 use crate::repository;
+use crate::repository::PageAudience;
 use crate::utils::i18n;
 
 const MAX_EMBED_DEPTH: usize = 10;
@@ -58,10 +59,34 @@ pub fn yjs_to_markdown(yjs_document: &[u8]) -> Option<String> {
     }
 }
 
+/// Everything needed to follow an `embedded_document` node: the connection to
+/// read the embedded page with, and who the export is for.
+///
+/// They are bundled rather than passed separately because they must not be
+/// separable. A page the caller may read can embed one they may not, so an
+/// exporter holding a connection but no audience would silently render content
+/// past the ACL. Requiring both to resolve an embed makes that a type error
+/// rather than a discipline.
+pub struct EmbedResolver<'a> {
+    pub conn: &'a mut DbConnection,
+    pub audience: PageAudience,
+}
+
+impl EmbedResolver<'_> {
+    /// Reborrow for a recursive call. `Option<&mut _>` is not `Copy`, and
+    /// `as_deref_mut` does not apply to a plain struct.
+    fn reborrow(&mut self) -> EmbedResolver<'_> {
+        EmbedResolver {
+            conn: self.conn,
+            audience: self.audience,
+        }
+    }
+}
+
 /// Convert a Yjs document to Markdown with recursive embed resolution
 pub fn yjs_to_markdown_with_embeds(
     yjs_document: &[u8],
-    conn: &mut DbConnection,
+    resolver: &mut EmbedResolver<'_>,
     visited: &mut HashSet<Uuid>,
     current_uuid: Option<Uuid>,
     depth: usize,
@@ -112,7 +137,7 @@ pub fn yjs_to_markdown_with_embeds(
 
     let mut output = String::new();
     for child in fragment.children(&txn) {
-        let block = node_to_markdown_with_embeds(&child, &txn, 0, conn, visited, depth, locale);
+        let block = node_to_markdown_with_embeds(&child, &txn, 0, resolver, visited, depth, locale);
         if !block.is_empty() {
             output.push_str(&block);
             output.push('\n');
@@ -159,7 +184,7 @@ fn node_to_markdown_with_embeds(
     node: &XmlOut,
     txn: &yrs::Transaction,
     list_depth: usize,
-    conn: &mut DbConnection,
+    resolver: &mut EmbedResolver<'_>,
     visited: &mut HashSet<Uuid>,
     embed_depth: usize,
     locale: &LanguageIdentifier,
@@ -173,7 +198,7 @@ fn node_to_markdown_with_embeds(
                 elem,
                 txn,
                 list_depth,
-                Some(conn),
+                Some(resolver.reborrow()),
                 visited,
                 embed_depth,
                 Some(locale),
@@ -186,7 +211,7 @@ fn node_to_markdown_with_embeds(
                     &child,
                     txn,
                     list_depth,
-                    conn,
+                    resolver,
                     visited,
                     embed_depth,
                     locale,
@@ -207,7 +232,7 @@ fn element_to_markdown(
     elem: &yrs::XmlElementRef,
     txn: &yrs::Transaction,
     list_depth: usize,
-    mut conn: Option<&mut DbConnection>,
+    mut resolver: Option<EmbedResolver<'_>>,
     visited: &mut HashSet<Uuid>,
     embed_depth: usize,
     locale: Option<&LanguageIdentifier>,
@@ -240,7 +265,7 @@ fn element_to_markdown(
                 elem,
                 txn,
                 list_depth,
-                conn.as_deref_mut(),
+                resolver.as_mut().map(EmbedResolver::reborrow),
                 visited,
                 embed_depth,
                 locale,
@@ -262,7 +287,7 @@ fn element_to_markdown(
                             li,
                             txn,
                             list_depth,
-                            conn.as_deref_mut(),
+                            resolver.as_mut().map(EmbedResolver::reborrow),
                             visited,
                             embed_depth,
                             locale,
@@ -284,7 +309,7 @@ fn element_to_markdown(
                             li,
                             txn,
                             list_depth,
-                            conn.as_deref_mut(),
+                            resolver.as_mut().map(EmbedResolver::reborrow),
                             visited,
                             embed_depth,
                             locale,
@@ -340,10 +365,20 @@ fn element_to_markdown(
                 .map(|v| v.to_string(txn))
                 .unwrap_or(untitled_fallback);
 
-            if let Some(conn) = conn {
+            if let Some(mut resolver) = resolver {
                 if let (Ok(uuid), Some(loc)) = (Uuid::parse_str(&doc_uuid_str), locale) {
                     if embed_depth < MAX_EMBED_DEPTH && !visited.contains(&uuid) {
-                        if let Ok(page) = repository::get_documentation_page_by_uuid(&uuid, conn) {
+                        let conn = &mut *resolver.conn;
+                        // An embedded page carries its own ACL. Read it only if
+                        // this export's audience may read it; otherwise fall
+                        // through to the reference fallback below, which prints
+                        // the title the embedding document already contains and
+                        // none of the embedded content.
+                        let readable = repository::get_documentation_page_by_uuid(&uuid, conn)
+                            .ok()
+                            .filter(|page| resolver.audience.can_read(resolver.conn, page.id));
+                        if let Some(page) = readable {
+                            let conn = &mut *resolver.conn;
                             let yjs_doc = page.yjs_document.as_ref()
                                 .cloned()
                                 .or_else(|| {
@@ -357,7 +392,7 @@ fn element_to_markdown(
                             if let Some(doc_bytes) = yjs_doc {
                                 if let Some(content) = yjs_to_markdown_with_embeds(
                                     &doc_bytes,
-                                    conn,
+                                    &mut resolver,
                                     visited,
                                     Some(uuid),
                                     embed_depth + 1,
@@ -514,7 +549,7 @@ fn collect_block_children(
     elem: &yrs::XmlElementRef,
     txn: &yrs::Transaction,
     list_depth: usize,
-    mut conn: Option<&mut DbConnection>,
+    mut resolver: Option<EmbedResolver<'_>>,
     visited: &mut HashSet<Uuid>,
     embed_depth: usize,
     locale: Option<&LanguageIdentifier>,
@@ -529,7 +564,7 @@ fn collect_block_children(
                     child_elem,
                     txn,
                     list_depth,
-                    conn.as_deref_mut(),
+                    resolver.as_mut().map(EmbedResolver::reborrow),
                     visited,
                     embed_depth,
                     locale,
@@ -555,7 +590,7 @@ fn collect_list_item_content(
     li: &yrs::XmlElementRef,
     txn: &yrs::Transaction,
     list_depth: usize,
-    mut conn: Option<&mut DbConnection>,
+    mut resolver: Option<EmbedResolver<'_>>,
     visited: &mut HashSet<Uuid>,
     embed_depth: usize,
     locale: Option<&LanguageIdentifier>,
@@ -575,7 +610,7 @@ fn collect_list_item_content(
                     child_elem,
                     txn,
                     list_depth + 1,
-                    conn.as_deref_mut(),
+                    resolver.as_mut().map(EmbedResolver::reborrow),
                     visited,
                     embed_depth,
                     locale,
@@ -586,7 +621,7 @@ fn collect_list_item_content(
                     child_elem,
                     txn,
                     list_depth,
-                    conn.as_deref_mut(),
+                    resolver.as_mut().map(EmbedResolver::reborrow),
                     visited,
                     embed_depth,
                     locale,

--- a/backend/tests/directory_scoping.rs
+++ b/backend/tests/directory_scoping.rs
@@ -1,0 +1,119 @@
+//! Identity resolution is scoped by workspace membership.
+//!
+//! `users` has no row-level security, deliberately: an account spans
+//! workspaces, so there is no workspace column for RLS to key on. That makes a
+//! uuid-keyed read of `users` unscoped, and pinning the request's workspace
+//! does not fix it, because the pin constrains the RLS-bearing tables joined
+//! alongside the identity row rather than the row itself.
+//!
+//! These drive `repository::directory` directly, since it is the join that
+//! carries the property.
+
+#![allow(clippy::expect_used)]
+
+use backend::db::DbConnection;
+use backend::repository::directory;
+use backend::repository::workspaces::{add_membership, remove_membership, SeatWriteAuthority};
+use backend::sync::actor::ActorContext;
+use backend::sync::session::with_actor_context;
+
+mod common;
+
+fn join(conn: &mut DbConnection, workspace_id: i32, user: uuid::Uuid, role: &str) {
+    let actor = ActorContext::user(user, None).with_workspace(workspace_id);
+    with_actor_context::<_, diesel::result::Error>(conn, &actor, |c| {
+        add_membership(
+            c,
+            workspace_id,
+            user,
+            role,
+            SeatWriteAuthority::ControlPlane,
+        )?;
+        Ok(())
+    })
+    .expect("add membership");
+}
+
+#[test]
+fn a_member_of_another_workspace_does_not_resolve() {
+    common::ensure_test_keyring();
+    let test_db = common::TestDb::new();
+    let pool = test_db.pool_with_size(2);
+    let mut conn = pool.get().expect("conn");
+
+    let ours = common::mint_workspace(&mut conn, "acme-dir-ours", "Ours");
+    let theirs = common::mint_workspace(&mut conn, "acme-dir-theirs", "Theirs");
+    let colleague = common::insert_user(&mut conn, "Our Colleague");
+    let stranger = common::insert_user(&mut conn, "Their Employee");
+
+    join(&mut conn, ours, colleague.uuid, "agent");
+    join(&mut conn, theirs, stranger.uuid, "agent");
+
+    assert!(
+        directory::find_member(&mut conn, ours, colleague.uuid)
+            .expect("query")
+            .is_some(),
+        "a member of this workspace resolves"
+    );
+    assert!(
+        directory::find_member(&mut conn, ours, stranger.uuid)
+            .expect("query")
+            .is_none(),
+        "someone else's employee must not resolve by uuid alone"
+    );
+}
+
+#[test]
+fn a_batch_lookup_is_not_a_cheaper_oracle() {
+    common::ensure_test_keyring();
+    let test_db = common::TestDb::new();
+    let pool = test_db.pool_with_size(2);
+    let mut conn = pool.get().expect("conn");
+
+    let ours = common::mint_workspace(&mut conn, "acme-dir-batch", "Ours Batch");
+    let theirs = common::mint_workspace(&mut conn, "acme-dir-batch-x", "Theirs Batch");
+    let colleague = common::insert_user(&mut conn, "Batch Colleague");
+    let stranger = common::insert_user(&mut conn, "Batch Stranger");
+
+    join(&mut conn, ours, colleague.uuid, "agent");
+    join(&mut conn, theirs, stranger.uuid, "agent");
+
+    let found =
+        directory::find_members(&mut conn, ours, &[colleague.uuid, stranger.uuid]).expect("query");
+    let uuids: Vec<uuid::Uuid> = found.iter().map(|u| u.uuid).collect();
+    assert!(uuids.contains(&colleague.uuid));
+    assert!(
+        !uuids.contains(&stranger.uuid),
+        "batching must not resolve what the singular lookup hides"
+    );
+}
+
+/// The reason `removed_at` had to land before this join could. Identity
+/// resolution deliberately ignores membership status, or every person who has
+/// ever left renders as an unknown user on the tickets and comments they left
+/// behind.
+#[test]
+fn a_former_colleague_still_resolves() {
+    common::ensure_test_keyring();
+    let test_db = common::TestDb::new();
+    let pool = test_db.pool_with_size(2);
+    let mut conn = pool.get().expect("conn");
+
+    let ws = common::mint_workspace(&mut conn, "acme-dir-former", "Ours Former");
+    let leaver = common::insert_user(&mut conn, "Former Colleague");
+    join(&mut conn, ws, leaver.uuid, "agent");
+
+    let actor = ActorContext::user(leaver.uuid, None).with_workspace(ws);
+    with_actor_context::<_, diesel::result::Error>(&mut conn, &actor, |c| {
+        remove_membership(c, ws, leaver.uuid, SeatWriteAuthority::ControlPlane)?;
+        Ok(())
+    })
+    .expect("remove");
+
+    assert!(
+        directory::find_member(&mut conn, ws, leaver.uuid)
+            .expect("query")
+            .is_some(),
+        "a former member's name must still resolve, or their history renders blank"
+    );
+}

--- a/backend/tests/documentation_export_acl.rs
+++ b/backend/tests/documentation_export_acl.rs
@@ -1,0 +1,193 @@
+//! Documentation export honours the page ACL, on the page and on its embeds.
+//!
+//! `export_page_as_markdown` used to read a page and follow every
+//! `embedded_document` node in it without consulting
+//! `can_user_access_page`, which the ordinary page read does consult. The
+//! interesting half is the embed: a page the caller may read can embed one
+//! they may not, so checking only the top-level page checks the wrong thing.
+//!
+//! These drive `yjs_to_markdown_with_embeds` directly, the way
+//! `portal_session` drives the portal primitives, because that function is
+//! where the audience travels with the recursion.
+
+#![allow(clippy::expect_used)]
+
+use diesel::prelude::*;
+use yrs::types::xml::XmlIn;
+use yrs::{Doc, ReadTxn, Transact, WriteTxn, XmlElementPrelim, XmlFragment};
+
+use backend::db::DbConnection;
+use backend::models::{DocumentationStatus, NewDocumentationPage, User};
+use backend::repository::PageAudience;
+use backend::utils::markdown_export::{yjs_to_markdown_with_embeds, EmbedResolver};
+
+mod common;
+
+/// A y-prosemirror fragment holding `text`, built by the converter the app
+/// itself uses so the fixture cannot drift from the real document shape.
+fn page_body(text: &str) -> Vec<u8> {
+    backend::services::seed::markdown_to_yjs(text).expect("build body")
+}
+
+/// A fragment that embeds `child_uuid`, the shape the editor writes.
+fn page_embedding(child_uuid: uuid::Uuid, child_title: &str) -> Vec<u8> {
+    let doc = Doc::new();
+    let fragment = {
+        let mut txn = doc.transact_mut();
+        txn.get_or_insert_xml_fragment("prosemirror")
+    };
+    {
+        let mut txn = doc.transact_mut();
+        let mut embed = XmlElementPrelim::new("embedded_document", Vec::<XmlIn>::new());
+        embed
+            .attributes
+            .insert("documentUuid".into(), child_uuid.to_string());
+        embed
+            .attributes
+            .insert("documentTitle".into(), child_title.to_string());
+        fragment.push_back(&mut txn, embed);
+    }
+    let txn = doc.transact();
+    txn.encode_state_as_update_v1(&yrs::StateVector::default())
+}
+
+fn insert_page(
+    conn: &mut DbConnection,
+    author: &User,
+    title: &str,
+    slug: &str,
+    body: Vec<u8>,
+) -> backend::models::DocumentationPage {
+    use backend::schema::documentation_pages;
+    let new = NewDocumentationPage {
+        uuid: uuid::Uuid::new_v4(),
+        title: title.to_string(),
+        slug: slug.to_string(),
+        icon: None,
+        cover_image: None,
+        status: DocumentationStatus::Published,
+        created_by: author.uuid,
+        last_edited_by: author.uuid,
+        parent_id: None,
+        display_order: None,
+        is_public: false,
+        is_template: false,
+        yjs_state_vector: None,
+        yjs_document: Some(body),
+        yjs_client_id: None,
+        has_unsaved_changes: false,
+    };
+    diesel::insert_into(documentation_pages::table)
+        .values(&new)
+        .get_result(conn)
+        .expect("insert page")
+}
+
+/// Give the page an explicit visibility override naming somebody else, which
+/// is the cheapest way to make `can_user_access_page` say no: any override at
+/// all switches the page from "inherit" to "listed users and groups only".
+fn restrict_page_to(conn: &mut DbConnection, page_id: i32, workspace_id: i32, grantee: uuid::Uuid) {
+    use backend::schema::documentation_page_visibility as v;
+    diesel::insert_into(v::table)
+        .values((
+            v::page_id.eq(page_id),
+            v::user_uuid.eq(Some(grantee)),
+            v::workspace_id.eq(workspace_id),
+        ))
+        .execute(conn)
+        .expect("restrict page");
+}
+
+struct Fixture {
+    parent_body: Vec<u8>,
+    secret_title: String,
+    secret_text: String,
+    reader: uuid::Uuid,
+}
+
+fn setup(conn: &mut DbConnection, slug: &str) -> Fixture {
+    let workspace_id = common::mint_workspace(conn, slug, slug);
+    backend::sync::session::pin_workspace(conn, workspace_id).expect("pin");
+    let author = common::insert_user(conn, "Doc Author");
+    let reader = common::insert_user(conn, "Doc Reader");
+    let other = common::insert_user(conn, "Someone Else");
+
+    let secret_text = "the embedded secret".to_string();
+    let secret = insert_page(
+        conn,
+        &author,
+        "Secret Page",
+        &format!("{slug}-secret"),
+        page_body(&secret_text),
+    );
+    restrict_page_to(conn, secret.id, workspace_id, other.uuid);
+
+    let parent_body = page_embedding(secret.uuid, "Secret Page");
+    Fixture {
+        parent_body,
+        secret_title: "Secret Page".to_string(),
+        secret_text,
+        reader: reader.uuid,
+    }
+}
+
+fn render(conn: &mut DbConnection, body: &[u8], audience: PageAudience) -> String {
+    let mut visited = std::collections::HashSet::new();
+    let locale: unic_langid::LanguageIdentifier = "en-US".parse().expect("locale");
+    let mut resolver = EmbedResolver { conn, audience };
+    yjs_to_markdown_with_embeds(body, &mut resolver, &mut visited, None, 0, &locale)
+        .unwrap_or_default()
+}
+
+#[test]
+fn an_export_omits_an_embedded_page_the_reader_cannot_open() {
+    common::ensure_test_keyring();
+    let test_db = common::TestDb::new();
+    let pool = test_db.pool_with_size(2);
+    let mut conn = pool.get().expect("conn");
+    let f = setup(&mut conn, "acme-embed-denied");
+
+    let out = render(
+        &mut conn,
+        &f.parent_body,
+        PageAudience::User {
+            user_uuid: f.reader,
+            is_admin: false,
+        },
+    );
+
+    assert!(
+        !out.contains(&f.secret_text),
+        "an embedded page outside the reader's ACL must not be rendered: {out}"
+    );
+    assert!(
+        out.contains(&f.secret_title),
+        "the fallback reference still names the page, which the embedding \
+         document already contained: {out}"
+    );
+}
+
+#[test]
+fn an_export_includes_an_embedded_page_the_reader_can_open() {
+    common::ensure_test_keyring();
+    let test_db = common::TestDb::new();
+    let pool = test_db.pool_with_size(2);
+    let mut conn = pool.get().expect("conn");
+    let f = setup(&mut conn, "acme-embed-allowed");
+
+    // Same document, same fixture, admin audience: proves the omission above
+    // is the ACL talking and not the embed machinery failing to resolve.
+    let out = render(
+        &mut conn,
+        &f.parent_body,
+        PageAudience::User {
+            user_uuid: f.reader,
+            is_admin: true,
+        },
+    );
+
+    assert!(
+        out.contains(&f.secret_text),
+        "an admin's export must still resolve the embed: {out}"
+    );
+}

--- a/backend/tests/integration_routes_require_admin.rs
+++ b/backend/tests/integration_routes_require_admin.rs
@@ -1,0 +1,68 @@
+//! Every route on the Entra/Intune integration is workspace-admin only.
+//!
+//! The integration runs on the organisation's own Graph app credentials, so
+//! reading its configuration, probing the live connection, or cancelling a
+//! running directory sync are all admin actions. Eight of these handlers used
+//! to check only that the caller was authenticated, which made them member-
+//! reachable while the sibling Graph proxy in `microsoft_graph.rs` required
+//! admin for the same credentials.
+//!
+//! Asserted at the source rather than over HTTP: the gate itself
+//! (`require_workspace_role`) needs a resolved workspace and a membership row,
+//! and what regresses in practice is a ninth handler being added with the weak
+//! check copied from its neighbours.
+
+use std::fs;
+use std::path::PathBuf;
+
+use regex::Regex;
+
+/// Bare authentication: claims are read out of the request extensions and
+/// nothing further is asked. Correct for a self-service route, wrong for every
+/// route in these two modules.
+const BARE_AUTH: &str = "req.extensions().get::<crate::models::Claims>()";
+
+#[test]
+fn graph_integration_handlers_require_workspace_admin() {
+    let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let mut offenders: Vec<String> = Vec::new();
+    let routed =
+        Regex::new(r"web::(?:get|post|put|patch|delete)\(\)\.to\((\w+)\)").expect("route regex");
+
+    for module in ["msgraph_integration.rs", "microsoft_graph.rs"] {
+        let path = manifest.join("src/handlers").join(module);
+        let src = fs::read_to_string(&path).expect("read module");
+        // Drop the test module, which may legitimately build bare claims.
+        let src = src.split("#[cfg(test)]").next().unwrap_or(&src).to_string();
+
+        let handlers: Vec<String> = routed
+            .captures_iter(&src)
+            .map(|c| c[1].to_string())
+            .collect();
+        assert!(
+            !handlers.is_empty(),
+            "{module}: found no routes; the scanner has drifted from the config fn"
+        );
+
+        for name in handlers {
+            let Some(start) = src.find(&format!("fn {name}(")) else {
+                continue;
+            };
+            let body = &src[start..];
+            let end = body.find("\n}\n").map(|i| i + 2).unwrap_or(body.len());
+            let body = &body[..end];
+            if body.contains(BARE_AUTH) && !body.contains("require_workspace_role") {
+                offenders.push(format!("{module}::{name}"));
+            }
+        }
+    }
+
+    assert!(
+        offenders.is_empty(),
+        "These Graph integration handlers gate on being authenticated rather than \
+         on being a workspace admin, though they act through the organisation's \
+         Graph credentials:\n  {}\n\nAdd:\n  \
+         crate::utils::rbac::require_workspace_role(&req, crate::models::WorkspaceRole::Admin)",
+        offenders.join("\n  ")
+    );
+}

--- a/backend/tests/user_contact_gate.rs
+++ b/backend/tests/user_contact_gate.rs
@@ -1,0 +1,67 @@
+//! Every contact handler runs the contact gate, reads included.
+//!
+//! `user_contact.rs` states its own contract at the top of the module:
+//! "Profile reads/writes mirror the user-update gate (self or admin)". The
+//! writes did. The three read handlers took `AuthContext`, bound it to `_auth`
+//! and discarded it, so any member of a workspace could read any other
+//! member's profile fields, phone numbers and postal addresses. The handlers
+//! contradicted the module's own stated contract, which is the kind of thing
+//! review does not catch because the signature looks right.
+//!
+//! Scoped to this module on purpose. A general "no handler discards
+//! `AuthContext`" lint was measured and rejected: 43 handlers bind `_auth`,
+//! and nearly all are legitimate, workspace-scoped resources where the
+//! `TenantConn` RLS pin is the whole authorization and the extractor is
+//! present only to require authentication. That lint would have meant ~42
+//! exemption markers for one finding, the same reason the per-handler
+//! authorization lint was rejected in `route_auth_funnel_lint`.
+
+use std::fs;
+use std::path::PathBuf;
+
+use regex::Regex;
+
+const GATE: &str = "guard_contact_access";
+
+#[test]
+fn contact_handlers_run_the_contact_gate() {
+    let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let src = fs::read_to_string(manifest.join("src/handlers/user_contact.rs"))
+        .expect("read user_contact.rs");
+
+    // Handlers only: this module's helpers take neither extractor.
+    let fn_re = Regex::new(r"(?m)^pub async fn (\w+)\(").expect("fn regex");
+    let mut ungated: Vec<String> = Vec::new();
+
+    for caps in fn_re.captures_iter(&src) {
+        let name = caps.get(1).expect("name").as_str();
+        let start = caps.get(0).expect("m").start();
+        let end = src[start..]
+            .find("\n}\n")
+            .map(|i| start + i)
+            .unwrap_or(src.len());
+        let body = &src[start..end];
+
+        // Only handlers with a per-person subject are in scope. The field-schema
+        // handlers act on the workspace's schema, not on anyone's details, and
+        // the module doc says schema reads are open to authenticated staff.
+        if !body.contains("web::Path<Uuid>") {
+            continue;
+        }
+        // A decision about the subject is either the shared gate or an explicit
+        // comparison against it. Taking `AuthContext` and binding it to `_auth`
+        // is neither, and is exactly what the reads used to do.
+        if !body.contains(GATE) && !body.contains("auth.user_uuid != user_uuid") {
+            ungated.push(name.to_string());
+        }
+    }
+
+    assert!(
+        ungated.is_empty(),
+        "These contact handlers name a subject user in their path but make no \
+         authorization decision about them, so they read or write one person's \
+         contact details on another person's say-so:\n  {}\n\n\
+         Call `{GATE}`, which is the gate the module's own doc comment describes.",
+        ungated.join("\n  "),
+    );
+}

--- a/backend/tests/workspace_member_soft_remove.rs
+++ b/backend/tests/workspace_member_soft_remove.rs
@@ -1,0 +1,262 @@
+//! Soft-removed memberships: the row survives, the access does not.
+//!
+//! `remove_membership` stamps `removed_at` instead of deleting, so a former
+//! colleague's name still resolves on the tickets and comments they left
+//! behind. Everything else must behave as if the row were gone, and the
+//! re-invite path has to work, since a conflicting row now always exists.
+
+#![allow(clippy::expect_used)]
+
+use diesel::prelude::*;
+
+use backend::db::DbConnection;
+use backend::repository::workspaces::{
+    add_membership, count_staff_members, membership, remove_membership, AddMembershipOutcome,
+    RemoveMembershipOutcome, SeatWriteAuthority,
+};
+use backend::sync::actor::ActorContext;
+use backend::sync::session::with_actor_context;
+
+mod common;
+
+fn try_as_actor<T>(
+    conn: &mut DbConnection,
+    workspace_id: i32,
+    user: uuid::Uuid,
+    f: impl FnOnce(&mut DbConnection) -> QueryResult<T>,
+) -> QueryResult<T> {
+    let actor = ActorContext::user(user, None).with_workspace(workspace_id);
+    with_actor_context::<_, diesel::result::Error>(conn, &actor, f)
+}
+
+fn as_actor<T>(
+    conn: &mut DbConnection,
+    workspace_id: i32,
+    user: uuid::Uuid,
+    f: impl FnOnce(&mut DbConnection) -> QueryResult<T>,
+) -> T {
+    try_as_actor(conn, workspace_id, user, f).expect("actor txn")
+}
+
+/// Whether adding this member succeeded. The seat-limit trigger raises, which
+/// aborts the transaction, so the error has to propagate out of the actor
+/// wrapper for the rollback to happen; swallowing it inside leaves the
+/// connection poisoned for every later statement.
+fn try_add_staff(conn: &mut DbConnection, workspace_id: i32, user: uuid::Uuid) -> bool {
+    try_as_actor(conn, workspace_id, user, |c| {
+        add_membership(
+            c,
+            workspace_id,
+            user,
+            "agent",
+            SeatWriteAuthority::ControlPlane,
+        )
+    })
+    .is_ok()
+}
+
+/// The raw row, ignoring `removed_at`, which is what identity resolution does.
+fn row_exists(conn: &mut DbConnection, workspace_id: i32, user: uuid::Uuid) -> bool {
+    use backend::schema::workspace_members as wm;
+    diesel::select(diesel::dsl::exists(
+        wm::table
+            .filter(wm::workspace_id.eq(workspace_id))
+            .filter(wm::user_uuid.eq(user)),
+    ))
+    .get_result(conn)
+    .expect("row exists")
+}
+
+fn set_seat_limit(conn: &mut DbConnection, workspace_id: i32, limit: i32) {
+    use backend::schema::workspaces;
+    diesel::update(workspaces::table.filter(workspaces::id.eq(workspace_id)))
+        .set(workspaces::seat_limit.eq(limit))
+        .execute(conn)
+        .expect("set seat limit");
+}
+
+#[test]
+fn removal_keeps_the_row_but_ends_the_membership() {
+    common::ensure_test_keyring();
+    let test_db = common::TestDb::new();
+    let pool = test_db.pool_with_size(2);
+    let mut conn = pool.get().expect("conn");
+
+    let ws = common::mint_workspace(&mut conn, "acme-soft-remove", "Acme Soft Remove");
+    let leaver = common::insert_user(&mut conn, "The Leaver");
+
+    as_actor(&mut conn, ws, leaver.uuid, |c| {
+        add_membership(
+            c,
+            ws,
+            leaver.uuid,
+            "agent",
+            SeatWriteAuthority::ControlPlane,
+        )?;
+        Ok(())
+    });
+    assert!(
+        as_actor(&mut conn, ws, leaver.uuid, |c| membership(
+            c,
+            ws,
+            leaver.uuid
+        ))
+        .is_some(),
+        "precondition: an active membership"
+    );
+
+    let outcome = as_actor(&mut conn, ws, leaver.uuid, |c| {
+        remove_membership(c, ws, leaver.uuid, SeatWriteAuthority::ControlPlane)
+    });
+    assert!(matches!(outcome, RemoveMembershipOutcome::Removed));
+
+    assert!(
+        as_actor(&mut conn, ws, leaver.uuid, |c| membership(
+            c,
+            ws,
+            leaver.uuid
+        ))
+        .is_none(),
+        "a removed member must not resolve as a member"
+    );
+    assert!(
+        row_exists(&mut conn, ws, leaver.uuid),
+        "but the row must survive, or their name vanishes from everything they touched"
+    );
+}
+
+#[test]
+fn a_removed_staff_member_frees_their_seat() {
+    common::ensure_test_keyring();
+    let test_db = common::TestDb::new();
+    let pool = test_db.pool_with_size(2);
+    let mut conn = pool.get().expect("conn");
+
+    let ws = common::mint_workspace(&mut conn, "acme-seat-freed", "Acme Seat Freed");
+    let first = common::insert_user(&mut conn, "First Agent");
+    let second = common::insert_user(&mut conn, "Second Agent");
+
+    as_actor(&mut conn, ws, first.uuid, |c| {
+        add_membership(c, ws, first.uuid, "agent", SeatWriteAuthority::ControlPlane)?;
+        Ok(())
+    });
+    set_seat_limit(&mut conn, ws, 1);
+
+    // The seat is taken, so a second agent is refused.
+    assert!(
+        !try_add_staff(&mut conn, ws, second.uuid),
+        "precondition: the seat cap is enforced"
+    );
+
+    as_actor(&mut conn, ws, first.uuid, |c| {
+        remove_membership(c, ws, first.uuid, SeatWriteAuthority::ControlPlane)
+    });
+    assert_eq!(
+        as_actor(&mut conn, ws, first.uuid, |c| count_staff_members(c, ws)),
+        0,
+        "a removed staff member must stop consuming a licensed seat"
+    );
+
+    assert!(
+        try_add_staff(&mut conn, ws, second.uuid),
+        "and the freed seat must be usable"
+    );
+}
+
+#[test]
+fn re_adding_a_removed_member_restores_them() {
+    common::ensure_test_keyring();
+    let test_db = common::TestDb::new();
+    let pool = test_db.pool_with_size(2);
+    let mut conn = pool.get().expect("conn");
+
+    let ws = common::mint_workspace(&mut conn, "acme-rejoin", "Acme Rejoin");
+    let returner = common::insert_user(&mut conn, "The Returner");
+
+    as_actor(&mut conn, ws, returner.uuid, |c| {
+        add_membership(
+            c,
+            ws,
+            returner.uuid,
+            "agent",
+            SeatWriteAuthority::ControlPlane,
+        )?;
+        Ok(())
+    });
+    as_actor(&mut conn, ws, returner.uuid, |c| {
+        remove_membership(c, ws, returner.uuid, SeatWriteAuthority::ControlPlane)
+    });
+
+    // The row still exists, so the insert conflicts. Under the old
+    // `ON CONFLICT DO NOTHING` this silently left them removed.
+    let outcome = as_actor(&mut conn, ws, returner.uuid, |c| {
+        add_membership(
+            c,
+            ws,
+            returner.uuid,
+            "agent",
+            SeatWriteAuthority::ControlPlane,
+        )
+    });
+    assert!(matches!(outcome, AddMembershipOutcome::Added(n) if n == 1));
+    assert!(
+        as_actor(&mut conn, ws, returner.uuid, |c| membership(
+            c,
+            ws,
+            returner.uuid
+        ))
+        .is_some(),
+        "re-adding a removed member must make them a member again"
+    );
+}
+
+/// Re-invites are hires. Removing a staff member frees their seat, so coming
+/// back has to compete for one like anyone else, or a workspace could cycle
+/// people through removal and re-adding to exceed its licence.
+///
+/// Worth knowing which mechanism enforces this. Re-activation runs through
+/// `add_membership`'s `ON CONFLICT DO UPDATE`, and a conflicting upsert fires
+/// BEFORE INSERT and then BEFORE UPDATE, so the seat check refuses on the
+/// INSERT pass. The `OLD.removed_at IS NULL` condition added to the trigger's
+/// UPDATE short-circuit is defence-in-depth for a future direct
+/// `UPDATE ... SET removed_at = NULL`, and this test passes with or without
+/// it; it is the behaviour that is pinned here, not that clause.
+#[test]
+fn re_adding_a_removed_staff_member_still_respects_the_seat_cap() {
+    common::ensure_test_keyring();
+    let test_db = common::TestDb::new();
+    let pool = test_db.pool_with_size(2);
+    let mut conn = pool.get().expect("conn");
+
+    let ws = common::mint_workspace(&mut conn, "acme-rejoin-cap", "Acme Rejoin Cap");
+    let leaver = common::insert_user(&mut conn, "Departed Agent");
+    let replacement = common::insert_user(&mut conn, "Replacement Agent");
+
+    as_actor(&mut conn, ws, leaver.uuid, |c| {
+        add_membership(
+            c,
+            ws,
+            leaver.uuid,
+            "agent",
+            SeatWriteAuthority::ControlPlane,
+        )?;
+        Ok(())
+    });
+    set_seat_limit(&mut conn, ws, 1);
+
+    // They leave, and the one seat is given to somebody else.
+    as_actor(&mut conn, ws, leaver.uuid, |c| {
+        remove_membership(c, ws, leaver.uuid, SeatWriteAuthority::ControlPlane)
+    });
+    assert!(
+        try_add_staff(&mut conn, ws, replacement.uuid),
+        "the freed seat goes to the replacement"
+    );
+
+    // Now the leaver comes back. The seat is gone, so this must be refused.
+    assert!(
+        !try_add_staff(&mut conn, ws, leaver.uuid),
+        "re-activating a removed staff member consumes a seat and must be capped \
+         like any other hire"
+    );
+}

--- a/backend/tests/workspace_members_active_filter_lint.rs
+++ b/backend/tests/workspace_members_active_filter_lint.rs
@@ -1,0 +1,129 @@
+//! Lint: a read of `workspace_members` says whether it wants active members.
+//!
+//! `workspace_members` rows outlive the membership. `remove_membership` stamps
+//! `removed_at` rather than deleting, because the row is what lets a former
+//! colleague's name still render on the tickets, comments and audit entries
+//! they left behind. That makes every read ambiguous in a way it was not
+//! before:
+//!
+//! - **Role, permission and seat reads** must filter `removed_at IS NULL`.
+//!   Forgetting leaves a removed member holding their role, or consuming a
+//!   licensed seat forever.
+//! - **Identity resolution** must NOT filter, or the history the column exists
+//!   to preserve renders as an unknown user again.
+//!
+//! Both are one-line changes and neither fails loudly, so the mistake is
+//! invisible in review and in production. This makes the choice explicit.
+//!
+//! ## Escape hatch
+//!
+//! A read that deliberately spans removed members carries, on the line above
+//! the query or its enclosing `pub fn`:
+//!
+//! ```ignore
+//! // members-any-status: <why this read includes removed members>
+//! ```
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use regex::Regex;
+
+/// Files whose `workspace_members` use is not a tenant read at all.
+const SKIP: &[&str] = &["schema.rs", "test_helpers.rs"];
+
+/// Everything from the first `#[cfg(test)]` onward. Test modules build and tear
+/// down membership rows directly, which is not the behaviour under review;
+/// the other lints in this directory drop them the same way.
+fn strip_test_modules(src: &str) -> &str {
+    match src.find("#[cfg(test)]") {
+        Some(i) => &src[..i],
+        None => src,
+    }
+}
+
+const MARKER: &str = "members-any-status:";
+
+#[derive(Debug)]
+struct Violation {
+    relpath: String,
+    line: usize,
+    snippet: String,
+}
+
+fn scan(root: &Path, out: &mut Vec<Violation>) {
+    let table_re = Regex::new(r"workspace_members::table|FROM workspace_members").expect("re");
+    // The filter can be Diesel or raw SQL, and may sit several lines below the
+    // table reference, so the window is the query, not the line.
+    let filtered_re = Regex::new(r"removed_at\s*(?:\.is_null\(\)|IS NULL)").expect("re");
+
+    for entry in walkdir::WalkDir::new(root)
+        .into_iter()
+        .filter_map(Result::ok)
+        .filter(|e| e.path().extension().and_then(|s| s.to_str()) == Some("rs"))
+    {
+        let path = entry.path();
+        let name = path.file_name().and_then(|s| s.to_str()).unwrap_or("");
+        if SKIP.contains(&name) {
+            continue;
+        }
+        let Ok(src) = fs::read_to_string(path) else {
+            continue;
+        };
+        let lines: Vec<&str> = strip_test_modules(&src).lines().collect();
+        for (i, line) in lines.iter().enumerate() {
+            if !table_re.is_match(line) {
+                continue;
+            }
+            // A query is at most ~18 lines here; look that far for the filter.
+            let end = (i + 18).min(lines.len());
+            let window = lines[i..end].join("\n");
+            if filtered_re.is_match(&window) {
+                continue;
+            }
+            // The marker may be above the query or above its enclosing fn.
+            let back = i.saturating_sub(25);
+            if lines[back..i].iter().any(|l| l.contains(MARKER)) {
+                continue;
+            }
+            out.push(Violation {
+                relpath: path
+                    .strip_prefix(root.parent().unwrap_or(root))
+                    .unwrap_or(path)
+                    .to_string_lossy()
+                    .replace('\\', "/"),
+                line: i + 1,
+                snippet: line.trim().chars().take(70).collect(),
+            });
+        }
+    }
+}
+
+#[test]
+fn workspace_members_reads_state_whether_they_want_active_members() {
+    let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let src_root = manifest.join("src");
+    assert!(src_root.exists());
+
+    let mut violations = Vec::new();
+    scan(&src_root, &mut violations);
+
+    if !violations.is_empty() {
+        let mut msg = String::from(
+            "\nThese reads of `workspace_members` neither filter `removed_at IS NULL`\n\
+             nor say that they mean to include removed members.\n\n\
+             A removed membership row still exists, so an unfiltered role, permission\n\
+             or seat read silently treats a removed person as a current one.\n\n\
+             Add `.filter(workspace_members::removed_at.is_null())` (or `AND removed_at\n\
+             IS NULL` in raw SQL), or, if the read genuinely spans removed members —\n\
+             identity resolution for historical records is the reason this column\n\
+             exists — put this directly above the query or its enclosing fn:\n\n  \
+             // members-any-status: <why>\n\n\
+             Sites:\n\n",
+        );
+        for v in &violations {
+            msg.push_str(&format!("  {}:{}  {}\n", v.relpath, v.line, v.snippet));
+        }
+        panic!("{msg}");
+    }
+}


### PR DESCRIPTION
> Stacks on #328 (soft-remove), which must merge first. The `directory` join deliberately ignores `removed_at`, so it depends on that column existing.

Two reads that resolved a person from a uuid without asking whether the caller was entitled to see them.

## Identity: `users` has no RLS, and that is not a bug

An account spans workspaces, so `users` has no workspace column for RLS to key on. It is global by design. The consequence is that a uuid-keyed read of it is unscoped, and pinning the request's workspace does not fix that: the pin constrains the RLS-bearing tables joined *alongside* the identity row (the role lookup), not the row itself. `handlers::users::get_user_by_uuid` pinned, looked correct, and returned any user in the deployment — name, avatar, primary email — to any authenticated member of any workspace.

The scope has to come from a join, so identity reads now go through `repository::directory`, which joins `workspace_members`. Both the singular and the batch endpoint use it, or batching becomes a cheaper oracle for exactly what the singular one hides. Unknown uuids are absent rather than reported, so neither endpoint distinguishes "no such user" from "not someone you can see".

`directory` deliberately ignores `removed_at`. It answers *who someone is*, not *what they may do*: a former colleague still has to render as a name on the tickets and comments they left behind. That is the whole reason #328 had to land first, and there is a test pinning it.

## Contact details: the module contradicted its own doc comment

`user_contact.rs` states at the top: "Profile reads/writes mirror the user-update gate (self or admin)". The writes did. The three read handlers took `AuthContext`, bound it to `_auth` and discarded it, so any member of a workspace could read any other member's profile fields, phone numbers and postal addresses. The signature looked right, which is why review would not catch it.

One gate now covers both directions, renamed `guard_contact_access` to reflect what it governs.

## A lint I measured and did not build

A discarded `_auth` is what went wrong here, and also in `list_page_tickets` (#325), so a general lint looked worth having. It is not: 43 handlers bind `_auth`, and nearly all are legitimate — workspace-scoped resources where the `TenantConn` RLS pin is the whole authorization and the extractor is present only to require authentication. That is ~42 exemption markers for one finding, the same arithmetic that rejected the per-handler authorization lint in #327.

So the invariant is scoped to this module, and asserts the precise property: a handler naming a subject user in its path must make an authorization decision about that subject. My first cut asserted "takes `AuthContext`" and wrongly flagged the two field-schema handlers, which act on the workspace's schema rather than on a person. Mutation-checked: reverting one read's gate turns it red.

## Noticed, not changed

`set_user_profile_fields` uses a stricter inline self-or-admin check than the shared gate, so an agent may edit a requester's phone number but not their profile fields. That asymmetry predates this work, and widening a write permission does not belong in a security fix.

Local: `cargo fmt` clean, `cargo clippy --all-targets` with no new warnings, `cargo test` 1947 passed / 0 failed.

https://claude.ai/code/session_017iEcp3fFMB594JYRZxcQ5H