### PR TITLE
Bind an API token to the workspace it was minted in

### DIFF
--- a/backend/src/middleware/api_token.rs
+++ b/backend/src/middleware/api_token.rs
@@ -124,10 +124,19 @@ pub fn try_bearer_auth(
             warn!("Failed to update token last_used_at: {}", e);
         }
 
-        Ok::<_, diesel::result::Error>((api_token, user, email))
+        // The workspace the token was minted in. Resolved here, inside the
+        // bypass, because the request has no pin yet; it becomes the ceiling
+        // the membership gate enforces. Archive state is deliberately ignored
+        // (see `uuid_for_id`): an archived binding is still the token's
+        // binding, and refusing it is the gate's job, not this lookup's.
+        let workspace_uuid =
+            crate::repository::workspaces::uuid_for_id(conn, api_token.workspace_id)?
+                .ok_or(diesel::result::Error::NotFound)?;
+
+        Ok::<_, diesel::result::Error>((api_token, user, email, workspace_uuid))
     });
 
-    let (api_token, user, email) = match lookup_result {
+    let (api_token, user, email, bound_workspace) = match lookup_result {
         Ok(triple) => triple,
         Err(diesel::result::Error::NotFound) => {
             warn!(path = %req.path(), "API token not found or expired");
@@ -179,7 +188,9 @@ pub fn try_bearer_auth(
         platform_role: user.platform_role.clone(),
         scope,
         sid: None,
-        workspace_uuid: None,
+        // The token's binding, carried on the claims so every surface that
+        // already checks `workspace_uuid` (the collab doc gate) applies it too.
+        workspace_uuid: Some(bound_workspace),
         exp: (now + chrono::Duration::hours(24)).timestamp() as usize,
         iat: now.timestamp() as usize,
     };
@@ -232,10 +243,15 @@ pub(crate) async fn authenticate<B: MessageBody>(
                 let mut conn = pool.get().map_err(|_| {
                     actix_web::error::ErrorInternalServerError("Database connection failed")
                 })?;
-                // Membership 403 gate: a token issued in workspace A can't be
-                // used against workspace B.
-                crate::middleware::cookie_auth::enforce_workspace_membership(
-                    &req, &mut conn, &claims,
+                // Membership gate plus the token's own workspace binding, so a
+                // token minted in workspace A is refused against workspace B
+                // even when its owner is a member of both. `try_bearer_auth`
+                // always sets the binding.
+                let bound = claims.workspace_uuid.ok_or_else(|| {
+                    actix_web::error::ErrorInternalServerError("API token has no workspace binding")
+                })?;
+                crate::middleware::cookie_auth::enforce_api_token_workspace(
+                    &req, &mut conn, &claims, bound,
                 )?;
                 drop(conn);
                 return finalize(req, next, claims).await;

--- a/backend/src/middleware/cookie_auth.rs
+++ b/backend/src/middleware/cookie_auth.rs
@@ -50,6 +50,25 @@ pub enum WorkspaceCarrier<'a> {
         token_workspace: Option<uuid::Uuid>,
         req: &'a actix_web::HttpRequest,
     },
+    /// A personal API token (`nsk_…`). The `api_tokens` row records the
+    /// workspace the token was minted in, and that binding is a **ceiling, not
+    /// a selection**: the request's own origin / selection is resolved exactly
+    /// as [`WorkspaceCarrier::RequestOrigin`] does and must MATCH the binding.
+    /// Membership alone is not enough, so an admin of both A and B cannot point
+    /// A's token at B.
+    ///
+    /// A request that names no workspace resolves to `None`, exactly as
+    /// `RequestOrigin` does, and is left to the caller's [`UnresolvedPolicy`].
+    /// Using the binding as a selection here was tried and reverted: the same
+    /// unresolved case covers a platform admin's cross-workspace call to
+    /// `/api/admin/workspaces/{id}/members` (under `dual_auth_middleware`,
+    /// `startup.rs`), which has no workspace to be a member of. Pinning the
+    /// binding there turns a never-gated request into a gated one and 403s a
+    /// legitimate call.
+    ApiToken {
+        bound_workspace: uuid::Uuid,
+        req: &'a ServiceRequest,
+    },
 }
 
 /// What to do when a carrier resolves to NO workspace. Fail-closed by default: a
@@ -95,7 +114,7 @@ pub fn resolve_pin_and_gate(
         ));
     }
 
-    match resolve_carrier(conn, carrier)? {
+    match resolve_carrier(conn, claims, carrier)? {
         Some(ctx) => {
             // A workspace-scoped request whose subject doesn't parse is
             // malformed; fail closed (auth already validated the token, so this
@@ -120,18 +139,37 @@ pub fn resolve_pin_and_gate(
 /// PROVIDED identifier that is unknown (existence not leaked).
 fn resolve_carrier(
     conn: &mut DbConnection,
+    claims: &Claims,
     carrier: WorkspaceCarrier<'_>,
 ) -> Result<Option<crate::extractors::WorkspaceContext>, Error> {
     match carrier {
-        WorkspaceCarrier::RequestOrigin(req) => {
-            if let Some(ctx) = req
-                .extensions()
-                .get::<crate::extractors::WorkspaceContext>()
-                .cloned()
-            {
-                return Ok(Some(ctx));
+        WorkspaceCarrier::RequestOrigin(req) => origin_context(req, conn),
+        WorkspaceCarrier::ApiToken {
+            bound_workspace,
+            req,
+        } => {
+            match origin_context(req, conn)? {
+                Some(ctx) => {
+                    // A token whose workspace has since been deleted gets the
+                    // same 403 a non-member gets.
+                    let bound = resolve_provided_uuid(conn, bound_workspace)?;
+                    if ctx.workspace_id != bound.workspace_id {
+                        warn!(
+                            user = %claims.sub,
+                            bound_workspace = %bound_workspace,
+                            attempted_workspace = %ctx.workspace_uuid,
+                            "API token presented against a workspace it is not bound to"
+                        );
+                        return Err(actix_web::error::ErrorForbidden(
+                            "This API token is bound to a different workspace",
+                        ));
+                    }
+                    Ok(Some(ctx))
+                }
+                // Nothing named a workspace, so there is nothing to compare the
+                // binding against. Not a selection; see the carrier doc.
+                None => Ok(None),
             }
-            selected_workspace_context(req, conn)
         }
         WorkspaceCarrier::ConnectionToken {
             token_workspace,
@@ -144,6 +182,24 @@ fn resolve_carrier(
                 .cloned()),
         },
     }
+}
+
+/// The REST resolution rule, shared by the `RequestOrigin` and `ApiToken`
+/// carriers so the two cannot drift: the Host-derived context wins, and the
+/// `X-Nosdesk-Workspace` selection header is consulted only when the origin
+/// resolved to nothing.
+fn origin_context(
+    req: &ServiceRequest,
+    conn: &mut DbConnection,
+) -> Result<Option<crate::extractors::WorkspaceContext>, Error> {
+    if let Some(ctx) = req
+        .extensions()
+        .get::<crate::extractors::WorkspaceContext>()
+        .cloned()
+    {
+        return Ok(Some(ctx));
+    }
+    selected_workspace_context(req, conn)
 }
 
 /// Resolve a provided workspace uuid, mapping an unknown uuid to the same 403 a
@@ -187,6 +243,38 @@ pub fn enforce_workspace_membership(
         // Publish the resolved (possibly selection-derived) context so
         // downstream handlers + pins read the selected workspace. Re-inserting a
         // Host-derived context is a harmless no-op.
+        GateOutcome::Scoped(ctx) => {
+            req.extensions_mut().insert(ctx);
+        }
+        GateOutcome::Unscoped => {}
+    }
+    Ok(())
+}
+
+/// The API-token variant of [`enforce_workspace_membership`]: the same resolve,
+/// pin and gate, with the token's own workspace binding as an additional
+/// ceiling on top.
+pub fn enforce_api_token_workspace(
+    req: &ServiceRequest,
+    conn: &mut DbConnection,
+    claims: &Claims,
+    bound_workspace: uuid::Uuid,
+) -> Result<(), Error> {
+    match resolve_pin_and_gate(
+        conn,
+        claims,
+        WorkspaceCarrier::ApiToken {
+            bound_workspace,
+            req,
+        },
+        // AllowRlsBackstop, the same as REST and for the same reason: a request
+        // that names no workspace is an apex or platform route (a platform
+        // admin's cross-workspace call, say), and the binding is a ceiling on
+        // which workspace a token may act in, not a selection of one.
+        UnresolvedPolicy::AllowRlsBackstop,
+    )? {
+        // Publish the resolved context, as the cookie/session gate does, so the
+        // handler's `TenantConn` pins the same workspace.
         GateOutcome::Scoped(ctx) => {
             req.extensions_mut().insert(ctx);
         }

--- a/backend/src/repository/workspaces.rs
+++ b/backend/src/repository/workspaces.rs
@@ -162,6 +162,23 @@ pub fn find_by_id(conn: &mut DbConnection, id: i32) -> QueryResult<Option<Worksp
         .optional()
 }
 
+/// The workspace uuid for an id, **regardless of archive state**.
+///
+/// `api_tokens.workspace_id` is an FK, so the row always exists, and the
+/// binding is a fact about the token even when the workspace is archived.
+/// [`find_by_id`] filters archived workspaces, which would turn an archived
+/// binding into a failed token lookup and a 401: that strands every token
+/// minted in a workspace the moment it is archived, including the platform
+/// admin's token needed to restore it. Refusing belongs at the membership
+/// gate, not at the credential check.
+pub fn uuid_for_id(conn: &mut DbConnection, id: i32) -> QueryResult<Option<Uuid>> {
+    workspaces::table
+        .filter(workspaces::id.eq(id))
+        .select(workspaces::uuid)
+        .first(conn)
+        .optional()
+}
+
 /// Load a workspace by its public uuid. Used by selection-based
 /// resolution (Model C): the agent app sends the chosen workspace
 /// uuid in the `X-Nosdesk-Workspace` header and the auth gate

--- a/backend/src/utils/tracing_redact.rs
+++ b/backend/src/utils/tracing_redact.rs
@@ -89,6 +89,13 @@ const ALLOWED_FIELDS: &[&str] = &[
     "user_uuid",
     "webhook_id",
     "workspace_id",
+    // The workspace an API token is bound to, and the one a request tried to
+    // reach with it. Both are workspace uuids, logged together when the two
+    // disagree so the refusal can be told apart from an ordinary non-member
+    // 403. Without them the line says only that some token was refused
+    // somewhere.
+    "bound_workspace",
+    "attempted_workspace",
     // bounded enums + operational dimensions. No free text.
     "aggregate",
     // Which realm a refresh token belongs to: exactly "agent" or "portal".

--- a/backend/tests/api_token_workspace_binding.rs
+++ b/backend/tests/api_token_workspace_binding.rs
@@ -1,0 +1,247 @@
+//! A personal API token is bound to the workspace it was minted in.
+//!
+//! `api_tokens.workspace_id` records that workspace, and
+//! `enforce_api_token_workspace` makes it a ceiling: membership in the workspace
+//! the request names is necessary but no longer sufficient. Without this, an
+//! admin of both A and B could point A's token at B, which defeats the point of
+//! minting a token per workspace.
+//!
+//! Single `#[test]` because the selection-header cases mutate process-wide env;
+//! keeping it one test means the toggles cannot race a sibling.
+
+#![allow(clippy::expect_used)]
+
+use actix_web::test::TestRequest;
+use actix_web::HttpMessage as _;
+use diesel::prelude::*;
+
+use backend::extractors::WorkspaceContext;
+use backend::middleware::cookie_auth::enforce_api_token_workspace;
+use backend::middleware::workspace_context::WORKSPACE_SELECTION_HEADER;
+use backend::models::Claims;
+use backend::repository::workspaces::{add_membership, find_by_id, SeatWriteAuthority};
+use backend::sync::actor::ActorContext;
+use backend::sync::session::with_actor_context;
+
+mod common;
+
+/// Claims as `try_bearer_auth` builds them for an API token: full scope, no
+/// session, and the token's workspace binding.
+fn token_claims(user_uuid: uuid::Uuid, bound: uuid::Uuid) -> Claims {
+    Claims {
+        sub: user_uuid.to_string(),
+        name: "Token Owner".to_string(),
+        email: String::new(),
+        platform_role: "user".to_string(),
+        scope: "full".to_string(),
+        sid: None,
+        workspace_uuid: Some(bound),
+        exp: (chrono::Utc::now() + chrono::Duration::hours(1)).timestamp() as usize,
+        iat: chrono::Utc::now().timestamp() as usize,
+    }
+}
+
+fn context_of(conn: &mut backend::db::DbConnection, workspace_id: i32) -> WorkspaceContext {
+    let ws = find_by_id(conn, workspace_id)
+        .expect("workspace lookup")
+        .expect("workspace exists");
+    WorkspaceContext {
+        workspace_id: ws.id,
+        workspace_uuid: ws.uuid,
+        slug: ws.slug,
+        name: ws.name,
+        custom_domain: ws.custom_domain,
+        organisation_id: ws.organisation_id,
+    }
+}
+
+fn status_of(err: &actix_web::Error) -> u16 {
+    err.as_response_error().status_code().as_u16()
+}
+
+#[test]
+fn api_token_is_refused_outside_the_workspace_it_was_minted_in() {
+    common::ensure_test_keyring();
+    let test_db = common::TestDb::new();
+    let pool = test_db.pool_with_size(2);
+
+    // One user who is a member of BOTH workspaces, holding a token minted in A.
+    // Membership is deliberately not the thing under test here.
+    let (a_id, a_uuid, b_id, outsider_uuid, owner) = {
+        let mut conn = pool.get().expect("conn");
+        let a = common::mint_workspace(&mut conn, "tok-a", "Token A");
+        let b = common::mint_workspace(&mut conn, "tok-b", "Token B");
+        let owner = common::insert_user(&mut conn, "Token Owner");
+        let outsider = common::insert_user(&mut conn, "Token Outsider");
+        let a_uuid = context_of(&mut conn, a).workspace_uuid;
+        (a, a_uuid, b, outsider.uuid, owner)
+    };
+    let owner_uuid = owner.uuid;
+    let pool_data = actix_web::web::Data::new(pool.clone());
+    for ws_id in [a_id, b_id] {
+        let mut conn = pool.get().expect("conn");
+        let actor = ActorContext::user(owner_uuid, None).with_workspace(ws_id);
+        with_actor_context::<_, diesel::result::Error>(&mut conn, &actor, |c| {
+            add_membership(
+                c,
+                ws_id,
+                owner_uuid,
+                "admin",
+                SeatWriteAuthority::ControlPlane,
+            )?;
+            Ok(())
+        })
+        .expect("add membership");
+    }
+
+    // --- Host-derived origin (no selection env needed) ---
+
+    // Token bound to A, presented at B's origin, by a member of B. This is the
+    // case that passed on membership alone.
+    {
+        let mut conn = pool.get().expect("conn");
+        let req = TestRequest::default().to_srv_request();
+        req.extensions_mut().insert(context_of(&mut conn, b_id));
+        let err =
+            enforce_api_token_workspace(&req, &mut conn, &token_claims(owner_uuid, a_uuid), a_uuid)
+                .expect_err("a token bound to A must not authenticate against B");
+        assert_eq!(status_of(&err), 403);
+        assert!(
+            err.to_string().contains("bound to a different workspace"),
+            "the refusal must say why: {err}"
+        );
+    }
+
+    // Same token at A's own origin: allowed.
+    {
+        let mut conn = pool.get().expect("conn");
+        let req = TestRequest::default().to_srv_request();
+        req.extensions_mut().insert(context_of(&mut conn, a_id));
+        enforce_api_token_workspace(&req, &mut conn, &token_claims(owner_uuid, a_uuid), a_uuid)
+            .expect("a token at its own workspace must pass");
+        let published = req
+            .extensions()
+            .get::<WorkspaceContext>()
+            .map(|w| w.workspace_id);
+        assert_eq!(published, Some(a_id));
+    }
+
+    // A token whose holder is not a member of the bound workspace is still
+    // refused by the membership gate. The binding is a ceiling, not a grant.
+    {
+        let mut conn = pool.get().expect("conn");
+        let req = TestRequest::default().to_srv_request();
+        req.extensions_mut().insert(context_of(&mut conn, a_id));
+        let err = enforce_api_token_workspace(
+            &req,
+            &mut conn,
+            &token_claims(outsider_uuid, a_uuid),
+            a_uuid,
+        )
+        .expect_err("a non-member must be refused even at the bound workspace");
+        assert_eq!(status_of(&err), 403);
+    }
+
+    // No origin and no selection: nothing to compare the binding against, so
+    // the request stays unscoped and RLS is the backstop, exactly as it was
+    // before the binding existed. The binding must NOT act as a selection here:
+    // this same case is a platform admin's cross-workspace call, which has no
+    // workspace to be a member of, and pinning the binding would 403 it.
+    {
+        let mut conn = pool.get().expect("conn");
+        let req = TestRequest::default().to_srv_request();
+        enforce_api_token_workspace(&req, &mut conn, &token_claims(owner_uuid, a_uuid), a_uuid)
+            .expect("an unresolved workspace must fall through, not be gated");
+        assert!(
+            req.extensions().get::<WorkspaceContext>().is_none(),
+            "the binding must not select a workspace the request never named"
+        );
+    }
+
+    // The same unresolved call by someone who is not a member of the bound
+    // workspace also falls through, which is the regression this shape avoids.
+    {
+        let mut conn = pool.get().expect("conn");
+        let req = TestRequest::default().to_srv_request();
+        enforce_api_token_workspace(
+            &req,
+            &mut conn,
+            &token_claims(outsider_uuid, a_uuid),
+            a_uuid,
+        )
+        .expect("a platform-admin style cross-workspace call must not be gated");
+    }
+
+    // --- Selection header (single-origin agent app) ---
+    std::env::set_var("NOSDESK_DEPLOYMENT_MODE", "hosted");
+    std::env::set_var("NOSDESK_WORKSPACE_SELECTION", "1");
+
+    // Selecting B with a token bound to A: refused, even though the holder is a
+    // member of B.
+    {
+        let mut conn = pool.get().expect("conn");
+        let req = TestRequest::default()
+            .insert_header((WORKSPACE_SELECTION_HEADER, "tok-b"))
+            .to_srv_request();
+        let err =
+            enforce_api_token_workspace(&req, &mut conn, &token_claims(owner_uuid, a_uuid), a_uuid)
+                .expect_err("selecting another workspace must not widen the binding");
+        assert_eq!(status_of(&err), 403);
+    }
+
+    // Selecting A: allowed.
+    {
+        let mut conn = pool.get().expect("conn");
+        let req = TestRequest::default()
+            .insert_header((WORKSPACE_SELECTION_HEADER, "tok-a"))
+            .to_srv_request();
+        enforce_api_token_workspace(&req, &mut conn, &token_claims(owner_uuid, a_uuid), a_uuid)
+            .expect("selecting the bound workspace must pass");
+    }
+
+    std::env::remove_var("NOSDESK_WORKSPACE_SELECTION");
+    std::env::remove_var("NOSDESK_DEPLOYMENT_MODE");
+
+    // Archiving the bound workspace must not strand the token. `find_by_id`
+    // hides archived workspaces, so resolving the binding through it would turn
+    // an archived binding into a failed token lookup and a 401, killing every
+    // token minted in a workspace the moment it is archived, including the
+    // platform admin's token needed to restore it.
+    {
+        let mut conn = pool.get().expect("conn");
+        diesel::sql_query("UPDATE workspaces SET archived_at = now() WHERE id = $1")
+            .bind::<diesel::sql_types::Integer, _>(a_id)
+            .execute(&mut conn)
+            .expect("archive workspace A");
+
+        // The distinction the fix rests on: the archive-filtering finder now
+        // hides the row, the binding finder does not.
+        assert!(
+            backend::repository::workspaces::find_by_id(&mut conn, a_id)
+                .expect("lookup")
+                .is_none(),
+            "find_by_id must hide an archived workspace"
+        );
+        assert_eq!(
+            backend::repository::workspaces::uuid_for_id(&mut conn, a_id).expect("lookup"),
+            Some(a_uuid),
+            "the binding must still resolve once the workspace is archived"
+        );
+
+        // End to end through the real credential path: mint a token in A (the
+        // FK means A must exist, and it is archived by now), present it, and
+        // require that it still authenticates and still carries its binding.
+        let token = common::mint_api_token(&mut conn, &owner, "archived-binding");
+        let req = TestRequest::default()
+            .insert_header(("Authorization", format!("Bearer {token}")))
+            .to_srv_request();
+        let claims = backend::middleware::api_token::try_bearer_auth(&req, &pool_data)
+            .expect("an archived binding must not fail authentication")
+            .expect("a bearer token was presented");
+        assert_eq!(
+            claims.workspace_uuid,
+            Some(a_uuid),
+            "the token must still carry the workspace it was minted in"
+        );
+    }
+}

--- a/frontend/src/views/ApiTokensView.vue
+++ b/frontend/src/views/ApiTokensView.vue
@@ -15,8 +15,10 @@ import Modal from '@/components/Modal.vue';
 import apiTokenService from '@nosdesk/core/services/apiTokenService';
 import { formatRelativeTime } from '@nosdesk/core/utils/dateUtils';
 import type { ApiToken, ApiTokenCreated, CreateApiTokenRequest } from '@nosdesk/core/types/apiToken';
+import { useMyWorkspacesStore } from '@/stores/myWorkspaces';
 
 const fluent = useFluent();
+const myWorkspaces = useMyWorkspacesStore();
 const t = (key: string, args?: Record<string, string | number>) => fluent.$t(key, args);
 
 // Token list is cached by Pinia Colada keyed here, so navigating away
@@ -52,6 +54,10 @@ const showRevokeConfirm = ref(false);
 const showTokenCreated = ref(false);
 const tokenToRevoke = ref<ApiToken | null>(null);
 const createdToken = ref<ApiTokenCreated | null>(null);
+
+// A token is bound to the workspace it was minted in and is refused anywhere
+// else, so say which one that is before and after minting.
+const boundWorkspaceName = computed(() => myWorkspaces.activeWorkspace?.name ?? '');
 const copiedToken = ref(false);
 
 // Form state
@@ -537,6 +543,10 @@ const revokeToken = async () => {
           </p>
         </div>
 
+        <p v-if="boundWorkspaceName" class="text-xs text-tertiary">
+          {{ t('admin-api-tokens-workspace-bound', { workspace: boundWorkspaceName }) }}
+        </p>
+
         <!-- Actions -->
         <div class="flex justify-end gap-2 pt-2">
           <button
@@ -586,6 +596,10 @@ const revokeToken = async () => {
 
         <p class="text-xs text-tertiary">
           {{ $t('admin-api-tokens-bearer-hint-prefix') }} <code class="px-1 py-0.5 bg-surface-alt rounded">Authorization: Bearer &lt;token&gt;</code> {{ $t('admin-api-tokens-bearer-hint-suffix') }}
+        </p>
+
+        <p v-if="boundWorkspaceName" class="text-xs text-tertiary">
+          {{ t('admin-api-tokens-workspace-bound', { workspace: boundWorkspaceName }) }}
         </p>
 
         <div class="flex justify-end pt-2">

--- a/i18n/locales/en-AU/main.ftl
+++ b/i18n/locales/en-AU/main.ftl
@@ -1099,6 +1099,7 @@ admin-api-tokens-copied = Copied!
 admin-api-tokens-copy-title = Copy to clipboard
 admin-api-tokens-bearer-hint-prefix = Use this token with the
 admin-api-tokens-bearer-hint-suffix = header
+admin-api-tokens-workspace-bound = This token works only in { $workspace }. Create a separate token for another workspace.
 admin-api-tokens-done = Done
 admin-api-tokens-revoke-modal-title = Revoke Token
 admin-api-tokens-revoke-confirm-message = Sure you want to revoke the token "{ $name }"?

--- a/i18n/locales/en-GB/main.ftl
+++ b/i18n/locales/en-GB/main.ftl
@@ -1086,6 +1086,7 @@ admin-api-tokens-copied = Copied!
 admin-api-tokens-copy-title = Copy to clipboard
 admin-api-tokens-bearer-hint-prefix = Use this token with the
 admin-api-tokens-bearer-hint-suffix = header
+admin-api-tokens-workspace-bound = This token works only in { $workspace }. Create a separate token for another workspace.
 admin-api-tokens-done = Done
 admin-api-tokens-revoke-modal-title = Revoke Token
 admin-api-tokens-revoke-confirm-message = Are you sure you want to revoke the token "{ $name }"?

--- a/i18n/locales/en-US/main.ftl
+++ b/i18n/locales/en-US/main.ftl
@@ -1517,6 +1517,7 @@ admin-api-tokens-copied = Copied!
 admin-api-tokens-copy-title = Copy to clipboard
 admin-api-tokens-bearer-hint-prefix = Use this token with the
 admin-api-tokens-bearer-hint-suffix = header
+admin-api-tokens-workspace-bound = This token works only in { $workspace }. Create a separate token for another workspace.
 admin-api-tokens-done = Done
 admin-api-tokens-revoke-modal-title = Revoke Token
 admin-api-tokens-revoke-confirm-message = Are you sure you want to revoke the token "{ $name }"?

--- a/i18n/locales/fr-FR/main.ftl
+++ b/i18n/locales/fr-FR/main.ftl
@@ -1372,6 +1372,7 @@ admin-api-tokens-copied = Copié !
 admin-api-tokens-copy-title = Copier dans le presse-papiers
 admin-api-tokens-bearer-hint-prefix = Utilisez ce jeton avec l'en-tête
 admin-api-tokens-bearer-hint-suffix = .
+admin-api-tokens-workspace-bound = Ce jeton fonctionne uniquement dans { $workspace }. Créez un jeton distinct pour un autre espace de travail.
 admin-api-tokens-done = Terminé
 admin-api-tokens-revoke-modal-title = Révoquer le jeton
 admin-api-tokens-revoke-confirm-message = Confirmez-vous la révocation du jeton « { $name } » ?

--- a/i18n/locales/nl-NL/main.ftl
+++ b/i18n/locales/nl-NL/main.ftl
@@ -1369,6 +1369,7 @@ admin-api-tokens-copied = Gekopieerd!
 admin-api-tokens-copy-title = Naar klembord kopiëren
 admin-api-tokens-bearer-hint-prefix = Gebruik dit token met de
 admin-api-tokens-bearer-hint-suffix = header
+admin-api-tokens-workspace-bound = Dit token werkt alleen in { $workspace }. Maak een apart token voor een andere werkruimte.
 admin-api-tokens-done = Klaar
 admin-api-tokens-revoke-modal-title = Token intrekken
 admin-api-tokens-revoke-confirm-message = Weet u zeker dat u het token "{ $name }" wilt intrekken?


### PR DESCRIPTION
`api_tokens.workspace_id` has always recorded which workspace a token was created in, and nothing compared it. The holder only had to be a member of whichever workspace the request named, so someone who belongs to two workspaces could use either token against either one.

## The change

`WorkspaceCarrier::ApiToken` puts the binding through the same resolve, pin and gate funnel every other connection surface uses, rather than a second implementation of it. The request's origin or selection header resolves exactly as `RequestOrigin` does (both now share `origin_context`) and must equal the binding.

**The binding is a ceiling, not a selection.** A request that names no workspace resolves to `None` and falls through on the RLS backstop, as REST already did. An earlier revision used the binding as a selection there; `admin_workspace_members` caught it, because that same unresolved case is a platform admin's cross-workspace call to `/api/admin/workspaces/{id}/members`, which has no workspace to be a member of.

`try_bearer_auth` resolves the bound workspace inside the existing bypass transaction and carries it on the claims, which applies it to the collab document gate as well. The lookup ignores archive state via a new `workspaces::uuid_for_id`: `find_by_id` hides archived workspaces, and resolving through it turned an archived binding into a 401, stranding every token minted in a workspace the moment it was archived, including the one needed to restore it (`admin_workspaces` caught that one).

## Visibility

The binding was undiagnosable from the UI. `NewApiToken` has no `workspace_id` field, so it comes from a column default, and the token screens never named a workspace. Both dialogs now say which workspace the token will work in, and the refusal says why rather than being indistinguishable from a non-member 403: the caller has already reached that workspace's origin and holds a valid credential, so nothing leaks.

## Verification

Full suite: 1961 passed, 0 failed. Both load-bearing branches are mutation-checked (reverting the carrier to `RequestOrigin`/`AllowRlsBackstop` fails the cross-workspace assertion; reverting `uuid_for_id` to `find_by_id` fails the archived-binding assertion). An earlier version of the archived-binding test was vacuous, since it never reached `try_bearer_auth`; it now drives the real credential path.

https://claude.ai/code/session_017iEcp3fFMB594JYRZxcQ5H