### PR TITLE
Let a secondary email prove itself

### DIFF
--- a/backend/src/handlers/email_verification.rs
+++ b/backend/src/handlers/email_verification.rs
@@ -1,0 +1,98 @@
+//! Redeem an address-confirmation link.
+//!
+//! Public and unauthenticated on purpose: the link is clicked from a mail
+//! client, which may not be the browser holding the session, and requiring a
+//! login first would mean a user who cannot receive mail at their signed-in
+//! address can never confirm a second one. Possession of the token is the
+//! proof; nothing here reveals anything to someone who does not hold one.
+
+use actix_web::{web, HttpRequest, HttpResponse, Responder};
+use serde::Deserialize;
+use serde_json::json;
+use tracing::{info, warn};
+
+use crate::handlers::errors;
+use crate::handlers::helpers;
+use crate::utils::reset_tokens::TokenType;
+
+pub fn config(cfg: &mut web::ServiceConfig) {
+    cfg.route("/verify-email", web::post().to(verify_email));
+}
+
+#[derive(Debug, Deserialize)]
+pub struct VerifyEmailRequest {
+    pub token: String,
+}
+
+/// `POST /api/public/verify-email`
+///
+/// Claiming the token and verifying the row are separate steps, and the claim
+/// comes first: it is a single atomic UPDATE guarded on `is_used = false`, so
+/// two clicks on the same link cannot both proceed.
+pub async fn verify_email(
+    db_pool: web::Data<crate::db::Pool>,
+    _req: HttpRequest,
+    body: web::Json<VerifyEmailRequest>,
+) -> impl Responder {
+    let mut conn = match helpers::db_conn(&db_pool) {
+        Ok(c) => c,
+        Err(e) => return e,
+    };
+
+    let (user_uuid, metadata) =
+        match crate::repository::reset_tokens::validate_and_consume_token_with_metadata(
+            &mut conn,
+            &body.token,
+            TokenType::EmailVerification.as_str(),
+        ) {
+            Ok(claimed) => claimed,
+            Err(_) => {
+                // Expired, already used, wrong type, or never existed. One message
+                // for all of them: telling them apart tells a token-guesser which
+                // of their guesses was once real.
+                return errors::bad_request("This confirmation link is invalid or has expired");
+            }
+        };
+
+    let Some(email_id) = metadata
+        .as_ref()
+        .and_then(|m| m.get("user_email_id"))
+        .and_then(serde_json::Value::as_i64)
+    else {
+        warn!(%user_uuid, "email verification: token carries no user_email_id");
+        return errors::bad_request("This confirmation link is invalid or has expired");
+    };
+    let Some(address) = metadata
+        .as_ref()
+        .and_then(|m| m.get("address"))
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_owned)
+    else {
+        warn!(%user_uuid, "email verification: token carries no address");
+        return errors::bad_request("This confirmation link is invalid or has expired");
+    };
+
+    match crate::repository::user_emails::mark_verified_if_matches(
+        &mut conn,
+        email_id as i32,
+        user_uuid,
+        &address,
+    ) {
+        Ok(1) => {
+            info!(%user_uuid, email_id, "Email address confirmed");
+            HttpResponse::Ok().json(json!({ "status": "verified", "email": address }))
+        }
+        // The row was deleted, reassigned, or now holds a different address.
+        // The token was still spent, which is correct: it was valid once and a
+        // link is not a standing permission to verify whatever that row later
+        // becomes.
+        Ok(_) => {
+            warn!(%user_uuid, email_id, "email verification: row no longer matches the token");
+            errors::bad_request("That address is no longer on this account")
+        }
+        Err(e) => {
+            warn!(%user_uuid, email_id, error = ?e, "email verification: update failed");
+            errors::internal("Could not confirm this address")
+        }
+    }
+}

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -34,6 +34,7 @@ pub mod documentation_collections;
 pub mod email;
 pub mod email_queue;
 pub mod email_suppressions;
+pub mod email_verification;
 pub mod errors;
 pub mod feature_flags;
 pub mod files;
@@ -97,8 +98,8 @@ pub use users::{
     delete_user_auth_identity_by_uuid, delete_user_email, get_paginated_users,
     get_user_auth_identities, get_user_auth_identities_by_uuid, get_user_by_uuid, get_user_emails,
     get_user_security_info, get_user_with_emails, get_users, get_users_batch, purge_user_now,
-    regenerate_avatar_thumbnails, resend_invitation, restore_user, update_user_by_uuid,
-    update_user_email, upload_user_image,
+    regenerate_avatar_thumbnails, resend_invitation, resend_user_email_verification, restore_user,
+    update_user_by_uuid, update_user_email, upload_user_image,
 };
 // Export specific items from tickets to avoid conflicts
 // `config` is intentionally per-module and always referenced via its full path

--- a/backend/src/handlers/users.rs
+++ b/backend/src/handlers/users.rs
@@ -98,6 +98,10 @@ pub fn config(cfg: &mut web::ServiceConfig) {
             "/users/{uuid}/emails/{email_id}",
             web::delete().to(crate::handlers::delete_user_email),
         )
+        .route(
+            "/users/{uuid}/emails/{email_id}/resend-verification",
+            web::post().to(crate::handlers::resend_user_email_verification),
+        )
         // User contact profile (standard cols + custom-field values).
         .route(
             "/users/{uuid}/profile-fields",
@@ -2507,6 +2511,7 @@ pub async fn get_user_emails(
 pub async fn add_user_email(
     db_pool: web::Data<crate::db::Pool>,
     req: HttpRequest,
+    ws: WorkspaceContext,
     path: web::Path<String>,
     email_data: web::Json<serde_json::Value>,
 ) -> impl Responder {
@@ -2564,11 +2569,29 @@ pub async fn add_user_email(
     };
 
     match user_emails_repo::add_email(&mut conn, &new_email) {
-        Ok(created_email) => HttpResponse::Created().json(json!({
-            "status": "success",
-            "message": "Email added successfully",
-            "email": created_email
-        })),
+        Ok(created_email) => {
+            // Send the confirmation immediately: an address that arrives
+            // unverified with no way to prove itself is the state this whole
+            // flow exists to end. Best-effort, so a mail failure does not undo
+            // the add; the profile offers a resend.
+            crate::services::email_verification::send_verification(
+                &mut conn,
+                &user,
+                &created_email,
+                ws.workspace_id,
+                crate::utils::client_ip::from_http_request(&req)
+                    .map(|ip| ip.to_string())
+                    .as_deref(),
+                req.headers()
+                    .get(actix_web::http::header::USER_AGENT)
+                    .and_then(|v| v.to_str().ok()),
+            );
+            HttpResponse::Created().json(json!({
+                "status": "success",
+                "message": "Email added successfully",
+                "email": created_email
+            }))
+        }
         Err(e) => {
             error!(error = ?e, "Error adding email");
             errors::internal("Failed to add email")
@@ -2649,6 +2672,86 @@ pub async fn update_user_email(
             errors::internal("Failed to update email")
         }
     }
+}
+
+/// Re-send the confirmation link for an unverified address.
+///
+/// Rate limiting is the token table's own: `count_recent_tokens` is what stops
+/// this becoming a way to have us mail someone repeatedly, since the address
+/// need not belong to the person asking until it is confirmed.
+pub async fn resend_user_email_verification(
+    db_pool: web::Data<crate::db::Pool>,
+    req: HttpRequest,
+    ws: WorkspaceContext,
+    path: web::Path<(String, i32)>,
+) -> impl Responder {
+    let (user_uuid, email_id) = path.into_inner();
+    let mut conn = match helpers::db_conn(&db_pool) {
+        Ok(c) => c,
+        Err(e) => return e,
+    };
+
+    let claims = match crate::utils::jwt::JwtUtils::extract_claims(&req) {
+        Ok(claims) => claims,
+        Err(_) => return errors::unauthorized("Authentication required"),
+    };
+    if claims.sub != user_uuid && !is_platform_admin(&claims) {
+        return errors::forbidden("Not authorized");
+    }
+
+    let uuid_parsed = match utils::parse_uuid(&user_uuid) {
+        Ok(uuid) => uuid,
+        Err(_) => return errors::bad_request("Invalid UUID format"),
+    };
+    let user = match repository::get_user_by_uuid(&uuid_parsed, &mut conn) {
+        Ok(user) => user,
+        Err(_) => return errors::not_found_msg("User not found"),
+    };
+
+    let email = match user_emails_repo::get_user_emails_by_uuid(&mut conn, &uuid_parsed) {
+        Ok(rows) => match rows.into_iter().find(|e| e.id == email_id) {
+            Some(e) => e,
+            None => return errors::not_found_msg("Email not found"),
+        },
+        Err(e) => {
+            error!(error = ?e, "Error loading emails for resend");
+            return errors::internal("Failed to load email");
+        }
+    };
+
+    if email.is_verified {
+        return errors::bad_request("That address is already confirmed");
+    }
+
+    // Every outstanding link for this user is superseded. Without this, an
+    // address removed and re-added, or simply resent a few times, leaves older
+    // tokens live, and each one is a standing claim on whatever row it names.
+    if let Err(e) = crate::repository::reset_tokens::invalidate_tokens_by_type(
+        &mut conn,
+        uuid_parsed,
+        crate::utils::reset_tokens::TokenType::EmailVerification.as_str(),
+    ) {
+        error!(error = ?e, "Error invalidating prior verification tokens");
+        return errors::internal("Failed to send confirmation");
+    }
+
+    crate::services::email_verification::send_verification(
+        &mut conn,
+        &user,
+        &email,
+        ws.workspace_id,
+        crate::utils::client_ip::from_http_request(&req)
+            .map(|ip| ip.to_string())
+            .as_deref(),
+        req.headers()
+            .get(actix_web::http::header::USER_AGENT)
+            .and_then(|v| v.to_str().ok()),
+    );
+
+    HttpResponse::Ok().json(json!({
+        "status": "success",
+        "message": "Confirmation email sent"
+    }))
 }
 
 /// Delete an email address

--- a/backend/src/repository/reset_tokens.rs
+++ b/backend/src/repository/reset_tokens.rs
@@ -118,10 +118,29 @@ pub fn validate_and_consume_token(
     raw_token: &str,
     expected_token_type: &str,
 ) -> Result<Uuid, String> {
+    validate_and_consume_token_with_metadata(conn, raw_token, expected_token_type)
+        .map(|(user_uuid, _)| user_uuid)
+}
+
+// sync-audit-only: auth flow mirror of mark_token_as_used; covered by security_events
+/// As [`validate_and_consume_token`], also returning the token's `metadata`.
+///
+/// Email confirmation needs it: `reset_tokens` is user-scoped, and a user may
+/// hold several unverified addresses, so which address a token confirms is
+/// recorded in `metadata` rather than being derivable from its subject.
+///
+/// One implementation on purpose. The single-use guarantee is the `is_used =
+/// false` predicate inside this one UPDATE, so a second claim path would be a
+/// second chance to get atomicity wrong.
+pub fn validate_and_consume_token_with_metadata(
+    conn: &mut DbConnection,
+    raw_token: &str,
+    expected_token_type: &str,
+) -> Result<(Uuid, Option<serde_json::Value>), String> {
     let token_hash_value = ResetTokenUtils::hash_token(raw_token);
     let now = Utc::now();
 
-    let user_uuid: Option<Uuid> = diesel::update(
+    let claimed: Option<(Uuid, Option<serde_json::Value>)> = diesel::update(
         reset_tokens::table
             .filter(reset_tokens::token_hash.eq(&token_hash_value))
             .filter(reset_tokens::token_type.eq(expected_token_type))
@@ -132,12 +151,12 @@ pub fn validate_and_consume_token(
         reset_tokens::is_used.eq(true),
         reset_tokens::used_at.eq(Some(now)),
     ))
-    .returning(reset_tokens::user_uuid)
+    .returning((reset_tokens::user_uuid, reset_tokens::metadata))
     .get_result(conn)
     .optional()
     .map_err(|e| format!("Failed to claim token: {e}"))?;
 
-    user_uuid.ok_or_else(|| "Invalid or expired token".to_string())
+    claimed.ok_or_else(|| "Invalid or expired token".to_string())
 }
 
 #[cfg(test)]

--- a/backend/src/repository/user_emails.rs
+++ b/backend/src/repository/user_emails.rs
@@ -168,6 +168,36 @@ pub fn mark_primary_verified(
 }
 
 // sync-audit-only: user_emails is a contact-detail table with no audit trigger and no sync aggregate; nothing subscribes to email add/update/remove
+/// Mark one address verified, but only if the row still matches the claim the
+/// token was minted against.
+///
+/// Both predicates matter. `user_uuid` stops a token verifying a row on another
+/// account, and `email` stops it verifying a row that has since been pointed at
+/// a different address: the proof was of the address in the token, not of
+/// whatever that row holds when the link is finally clicked.
+///
+/// The address is required rather than optional so there is no call shape in
+/// which the second check is skipped.
+///
+/// Returns the number of rows updated, so 0 means "no longer matches" rather
+/// than an error.
+pub fn mark_verified_if_matches(
+    conn: &mut DbConnection,
+    email_id: i32,
+    user_uuid: Uuid,
+    address: &str,
+) -> Result<usize, diesel::result::Error> {
+    diesel::update(
+        user_emails::table
+            .find(email_id)
+            .filter(user_emails::user_uuid.eq(user_uuid))
+            .filter(user_emails::email.eq(address)),
+    )
+    .set(user_emails::is_verified.eq(true))
+    .execute(conn)
+}
+
+// sync-audit-only: user_emails is a contact-detail table with no audit trigger and no sync aggregate; nothing subscribes to email add/update/remove
 /// Remove one email row by id.
 pub fn delete_email(
     conn: &mut DbConnection,
@@ -253,5 +283,59 @@ mod tests {
              address; if this fails, `is_verified` is back on UserEmailUpdate"
         );
         assert!(updated.is_primary, "the fields it may set still apply");
+    }
+
+    /// The two predicates on the update are the whole guard, so each gets a
+    /// case that fails if it is dropped.
+    #[test]
+    fn verification_applies_only_to_the_row_the_token_named() {
+        let mut conn = setup_test_connection();
+        let owner = TestFixtures::create_user(&mut conn, "owner", "user");
+        let other = TestFixtures::create_user(&mut conn, "other", "user");
+        let email =
+            TestFixtures::create_user_email(&mut conn, owner.uuid, "claimed@example.com", true);
+        diesel::update(user_emails::table.find(email.id))
+            .set(user_emails::is_verified.eq(false))
+            .execute(&mut conn)
+            .expect("start unverified");
+
+        // Right row, right address: verified.
+        assert_eq!(
+            mark_verified_if_matches(&mut conn, email.id, owner.uuid, "claimed@example.com")
+                .expect("update"),
+            1
+        );
+
+        diesel::update(user_emails::table.find(email.id))
+            .set(user_emails::is_verified.eq(false))
+            .execute(&mut conn)
+            .expect("reset");
+
+        // Another account's token must not verify this row.
+        assert_eq!(
+            mark_verified_if_matches(&mut conn, email.id, other.uuid, "claimed@example.com")
+                .expect("update"),
+            0,
+            "a token minted for one account must not verify another account's address"
+        );
+
+        // A token minted against a different address must not verify whatever
+        // the row holds now.
+        assert_eq!(
+            mark_verified_if_matches(&mut conn, email.id, owner.uuid, "stale@example.com")
+                .expect("update"),
+            0,
+            "the proof was of the address in the token, not of the row"
+        );
+
+        let after = get_user_emails_by_uuid(&mut conn, &owner.uuid)
+            .expect("reload")
+            .into_iter()
+            .find(|e| e.id == email.id)
+            .expect("row present");
+        assert!(
+            !after.is_verified,
+            "neither rejected call may have verified the address"
+        );
     }
 }

--- a/backend/src/services/email_verification.rs
+++ b/backend/src/services/email_verification.rs
@@ -1,0 +1,136 @@
+//! Address confirmation for emails added to a user profile.
+//!
+//! An address on a profile is a claim until something proves it. The proof
+//! here is the same one the portal sign-in link uses: possession of a link
+//! sent to the address. The consequence is much smaller, since clicking it
+//! verifies one `user_emails` row rather than signing anyone in.
+//!
+//! Why the claim needs proving at all: `is_verified` is the inbound-mail
+//! impersonation guard (`user_helpers::find_verified_user_by_email`), so an
+//! unproven address that counted as verified would let its claimant receive
+//! attribution for mail the real owner sent. Before this existed the flag was
+//! settable from a request body, which is to say it asserted nothing.
+//!
+//! The token carries the `user_emails` row id in its `metadata`, not just the
+//! user: `reset_tokens` is user-scoped and one user may have several unverified
+//! addresses at once, so "which address did they confirm" is not derivable from
+//! the token's subject.
+
+use serde_json::json;
+use tracing::{error, info};
+
+use crate::models::{User, UserEmail};
+use crate::utils::reset_tokens::{ResetTokenUtils, TokenType};
+
+/// Mint a confirmation token for `email` and enqueue the email to it.
+///
+/// Best-effort by design: the caller has already added the address, and a mail
+/// failure should not undo that or fail their request. Failures are logged and
+/// the user can resend.
+pub fn send_verification(
+    conn: &mut crate::db::DbConnection,
+    user: &User,
+    email: &UserEmail,
+    workspace_id: i32,
+    ip_address: Option<&str>,
+    user_agent: Option<&str>,
+) {
+    if email.is_verified {
+        return;
+    }
+
+    let token = ResetTokenUtils::generate_token();
+    let token_hash = ResetTokenUtils::hash_token(&token);
+    let token_type = TokenType::EmailVerification;
+    let expires_at = chrono::Utc::now() + token_type.expiration_duration();
+
+    if let Err(e) = crate::repository::reset_tokens::create_reset_token(
+        conn,
+        &token_hash,
+        user.uuid,
+        token_type.as_str(),
+        ip_address,
+        user_agent,
+        expires_at,
+        // The row id is what redemption acts on; the address is recorded beside
+        // it so a token cannot be replayed against a row that has since been
+        // pointed at a different address.
+        Some(json!({ "user_email_id": email.id, "address": email.email })),
+    ) {
+        error!(user_uuid = %user.uuid, error = ?e, "email verification: could not mint token");
+        return;
+    }
+
+    let workspace = match crate::repository::workspaces::find_by_id(conn, workspace_id) {
+        Ok(Some(w)) => w,
+        _ => {
+            error!(user_uuid = %user.uuid, workspace_id, "email verification: workspace not found");
+            return;
+        }
+    };
+
+    // Same rule as the password-reset link, and for the same reason: never
+    // derive the link host from the request `Host` header. A forged one would
+    // point the confirmation link at a domain the attacker controls, handing
+    // them a token that verifies an address on someone else's account.
+    let Some(base_url) = crate::utils::tenant_origin::email_link_base(
+        crate::utils::tenant_origin::workspace_origin(&workspace),
+    ) else {
+        error!(
+            user_uuid = %user.uuid,
+            "refusing to send address confirmation: no canonical origin and FRONTEND_URL is unset"
+        );
+        return;
+    };
+
+    let email_service = match crate::utils::email::EmailService::from_env() {
+        Ok(s) => s,
+        Err(e) => {
+            error!(error = ?e, "email verification: mail is not configured");
+            return;
+        }
+    };
+
+    let recipient = email.email.clone();
+    let user_name = user.name.clone();
+    let user_uuid = user.uuid;
+
+    // Branding and the outbound queue are workspace-isolated. Pinned as the
+    // RLS-enforced runtime role rather than the bypass variant, so the branding
+    // read (which carries no explicit workspace filter) returns THIS
+    // workspace's settings instead of an arbitrary tenant's.
+    //
+    // `with_actor_context` on the connection already in hand, rather than
+    // `run_in_workspace`, which is the same call preceded by `pool.get()`. The
+    // caller is holding a connection for the whole request, so going through
+    // the pool here would hold two at once, and a burst near the pool size is
+    // how that turns into a deadlock.
+    let actor = crate::sync::actor::ActorContext::system("background:email_verification")
+        .with_workspace(workspace_id);
+    let enqueued = crate::sync::session::with_actor_context::<_, diesel::result::Error>(
+        conn,
+        &actor,
+        move |conn| {
+            let branding = crate::utils::email_branding::get_email_branding(conn, &base_url);
+            let locale = crate::repository::user_locale::resolve_effective_locale(conn, user_uuid);
+            crate::services::transactional_email::enqueue_email_verification(
+                conn,
+                &email_service,
+                &branding,
+                &recipient,
+                &user_name,
+                &token,
+                &locale,
+            )
+        },
+    );
+
+    match enqueued {
+        Ok(row) => info!(
+            queue_id = row.id,
+            user_uuid = %user.uuid,
+            "Address confirmation email enqueued"
+        ),
+        Err(e) => error!(user_uuid = %user.uuid, error = ?e, "email verification: enqueue failed"),
+    }
+}

--- a/backend/src/services/mod.rs
+++ b/backend/src/services/mod.rs
@@ -10,6 +10,7 @@ pub mod custom_fields;
 pub mod dkim_verification;
 pub mod dns_diagnostics;
 pub mod email_queue;
+pub mod email_verification;
 pub mod imports;
 pub mod inbound_email;
 pub mod ldap;

--- a/backend/src/services/transactional_email.rs
+++ b/backend/src/services/transactional_email.rs
@@ -414,6 +414,68 @@ pub fn enqueue_portal_magic_link(
     outbound_emails::enqueue_idempotent(conn, row)
 }
 
+/// Build the `NewOutboundEmail` row for an address-confirmation send.
+/// See `prepare_password_reset` for the rationale.
+pub fn prepare_email_verification(
+    svc: &EmailService,
+    branding: &EmailBranding,
+    recipient: &str,
+    user_name: &str,
+    verification_token: &str,
+    locale: &unic_langid::LanguageIdentifier,
+) -> NewOutboundEmail {
+    let (subject, body_html, body_text) =
+        svc.compose_email_verification(user_name, recipient, verification_token, branding, locale);
+    let message_id = make_message_id("email-verify", &from_email_domain(svc));
+    let headers_json = serde_json::json!({
+        "Auto-Submitted": "auto-generated",
+    });
+
+    NewOutboundEmail {
+        channel_id: None,
+        ticket_id: None,
+        comment_id: None,
+        recipient: recipient.to_string(),
+        subject,
+        body_text,
+        body_html: Some(body_html),
+        message_id,
+        in_reply_to: None,
+        references_list: vec![],
+        headers_json,
+        correlation_id: None,
+        idempotency_key: Some(format!("email_verification:{}", hash16(verification_token))),
+        sender_identity: outbound_email_sender_identity::WORKSPACE.to_string(),
+        // TRANSACTIONAL, not a notification: this is the address proving
+        // itself, so suppression preferences must not withhold it. A user who
+        // muted notification mail still has to be able to confirm an address.
+        mail_class: outbound_email_mail_class::TRANSACTIONAL.to_string(),
+    }
+}
+
+/// Enqueue an address-confirmation email. The key derives from the token, so
+/// a resend (new token) is a new send; idempotency only catches enqueue
+/// retries inside one request.
+pub fn enqueue_email_verification(
+    conn: &mut DbConnection,
+    svc: &EmailService,
+    branding: &EmailBranding,
+    recipient: &str,
+    user_name: &str,
+    verification_token: &str,
+    locale: &unic_langid::LanguageIdentifier,
+) -> Result<OutboundEmail, DieselError> {
+    let row = prepare_email_verification(
+        svc,
+        branding,
+        recipient,
+        user_name,
+        verification_token,
+        locale,
+    );
+    outbound_emails::enqueue_idempotent(conn, row)
+}
+
 /// Build the signed one-click unsubscribe URL for a notification email, on the
 /// same origin as `cta_url` (the product app that serves the endpoint). `None`
 /// when the recipient uuid or the CTA origin can't be parsed, or `JWT_SECRET`

--- a/backend/src/startup.rs
+++ b/backend/src/startup.rs
@@ -773,6 +773,9 @@ pub fn configure_app(
                     .app_data(state.public_limiter_data.clone())
                     .wrap(RateLimiter::default())
                     .configure(crate::handlers::guest::config)
+                    // Address confirmation is redeemed from a mail client, so
+                    // it cannot require the session; the token is the proof.
+                    .configure(crate::handlers::email_verification::config)
             )
 
             // Public WebSocket for collaboration (auth handled in WebSocket handler)

--- a/backend/src/utils/email.rs
+++ b/backend/src/utils/email.rs
@@ -1645,6 +1645,92 @@ impl EmailService {
         (subject, html_body, body_text)
     }
 
+    /// Compose the "confirm this address" email for an address added to a
+    /// profile.
+    ///
+    /// Deliberately shaped like [`Self::compose_portal_magic_link`]: the same
+    /// proof (possession of a link sent to the address) with a much smaller
+    /// consequence, since clicking it verifies one address rather than signing
+    /// anyone in. The copy says which address is being confirmed, because a
+    /// user with several addresses cannot otherwise tell which one this is
+    /// about.
+    pub fn compose_email_verification(
+        &self,
+        user_name: &str,
+        address: &str,
+        verification_token: &str,
+        branding: &EmailBranding,
+        locale: &unic_langid::LanguageIdentifier,
+    ) -> (String, String, String) {
+        let verify_link = format!(
+            "{}/verify-email?token={}",
+            branding.base_url, verification_token
+        );
+        let template = EmailTemplate::new(branding);
+        let tr = |key: &str, args: &[(&str, fluent_bundle::FluentValue<'static>)]| {
+            crate::utils::i18n::tr_with(locale, key, args)
+        };
+
+        let name_html = escape_html(user_name);
+        let app_html = escape_html(&branding.app_name);
+        let address_html = escape_html(address);
+
+        let title = tr("email-verify-title", &[("app", app_html.clone().into())]);
+        let greeting = tr(
+            "email-verify-greeting",
+            &[("name", name_html.clone().into())],
+        );
+        let intro = tr(
+            "email-verify-intro",
+            &[
+                ("app", app_html.clone().into()),
+                ("address", address_html.clone().into()),
+            ],
+        );
+        let cta_label = tr("email-verify-cta-label", &[]);
+        let notice_items: Vec<String> = [
+            "email-verify-notice-expiry",
+            "email-verify-notice-unexpected",
+        ]
+        .iter()
+        .map(|key| tr(key, &[]))
+        .collect();
+
+        let html_body = template.render(
+            EmailLayout {
+                headline: &title,
+                body: vec![text(greeting), text(intro)],
+                cta: Some(Cta {
+                    label: cta_label,
+                    url: verify_link.clone(),
+                }),
+                notice: Some(Notice {
+                    kind: NoticeType::Info,
+                    items: notice_items,
+                }),
+                signoff: None,
+                preheader: &title,
+            },
+            locale,
+        );
+
+        let subject = tr(
+            "email-verify-subject",
+            &[("app", branding.app_name.clone().into())],
+        );
+
+        let body_text = tr(
+            "email-verify-body-text",
+            &[
+                ("name", user_name.to_string().into()),
+                ("address", address.to_string().into()),
+                ("link", verify_link.clone().into()),
+            ],
+        );
+
+        (subject, html_body, body_text)
+    }
+
     /// Send a confirmation email for a guest ticket submission. The link
     /// uses the same accept-invitation flow as a normal invitation, but the
     /// copy is tailored to the ticket-submission context — the email is

--- a/backend/src/utils/reset_tokens.rs
+++ b/backend/src/utils/reset_tokens.rs
@@ -12,6 +12,14 @@ pub enum TokenType {
     /// possession of the emailed link proves the customer owns the address,
     /// which is their whole identity in the portal.
     PortalMagicLink,
+    /// Proves someone controls an address they added to their profile. Same
+    /// reasoning as the portal link, narrower consequence: it verifies one
+    /// `user_emails` row rather than signing anyone in.
+    ///
+    /// The row is named in the token's `metadata`, not derived from the user,
+    /// because `reset_tokens` is user-scoped and a user may have several
+    /// unverified addresses at once.
+    EmailVerification,
 }
 
 impl TokenType {
@@ -20,6 +28,7 @@ impl TokenType {
             TokenType::PasswordReset => "password_reset",
             TokenType::Invitation => "invitation",
             TokenType::PortalMagicLink => "portal_magic_link",
+            TokenType::EmailVerification => "email_verification",
         }
     }
 
@@ -29,6 +38,11 @@ impl TokenType {
             TokenType::PasswordReset => Duration::hours(1), // 1 hour for password resets
             TokenType::Invitation => Duration::days(7),     // 7 days for user invitations
             TokenType::PortalMagicLink => Duration::minutes(20), // short-lived sign-in link
+            // A day: long enough to survive "I'll do it tonight", short enough
+            // that a forwarded mailbox archive is not a standing claim on the
+            // address. Nothing is signed in by it, so the risk of the longer
+            // window is bounded.
+            TokenType::EmailVerification => Duration::hours(24),
         }
     }
 }

--- a/backend/src/utils/tracing_redact.rs
+++ b/backend/src/utils/tracing_redact.rs
@@ -96,6 +96,11 @@ const ALLOWED_FIELDS: &[&str] = &[
     // somewhere.
     "bound_workspace",
     "attempted_workspace",
+    // The `user_emails` row an address-confirmation link names. Safe for the
+    // reason the address itself would not be: it is an opaque internal id, so
+    // it correlates a confirmation attempt across log lines without putting
+    // anybody's email address in the log.
+    "email_id",
     // bounded enums + operational dimensions. No free text.
     "aggregate",
     // Which realm a refresh token belongs to: exactly "agent" or "portal".

--- a/backend/tests/email_verification_round_trip.rs
+++ b/backend/tests/email_verification_round_trip.rs
@@ -1,0 +1,168 @@
+//! The confirmation round trip: mint, compose, redeem.
+//!
+//! Each piece of this flow is unit-tested, but the thing that actually has to
+//! hold is that the token minted for a row is the token the email carries and
+//! the token redemption accepts. That seam is where a flow like this breaks
+//! while every part of it passes, so this test walks it end to end, pulling the
+//! token out of the composed email body rather than from the code that made it.
+//!
+//! SMTP is not involved: `EmailService` is a disabled stub, so this exercises
+//! composition and redemption, not delivery.
+
+#![allow(clippy::expect_used)]
+
+use backend::models::NewUserEmail;
+use backend::utils::email::EmailBranding;
+use backend::utils::email::{EmailConfig, EmailService, SmtpSecurity};
+use backend::utils::reset_tokens::{ResetTokenUtils, TokenType};
+
+mod common;
+
+fn email_service_stub() -> EmailService {
+    EmailService::new(EmailConfig {
+        smtp_host: String::new(),
+        smtp_port: 587,
+        smtp_username: String::new(),
+        smtp_password: String::new(),
+        from_name: String::new(),
+        from_email: String::new(),
+        enabled: false,
+        security: SmtpSecurity::StartTls,
+    })
+}
+
+fn branding() -> EmailBranding {
+    EmailBranding {
+        app_name: "Nosdesk".to_string(),
+        logo_url: None,
+        primary_color: "#000000".to_string(),
+        base_url: "https://help.example.com".to_string(),
+        ..Default::default()
+    }
+}
+
+/// Pull the token back out of the link exactly as a mail client would: by
+/// reading it off the page, not by remembering what we generated.
+fn token_from_body(body: &str) -> String {
+    let at = body
+        .find("/verify-email?token=")
+        .expect("body carries the link");
+    body[at + "/verify-email?token=".len()..]
+        .chars()
+        .take_while(|c| c.is_ascii_alphanumeric())
+        .collect()
+}
+
+#[test]
+fn a_confirmation_link_verifies_the_address_once() {
+    common::ensure_test_keyring();
+    let db = common::TestDb::new();
+    let mut conn = db.conn();
+
+    let user = common::insert_user(&mut conn, "Round Trip");
+    let created = backend::repository::user_emails::add_email(
+        &mut conn,
+        &NewUserEmail {
+            user_uuid: user.uuid,
+            email: "second@example.com".to_string(),
+            email_type: "personal".to_string(),
+            is_primary: false,
+            is_verified: false,
+            source: Some("manual".to_string()),
+        },
+    )
+    .expect("add email");
+    assert!(!created.is_verified, "a new address starts unproven");
+
+    // Mint exactly as the send path does, including the metadata that names
+    // which row this proves.
+    let issued = ResetTokenUtils::create_reset_token(user.uuid, TokenType::EmailVerification);
+    backend::repository::reset_tokens::create_reset_token(
+        &mut conn,
+        &issued.token_hash,
+        user.uuid,
+        TokenType::EmailVerification.as_str(),
+        None,
+        None,
+        issued.expires_at,
+        Some(serde_json::json!({
+            "user_email_id": created.id,
+            "address": created.email,
+        })),
+    )
+    .expect("mint token");
+
+    // Compose the email and recover the token from the link it contains. If the
+    // link were built from a different value, or the token were mangled in the
+    // template, this is where it would show.
+    let svc = email_service_stub();
+    let (_subject, html, body_text) = svc.compose_email_verification(
+        &user.name,
+        &created.email,
+        &issued.raw_token,
+        &branding(),
+        &"en-US".parse().expect("locale"),
+    );
+    let emailed_token = token_from_body(&body_text);
+    assert_eq!(
+        emailed_token, issued.raw_token,
+        "the link must carry the token that was minted"
+    );
+
+    // The HTML body is the one most people actually click, and it is built by a
+    // different path from the text body (the template's CTA href rather than a
+    // Fluent string), so checking only the text version would leave the link
+    // most recipients use untested.
+    assert_eq!(
+        token_from_body(&html),
+        issued.raw_token,
+        "the HTML button must point at the same token as the text link"
+    );
+    assert!(
+        !html.contains("&amp;token=") && html.matches("/verify-email?token=").count() >= 1,
+        "the href must not be double-escaped into a dead link"
+    );
+
+    // Redeem it the way the public handler does.
+    let (claimed_user, metadata) =
+        backend::repository::reset_tokens::validate_and_consume_token_with_metadata(
+            &mut conn,
+            &emailed_token,
+            TokenType::EmailVerification.as_str(),
+        )
+        .expect("a fresh token must redeem");
+    assert_eq!(claimed_user, user.uuid);
+
+    let meta = metadata.expect("metadata present");
+    let email_id = meta["user_email_id"].as_i64().expect("row id") as i32;
+    let address = meta["address"].as_str().expect("address");
+
+    assert_eq!(
+        backend::repository::user_emails::mark_verified_if_matches(
+            &mut conn,
+            email_id,
+            claimed_user,
+            address
+        )
+        .expect("verify"),
+        1
+    );
+
+    let after = backend::repository::user_emails::get_user_emails_by_uuid(&mut conn, &user.uuid)
+        .expect("reload")
+        .into_iter()
+        .find(|e| e.id == created.id)
+        .expect("row present");
+    assert!(after.is_verified, "the address is confirmed");
+
+    // Single use. A forwarded mailbox is not a second chance.
+    assert!(
+        backend::repository::reset_tokens::validate_and_consume_token_with_metadata(
+            &mut conn,
+            &emailed_token,
+            TokenType::EmailVerification.as_str(),
+        )
+        .is_err(),
+        "a confirmation link must not redeem twice"
+    );
+}

--- a/frontend/src/components/settings/UserEmailsCard.vue
+++ b/frontend/src/components/settings/UserEmailsCard.vue
@@ -127,6 +127,24 @@ const setAsPrimary = async (emailId: number, emailAddress: string) => {
 };
 
 // Delete email
+const resending = ref<Set<number>>(new Set());
+const resentFor = ref<Set<number>>(new Set());
+
+// Re-send the confirmation link. Reported per row rather than as a toast that
+// disappears: the user's next step is to go and read their mail, and they may
+// come back to this screen before it arrives.
+const resendVerification = async (emailId: number) => {
+  resending.value = new Set([...resending.value, emailId]);
+  try {
+    await userService.resendEmailVerification(props.userUuid, emailId);
+    resentFor.value = new Set([...resentFor.value, emailId]);
+  } catch (error) {
+    emit('error', extractErrorMessage(error, t('settings-emails-resend-error')));
+  } finally {
+    resending.value = new Set([...resending.value].filter((id) => id !== emailId));
+  }
+};
+
 const pendingDeleteEmail = ref<{ id: number; address: string } | null>(null);
 
 const deleteEmail = (emailId: number, emailAddress: string) => {
@@ -251,6 +269,21 @@ watch(() => props.userUuid, () => {
             :label="email.is_verified ? $t('settings-emails-verified-badge') : $t('settings-emails-unverified-badge')"
             :tone="email.is_verified ? 'positive' : 'caution'"
           />
+
+          <template v-if="canEdit && email.id !== 0 && !email.is_verified">
+            <span v-if="resentFor.has(email.id)" class="text-2xs text-tertiary">
+              {{ $t('settings-emails-resend-sent') }}
+            </span>
+            <Button
+              v-else
+              variant="secondary"
+              size="sm"
+              :disabled="resending.has(email.id)"
+              @click="resendVerification(email.id)"
+            >
+              {{ resending.has(email.id) ? $t('settings-emails-resend-sending') : $t('settings-emails-resend') }}
+            </Button>
+          </template>
 
           <template v-if="canEdit && email.id !== 0 && !email.is_primary">
             <Button variant="secondary" size="sm" @click="setAsPrimary(email.id, email.email)">

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -94,6 +94,17 @@ const router = createRouter({
       }
     },
     {
+      // Opened from a mail client, so it must render without a session.
+      path: '/verify-email',
+      name: 'verify-email',
+      component: () => import('@/views/VerifyEmailView.vue'),
+      meta: {
+        layout: 'blank',
+        requiresAuth: false,
+        titleKey: 'route-title-verify-email'
+      }
+    },
+    {
       path: '/mfa-setup',
       name: 'mfa-setup',
       component: () => import('@/views/MFASetupView.vue'),

--- a/frontend/src/services/userService.ts
+++ b/frontend/src/services/userService.ts
@@ -201,8 +201,12 @@ const userService = {
     }
   },
 
-  // Update email (set as primary or verified)
-  async updateUserEmail(uuid: string, emailId: number, updates: { is_primary?: boolean; is_verified?: boolean }): Promise<UserEmail | null> {
+  // Update email (set as primary).
+  //
+  // No `is_verified`: verification is a claim about the address, provable only
+  // by a challenge sent to it, so the server does not read it from the body.
+  // Use `resendEmailVerification` / the emailed link instead.
+  async updateUserEmail(uuid: string, emailId: number, updates: { is_primary?: boolean }): Promise<UserEmail | null> {
     try {
       const response = await apiClient.put(`/users/${uuid}/emails/${emailId}`, updates);
       return response.data.email || null;
@@ -210,6 +214,23 @@ const userService = {
       logger.error('Failed to update user email', { error, uuid, emailId, updates });
       throw error;
     }
+  },
+
+  // Re-send the confirmation link for an unverified address.
+  async resendEmailVerification(uuid: string, emailId: number): Promise<void> {
+    try {
+      await apiClient.post(`/users/${uuid}/emails/${emailId}/resend-verification`);
+    } catch (error) {
+      logger.error('Failed to resend verification email', { error, uuid, emailId });
+      throw error;
+    }
+  },
+
+  // Redeem a confirmation link. Public and unauthenticated: the link is opened
+  // from a mail client, which may not be the browser holding the session.
+  async verifyEmailToken(token: string): Promise<{ email?: string }> {
+    const response = await apiClient.post('/public/verify-email', { token });
+    return response.data ?? {};
   },
 
   // Delete an email address

--- a/frontend/src/views/VerifyEmailView.vue
+++ b/frontend/src/views/VerifyEmailView.vue
@@ -1,0 +1,81 @@
+<script setup lang="ts">
+// Redeems an address-confirmation link.
+//
+// Unauthenticated by design: the link is opened from a mail client, which may
+// not be the browser holding the session, and requiring a login first would
+// strand anyone confirming a second address from a different device. The token
+// is the proof.
+import { ref, onMounted } from 'vue';
+import { useRoute, useRouter } from 'vue-router';
+import { useFluent } from 'fluent-vue';
+import userService from '@/services/userService';
+import { extractErrorMessage } from '@/utils/errors';
+import Button from '@/components/common/Button.vue';
+import Icon from '@/components/common/Icon.vue';
+import Spinner from '@/components/common/Spinner.vue';
+
+const route = useRoute();
+const router = useRouter();
+const fluent = useFluent();
+const t = (key: string, args?: Record<string, string | number>) => fluent.$t(key, args);
+
+type State = 'working' | 'verified' | 'failed';
+const state = ref<State>('working');
+const address = ref('');
+const errorMessage = ref('');
+
+onMounted(async () => {
+  const token = route.query.token;
+  if (typeof token !== 'string' || !token) {
+    state.value = 'failed';
+    errorMessage.value = t('verify-email-missing-token');
+    return;
+  }
+  try {
+    const result = await userService.verifyEmailToken(token);
+    address.value = result.email ?? '';
+    state.value = 'verified';
+  } catch (error) {
+    // The server answers the same way for expired, already-used and unknown
+    // tokens, so the copy here stays equally undifferentiated.
+    errorMessage.value = extractErrorMessage(error, t('verify-email-failed-body'));
+    state.value = 'failed';
+  }
+});
+</script>
+
+<template>
+  <div class="min-h-screen flex items-center justify-center px-4">
+    <div class="w-full max-w-md flex flex-col items-center gap-4 text-center">
+      <template v-if="state === 'working'">
+        <Spinner size="lg" class="text-accent" />
+        <p class="text-secondary text-sm">{{ $t('verify-email-working') }}</p>
+      </template>
+
+      <template v-else-if="state === 'verified'">
+        <div class="w-12 h-12 rounded-full bg-status-success/10 flex items-center justify-center">
+          <Icon name="check" class="h-6 w-6 text-status-success" />
+        </div>
+        <h1 class="text-xl font-semibold text-primary">{{ $t('verify-email-success-title') }}</h1>
+        <p class="text-secondary text-sm">
+          {{ address ? t('verify-email-success-body-address', { address }) : $t('verify-email-success-body') }}
+        </p>
+        <Button variant="primary" @click="router.push('/')">
+          {{ $t('verify-email-continue') }}
+        </Button>
+      </template>
+
+      <template v-else>
+        <div class="w-12 h-12 rounded-full bg-status-error/10 flex items-center justify-center">
+          <Icon name="warning" class="h-6 w-6 text-status-error" />
+        </div>
+        <h1 class="text-xl font-semibold text-primary">{{ $t('verify-email-failed-title') }}</h1>
+        <p class="text-secondary text-sm">{{ errorMessage }}</p>
+        <p class="text-tertiary text-xs">{{ $t('verify-email-failed-hint') }}</p>
+        <Button variant="secondary" @click="router.push('/')">
+          {{ $t('verify-email-continue') }}
+        </Button>
+      </template>
+    </div>
+  </div>
+</template>

--- a/i18n/locales/en-US/main.ftl
+++ b/i18n/locales/en-US/main.ftl
@@ -88,6 +88,41 @@ invitation-body-text =
 # Customer-portal passwordless sign-in email. Same HTML/plaintext
 # split as the invitation: HTML keys carry inline <strong> emphasis,
 # variables are HTML-escaped at the Rust boundary.
+route-title-verify-email = Confirm email
+verify-email-working = Confirming your address…
+verify-email-success-title = Address confirmed
+verify-email-success-body = This address is now confirmed on your account.
+verify-email-success-body-address = { $address } is now confirmed on your account.
+verify-email-failed-title = Couldn't confirm this address
+verify-email-failed-body = This confirmation link is invalid or has expired.
+verify-email-failed-hint = Confirmation links expire after 24 hours and can be used once. You can send a new one from your profile.
+verify-email-missing-token = This link is missing its confirmation code.
+verify-email-continue = Continue
+settings-emails-resend = Resend confirmation
+settings-emails-resend-sending = Sending…
+settings-emails-resend-sent = Confirmation sent
+settings-emails-resend-error = Could not send the confirmation email.
+
+email-verify-subject = Confirm your email address for { $app }
+email-verify-title = Confirm your email address
+email-verify-greeting = Hello <strong>{ $name }</strong>,
+email-verify-intro = Use the button below to confirm <strong>{ $address }</strong> so it can be used with your <strong>{ $app }</strong> account.
+email-verify-cta-label = Confirm this address
+email-verify-notice-expiry = This link expires in <strong>24 hours</strong> and can be used once
+email-verify-notice-unexpected = If you didn't add this address, you can safely ignore this email
+email-verify-body-text =
+    Hello { $name },
+
+    Use this link to confirm { $address } so it can be used with your account:
+
+    { $link }
+
+    A few things to know:
+      - This link expires in 24 hours and can be used once.
+      - If you didn't add this address, you can safely ignore this email.
+
+    -- { $app }
+
 portal-magic-link-subject = Sign in to { $app } support
 portal-magic-link-title = Sign in to { $app }
 portal-magic-link-greeting = Hello <strong>{ $name }</strong>,

--- a/i18n/locales/fr-FR/main.ftl
+++ b/i18n/locales/fr-FR/main.ftl
@@ -50,6 +50,41 @@ invitation-body-text =
     -- { $app }
 
 # Connexion sans mot de passe au portail client (traduction automatique, en attente de relecture).
+route-title-verify-email = Confirmer l’e-mail
+verify-email-working = Confirmation de votre adresse…
+verify-email-success-title = Adresse confirmée
+verify-email-success-body = Cette adresse est désormais confirmée sur votre compte.
+verify-email-success-body-address = { $address } est désormais confirmée sur votre compte.
+verify-email-failed-title = Impossible de confirmer cette adresse
+verify-email-failed-body = Ce lien de confirmation est invalide ou a expiré.
+verify-email-failed-hint = Les liens de confirmation expirent après 24 heures et ne servent qu’une fois. Vous pouvez en envoyer un nouveau depuis votre profil.
+verify-email-missing-token = Ce lien ne contient pas de code de confirmation.
+verify-email-continue = Continuer
+settings-emails-resend = Renvoyer la confirmation
+settings-emails-resend-sending = Envoi…
+settings-emails-resend-sent = Confirmation envoyée
+settings-emails-resend-error = Impossible d’envoyer l’e-mail de confirmation.
+
+email-verify-subject = Confirmez votre adresse e-mail pour { $app }
+email-verify-title = Confirmez votre adresse e-mail
+email-verify-greeting = Bonjour <strong>{ $name }</strong>,
+email-verify-intro = Utilisez le bouton ci-dessous pour confirmer <strong>{ $address }</strong> afin de l'utiliser avec votre compte <strong>{ $app }</strong>.
+email-verify-cta-label = Confirmer cette adresse
+email-verify-notice-expiry = Ce lien expire dans <strong>24 heures</strong> et ne peut être utilisé qu'une fois
+email-verify-notice-unexpected = Si vous n'avez pas ajouté cette adresse, vous pouvez ignorer cet e-mail
+email-verify-body-text =
+    Bonjour { $name },
+
+    Utilisez ce lien pour confirmer { $address } afin de l'utiliser avec votre compte :
+
+    { $link }
+
+    À savoir :
+      - Ce lien expire dans 24 heures et ne peut être utilisé qu'une fois.
+      - Si vous n'avez pas ajouté cette adresse, vous pouvez ignorer cet e-mail.
+
+    -- { $app }
+
 portal-magic-link-subject = Connectez-vous à l'assistance { $app }
 portal-magic-link-title = Connectez-vous à { $app }
 portal-magic-link-greeting = Bonjour <strong>{ $name }</strong>,

--- a/i18n/locales/nl-NL/main.ftl
+++ b/i18n/locales/nl-NL/main.ftl
@@ -47,6 +47,41 @@ invitation-body-text =
     -- { $app }
 
 # Wachtwoordloze aanmelding bij het klantenportaal (automatische vertaling, in afwachting van revisie).
+route-title-verify-email = E-mail bevestigen
+verify-email-working = Je adres wordt bevestigd…
+verify-email-success-title = Adres bevestigd
+verify-email-success-body = Dit adres is nu bevestigd op je account.
+verify-email-success-body-address = { $address } is nu bevestigd op je account.
+verify-email-failed-title = Kan dit adres niet bevestigen
+verify-email-failed-body = Deze bevestigingslink is ongeldig of verlopen.
+verify-email-failed-hint = Bevestigingslinks verlopen na 24 uur en zijn eenmalig te gebruiken. Je kunt vanuit je profiel een nieuwe sturen.
+verify-email-missing-token = In deze link ontbreekt de bevestigingscode.
+verify-email-continue = Doorgaan
+settings-emails-resend = Bevestiging opnieuw sturen
+settings-emails-resend-sending = Versturen…
+settings-emails-resend-sent = Bevestiging verstuurd
+settings-emails-resend-error = Kan de bevestigingsmail niet versturen.
+
+email-verify-subject = Bevestig je e-mailadres voor { $app }
+email-verify-title = Bevestig je e-mailadres
+email-verify-greeting = Hallo <strong>{ $name }</strong>,
+email-verify-intro = Gebruik de knop hieronder om <strong>{ $address }</strong> te bevestigen zodat het bij je <strong>{ $app }</strong>-account gebruikt kan worden.
+email-verify-cta-label = Dit adres bevestigen
+email-verify-notice-expiry = Deze link verloopt over <strong>24 uur</strong> en kan één keer gebruikt worden
+email-verify-notice-unexpected = Heb je dit adres niet toegevoegd, dan kun je deze e-mail negeren
+email-verify-body-text =
+    Hallo { $name },
+
+    Gebruik deze link om { $address } te bevestigen zodat het bij je account gebruikt kan worden:
+
+    { $link }
+
+    Goed om te weten:
+      - Deze link verloopt over 24 uur en kan één keer gebruikt worden.
+      - Heb je dit adres niet toegevoegd, dan kun je deze e-mail negeren.
+
+    -- { $app }
+
 portal-magic-link-subject = Meld u aan bij { $app }-ondersteuning
 portal-magic-link-title = Meld u aan bij { $app }
 portal-magic-link-greeting = Hallo <strong>{ $name }</strong>,


### PR DESCRIPTION
Completes the email track: #335 stopped a user asserting their own address was verified, and this gives them a legitimate way to make it true. Until now the pill read "Unverified" forever, with no token, send, endpoint or resend behind it.

## No new table

`reset_tokens` already carries password reset, invitations and the portal magic link, with a `token_type` discriminator, per-type expiry and a `metadata` column. The magic link's own doc comment states the semantics this needs: *possession of an emailed link proves the recipient owns the address*. This is that proof with a smaller consequence, since clicking verifies one row rather than signing anyone in.

The row is named in the token's `metadata` rather than derived from its subject, because `reset_tokens` is user-scoped and one user may hold several unverified addresses at once.

## One claim path

`validate_and_consume_token` grew a sibling that also returns metadata, and the original delegates to it. Deliberately one implementation: the single-use guarantee is the `is_used = false` predicate inside that single `UPDATE`, so a second claim path would be a second chance to get atomicity wrong.

## Two guards, neither optional

Redemption requires that the row still belongs to the token's user **and** still holds the address the token was minted against. The address parameter is non-optional so there is no call shape that skips the second check. A spent token that no longer matches stays spent: a link is not a standing permission to verify whatever that row later becomes.

Both guards are mutation-checked, and fail at distinct assertions.

## Other decisions worth review

- **Link host** comes from `email_link_base`, never the request `Host`. A forged one would hand an attacker a token verifying an address on someone else's account, which is the reasoning password reset already documents.
- **Redemption is public and unauthenticated.** The link opens in a mail client, which may not be the browser holding the session, and requiring a login first would strand anyone confirming an address from another device. It sits under the existing rate-limited `/api/public` scope.
- **One connection, not two.** `send_verification` uses the connection already in hand rather than `run_in_workspace`, which is that call preceded by `pool.get()`. The caller holds a connection for the whole request, and a burst near the pool size is how holding two becomes a deadlock (`api_token.rs::finalize` documents this). `password_reset` still has the older shape; same fix applies if wanted.
- **Mail class is TRANSACTIONAL**, so suppression preferences cannot withhold it. Someone who muted notification mail still has to be able to confirm an address.

## Verification

1964 tests pass, 0 fail. The round-trip test recovers the token from the **composed email body** rather than from the code that minted it, and checks the HTML button as well as the text link, since they are built by different paths and the HTML one is what most recipients click. Pointing the template's CTA at a stale token fails it.

**Not covered: SMTP delivery.** Composition, both body formats, the token round trip and single use are tested; nobody has watched a message arrive. Mailpit at `localhost:8025` is the check, and it needs the dev stack rebuilt.

https://claude.ai/code/session_017iEcp3fFMB594JYRZxcQ5H