### PR TITLE
Scope the email suppression list per workspace

### DIFF
--- a/backend/migrations/2026-09-10-000001_email_suppressions_workspace_scope/down.sql
+++ b/backend/migrations/2026-09-10-000001_email_suppressions_workspace_scope/down.sql
@@ -1,0 +1,18 @@
+-- Collapse back to one global list. Duplicate addresses across workspaces
+-- fold into the row with the highest bounce_count, since the column loses its
+-- per-tenant meaning.
+DROP POLICY IF EXISTS email_suppressions_workspace_isolation ON email_suppressions;
+ALTER TABLE email_suppressions NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE email_suppressions DISABLE ROW LEVEL SECURITY;
+
+DELETE FROM email_suppressions es
+ WHERE EXISTS (
+   SELECT 1 FROM email_suppressions keep
+    WHERE keep.email = es.email
+      AND (keep.bounce_count, keep.workspace_id) > (es.bounce_count, es.workspace_id)
+ );
+
+ALTER TABLE email_suppressions DROP CONSTRAINT email_suppressions_pkey;
+ALTER TABLE email_suppressions DROP CONSTRAINT email_suppressions_workspace_id_fkey;
+ALTER TABLE email_suppressions DROP COLUMN workspace_id;
+ALTER TABLE email_suppressions ADD PRIMARY KEY (email);

--- a/backend/migrations/2026-09-10-000001_email_suppressions_workspace_scope/up.sql
+++ b/backend/migrations/2026-09-10-000001_email_suppressions_workspace_scope/up.sql
@@ -1,0 +1,97 @@
+-- Scope the email suppression list per workspace.
+--
+-- The table was keyed on the address alone with no `workspace_id`, so the RLS
+-- GUC that `TenantConn` primes was a no-op for it and the three admin
+-- endpoints had no tenant predicate. On a multi-workspace deployment that let
+-- any workspace admin read, add to, and delete from every other tenant's
+-- suppression list. Reading it is the sharper half: the module's own doc
+-- withholds the list from agents precisely because it reveals email addresses
+-- they should not know, and a peer tenant knows them less.
+--
+-- Suppression is a property of a RELATIONSHIP, not of an address. A manual
+-- entry records that this workspace was asked to stop writing to someone, and
+-- deleting a peer's entry could resume mail to a person who opted out. Shared
+-- sender reputation is the ESP's concern, and SES keeps its own account-level
+-- suppression list for exactly that.
+--
+-- No audit trigger on this table, so the backfill needs no DISABLE TRIGGER
+-- dance (the DISABLE/ENABLE pair around it in the initial schema is a
+-- seed-load artefact). It is not a partitioned table either.
+
+ALTER TABLE email_suppressions ADD COLUMN workspace_id INTEGER;
+
+DO $$
+DECLARE
+    ws_count INTEGER;
+    sole_ws  INTEGER;
+    orphaned INTEGER;
+BEGIN
+    SELECT count(*) INTO ws_count FROM workspaces;
+
+    IF ws_count <= 1 THEN
+        -- Every self-hosted Community build is here: one workspace, so every
+        -- existing suppression is unambiguously its own and nothing is lost.
+        SELECT id INTO sole_ws FROM workspaces LIMIT 1;
+        UPDATE email_suppressions SET workspace_id = sole_ws;
+    ELSE
+        -- Attribute each suppression to the workspaces that actually mailed
+        -- that address. Deriving it from evidence rather than assigning
+        -- everything to one workspace matters here: copying a row into a
+        -- workspace that never wrote to the address would hand that tenant an
+        -- email address it has no relationship with, which is the leak this
+        -- migration exists to close.
+        --
+        -- One row per (workspace, address) pair. The first is claimed by
+        -- UPDATE; any others are inserted as copies, since two tenants can
+        -- each legitimately have hard-bounced the same address.
+        UPDATE email_suppressions es
+           SET workspace_id = sub.workspace_id
+          FROM (
+            SELECT lower(oe.recipient) AS email,
+                   min(oe.workspace_id) AS workspace_id
+              FROM outbound_emails oe
+             GROUP BY lower(oe.recipient)
+          ) sub
+         WHERE sub.email = es.email;
+
+        INSERT INTO email_suppressions
+            (email, reason, bounce_diagnostic, bounce_count, created_at, last_seen_at, metadata, workspace_id)
+        SELECT es.email, es.reason, es.bounce_diagnostic, es.bounce_count,
+               es.created_at, es.last_seen_at, es.metadata, others.workspace_id
+          FROM email_suppressions es
+          JOIN (
+            SELECT DISTINCT lower(oe.recipient) AS email, oe.workspace_id
+              FROM outbound_emails oe
+          ) others ON others.email = es.email
+         WHERE es.workspace_id IS NOT NULL
+           AND others.workspace_id <> es.workspace_id;
+    END IF;
+
+    -- Anything still unattributed was never sent to by any workspace this
+    -- database still has history for. Dropping it is the only non-leaking
+    -- option, and it self-heals: the next hard bounce re-suppresses, for the
+    -- workspace that actually sent. Report the count so an operator reading
+    -- the migration log knows what went.
+    SELECT count(*) INTO orphaned FROM email_suppressions WHERE workspace_id IS NULL;
+    IF orphaned > 0 THEN
+        RAISE NOTICE 'email_suppressions: dropping % row(s) that no workspace has outbound history for', orphaned;
+        DELETE FROM email_suppressions WHERE workspace_id IS NULL;
+    END IF;
+END $$;
+
+ALTER TABLE email_suppressions ALTER COLUMN workspace_id SET NOT NULL;
+
+ALTER TABLE email_suppressions
+    ADD CONSTRAINT email_suppressions_workspace_id_fkey
+    FOREIGN KEY (workspace_id) REFERENCES workspaces(id) ON DELETE CASCADE;
+
+-- The address is only unique within a workspace now, so two tenants can each
+-- suppress the same person independently.
+ALTER TABLE email_suppressions DROP CONSTRAINT email_suppressions_pkey;
+ALTER TABLE email_suppressions ADD PRIMARY KEY (workspace_id, email);
+
+ALTER TABLE email_suppressions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE email_suppressions FORCE ROW LEVEL SECURITY;
+CREATE POLICY email_suppressions_workspace_isolation ON email_suppressions
+    USING (workspace_id = (NULLIF(current_setting('app.workspace_id', true), ''))::integer)
+    WITH CHECK (workspace_id = (NULLIF(current_setting('app.workspace_id', true), ''))::integer);

--- a/backend/src/handlers/email_suppressions.rs
+++ b/backend/src/handlers/email_suppressions.rs
@@ -7,7 +7,10 @@
 //!
 //! Workspace-admin-gated via `rbac::require_workspace_role`; no
 //! per-agent access (an agent seeing the suppression list could
-//! reveal email addresses they shouldn't know about).
+//! reveal email addresses they shouldn't know about). The same reasoning
+//! scopes the list per workspace: a peer tenant's admin knows those addresses
+//! less than an agent does, and deleting a peer's manual entry would resume
+//! mail to someone who asked them to stop.
 
 use actix_web::{web, HttpRequest, HttpResponse, Responder};
 use chrono::{DateTime, Utc};
@@ -72,13 +75,15 @@ pub async fn list(
     }
     let limit = query.limit.unwrap_or(50).clamp(1, 200);
     let before = query.before;
-    // `email_suppressions` is a platform-global table (no
-    // `workspace_id`), so the RLS GUC TenantConn primes is a no-op
-    // for it. Wrapping it in `tc.run` still gives us the transaction
-    // boundary that pairs the list + count counters consistently.
+    let Some(workspace_id) = tc.workspace_id() else {
+        return errors::forbidden("A resolved workspace is required");
+    };
+    // Both queries filter on the workspace explicitly. The table now carries
+    // RLS too, but the filter is what makes the query correct on its face;
+    // RLS is the backstop for a caller that forgets to pin.
     let result: diesel::QueryResult<(Vec<EmailSuppression>, i64)> = tc.run(|conn| {
-        let rows = repo::list(conn, limit, before)?;
-        let total = repo::count(conn)?;
+        let rows = repo::list(conn, workspace_id, limit, before)?;
+        let total = repo::count(conn, workspace_id)?;
         Ok((rows, total))
     });
     let (rows, total) = match result {
@@ -123,10 +128,14 @@ pub async fn create(
     if email.is_empty() || !email.contains('@') {
         return errors::bad_request("Email must look like an address");
     }
+    let Some(workspace_id) = tc.workspace_id() else {
+        return errors::forbidden("A resolved workspace is required");
+    };
     let new = NewEmailSuppression {
         email,
         reason: email_suppression_reason::MANUAL.to_string(),
         bounce_diagnostic: body.note.clone(),
+        workspace_id,
     };
     match tc.run(|conn| repo::upsert(conn, new)) {
         Ok(row) => HttpResponse::Ok().json(RowResponse::from(row)),
@@ -146,7 +155,12 @@ pub async fn delete(
         return resp;
     }
     let email = path.into_inner();
-    match tc.run(|conn| repo::remove(conn, &email)) {
+    let Some(workspace_id) = tc.workspace_id() else {
+        return errors::forbidden("A resolved workspace is required");
+    };
+    // A peer tenant's entry is now indistinguishable from an address that was
+    // never on the list, which is the right shape: no cross-tenant oracle.
+    match tc.run(|conn| repo::remove(conn, workspace_id, &email)) {
         Ok(0) => errors::not_found_msg("Address is not on the suppression list"),
         Ok(_) => HttpResponse::NoContent().finish(),
         Err(e) => {

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -7837,7 +7837,7 @@ pub mod outbound_email_mail_class {
 // migration `2026-05-12-110000_email_suppressions`.
 
 #[derive(Debug, Clone, Serialize, Deserialize, Queryable, Identifiable)]
-#[diesel(primary_key(email))]
+#[diesel(primary_key(workspace_id, email))]
 #[diesel(table_name = crate::schema::email_suppressions)]
 pub struct EmailSuppression {
     pub email: String,
@@ -7854,6 +7854,8 @@ pub struct EmailSuppression {
     pub created_at: chrono::DateTime<chrono::Utc>,
     pub last_seen_at: chrono::DateTime<chrono::Utc>,
     pub metadata: serde_json::Value,
+    /// The workspace this suppression belongs to; the list is per relationship.
+    pub workspace_id: i32,
 }
 
 #[derive(Debug, Clone, Insertable)]
@@ -7862,6 +7864,10 @@ pub struct NewEmailSuppression {
     pub email: String,
     pub reason: String,
     pub bounce_diagnostic: Option<String>,
+    /// Suppression is per relationship, not per address: it records that
+    /// *this* workspace should stop writing to someone. Required with no
+    /// default, so a new write site has to say which workspace it speaks for.
+    pub workspace_id: i32,
 }
 
 /// Suppression reason constants.

--- a/backend/src/repository/email_suppressions.rs
+++ b/backend/src/repository/email_suppressions.rs
@@ -6,9 +6,19 @@
 //!
 //! All writes canonicalise the email to lower-case so that
 //! `Alice@Example.com` and `alice@example.com` hash to the same
-//! row. The table's primary key is the lower-cased address so
+//! row. The primary key is `(workspace_id, lower(email))`, so
 //! re-inserting bumps `bounce_count` and `last_seen_at` via
 //! `ON CONFLICT DO UPDATE` rather than failing.
+//!
+//! **Every function here takes a `workspace_id`, and none of them may be
+//! given one it inferred.** Suppression is a property of a relationship: it
+//! records that a particular workspace should stop writing to someone. The
+//! table also carries FORCE row-level security now, which makes an unpinned
+//! read return zero rows — and for `is_suppressed`, zero rows reads as "go
+//! ahead and send". Passing the workspace explicitly means the query filters
+//! on it directly and RLS is the backstop rather than the mechanism, so a
+//! caller that forgets to pin still gets the right answer instead of a
+//! silent green light.
 
 use chrono::{DateTime, Utc};
 use diesel::prelude::*;
@@ -33,7 +43,7 @@ pub fn upsert(
     };
     diesel::insert_into(email_suppressions::table)
         .values(&normalized)
-        .on_conflict(email_suppressions::email)
+        .on_conflict((email_suppressions::workspace_id, email_suppressions::email))
         .do_update()
         .set((
             email_suppressions::bounce_count.eq(email_suppressions::bounce_count + 1),
@@ -47,12 +57,18 @@ pub fn upsert(
 /// match via lower-case fold (mirrors `upsert`). The caller uses
 /// this on the outbound enqueue hot path, so it's a single keyed
 /// lookup rather than a list scan.
-pub fn is_suppressed(conn: &mut DbConnection, email: &str) -> Result<bool, diesel::result::Error> {
+pub fn is_suppressed(
+    conn: &mut DbConnection,
+    workspace_id: i32,
+    email: &str,
+) -> Result<bool, diesel::result::Error> {
     use diesel::dsl::exists;
     use diesel::select;
     let normalized = email.trim().to_ascii_lowercase();
     select(exists(
-        email_suppressions::table.filter(email_suppressions::email.eq(&normalized)),
+        email_suppressions::table
+            .filter(email_suppressions::workspace_id.eq(workspace_id))
+            .filter(email_suppressions::email.eq(&normalized)),
     ))
     .get_result(conn)
 }
@@ -60,10 +76,12 @@ pub fn is_suppressed(conn: &mut DbConnection, email: &str) -> Result<bool, diese
 /// Paginated list for the admin view, newest first.
 pub fn list(
     conn: &mut DbConnection,
+    workspace_id: i32,
     limit: i64,
     before: Option<DateTime<Utc>>,
 ) -> Result<Vec<EmailSuppression>, diesel::result::Error> {
     let mut q = email_suppressions::table
+        .filter(email_suppressions::workspace_id.eq(workspace_id))
         .order(email_suppressions::created_at.desc())
         .limit(limit)
         .into_boxed();
@@ -74,16 +92,27 @@ pub fn list(
 }
 
 /// Total count for the admin stats card.
-pub fn count(conn: &mut DbConnection) -> Result<i64, diesel::result::Error> {
-    email_suppressions::table.count().get_result(conn)
+pub fn count(conn: &mut DbConnection, workspace_id: i32) -> Result<i64, diesel::result::Error> {
+    email_suppressions::table
+        .filter(email_suppressions::workspace_id.eq(workspace_id))
+        .count()
+        .get_result(conn)
 }
 
 // sync-audit-only: suppression list mutation; operational table for email deliverability
 /// Remove a suppression. Returns the number of rows deleted so the
 /// admin handler can disambiguate "address not on the list" from
 /// "removed successfully" without a separate existence check.
-pub fn remove(conn: &mut DbConnection, email: &str) -> Result<usize, diesel::result::Error> {
+pub fn remove(
+    conn: &mut DbConnection,
+    workspace_id: i32,
+    email: &str,
+) -> Result<usize, diesel::result::Error> {
     let normalized = email.trim().to_ascii_lowercase();
-    diesel::delete(email_suppressions::table.filter(email_suppressions::email.eq(&normalized)))
-        .execute(conn)
+    diesel::delete(
+        email_suppressions::table
+            .filter(email_suppressions::workspace_id.eq(workspace_id))
+            .filter(email_suppressions::email.eq(&normalized)),
+    )
+    .execute(conn)
 }

--- a/backend/src/repository/outbound_emails.rs
+++ b/backend/src/repository/outbound_emails.rs
@@ -125,8 +125,19 @@ pub fn enqueue_or_suppress(
 ) -> Result<OutboundEmail, DieselError> {
     use diesel::Connection;
     conn.transaction::<OutboundEmail, DieselError, _>(|conn| {
-        let suppressed =
-            crate::repository::email_suppressions::is_suppressed(conn, &new_row.recipient)?;
+        // `outbound_emails.workspace_id` defaults from the `app.workspace_id`
+        // GUC, so this is only ever reached on a pinned connection: an unpinned
+        // one could not satisfy the NOT NULL column below. Read that same pin
+        // for the suppression check rather than inventing a second source of
+        // truth, and refuse outright if it is somehow absent — an unpinned
+        // suppression check would report "not suppressed" and send.
+        let workspace_id =
+            crate::sync::session::current_workspace_id(conn)?.ok_or(DieselError::NotFound)?;
+        let suppressed = crate::repository::email_suppressions::is_suppressed(
+            conn,
+            workspace_id,
+            &new_row.recipient,
+        )?;
         if suppressed {
             let row: OutboundEmail = diesel::insert_into(outbound_emails::table)
                 .values(&new_row)

--- a/backend/src/schema.rs
+++ b/backend/src/schema.rs
@@ -817,7 +817,7 @@ diesel::table! {
 }
 
 diesel::table! {
-    email_suppressions (email) {
+    email_suppressions (workspace_id, email) {
         email -> Text,
         reason -> Text,
         bounce_diagnostic -> Nullable<Text>,
@@ -825,6 +825,7 @@ diesel::table! {
         created_at -> Timestamptz,
         last_seen_at -> Timestamptz,
         metadata -> Jsonb,
+        workspace_id -> Int4,
     }
 }
 
@@ -2348,6 +2349,7 @@ diesel::joinable!(documentation_starred_pages -> workspaces (workspace_id));
 diesel::joinable!(documentation_subscriptions -> documentation_pages (page_id));
 diesel::joinable!(documentation_subscriptions -> users (user_uuid));
 diesel::joinable!(documentation_subscriptions -> workspaces (workspace_id));
+diesel::joinable!(email_suppressions -> workspaces (workspace_id));
 diesel::joinable!(group_includes -> users (created_by));
 diesel::joinable!(group_includes -> workspaces (workspace_id));
 diesel::joinable!(groups -> users (created_by));

--- a/backend/src/services/channels/auto_ack.rs
+++ b/backend/src/services/channels/auto_ack.rs
@@ -208,7 +208,11 @@ async fn send_auto_ack(
     // it would re-bounce and erode the shared relay's reputation. The queued
     // paths check this in the worker; this direct send must too. Silent skip is
     // correct here, auto-ack is best-effort system mail, not a human's reply.
-    if crate::services::outbound_email::recipient_is_suppressed(pool, &recipient_email) {
+    if crate::services::outbound_email::recipient_is_suppressed(
+        pool,
+        ticket.workspace_id,
+        &recipient_email,
+    ) {
         tracing::info!(
             recipient = %recipient_email,
             ticket = ticket.id,

--- a/backend/src/services/channels/email_imap.rs
+++ b/backend/src/services/channels/email_imap.rs
@@ -516,7 +516,11 @@ impl ChannelAdapter for EmailImapAdapter {
         // Unlike the auto-ack path, a technician deliberately authored this, so
         // surface it as an error (they can clear the suppression in admin) rather
         // than silently dropping their reply.
-        if crate::services::outbound_email::recipient_is_suppressed(&self.pool, recipient) {
+        if crate::services::outbound_email::recipient_is_suppressed(
+            &self.pool,
+            self.workspace_id,
+            recipient,
+        ) {
             return Err(ChannelError::Other(format!(
                 "recipient {recipient} is on the suppression list (prior hard bounce or \
                  complaint); remove them from suppressions to send"

--- a/backend/src/services/channels/pipeline.rs
+++ b/backend/src/services/channels/pipeline.rs
@@ -268,6 +268,9 @@ pub async fn process_event(
                         email: recipient.to_string(),
                         reason: crate::models::email_suppression_reason::HARD_BOUNCE.to_string(),
                         bounce_diagnostic: report.diagnostic.clone(),
+                        // The bounce came back to this channel, so it is this
+                        // workspace's relationship that broke.
+                        workspace_id: channel.workspace_id,
                     };
                     if let Err(e) = crate::repository::email_suppressions::upsert(conn, new) {
                         warn!(
@@ -1645,8 +1648,12 @@ mod tests {
 
         // Recipient should be on the suppression list (5.1.1 is hard).
         assert!(
-            crate::repository::email_suppressions::is_suppressed(&mut conn, "bob@example.org")
-                .unwrap(),
+            crate::repository::email_suppressions::is_suppressed(
+                &mut conn,
+                ch.workspace_id,
+                "bob@example.org",
+            )
+            .unwrap(),
             "recipient should be auto-suppressed",
         );
 
@@ -1694,6 +1701,7 @@ mod tests {
         assert!(
             !crate::repository::email_suppressions::is_suppressed(
                 &mut conn,
+                ch.workspace_id,
                 "backed-up@example.org",
             )
             .unwrap(),
@@ -1742,13 +1750,21 @@ mod tests {
         // suppression list, even though only one outbound row
         // existed (we sent to the list, not to the members).
         assert!(
-            crate::repository::email_suppressions::is_suppressed(&mut conn, "alice@example.org")
-                .unwrap(),
+            crate::repository::email_suppressions::is_suppressed(
+                &mut conn,
+                ch.workspace_id,
+                "alice@example.org",
+            )
+            .unwrap(),
             "alice should be auto-suppressed",
         );
         assert!(
-            crate::repository::email_suppressions::is_suppressed(&mut conn, "carol@example.org")
-                .unwrap(),
+            crate::repository::email_suppressions::is_suppressed(
+                &mut conn,
+                ch.workspace_id,
+                "carol@example.org",
+            )
+            .unwrap(),
             "carol should be auto-suppressed",
         );
     }
@@ -1784,11 +1800,12 @@ mod tests {
 
         // Read the suppression row's bounce_count after the first
         // arrival; sanity-check it's 1.
-        let after_first = crate::repository::email_suppressions::list(&mut conn, 10, None)
-            .unwrap()
-            .into_iter()
-            .find(|s| s.email == "bob@example.org")
-            .expect("recipient should be suppressed after first DSN");
+        let after_first =
+            crate::repository::email_suppressions::list(&mut conn, ch.workspace_id, 10, None)
+                .unwrap()
+                .into_iter()
+                .find(|s| s.email == "bob@example.org")
+                .expect("recipient should be suppressed after first DSN");
         assert_eq!(
             after_first.bounce_count, 1,
             "first arrival should leave bounce_count at 1"
@@ -1811,11 +1828,12 @@ mod tests {
 
         // bounce_count must remain at 1 — re-processing would have
         // bumped it via the upsert's ON CONFLICT DO UPDATE branch.
-        let after_second = crate::repository::email_suppressions::list(&mut conn, 10, None)
-            .unwrap()
-            .into_iter()
-            .find(|s| s.email == "bob@example.org")
-            .expect("recipient should still be suppressed");
+        let after_second =
+            crate::repository::email_suppressions::list(&mut conn, ch.workspace_id, 10, None)
+                .unwrap()
+                .into_iter()
+                .find(|s| s.email == "bob@example.org")
+                .expect("recipient should still be suppressed");
         assert_eq!(
             after_second.bounce_count, 1,
             "duplicate DSN must not increment bounce_count, got {}",
@@ -1852,8 +1870,12 @@ mod tests {
         assert_eq!(outcome, PipelineOutcome::SkippedBounce);
 
         assert!(
-            !crate::repository::email_suppressions::is_suppressed(&mut conn, "valid@example.org")
-                .unwrap(),
+            !crate::repository::email_suppressions::is_suppressed(
+                &mut conn,
+                ch.workspace_id,
+                "valid@example.org",
+            )
+            .unwrap(),
             "5.7.x policy rejection must NOT auto-suppress (sender-side failure)",
         );
     }

--- a/backend/src/services/email_queue/worker.rs
+++ b/backend/src/services/email_queue/worker.rs
@@ -164,23 +164,27 @@ pub async fn run_one_drain(
             // Reputation protection for conversation mail is enforced earlier, at
             // enqueue time (`enqueue_or_suppress`) and on the direct channel-send
             // paths, where the block is surfaced rather than silently dropping a
-            // human's reply. The list is global (no workspace_id), so a bypass
-            // read is fine; a failed lookup falls through to attempting the send.
-            let suppressed = if row.mail_class
-                == crate::models::outbound_email_mail_class::NOTIFICATION
-            {
-                // cross-tenant: email_suppressions is a global list (keyed by address, no workspace).
-                crate::sync::session::background_run(
-                    &pool,
-                    "background:email_queue_suppress_check",
-                    |conn| {
-                        crate::repository::email_suppressions::is_suppressed(conn, &row.recipient)
-                    },
-                )
-                .unwrap_or(false)
-            } else {
-                false
-            };
+            // human's reply. The list is scoped to the sending workspace, so
+            // the read is pinned to the queue row's own workspace; a failed
+            // lookup falls through to attempting the send.
+            let suppressed =
+                if row.mail_class == crate::models::outbound_email_mail_class::NOTIFICATION {
+                    crate::sync::session::run_in_workspace(
+                        &pool,
+                        "email_queue_suppress_check",
+                        row.workspace_id,
+                        |conn| {
+                            crate::repository::email_suppressions::is_suppressed(
+                                conn,
+                                row.workspace_id,
+                                &row.recipient,
+                            )
+                        },
+                    )
+                    .unwrap_or(false)
+                } else {
+                    false
+                };
             let outcome = if suppressed {
                 DispatchOutcome::Suppressed
             } else {
@@ -429,7 +433,7 @@ fn terminate_row(
                     // not a scrape of the error text, so it's safe to act on: a
                     // transient message that merely contained "550" can no longer
                     // masquerade as a hard reject. Dead-letter the row AND add the
-                    // recipient to the global suppression list so future sends
+                    // recipient to this workspace's suppression list so future sends
                     // short-circuit before the relay. Mirrors the inbound DSN path
                     // (`bounce_parser` -> `email_suppressions::upsert`).
                     if let Err(e) = repo::mark_dead(conn, row.id, &error, code.map(i32::from)) {
@@ -441,6 +445,7 @@ fn terminate_row(
                             reason: crate::models::email_suppression_reason::HARD_BOUNCE
                                 .to_string(),
                             bounce_diagnostic: Some(error.clone()),
+                            workspace_id: row.workspace_id,
                         };
                         match crate::repository::email_suppressions::upsert(conn, suppression) {
                             Ok(_) => {

--- a/backend/src/services/outbound_email.rs
+++ b/backend/src/services/outbound_email.rs
@@ -37,17 +37,26 @@ use crate::repository::workspaces;
 use crate::sync::session::{run_in_workspace, BackgroundRunError};
 use crate::utils::email::{DkimAlgorithm, DkimSigner, EmailConfig, EmailService, SmtpSecurity};
 
-/// True when `recipient` is on the (global) suppression list — a prior hard
+/// True when `recipient` is on `workspace_id`'s suppression list — a prior hard
 /// bounce or complaint. The queue worker checks this before every send; this is
 /// the same guard for the DIRECT (non-queued) send paths (auto-ack, technician
 /// replies), so none of them ships mail to a known-bad address and erodes the
-/// shared relay's reputation. Fails OPEN: a lookup error attempts the send
-/// rather than silently dropping it, matching the worker.
-pub fn recipient_is_suppressed(pool: &Pool, recipient: &str) -> bool {
-    // cross-tenant: email_suppressions is a global list (keyed by address, no workspace).
-    crate::sync::session::background_run(pool, "background:direct_send_suppress_check", |conn| {
-        crate::repository::email_suppressions::is_suppressed(conn, recipient)
-    })
+/// shared relay's reputation.
+///
+/// Fails OPEN: a lookup error attempts the send rather than silently dropping
+/// it, matching the worker. That is a deliberate choice for a *database error*,
+/// and it is the reason `workspace_id` is a parameter rather than something
+/// read from an ambient pin. The list carries FORCE row-level security, so an
+/// unpinned read returns zero rows, and zero rows here reads as "go ahead and
+/// send". Taking the workspace explicitly means the query filters on it
+/// directly and the answer does not depend on the caller having pinned.
+pub fn recipient_is_suppressed(pool: &Pool, workspace_id: i32, recipient: &str) -> bool {
+    crate::sync::session::run_in_workspace(
+        pool,
+        "direct_send_suppress_check",
+        workspace_id,
+        |conn| crate::repository::email_suppressions::is_suppressed(conn, workspace_id, recipient),
+    )
     .unwrap_or(false)
 }
 

--- a/backend/tests/email_suppression_scoping.rs
+++ b/backend/tests/email_suppression_scoping.rs
@@ -1,0 +1,139 @@
+//! The email suppression list is per workspace.
+//!
+//! It used to be keyed on the address alone with no `workspace_id`, so the RLS
+//! GUC that `TenantConn` primes was a no-op and the three admin endpoints had
+//! no tenant predicate: any workspace admin could read, extend and delete every
+//! other tenant's list. Reading it is the sharper half, since the list is a
+//! roster of addresses a tenant has corresponded with.
+//!
+//! **What these tests cover.** The test role is a superuser with BYPASSRLS, so
+//! row-level security does not apply here. That is deliberate about what is
+//! being asserted: every query carries an explicit `workspace_id` filter, and
+//! it is the filter, not RLS, that makes these queries correct. RLS is the
+//! backstop for a caller that forgets to pin, and the migration's
+//! ENABLE/FORCE/policy is covered by `tenant_table_rls_lint`.
+
+#![allow(clippy::expect_used)]
+
+use backend::db::DbConnection;
+use backend::models::{email_suppression_reason, NewEmailSuppression};
+use backend::repository::email_suppressions as repo;
+
+mod common;
+
+fn suppress(conn: &mut DbConnection, workspace_id: i32, email: &str) {
+    repo::upsert(
+        conn,
+        NewEmailSuppression {
+            email: email.to_string(),
+            reason: email_suppression_reason::HARD_BOUNCE.to_string(),
+            bounce_diagnostic: Some("550 user unknown".into()),
+            workspace_id,
+        },
+    )
+    .expect("upsert suppression");
+}
+
+#[test]
+fn one_workspace_suppressing_an_address_does_not_silence_another() {
+    common::ensure_test_keyring();
+    let test_db = common::TestDb::new();
+    let pool = test_db.pool_with_size(2);
+    let mut conn = pool.get().expect("conn");
+
+    let ours = common::mint_workspace(&mut conn, "acme-supp-ours", "Ours");
+    let theirs = common::mint_workspace(&mut conn, "acme-supp-theirs", "Theirs");
+
+    suppress(&mut conn, ours, "shared.contact@example.org");
+
+    assert!(
+        repo::is_suppressed(&mut conn, ours, "shared.contact@example.org").expect("query"),
+        "the workspace that recorded the bounce stops writing to them"
+    );
+    assert!(
+        !repo::is_suppressed(&mut conn, theirs, "shared.contact@example.org").expect("query"),
+        "a peer tenant's bounce must not silence our mail to our own contact"
+    );
+}
+
+#[test]
+fn the_admin_list_shows_only_this_workspaces_addresses() {
+    common::ensure_test_keyring();
+    let test_db = common::TestDb::new();
+    let pool = test_db.pool_with_size(2);
+    let mut conn = pool.get().expect("conn");
+
+    let ours = common::mint_workspace(&mut conn, "acme-supp-list", "Ours List");
+    let theirs = common::mint_workspace(&mut conn, "acme-supp-list-x", "Theirs List");
+
+    suppress(&mut conn, ours, "ours@example.org");
+    suppress(&mut conn, theirs, "theirs@example.org");
+
+    let rows = repo::list(&mut conn, ours, 50, None).expect("list");
+    let emails: Vec<&str> = rows.iter().map(|r| r.email.as_str()).collect();
+    assert!(emails.contains(&"ours@example.org"));
+    assert!(
+        !emails.contains(&"theirs@example.org"),
+        "the list is a roster of addresses a tenant corresponds with: {emails:?}"
+    );
+    assert_eq!(
+        repo::count(&mut conn, ours).expect("count"),
+        1,
+        "the stats card counts this workspace only"
+    );
+}
+
+/// The primary key moved from `(email)` to `(workspace_id, email)`, so the same
+/// person can be a live contact of one tenant and a hard bounce for another.
+#[test]
+fn two_workspaces_can_suppress_the_same_address_independently() {
+    common::ensure_test_keyring();
+    let test_db = common::TestDb::new();
+    let pool = test_db.pool_with_size(2);
+    let mut conn = pool.get().expect("conn");
+
+    let a = common::mint_workspace(&mut conn, "acme-supp-a", "A");
+    let b = common::mint_workspace(&mut conn, "acme-supp-b", "B");
+
+    suppress(&mut conn, a, "both@example.org");
+    suppress(&mut conn, b, "both@example.org");
+
+    assert!(repo::is_suppressed(&mut conn, a, "both@example.org").expect("query"));
+    assert!(repo::is_suppressed(&mut conn, b, "both@example.org").expect("query"));
+
+    // Removing one leaves the other, which is the whole point: a peer must not
+    // be able to resume mail to someone who asked us to stop.
+    assert_eq!(
+        repo::remove(&mut conn, a, "both@example.org").expect("remove"),
+        1
+    );
+    assert!(!repo::is_suppressed(&mut conn, a, "both@example.org").expect("query"));
+    assert!(
+        repo::is_suppressed(&mut conn, b, "both@example.org").expect("query"),
+        "removing one workspace's entry must not clear another's"
+    );
+}
+
+/// Deleting an address that is only on a peer's list reports "not on the list",
+/// the same answer as an address nobody has suppressed. No cross-tenant oracle.
+#[test]
+fn removing_a_peers_entry_reports_nothing_removed() {
+    common::ensure_test_keyring();
+    let test_db = common::TestDb::new();
+    let pool = test_db.pool_with_size(2);
+    let mut conn = pool.get().expect("conn");
+
+    let ours = common::mint_workspace(&mut conn, "acme-supp-del", "Ours Del");
+    let theirs = common::mint_workspace(&mut conn, "acme-supp-del-x", "Theirs Del");
+    suppress(&mut conn, theirs, "theirs.only@example.org");
+
+    assert_eq!(
+        repo::remove(&mut conn, ours, "theirs.only@example.org").expect("remove"),
+        0,
+        "a peer's entry is not ours to delete"
+    );
+    assert!(
+        repo::is_suppressed(&mut conn, theirs, "theirs.only@example.org").expect("query"),
+        "and it is still there"
+    );
+}


### PR DESCRIPTION
`email_suppressions` was keyed on the address alone with no `workspace_id`, so the RLS GUC that `TenantConn` primes was a no-op for it and the three admin endpoints carried no tenant predicate. On a multi-workspace deployment any workspace admin could read, extend and delete every other tenant's list.

Reading it is the sharper half. The module's own doc comment withholds the list from agents *because* it reveals email addresses they should not know — and a peer tenant knows them a good deal less than an agent does.

## Is suppression a property of the address or the relationship?

This is the design call, and it decides the shape of everything else.

Global is defensible on deliverability grounds: a hard bounce means the address is bad, and if tenants share a sending identity, one tenant mailing a known-bad address erodes everyone's reputation.

Per-relationship wins anyway. A manual entry records that *this* workspace was asked to stop writing to someone, and deleting a peer's entry could resume mail to a person who opted out — a compliance problem, not just an annoyance. The shared-reputation argument is the ESP's concern, and SES maintains its own account-level suppression list for precisely that. So the primary key becomes `(workspace_id, email)`, and the same person may be a live contact of one tenant and a hard bounce for another.

## The backfill derives the workspace rather than guessing

Existing rows have no workspace, and the obvious options are both bad. Assigning everything to one tenant loses suppressions for the others. Copying each address into every workspace preserves behaviour exactly — and hands every tenant a roster of addresses it has no relationship with, which is the leak this migration exists to close.

So:

1. **One workspace** → every row is unambiguously its own. This covers every self-hosted Community build, which is capped at one workspace.
2. **Otherwise** → attribute from `outbound_emails` evidence (it carries both `workspace_id` and `recipient`), one row per workspace that actually mailed the address.
3. **Unattributable** → dropped, with a `RAISE NOTICE` count so an operator reading the migration log knows what went. This is the one lossy step, and it self-heals: the next hard bounce re-suppresses, for the workspace that actually sent.

## The fail-open hazard, which was the real risk

Making this a tenant table means FORCE row-level security, and an unpinned read returns zero rows. For `is_suppressed`, zero rows reads as *"go ahead and send"* — so the naive version of this change would silently stop honouring suppressions.

`recipient_is_suppressed` was the exposed one. It ran under `background_run` with a `// cross-tenant:` marker precisely because the list was global, took no workspace, and already returned `false` on error.

Every function now takes `workspace_id` as a required parameter and filters on it explicitly, so the answer does not depend on the caller having pinned; RLS is the backstop, not the mechanism. `recipient_is_suppressed` runs under `run_in_workspace`. `enqueue_or_suppress` reads the pin it must already have — `outbound_emails.workspace_id` defaults from the same GUC, so it cannot be reached unpinned — and refuses rather than proceeding without one.

Making the parameter required rather than optional meant the compiler enumerated all nine call sites instead of me hunting for them.

## Notes

- Deleting an address that is only on a peer's list reports "not on the list", the same answer as an address nobody suppressed. No cross-tenant oracle.
- The three tenant-table lints (RLS forced with a policy, full DML grants, FK `ON DELETE CASCADE`) all pass against the new column.
- The tests assert the explicit filter, not RLS: the test role is a superuser with BYPASSRLS, so row-level security does not apply there. That is stated in the test file rather than left implied. Mutation-checked: removing the workspace filter from `is_suppressed` fails two of them.

Local: `cargo fmt` clean, `cargo clippy --all-targets` with no new warnings (verified by per-file count against main, since line numbers shift), `cargo test` 1952 passed / 0 failed.

https://claude.ai/code/session_017iEcp3fFMB594JYRZxcQ5H