### PR TITLE
Widen external_id before SAML needs it

### DIFF
--- a/backend/migrations/2026-09-10-000004_auth_identity_external_id_widen/down.sql
+++ b/backend/migrations/2026-09-10-000004_auth_identity_external_id_widen/down.sql
@@ -1,0 +1,4 @@
+-- Fails if any row already holds a subject longer than 255 characters, which
+-- is correct: those identities cannot be represented in the old type, and
+-- truncating one would orphan the account it belongs to.
+ALTER TABLE user_auth_identities ALTER COLUMN external_id TYPE VARCHAR(255);

--- a/backend/migrations/2026-09-10-000004_auth_identity_external_id_widen/up.sql
+++ b/backend/migrations/2026-09-10-000004_auth_identity_external_id_widen/up.sql
@@ -1,0 +1,28 @@
+-- `user_auth_identities.external_id` holds the provider's opaque subject, and
+-- varchar(255) is a bound nothing about the value justifies.
+--
+-- Preventative, not a fix for a live failure: today's providers all fit.
+-- OIDC `sub` is short, Microsoft object ids are GUIDs, and LDAP uses
+-- entryUUID / objectGUID. SAML is the one that would not necessarily fit: an
+-- email-format NameID is bounded by email length, 320 characters, and
+-- persistent NameIDs carry no length bound at all.
+--
+-- It is widened now rather than when SAML lands because the failure mode is
+-- expensive and badly-timed. Postgres rejects an over-length varchar rather
+-- than truncating, the surrounding provisioning fails with it, and it surfaces
+-- as "SSO is broken" at a customer's very first federated login, with nothing
+-- in the error pointing at a column width. That exact shape cost real time
+-- twice today: the OIDC issuer overflowed `user_emails.source` and then
+-- `user_auth_identities.provider_type`, both varchar(50), both silent until a
+-- signup failed.
+--
+-- Truncation would be worse than the error regardless: `external_id` is half
+-- the identity key, so a clipped subject would store an identity that no
+-- later login could match.
+--
+-- TEXT rather than a larger varchar, for the same reason as the other two:
+-- there is no length this column wants to enforce, and picking another number
+-- just moves the cliff. Both partial unique indexes
+-- (`user_auth_identities_global_uq`, `user_auth_identities_scoped_uq`) survive
+-- the type change.
+ALTER TABLE user_auth_identities ALTER COLUMN external_id TYPE TEXT;

--- a/backend/src/repository/user_helpers.rs
+++ b/backend/src/repository/user_helpers.rs
@@ -949,5 +949,21 @@ mod tests {
             stored, entra_issuer,
             "a clipped issuer would store an identity no later login could match"
         );
+
+        // `external_id` is the other half of that key, and SAML is where it
+        // gets long: an email-format NameID is bounded only by email length,
+        // 320. Preventative rather than a live case, since every provider in
+        // use today is short, but it is the same failure and it would surface
+        // at a customer's first federated login.
+        let long_name_id = format!("{}@{}.example.com", "n".repeat(64), "d".repeat(240));
+        assert!(long_name_id.len() > 255);
+        diesel::insert_into(user_auth_identities::table)
+            .values((
+                user_auth_identities::user_uuid.eq(_user.uuid),
+                user_auth_identities::provider_type.eq("https://idp.example.com/saml/metadata"),
+                user_auth_identities::external_id.eq(&long_name_id),
+            ))
+            .execute(&mut conn)
+            .expect("a 300-character NameID must fit external_id");
     }
 }

--- a/backend/src/schema.rs
+++ b/backend/src/schema.rs
@@ -1801,8 +1801,7 @@ diesel::table! {
         id -> Int4,
         user_uuid -> Uuid,
         provider_type -> Text,
-        #[max_length = 255]
-        external_id -> Varchar,
+        external_id -> Text,
         #[max_length = 320]
         email -> Nullable<Varchar>,
         metadata -> Nullable<Jsonb>,


### PR DESCRIPTION
`user_auth_identities.external_id` holds the provider's opaque subject and was `varchar(255)` — a bound nothing about the value justifies.

**Preventative, not a fix for a live failure.** Every provider in use today fits comfortably: OIDC `sub` is short, Microsoft object ids are GUIDs, LDAP uses entryUUID / objectGUID. SAML is the one that would not necessarily — an email-format NameID is bounded only by email length (320), and persistent NameIDs carry no length bound at all.

## Why now rather than when SAML lands

The failure shape. Postgres rejects an over-length varchar rather than truncating, the surrounding provisioning fails with it, and it surfaces as *"SSO is broken"* at a customer's **first federated login**, with nothing in the error pointing at a column width.

That shape cost real time twice today: the OIDC issuer overflowed `user_emails.source` (#335), and then `user_auth_identities.provider_type` (#337) — the second only found because the question "what happens if a Keycloak ID is too long?" was asked directly. This is the third column in the same family, and the only one left.

Truncation would be worse than the error regardless: `external_id` is half the identity key, so a clipped subject would store an identity that no later login could match.

## Verification

1965 tests pass, 0 fail. Both partial unique indexes (`user_auth_identities_global_uq`, `user_auth_identities_scoped_uq`) confirmed surviving the type change against the live schema.

The test inserts a 300-character email-format NameID, and the assertion was confirmed non-vacuous by reverting the column to `varchar(255)` **while leaving the migration marked applied** — the harness re-applies migrations on connect and will otherwise silently re-widen the column, making the check look like it passed.

## Context

Came out of reviewing whether the Model C identity architecture is sufficient for v1.1. It is, and SAML/SCIM/multi-IdP are safely deferrable: the identity layer already generalises, keying on `(provider_type, external_id)` with a nullable `workspace_id` and two partial unique indexes. This was the one cheap thing worth doing ahead of that work rather than during it.

https://claude.ai/code/session_017iEcp3fFMB594JYRZxcQ5H