### PR TITLE
Stop the list footer stranding its status text mid-bar

### DIFF
--- a/frontend/src/components/common/PaginationControls.vue
+++ b/frontend/src/components/common/PaginationControls.vue
@@ -118,7 +118,7 @@ const hasMultiplePages = computed(() => !props.isInfiniteMode && props.totalPage
       <!-- Left: Position info -->
       <div class="flex items-center gap-1 text-xs text-secondary">
         <template v-if="isInfiniteMode">
-          <span>{{ totalItems }} items</span>
+          <span>{{ t('pagination-controls-items', { count: totalItems }) }}</span>
         </template>
         <template v-else>
           <span>{{ t('pagination-controls-page') }}</span>
@@ -185,18 +185,21 @@ const hasMultiplePages = computed(() => !props.isInfiniteMode && props.totalPage
           size="xs"
           @update:model-value="handlePageSizeChange"
         />
-        <span>per page</span>
+        <span>{{ t('pagination-controls-per-page') }}</span>
       </div>
 
-      <!-- Center: Pagination controls -->
+      <!-- Center: navigation only.
+           The three slots each mean one thing: page size on the left,
+           navigation in the middle, position on the right. The item count
+           used to live here, which put it dead centre while the right slot
+           collapsed to an empty div, because its only child is gated on
+           `!isInfiniteMode`. Since infinite mode is the DEFAULT (pageSize
+           starts at 0), that lopsided bar was what every list view showed
+           out of the box. The count is position, not navigation, so it now
+           sits on the right beside where "Page x of y" goes. -->
       <div class="flex-1 flex items-center justify-center min-w-0">
-        <!-- Infinite scroll mode: Just show total -->
-        <template v-if="isInfiniteMode">
-          <span class="text-sm text-secondary">{{ totalItems }} items</span>
-        </template>
-
         <!-- Pagination mode: Page numbers -->
-        <template v-else-if="hasMultiplePages">
+        <template v-if="hasMultiplePages && !isInfiniteMode">
           <div class="flex items-center gap-2">
             <button
               @click="changePage(currentPage - 1)"
@@ -250,7 +253,13 @@ const hasMultiplePages = computed(() => !props.isInfiniteMode && props.totalPage
            for the `go-to-item` it emitted, and its label was
            hard-coded English. -->
       <div class="flex items-center gap-2 flex-shrink-0">
-        <template v-if="!isInfiniteMode">
+        <!-- Infinite mode has no page to report, so the total takes the
+             position slot: same place, same kind of information. -->
+        <template v-if="isInfiniteMode">
+          <span class="text-sm text-secondary">{{ t('pagination-controls-items', { count: totalItems }) }}</span>
+        </template>
+
+        <template v-else>
           <!-- Page info with direct input -->
           <div class="flex items-center gap-1.5 text-sm text-secondary">
             <span>{{ t('pagination-controls-page') }}</span>
@@ -265,7 +274,7 @@ const hasMultiplePages = computed(() => !props.isInfiniteMode && props.totalPage
               class="w-10 px-1.5 py-0.5 text-sm bg-surface-alt border border-default text-primary rounded focus:ring-accent focus:border-accent [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none font-mono text-center"
               ref="pageInput"
             />
-            <span>of {{ totalPages }}</span>
+            <span>{{ t('pagination-controls-of-total', { total: totalPages }) }}</span>
           </div>
         </template>
       </div>

--- a/i18n/locales/en-AU/main.ftl
+++ b/i18n/locales/en-AU/main.ftl
@@ -4888,6 +4888,12 @@ common-bulk-actions-aria = Bulk actions
 common-loading-more-aria = Loading more
 ptr-refreshing = Refreshing…
 ptr-updated = Updated
+pagination-controls-per-page = per page
+pagination-controls-of-total = of { $total }
+pagination-controls-items = { $count ->
+    [one] { $count } item
+   *[other] { $count } items
+}
 pagination-controls-page = Page
 pagination-controls-show = Show
 asset-modal-title = Select an asset

--- a/i18n/locales/en-GB/main.ftl
+++ b/i18n/locales/en-GB/main.ftl
@@ -4876,6 +4876,12 @@ common-bulk-actions-aria = Bulk actions
 common-loading-more-aria = Loading more
 ptr-refreshing = Refreshing…
 ptr-updated = Updated
+pagination-controls-per-page = per page
+pagination-controls-of-total = of { $total }
+pagination-controls-items = { $count ->
+    [one] { $count } item
+   *[other] { $count } items
+}
 pagination-controls-page = Page
 pagination-controls-show = Show
 asset-modal-title = Select an asset

--- a/i18n/locales/en-US/main.ftl
+++ b/i18n/locales/en-US/main.ftl
@@ -6213,6 +6213,12 @@ common-bulk-actions-aria = Bulk actions
 common-loading-more-aria = Loading more
 ptr-refreshing = Refreshing…
 ptr-updated = Updated
+pagination-controls-per-page = per page
+pagination-controls-of-total = of { $total }
+pagination-controls-items = { $count ->
+    [one] { $count } item
+   *[other] { $count } items
+}
 pagination-controls-page = Page
 pagination-controls-show = Show
 asset-modal-title = Select an asset

--- a/i18n/locales/fr-FR/main.ftl
+++ b/i18n/locales/fr-FR/main.ftl
@@ -6048,6 +6048,12 @@ common-bulk-actions-aria = Actions groupées
 common-loading-more-aria = Chargement de la suite
 ptr-refreshing = Actualisation…
 ptr-updated = Mis à jour
+pagination-controls-per-page = par page
+pagination-controls-of-total = sur { $total }
+pagination-controls-items = { $count ->
+    [one] { $count } élément
+   *[other] { $count } éléments
+}
 pagination-controls-page = Page
 pagination-controls-show = Afficher
 asset-modal-title = Sélectionner un actif

--- a/i18n/locales/nl-NL/main.ftl
+++ b/i18n/locales/nl-NL/main.ftl
@@ -6039,6 +6039,12 @@ common-bulk-actions-aria = Bulkacties
 common-loading-more-aria = Meer laden
 ptr-refreshing = Vernieuwen…
 ptr-updated = Bijgewerkt
+pagination-controls-per-page = per pagina
+pagination-controls-of-total = van { $total }
+pagination-controls-items = { $count ->
+    [one] { $count } item
+   *[other] { $count } items
+}
 pagination-controls-page = Pagina
 pagination-controls-show = Toon
 asset-modal-title = Selecteer een activum


### PR DESCRIPTION
The desktop pagination bar has three slots: page size, navigation, position. The item count sat in the **navigation** slot, so `flex-1 justify-center` put it dead centre while the position slot collapsed to an empty `div` — its only child is gated on `!isInfiniteMode`.

**Not an edge case.** `pageSize` defaults to `0` and `isInfiniteMode` is `pageSize == 0`, so this is what every list view shows out of the box:

```
[Show ▾ per page]  ·········  1,234 items  ·········  (empty)
   shrink-0         flex-1 justify-center          shrink-0, renders nothing
```

A control on the left, a count marooned in the middle, and nothing at the right edge.

## The change

The count is *position*, not *navigation*, so it moves to the position slot beside where "Page x of y" goes. Each slot now means one thing and both edges are occupied in either mode:

| | Left | Centre | Right |
|---|---|---|---|
| Infinite (default) | Show ▾ per page | *(nothing to navigate)* | 1,234 items |
| Paginated | Show ▾ per page | ‹ 1 2 3 › | Page 1 of 5 |

The **mobile** bar was already fine — two real children under `justify-between`, so it never had an empty slot to strand anything against. Left alone.

## Also: the last hardcoded strings in this component

`per page`, `of { $total }` and the item count were plain English while their neighbours (`pagination-controls-show`, `pagination-controls-page`) already went through Fluent. Since the count is the string being moved, all three are localised now, the count as a **plural selector** rather than a bare `N items`.

Verified by parsing all five catalogues and formatting at `count: 1` and `count: 7` — 0 parse errors, correct singular/plural in each, including `1 élément` / `7 éléments`. Worth doing: the closing brace has to sit at column 0, and my first attempt indented it, which Fluent reads as pattern continuation rather than the end of the selector.

https://claude.ai/code/session_017iEcp3fFMB594JYRZxcQ5H