### PR TITLE
Widen the other column the OIDC issuer is stored in

### DIFF
--- a/backend/migrations/2026-09-10-000003_auth_identity_provider_type_widen/down.sql
+++ b/backend/migrations/2026-09-10-000003_auth_identity_provider_type_widen/down.sql
@@ -1,0 +1,4 @@
+-- Fails if any row already holds an issuer longer than 50 characters, which is
+-- correct: those identities cannot be represented in the old type, and
+-- truncating one would orphan the account it belongs to.
+ALTER TABLE user_auth_identities ALTER COLUMN provider_type TYPE VARCHAR(50);

--- a/backend/migrations/2026-09-10-000003_auth_identity_provider_type_widen/up.sql
+++ b/backend/migrations/2026-09-10-000003_auth_identity_provider_type_widen/up.sql
@@ -1,0 +1,27 @@
+-- `user_auth_identities.provider_type` holds the OIDC issuer, and varchar(50)
+-- is too narrow for real ones.
+--
+-- This is the second half of a fix whose first half
+-- (2026-09-10-000002_user_emails_source_widen) was incomplete. The issuer is
+-- stored in two places, because a seat resolves on `(iss, sub)`: as the
+-- identity's `provider_type` here, and as the address's `source` there.
+-- Widening only one left first-time OIDC signup failing exactly as before,
+-- just at a different INSERT, so the earlier migration fixed nothing on its
+-- own.
+--
+-- Same mechanics as before: `oauth_provisioning` writes `iss.to_string()`
+-- straight in, Postgres rejects an over-length varchar rather than truncating
+-- it, and the surrounding `create_user` fails with it. Microsoft Entra's
+-- issuer, `https://login.microsoftonline.com/<tenant-guid>/v2.0`, is 75
+-- characters. A Keycloak realm at `https://<host>/realms/master` is about 45
+-- and fits, which is why this depends entirely on who the provider is and how
+-- it went unnoticed.
+--
+-- Truncation would be worse than the error, incidentally: `provider_type` is
+-- half the lookup key, so a clipped issuer would store an identity that no
+-- subsequent login could ever match.
+--
+-- TEXT, not a larger varchar: there is no length this column wants to
+-- enforce, and another number just moves the cliff. Indexes on the column
+-- survive the type change.
+ALTER TABLE user_auth_identities ALTER COLUMN provider_type TYPE TEXT;

--- a/backend/src/repository/user_helpers.rs
+++ b/backend/src/repository/user_helpers.rs
@@ -860,4 +860,94 @@ mod tests {
             _ => panic!("expected Existing on repeat submission"),
         }
     }
+
+    /// A long OIDC issuer must survive account creation.
+    ///
+    /// `source` records the issuer, because it is half the `(iss, sub)` key a
+    /// seat resolves on, and it was `varchar(50)` until
+    /// `2026-09-10-000002_user_emails_source_widen`. Postgres rejects an
+    /// over-length varchar rather than truncating it, so the insert failed,
+    /// `create_user_with_email` failed with it, and a first-time OIDC signup
+    /// never completed.
+    ///
+    /// Which providers this reached depended entirely on issuer length, which
+    /// is why it went unnoticed: a Keycloak realm at
+    /// `https://keycloak.example.com/realms/master` is 45 characters and fits,
+    /// while Microsoft Entra's
+    /// `https://login.microsoftonline.com/<tenant-guid>/v2.0` is 75 and does
+    /// not. The hosted platform issuer is short, and Microsoft logins arrive
+    /// through the `microsoft` provider path, which writes a literal string.
+    #[test]
+    fn a_long_oidc_issuer_survives_account_creation() {
+        let mut conn = setup_test_connection();
+
+        // The real shape, not an invented one: a tenant-scoped Entra issuer.
+        let entra_issuer =
+            "https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47/v2.0";
+        assert!(
+            entra_issuer.len() > 50,
+            "the regression only exists above 50 characters; this issuer is {}",
+            entra_issuer.len()
+        );
+
+        let new_user = crate::models::NewUser {
+            uuid: Uuid::new_v4(),
+            name: "Long Issuer".into(),
+            pronouns: None,
+            avatar_url: None,
+            banner_url: None,
+            avatar_thumb: None,
+            microsoft_uuid: None,
+            mfa_secret: None,
+            mfa_secret_kek_id: None,
+            mfa_enabled: false,
+            platform_role: None,
+        };
+
+        let (_user, email_record) = create_user_with_email(
+            new_user,
+            WorkspaceRole::Member,
+            "long-issuer@test.com".into(),
+            true,
+            Some(entra_issuer.to_string()),
+            &mut conn,
+            None,
+            crate::repository::workspaces::SeatWriteAuthority::ControlPlane,
+        )
+        .and_then(|o| o.into_created())
+        .expect("a 75-character issuer must not fail account creation");
+
+        assert_eq!(
+            email_record.source.as_deref(),
+            Some(entra_issuer),
+            "the issuer must round-trip whole; a truncated one would not match \
+             the (iss, sub) key a later login resolves on"
+        );
+
+        // The issuer is stored TWICE, because a seat resolves on (iss, sub):
+        // as this address's `source`, and as the identity's `provider_type`.
+        // Widening only one of them left signup failing exactly as before, at
+        // the other INSERT, so both belong in one test.
+        use crate::schema::user_auth_identities;
+        let identity_rows: i64 = diesel::insert_into(user_auth_identities::table)
+            .values((
+                user_auth_identities::user_uuid.eq(_user.uuid),
+                user_auth_identities::provider_type.eq(entra_issuer),
+                user_auth_identities::external_id.eq("sub-abc123"),
+            ))
+            .execute(&mut conn)
+            .expect("a 75-character issuer must fit provider_type too")
+            as i64;
+        assert_eq!(identity_rows, 1);
+
+        let stored: String = user_auth_identities::table
+            .filter(user_auth_identities::user_uuid.eq(_user.uuid))
+            .select(user_auth_identities::provider_type)
+            .first(&mut conn)
+            .expect("identity row");
+        assert_eq!(
+            stored, entra_issuer,
+            "a clipped issuer would store an identity no later login could match"
+        );
+    }
 }

--- a/backend/src/schema.rs
+++ b/backend/src/schema.rs
@@ -1800,8 +1800,7 @@ diesel::table! {
     user_auth_identities (id) {
         id -> Int4,
         user_uuid -> Uuid,
-        #[max_length = 50]
-        provider_type -> Varchar,
+        provider_type -> Text,
         #[max_length = 255]
         external_id -> Varchar,
         #[max_length = 320]


### PR DESCRIPTION
#335 widened `user_emails.source` for long OIDC issuers and **fixed nothing on its own**. The issuer is stored in two places, because a seat resolves on `(iss, sub)`:

- `user_emails.source` — widened in #335
- `user_auth_identities.provider_type` — still `varchar(50)`

`oauth_provisioning` writes `iss.to_string()` into `provider_type` at both insert sites, so a first-time OIDC signup with a long issuer still failed, just at the second INSERT a few lines later.

Found because the question was asked directly: *what happens if a Keycloak ID is too long?* My own test had passed because it only exercised the column I had already fixed.

## Which providers this hits

Entirely a function of issuer length, with a cliff at 50 characters.

| Issuer | Length | |
|---|---|---|
| `https://keycloak.cherrysofa.com/realms/master` | 45 | fits |
| `https://keycloak.cherrysofa.com/realms/nosdesk-issuer-length-test` | 65 | **fails** |
| `https://login.microsoftonline.com/<tenant-guid>/v2.0` | 75 | **fails** |

Never Microsoft-specific: Entra simply always exceeds it because of the tenant GUID. A Keycloak realm fits or does not depending on its name and hostname, so renaming a realm could break signup with no obvious cause.

## Why the error beats truncation

`provider_type` is half the lookup key. A clipped issuer would store an identity no later login could ever match, giving a silently unusable account instead of a loud failure. `TEXT` rather than a bigger `varchar` for the same reason as before: another number just moves the cliff.

## Completeness

Every other short column that could hold an issuer was checked rather than assumed this time. `sync_delta_tokens.provider_type` takes slugs like `"microsoft"`; the contact-detail `source` columns take transport names like `"ldap"` / `"scim"`. `provider_type` was the only one left.

## Verification

1965 tests pass, 0 fail. The test covers both columns, and was confirmed non-vacuous by reverting `provider_type` to `varchar(50)` **while leaving the migration marked applied** — the harness re-applies migrations on connect and had twice silently re-fixed the schema underneath the check, making the test look like it passed.

```
a 75-character issuer must fit provider_type too:
  DatabaseError("value too long for type character varying(50)")
```

https://claude.ai/code/session_017iEcp3fFMB594JYRZxcQ5H