### PR TITLE
Decide per field who may set it on PUT /api/tickets/{id}

### DIFF
--- a/backend/src/handlers/tickets.rs
+++ b/backend/src/handlers/tickets.rs
@@ -740,16 +740,66 @@ pub async fn create_ticket(
     }
 }
 
-// Update a ticket. The extractor gates visibility; this body
-// only runs for callers who can see the ticket.
+/// Refuse a move into a category the caller cannot see.
+///
+/// Shared by PUT and PATCH. It was only on PATCH, which is how PUT came to
+/// accept a category move that PATCH refused for the same caller.
+fn refuse_unseeable_category(
+    tc: &mut TenantConn,
+    auth: &AuthContext,
+    category_id: i32,
+) -> Option<HttpResponse> {
+    let user_uuid = auth.user_uuid;
+    let is_admin = auth.is_workspace_admin();
+    match tc.run(|conn| {
+        crate::repository::categories::can_user_see_category(
+            conn,
+            &user_uuid,
+            category_id,
+            is_admin,
+        )
+    }) {
+        Ok(true) => None,
+        Ok(false) => Some(errors::forbidden(
+            "Forbidden: You do not have access to the specified category",
+        )),
+        Err(_) => Some(errors::internal("Failed to check category visibility")),
+    }
+}
+
+// Update a ticket. `TicketAccess` gates visibility only, so the body decides
+// which of the submitted columns this caller may actually set.
 pub async fn update_ticket(
     mut tc: TenantConn,
     access: TicketAccess,
+    auth: AuthContext,
     ticket: web::Json<NewTicket>,
     req: HttpRequest,
 ) -> impl Responder {
     let ticket_id = access.ticket_id;
-    let new_ticket = ticket.into_inner();
+    let submitted = ticket.into_inner();
+
+    // A whole-row overwrite behind a read-only gate. Take the staff-controlled
+    // columns from the row as it stands unless the caller is staff, so a
+    // requester who can see the ticket cannot close it, reassign it, or hand it
+    // to somebody else.
+    let existing = match tc.run(|conn| repository::get_ticket_by_id(conn, ticket_id)) {
+        Ok(t) => t,
+        Err(_) => return errors::not_found_msg("Ticket not found"),
+    };
+    let new_ticket = submitted.redact_for(auth.can_handle_tickets(), &existing);
+
+    // A category move needs a visibility lookup rather than a comparison, so it
+    // is checked here rather than in `redact_for`, with the same helper PATCH
+    // uses. Only reached when the value actually changed, so an unchanged
+    // category on a ticket whose category the caller cannot see still saves.
+    if let Some(category_id) = new_ticket.category_id {
+        if existing.category_id != Some(category_id) {
+            if let Some(resp) = refuse_unseeable_category(&mut tc, &auth, category_id) {
+                return resp;
+            }
+        }
+    }
 
     // Validate assignee role if assignee is set
     if let Some(assignee_uuid) = new_ticket.assignee_uuid {
@@ -1229,28 +1279,8 @@ pub async fn update_ticket_partial(
 
     // Validate category visibility if category_id is being changed
     if let Some(Some(new_category_id)) = ticket_update.category_id {
-        let user_uuid = match crate::utils::parse_uuid(&user_info.sub) {
-            Ok(uuid) => uuid,
-            Err(_) => return errors::bad_request("Invalid user UUID in token"),
-        };
-        let is_admin = auth.is_workspace_admin();
-        match tc.run(|conn| {
-            crate::repository::categories::can_user_see_category(
-                conn,
-                &user_uuid,
-                new_category_id,
-                is_admin,
-            )
-        }) {
-            Ok(true) => {}
-            Ok(false) => {
-                return errors::forbidden(
-                    "Forbidden: You do not have access to the specified category",
-                );
-            }
-            Err(_) => {
-                return errors::internal("Failed to check category visibility");
-            }
+        if let Some(resp) = refuse_unseeable_category(&mut tc, &auth, new_category_id) {
+            return resp;
         }
     }
 

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -1055,6 +1055,59 @@ pub struct NewTicket {
     pub spam_suspected: bool,
 }
 
+impl NewTicket {
+    /// Keep only what a non-staff caller is allowed to set, taking every other
+    /// column from the ticket as it stands.
+    ///
+    /// `PUT /api/tickets/{id}` overwrites the whole row: `NewTicket` is an
+    /// `AsChangeset`, so every field in the body lands. Its only gate is
+    /// `TicketAccess`, which is a *read* gate by its own module doc, so a
+    /// requester or watcher who can merely see a ticket could set the columns
+    /// that belong to staff — close or reopen it via `workflow_state_id`,
+    /// assign it, change its priority or category, flip `triage_state`,
+    /// `verification_state` or `spam_suspected`, hand it to someone else via
+    /// `requester_uuid`, or mint a `guest_lookup_token`.
+    ///
+    /// Staff are unaffected. For everyone else the answer is "you may retitle
+    /// your own ticket", which is deliberately narrow: this endpoint has no
+    /// client (the apps use PATCH), so the cost of being strict is close to
+    /// zero, and widening it later is a decision someone can make on purpose.
+    ///
+    /// Category is not handled here even though it is staff-controlled, because
+    /// it needs a visibility lookup rather than a comparison; the handler runs
+    /// the same `can_user_see_category` check its PATCH sibling already does.
+    #[must_use]
+    pub fn redact_for(self, can_handle_tickets: bool, existing: &Ticket) -> Self {
+        if can_handle_tickets {
+            return self;
+        }
+        Self {
+            // The one field a requester owns.
+            title: self.title,
+            // Everything else is whatever it already was. Written field by
+            // field rather than with `..existing` so that adding a column to
+            // `NewTicket` fails to compile here, forcing a decision about who
+            // may set it instead of defaulting it open.
+            workflow_state_id: existing.workflow_state_id,
+            priority: existing.priority,
+            requester_uuid: existing.requester_uuid,
+            assignee_uuid: existing.assignee_uuid,
+            category_id: existing.category_id,
+            submitted_via: existing.submitted_via.clone(),
+            guest_lookup_token: existing.guest_lookup_token,
+            verification_state: existing.verification_state.clone(),
+            origin_channel_id: existing.origin_channel_id,
+            triage_state: existing.triage_state.clone(),
+            due_date: existing.due_date,
+            start_date: existing.start_date,
+            recurrence_rule: existing.recurrence_rule.clone(),
+            recurrence_template_id: existing.recurrence_template_id,
+            resolution_notes: existing.resolution_notes.clone(),
+            spam_suspected: existing.spam_suspected,
+        }
+    }
+}
+
 // Add a new struct for partial ticket updates
 #[derive(Debug, Default, Serialize, Deserialize, AsChangeset)]
 #[diesel(table_name = crate::schema::tickets)]
@@ -8227,4 +8280,172 @@ pub struct NewRuleApplication {
     pub actions_taken: Option<serde_json::Value>,
     pub actions_skipped: Option<serde_json::Value>,
     pub failure_reason: Option<String>,
+}
+
+#[cfg(test)]
+mod new_ticket_redaction_tests {
+    use super::*;
+
+    /// A ticket with every staff-controlled column set to a recognisable
+    /// value, so a field that leaks through redaction shows up as the
+    /// attacker's value rather than this one.
+    fn existing_ticket() -> Ticket {
+        let now = chrono::NaiveDateTime::UNIX_EPOCH;
+        Ticket {
+            id: 1,
+            title: "As filed".into(),
+            priority: TicketPriority::Low,
+            requester_uuid: Some(Uuid::from_u128(1)),
+            assignee_uuid: Some(Uuid::from_u128(2)),
+            created_at: now,
+            updated_at: now,
+            created_by: Some(Uuid::from_u128(1)),
+            closed_at: None,
+            closed_by: None,
+            category_id: Some(10),
+            submitted_via: Some("email".into()),
+            guest_lookup_token: Some(Uuid::from_u128(3)),
+            verification_state: Some("verified".into()),
+            origin_channel_id: Some(20),
+            workflow_state_id: 30,
+            triage_state: Some("triaged".into()),
+            due_date: Some(now),
+            recurrence_rule: Some("FREQ=DAILY".into()),
+            recurrence_template_id: Some(40),
+            resolution_notes: Some("resolved by staff".into()),
+            workspace_id: 1,
+            first_response_at: None,
+            sla_response_target_at: None,
+            sla_response_breached_at: None,
+            sla_resolution_target_at: None,
+            sla_resolution_breached_at: None,
+            uuid: Uuid::from_u128(4),
+            spam_suspected: false,
+            start_date: Some(now),
+            sla_clock_started_at: None,
+            sla_paused_at: None,
+            sla_override: "none".into(),
+        }
+    }
+
+    /// What a requester might PUT to take over their own ticket: every
+    /// staff-controlled column set to something of their choosing.
+    fn hostile_body() -> NewTicket {
+        NewTicket {
+            title: "Retitled by the requester".into(),
+            workflow_state_id: 99,
+            priority: TicketPriority::High,
+            requester_uuid: Some(Uuid::from_u128(999)),
+            assignee_uuid: Some(Uuid::from_u128(998)),
+            category_id: Some(997),
+            submitted_via: Some("forged".into()),
+            guest_lookup_token: Some(Uuid::from_u128(996)),
+            verification_state: Some("forged".into()),
+            origin_channel_id: Some(995),
+            triage_state: Some("forged".into()),
+            due_date: None,
+            start_date: None,
+            recurrence_rule: Some("FREQ=HOURLY".into()),
+            recurrence_template_id: Some(994),
+            resolution_notes: Some("forged".into()),
+            spam_suspected: true,
+        }
+    }
+
+    #[test]
+    fn a_requester_may_retitle_and_nothing_else() {
+        let existing = existing_ticket();
+        let out = hostile_body().redact_for(false, &existing);
+
+        assert_eq!(
+            out.title, "Retitled by the requester",
+            "the one field a requester owns"
+        );
+
+        // Everything a requester could otherwise have seized. Listed one by one
+        // rather than compared structurally, so a failure names the column.
+        assert_eq!(
+            out.workflow_state_id, existing.workflow_state_id,
+            "cannot close or reopen"
+        );
+        assert_eq!(out.priority, existing.priority, "cannot re-prioritise");
+        assert_eq!(
+            out.requester_uuid, existing.requester_uuid,
+            "cannot hand the ticket away"
+        );
+        assert_eq!(out.assignee_uuid, existing.assignee_uuid, "cannot assign");
+        assert_eq!(
+            out.category_id, existing.category_id,
+            "cannot move category"
+        );
+        assert_eq!(out.submitted_via, existing.submitted_via);
+        assert_eq!(
+            out.guest_lookup_token, existing.guest_lookup_token,
+            "cannot mint an unauthenticated lookup handle"
+        );
+        assert_eq!(out.verification_state, existing.verification_state);
+        assert_eq!(out.origin_channel_id, existing.origin_channel_id);
+        assert_eq!(
+            out.triage_state, existing.triage_state,
+            "cannot self-triage"
+        );
+        assert_eq!(out.due_date, existing.due_date);
+        assert_eq!(out.start_date, existing.start_date);
+        assert_eq!(out.recurrence_rule, existing.recurrence_rule);
+        assert_eq!(out.recurrence_template_id, existing.recurrence_template_id);
+        assert_eq!(out.resolution_notes, existing.resolution_notes);
+        assert_eq!(
+            out.spam_suspected, existing.spam_suspected,
+            "cannot clear a spam flag"
+        );
+    }
+
+    #[test]
+    fn staff_are_unaffected() {
+        let existing = existing_ticket();
+        let submitted = hostile_body();
+        let expected = hostile_body();
+        let out = submitted.redact_for(true, &existing);
+
+        // Staff get exactly what they sent; this is the ordinary edit path and
+        // redaction must not narrow it.
+        assert_eq!(out.title, expected.title);
+        assert_eq!(out.workflow_state_id, expected.workflow_state_id);
+        assert_eq!(out.assignee_uuid, expected.assignee_uuid);
+        assert_eq!(out.requester_uuid, expected.requester_uuid);
+        assert_eq!(out.priority, expected.priority);
+        assert_eq!(out.spam_suspected, expected.spam_suspected);
+        assert_eq!(out.guest_lookup_token, expected.guest_lookup_token);
+    }
+
+    /// A requester resubmitting the row they were shown must not be refused;
+    /// redaction has to be idempotent on an unchanged body, or the endpoint
+    /// silently rejects legitimate retitles.
+    #[test]
+    fn resubmitting_the_current_values_changes_nothing() {
+        let existing = existing_ticket();
+        let faithful = NewTicket {
+            title: existing.title.clone(),
+            workflow_state_id: existing.workflow_state_id,
+            priority: existing.priority,
+            requester_uuid: existing.requester_uuid,
+            assignee_uuid: existing.assignee_uuid,
+            category_id: existing.category_id,
+            submitted_via: existing.submitted_via.clone(),
+            guest_lookup_token: existing.guest_lookup_token,
+            verification_state: existing.verification_state.clone(),
+            origin_channel_id: existing.origin_channel_id,
+            triage_state: existing.triage_state.clone(),
+            due_date: existing.due_date,
+            start_date: existing.start_date,
+            recurrence_rule: existing.recurrence_rule.clone(),
+            recurrence_template_id: existing.recurrence_template_id,
+            resolution_notes: existing.resolution_notes.clone(),
+            spam_suspected: existing.spam_suspected,
+        };
+        let out = faithful.redact_for(false, &existing);
+        assert_eq!(out.title, existing.title);
+        assert_eq!(out.workflow_state_id, existing.workflow_state_id);
+        assert_eq!(out.category_id, existing.category_id);
+    }
 }


### PR DESCRIPTION
`NewTicket` is an `AsChangeset`, so the handler overwrote the whole row with whatever the body carried. Its only gate was `TicketAccess` — a *read* gate, by its own module doc.

So a requester or watcher who could merely see a ticket could set the columns that belong to staff: close or reopen it via `workflow_state_id`, assign it, re-prioritise it, move its category, flip `triage_state` / `verification_state` / `spam_suspected`, hand it to someone else via `requester_uuid`, or mint a `guest_lookup_token`.

The sibling asymmetry is the giveaway: `delete_ticket` opens with an admin check, and PATCH gates a category move with `can_user_see_category`. PUT had neither.

## `redact_for`

Staff-controlled columns come from the row as it stands unless the caller is staff. Two deliberate choices:

**It is written field by field, not with `..existing`.** Adding a column to `NewTicket` now fails to compile there, so someone has to decide who may set it. New fields defaulting open is how this drifted in the first place.

**Non-staff keep `title` and nothing else.** That is narrow on purpose. No client calls this endpoint — the apps use PATCH throughout, and a grep of `frontend/src` and `mobile/src` finds no PUT against `/tickets` at all — so being strict costs almost nothing here, and widening it later can be a deliberate decision rather than an accident.

## Category

Category is staff-controlled too, but it needs a visibility lookup rather than a comparison, so it stays in the handler. That check existed only on PATCH, which is exactly how PUT came to accept a category move that PATCH refused for the same caller. Both now call `refuse_unseeable_category`.

It fires only when the category actually changes, so a requester retitling a ticket whose category they cannot see still saves rather than being refused for a field they did not touch.

## Tests

Three unit tests against a ticket whose every staff column holds a recognisable value, so a field that leaks through shows up as the attacker's value rather than the ticket's.

Each column is asserted individually rather than by comparing structs, so a failure names the column that leaked. There is also an idempotence test: resubmitting the row you were shown must not be refused, or the endpoint silently rejects legitimate retitles.

Local: `cargo fmt` clean, `cargo clippy --all-targets` with no new warnings, `cargo test` 1955 passed / 0 failed.

https://claude.ai/code/session_017iEcp3fFMB594JYRZxcQ5H